### PR TITLE
T81 fix landmine crash the server

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -6099,21 +6099,24 @@ static void CG_Draw2D(void)
 // NERVE - SMF
 void CG_StartShakeCamera(float p, entityState_t *es)
 {
-	// cam does not shake
+	auto attacker = static_cast<char>(es->clientNum);
+
+	//ETJump: never shake cam from explosions
 	if (etj_explosivesShake.integer == 0) {
 		return;
 	}
-	// cam shakes only if this is not your explosion
-	else if (etj_explosivesShake.integer == 1 && es->clientNum == cg.clientNum) {
+
+	//ETJump: shake cam only from other players explosives
+	if (etj_explosivesShake.integer == 1 && attacker == cg.clientNum) {
 		return;
 	}
-	// cam shakes if you are the one who caused explosion
-	else if (etj_explosivesShake.integer == 2 && es->clientNum != cg.clientNum) {
+
+	//ETJump: shake cam only from own explosives
+	if (etj_explosivesShake.integer == 2 && attacker != cg.clientNum) {
 		return;
 	}
 
 	cg.cameraShakeScale = p;
-
 	cg.cameraShakeLength = 1000 * (p * p);
 	cg.cameraShakeTime   = cg.time + cg.cameraShakeLength;
 	cg.cameraShakePhase  = crandom() * M_PI; // start chain in random dir

--- a/src/game/g_missile.cpp
+++ b/src/game/g_missile.cpp
@@ -518,7 +518,9 @@ void G_ExplodeMissile(gentity_t *ent)
 			gentity_t *tent = G_TempEntity(ent->r.currentOrigin, EV_SHAKE);
 			tent->s.onFireStart = ent->splashDamage * 4;
 			tent->r.svFlags    |= SVF_BROADCAST;
-			tent->s.clientNum   = ent->parent->client->ps.clientNum; // send attacker's id
+			
+			//ETJump: map entities don't have attacker id so we send -1
+			tent->s.clientNum = (ent->parent) ? ent->parent->client->ps.clientNum : -1; //ETJump: send attacker's id
 		}
 	}
 }


### PR DESCRIPTION
> T81 When misc_landmine explodes, server will crash.

Map entities unlike players don't have any parents, so i was trying to access null pointer to grab attacker's id (#57) ...
Actually this affects any weapon that causes shaking.

Also I have put ETJump prefix to the comments, because i couldn't distinguish my own code after almost 3 months of writing it :d i am going to keep doing that to keep stuff clean for myself in future. 
