### PR TITLE
T36 fix limbo players not being put in spectators

### DIFF
--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -584,7 +584,8 @@ qboolean ClientInactivityTimer(gclient_t *client)
 	         (client->pers.cmd.buttons & BUTTON_ATTACK) ||
 	         (client->pers.cmd.wbuttons & WBUTTON_LEANLEFT) ||
 	         (client->pers.cmd.wbuttons & WBUTTON_LEANRIGHT)
-	         || client->ps.pm_type == PM_DEAD)
+			 // ETJump: we don't care about limbo players
+	         /*|| client->ps.pm_type == PM_DEAD*/)
 	{
 
 		client->inactivityWarning = qfalse;


### PR DESCRIPTION
> T36
> When a player drowns, he doesn't get moved to spec for inactivity.
> 
> Might be the same for ungibbed bodies.
