### PR TITLE
T79 fix runtimer gets rekt after vid_restart

### DIFF
--- a/src/cgame/cg_mainext.cpp
+++ b/src/cgame/cg_mainext.cpp
@@ -16,6 +16,8 @@ void InitGame()
 	ETJump_ClearDrawables();
 	timerun = std::unique_ptr<Timerun>(new Timerun(cg.clientNum));
 	timerunView = std::unique_ptr<ETJump::TimerunView>(new ETJump::TimerunView());
+	// restores timerun after vid_restart (if required)
+	trap_SendClientCommand("timerun_status");
 }
 
 /**

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -4531,6 +4531,22 @@ void Cmd_shrug_f(gentity_t *ent)
 	BG_AnimScriptEvent(&ent->client->ps, ent->client->pers.character->animModelInfo, ANIM_ET_NOPOWER, qtrue, qfalse);
 }
 
+// sends back timerun specific information, used to restore runtimer after cgame restart
+void Cmd_timerunStatus_f(gentity_t *ent)
+{
+	if (level.hasTimerun)
+	{
+		trap_SendServerCommand(ClientNum(ent), "hasTimerun 1");
+	}
+	else
+	{
+		trap_SendServerCommand(ClientNum(ent), "hasTimerun 0");
+	}
+
+	TimerunConnectNotify(ent);
+}
+
+
 /*
 =================
 Cmd_SwapPlacesWithBot_f
@@ -4655,7 +4671,7 @@ static command_t noIntermissionCommands[] =
 	//{ "save",				qfalse,	Cmd_Save_f },
 	{ "shrug",           qfalse, Cmd_shrug_f           },
 	//{ "savereset",          qfalse, Cmd_SaveReset_f },
-
+	{ "timerun_status",  qfalse, Cmd_timerunStatus_f   },
 };
 
 qboolean ClientIsFlooding(gentity_t *ent)


### PR DESCRIPTION
> T79 A: vid_restart disables timeruns until player reconnects
> T79 H: The timer disappears, but timeruns still work.

After vid_restart cgame looses all the information about runtimes,
including hasTimerun state, which caused view to ignore timer draw
procedure. This is some temporary fix i suppose, not perfect, but works
fine in current environment.
