### PR TITLE
fix: reset opacity for gamemodels

### DIFF
--- a/src/cgame/cg_ents.c
+++ b/src/cgame/cg_ents.c
@@ -497,6 +497,8 @@ static void CG_General(centity_t *cent)
 		VectorScale(ent.axis[2], cent->currentState.angles2[2], ent.axis[2]);
 		ent.nonNormalizedAxes = qtrue;
 
+		CG_EntitySetRGBA(&ent, 1.0, 1.0, 1.0, 1.0);
+
 		if (cent->currentState.apos.trType)
 		{
 			ent.reFlags |= REFLAG_ORIENT_LOD;


### PR DESCRIPTION
if you use std player textures for gamemodels they would get
transparent due to how shaders are currently support ghostplayers
transparency
