### PR TITLE
fix portal gun issues

### DIFF
--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -2620,18 +2620,18 @@ static void CG_PortalGate(centity_t *cent)
 {
 
 
-	polyVert_t POLYverts[4];
-	vec3_t     verts[4];
-	vec3_t     pushedOrigin, angleInverse;
-	vec3_t     axis[3];
-	float      radius = 64.0f; // TODO: Use #define instead
-	int        i;
+	polyVert_t  POLYverts[4];
+	vec3_t      verts[4];
+	vec3_t      pushedOrigin, angleInverse;
+	vec3_t      axis[3];
+	const float radius = 64.0f;
+	int         i;
 
 	//Predefined colors
 	byte clrBlue[4]   = { 0x00, 0x01, 0xff, 0xff };
 	byte clrOrange[4] = { 0xff, 0x7e, 0x00, 0xff };
 	byte clrRed[4]    = { 0xf3, 0x32, 0x27, 0xff };
-	byte clrLBlue[4]  = { 0x27, 0x82, 0xf4, 0xff }; //This is the red complement
+	byte clrGreen[4]  = { 0x09, 0x82, 0x09, 0xff }; //This is the red complement
 
 
 	//Check if player wants to see other player portals
@@ -2799,25 +2799,25 @@ static void CG_PortalGate(centity_t *cent)
 		else
 		{
 
-			POLYverts[0].modulate[0] = clrLBlue[0];     //R
-			POLYverts[0].modulate[1] = clrLBlue[1];     //G
-			POLYverts[0].modulate[2] = clrLBlue[2];     //B
-			POLYverts[0].modulate[3] = clrLBlue[3];     //A
+			POLYverts[0].modulate[0] = clrGreen[0];     //R
+			POLYverts[0].modulate[1] = clrGreen[1];     //G
+			POLYverts[0].modulate[2] = clrGreen[2];     //B
+			POLYverts[0].modulate[3] = clrGreen[3];     //A
 
-			POLYverts[1].modulate[0] = clrLBlue[0];     //R
-			POLYverts[1].modulate[1] = clrLBlue[1];     //G
-			POLYverts[1].modulate[2] = clrLBlue[2];     //B
-			POLYverts[1].modulate[3] = clrLBlue[3];     //A
+			POLYverts[1].modulate[0] = clrGreen[0];     //R
+			POLYverts[1].modulate[1] = clrGreen[1];     //G
+			POLYverts[1].modulate[2] = clrGreen[2];     //B
+			POLYverts[1].modulate[3] = clrGreen[3];     //A
 
-			POLYverts[2].modulate[0] = clrLBlue[0];     //R
-			POLYverts[2].modulate[1] = clrLBlue[1];     //G
-			POLYverts[2].modulate[2] = clrLBlue[2];     //B
-			POLYverts[2].modulate[3] = clrLBlue[3];     //A
+			POLYverts[2].modulate[0] = clrGreen[0];     //R
+			POLYverts[2].modulate[1] = clrGreen[1];     //G
+			POLYverts[2].modulate[2] = clrGreen[2];     //B
+			POLYverts[2].modulate[3] = clrGreen[3];     //A
 
-			POLYverts[3].modulate[0] = clrLBlue[0];     //R
-			POLYverts[3].modulate[1] = clrLBlue[1];     //G
-			POLYverts[3].modulate[2] = clrLBlue[2];     //B
-			POLYverts[3].modulate[3] = clrLBlue[3];     //A
+			POLYverts[3].modulate[0] = clrGreen[0];     //R
+			POLYverts[3].modulate[1] = clrGreen[1];     //G
+			POLYverts[3].modulate[2] = clrGreen[2];     //B
+			POLYverts[3].modulate[3] = clrGreen[3];     //A
 
 		}
 

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -3123,12 +3123,6 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 
 		break;
 
-	//Feen: PGM
-	case EV_PORTAL2_FIRE:
-		DEBUGNAME("EV_PORTAL2_FIRE");
-		//CG_Printf( "^1Portal Debug: ^7CG_EntityEvent() EV_PORTAL2_FIRE - received\n");
-		break;
-
 	case EV_PORTAL_TELEPORT:
 		DEBUGNAME("EV_PORTAL_TELEPORT");
 		portalDetected = qtrue; //Used below.....

--- a/src/game/bg_misc.cpp
+++ b/src/game/bg_misc.cpp
@@ -4203,7 +4203,6 @@ const char *eventnames[] =
 	"EV_ARTYMESSAGE",
 	"EV_AIRSTRIKEMESSAGE",
 	"EV_MEDIC_CALL",
-	"EV_PORTAL2_FIRE", //Feen: PGM
 	"EV_MAX_EVENTS",
 };
 

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -3901,35 +3901,6 @@ static void PM_Weapon(void)
 	//Feen Weapon Dbug
 //#ifdef GAMEDLL
 
-	//PGM Test...
-	if (pm->cmd.wbuttons & WBUTTON_ATTACK2)
-	{
-
-		if (pm->ps->weaponTime > 0)
-		{
-			pm->ps->weaponTime -= pml.msec;
-
-			if (pm->ps->weaponTime <= 0)
-			{
-				pm->ps->weaponTime = 0;
-			}
-
-		}
-		else
-		{
-
-			if (pm->cmd.weapon == WP_PORTAL_GUN)
-			{
-				PM_AddEvent(EV_PORTAL2_FIRE);
-			}
-			//Com_Printf("FWD: EV_PORTAL2_FIRE Added...\n");
-			pm->ps->weaponTime += 1000; //Feen: This equates to about .5 seconds
-
-			BG_AnimScriptEvent(pm->ps, pm->character->animModelInfo, ANIM_ET_FIREWEAPON, qfalse, qtrue);   //TEST
-
-		}
-	}
-
 #ifdef FEEN_WPN_DBG
 	//REGULAR BUTTONS
 	if (pm->cmd.buttons & BUTTON_ATTACK)
@@ -4376,14 +4347,6 @@ static void PM_Weapon(void)
 		{
 			pm->ps->weaponDelay = 0;
 			delayedFire         = qtrue; // weapon delay has expired.  Fire this frame
-
-			// double check the player is still holding the fire button down for these weapons
-			// so you don't get a delayed "non-fire" (fire hit and released, then shot fires)
-			switch (pm->ps->weapon)
-			{
-			default:
-				break;
-			}
 		}
 	}
 
@@ -4718,8 +4681,8 @@ static void PM_Weapon(void)
 	// check for fire
 	// if not on fire button and there's not a delayed shot this frame...
 	// consider also leaning, with delayed attack reset
-	if ((!(pm->cmd.buttons & (BUTTON_ATTACK | WBUTTON_ATTACK2)) && !delayedFire) ||
-	    (pm->ps->leanf != 0 && pm->ps->weapon != WP_GRENADE_LAUNCHER && pm->ps->weapon != WP_GRENADE_PINEAPPLE && pm->ps->weapon != WP_SMOKE_BOMB))
+	if ((!(pm->cmd.buttons & BUTTON_ATTACK) && !(pm->cmd.wbuttons & WBUTTON_ATTACK2) && !delayedFire) ||
+		(pm->ps->leanf != 0 && pm->ps->weapon != WP_GRENADE_LAUNCHER && pm->ps->weapon != WP_GRENADE_PINEAPPLE && pm->ps->weapon != WP_SMOKE_BOMB))
 	{
 		pm->ps->weaponTime  = 0;
 		pm->ps->weaponDelay = 0;

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -1123,7 +1123,6 @@ typedef enum
 	EV_ARTYMESSAGE,
 	EV_AIRSTRIKEMESSAGE,
 	EV_MEDIC_CALL,
-	EV_PORTAL2_FIRE, //Feen: PGM - Portal Gun Events - NOTE: EV_PORTAL1_FIRE event is covered by EV_FIRE_WEAPON event...
 	EV_PORTAL_TELEPORT,
 	EV_MAX_EVENTS   // just added as an 'endcap'
 } entity_event_t;

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -843,11 +843,6 @@ void ClientEvents(gentity_t *ent, int oldEventSequence)
 			FireWeapon(ent);
 			break;
 
-		//Feen: PGM -
-		case EV_PORTAL2_FIRE:
-			Weapon_Portal_Fire(ent, 2); //Red Portal
-			break;
-
 		default:
 			break;
 		} //switch case

--- a/src/game/g_weapon.cpp
+++ b/src/game/g_weapon.cpp
@@ -3880,7 +3880,7 @@ void Weapon_Portal_Fire(gentity_t *ent, int PortalNumber)
 	                              //      just have to play around with it...
 	                              //      and move it to g_local.h...
 
-	#define PORTAL_MIN_DIST 75.0f //Arbitrary, but it works...
+	#define PORTAL_MIN_DIST 24.0f // should be suitable for 12units thick wall
 
 
 	gentity_t *portal, *tent;
@@ -5256,7 +5256,15 @@ void FireWeapon(gentity_t *ent)
 
 	//Feen: PGM
 	case WP_PORTAL_GUN:
-		Weapon_Portal_Fire(ent, 1);   //Feen: '1' indicates blue portal, red portal calls will be made from weapaltfire calls
+
+		// '1' indicates blue portal, '2' indicates red portal
+		if (ent->client->wbuttons & WBUTTON_ATTACK2)
+		{
+			Weapon_Portal_Fire(ent, 2);
+		} else
+		{
+			Weapon_Portal_Fire(ent, 1);
+		}
 		break;
 
 	default:


### PR DESCRIPTION
- fix 2nd portal fire rate (was uneven with portal 1)
- fix can't set 2nd portal on opposite side of wall if 1st portal is set, due to min-overlap portals distance (lowered down distance)
- also fixed op fire rate for weapons if both attack and attack2 are pressed
- changed other players portal 1 color to green to make it more distinct on light surfaces
