### PR TITLE
T3 added new startTimer spawnflags

### DIFF
--- a/src/game/bg_misc.cpp
+++ b/src/game/bg_misc.cpp
@@ -2894,6 +2894,29 @@ qboolean BG_WeaponInWolfMP(int weapon)
 	}
 }
 
+qboolean BG_WeaponIsExplosive(int weap)
+{
+	switch (weap)
+	{
+	case WP_CARBINE:
+	case WP_KAR98:
+	case WP_M7:
+	case WP_GRENADE_LAUNCHER:
+	case WP_GRENADE_PINEAPPLE:
+	case WP_PANZERFAUST:
+	case WP_LANDMINE:
+	case WP_ARTY:
+	case WP_GPG40:
+	case WP_FLAMETHROWER:
+	case WP_MORTAR:
+	case WP_SATCHEL:
+	case WP_DYNAMITE:
+		return qtrue;
+	default:
+		return qfalse;
+	}
+}
+
 /*
 ============
 BG_PlayerTouchesItem

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -1617,6 +1617,7 @@ int BG_AkimboSidearm(int weaponNum);
 qboolean BG_CanUseWeapon(int classNum, int teamNum, weapon_t weapon);
 
 qboolean    BG_CanItemBeGrabbed(const entityState_t *ent, const playerState_t *ps, int *skill, int teamNum);
+qboolean    BG_WeaponIsExplosive(int weap);
 
 
 // content masks

--- a/src/game/etj_utilities.cpp
+++ b/src/game/etj_utilities.cpp
@@ -53,6 +53,10 @@ static void SelectCorrectWeapon(gclient_t *cl, const std::vector<int>& disallowe
 			{
 				cl->ps.weapon = WP_MP40;
 			}
+			else if (COM_BitCheck(cl->ps.weapons, WP_KAR98))
+			{
+				cl->ps.weapon = WP_KAR98;
+			}
 			else
 			{
 				cl->ps.weapon = WP_LUGER;
@@ -63,6 +67,10 @@ static void SelectCorrectWeapon(gclient_t *cl, const std::vector<int>& disallowe
 			if (COM_BitCheck(cl->ps.weapons, WP_THOMPSON))
 			{
 				cl->ps.weapon = WP_THOMPSON;
+			}
+			else if (COM_BitCheck(cl->ps.weapons, WP_CARBINE))
+			{
+				cl->ps.weapon = WP_CARBINE;
 			}
 			else
 			{
@@ -92,6 +100,7 @@ void Utilities::startRun(int clientNum)
 		WP_DYNAMITE,
 		WP_GRENADE_LAUNCHER,
 		WP_GRENADE_PINEAPPLE,
+		WP_M7,
 		WP_SATCHEL_DET,
 		WP_SATCHEL,
 		WP_MORTAR,

--- a/src/game/g_items.cpp
+++ b/src/game/g_items.cpp
@@ -929,9 +929,17 @@ void Touch_Item(gentity_t *ent, gentity_t *other, trace_t *trace)
 	{
 		return;     // dead people can't pickup
 	}
-
+	
 	// the same pickup rules are used for client side and server side
 	if (!BG_CanItemBeGrabbed(&ent->s, &other->client->ps, other->client->sess.skill, other->client->sess.sessionTeam))
+	{
+		return;
+	}
+
+	// ETJump: disable explosives pickup
+	if (BG_WeaponIsExplosive(ent->item->giTag) && 
+		other->client->sess.timerunActive &&
+		(other->client->sess.runSpawnflags & TIMERUN_DISABLE_EXPLOSIVES_PICKUP))
 	{
 		return;
 	}

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2726,11 +2726,13 @@ void LogServerState();
 
 qboolean G_IsOnFireteam(int entityNum, fireteamData_t **teamNum);
 
-#define TIMERUN_RESET_ON_TEAM_CHANGE    0x01
-#define TIMERUN_RESET_ON_DEATH          0x02
-#define TIMERUN_RESET_ON_END            0x04
-#define TIMERUN_RESET_ON_PMOVE_NULL     0x08
-#define TIMERUN_DISABLE_BACKUPS         0x10
+#define TIMERUN_RESET_ON_TEAM_CHANGE           0x01
+#define TIMERUN_RESET_ON_DEATH                 0x02
+#define TIMERUN_RESET_ON_END                   0x04
+#define TIMERUN_RESET_ON_PMOVE_NULL            0x08
+#define TIMERUN_DISABLE_BACKUPS                0x10
+#define TIMERUN_DISABLE_EXPLOSIVES_PICKUP      0x20
+#define TIMERUN_DISABLE_PORTALGUN_PICKUP       0x40
 
 void StartTimer(const char *runName, gentity_t *ent);
 void StopTimer(const char *runName, gentity_t *ent);

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -281,6 +281,13 @@ void weapon_portalgun_touch(gentity_t *self, gentity_t *other, trace_t *trace)
 		return;
 	}
 
+	// ETJump: disable portalgun pickup
+	if (other->client->sess.timerunActive &&
+		(other->client->sess.runSpawnflags & TIMERUN_DISABLE_PORTALGUN_PICKUP))
+	{
+		return;
+	}
+
 	// If portal team value is higher than 0 let's set users pteam value
 	// to that of the entity.
 	if (self->portalTeam > 0)

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -2080,14 +2080,17 @@ void SP_target_decay(gentity_t *self)
 // Begin of timeruns support
 
 // target_starttimer
+//------------------
 // name:    run name.
 // spawnflags:
-//  0 always reset the run
-//  1 reset the run on team change
-//  2 reset the run on death
-//  4 only reset when you reach the end
-//  8 reset the run if player doesnt use fixed pmove
-// 16 disable use of save slots and backups
+//    0 always reset the run
+//    1 reset the run on team change
+//    2 reset the run on death
+//    4 only reset when you reach the end
+//    8 reset/disable the run if player doesnt use fixed pmove
+//   16 disable use of save slots and backups
+//   32 disable explosive weapons pickup
+//   64 disable potralgun pickup
 void target_startTimer_use(gentity_t *self, gentity_t *other, gentity_t *activator)
 {
 	float speed = VectorLength(activator->client->ps.velocity);


### PR DESCRIPTION
> T3
> Two new spawnflags:
> 
> Can't pick up explosives
> Can't pick up the portal gun

added 2 new spawnflags to `target_startTimer`:
- 32  to disable explosives pickup while on a run
- 64  to disable  portalgun pickup while on a run

also made garand rnade not allowed once run starts
