### PR TITLE
T10, T47 fix trigger_teleporter and target_teleporter

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1547,6 +1547,7 @@ void InitTrigger(gentity_t *self);
 //
 void TeleportPlayer(gentity_t *player, vec3_t origin, vec3_t angles);
 void TeleportPlayerExt(gentity_t *player, vec3_t origin, vec3_t angles);
+void TeleportPlayerKeepAngles_Clank(gentity_t *player, gentity_t *trigger, vec3_t origin, vec3_t angles);
 void TeleportPlayerKeepAngles(gentity_t *player, gentity_t *trigger, vec3_t origin, vec3_t angles);
 void PortalTeleport(gentity_t *player, vec3_t origin, vec3_t angles);   //Feen: PGM
 void mg42_fire(gentity_t *other);

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -614,7 +614,8 @@ spawnflags:
 	1	Sets destination angles and resets velocity
 	2	Sets destination angles and converts velocity to match destination direction,
 		so we are now moving same way as our teleporter_dest angle is pointing at
-	4	Converts player's angles and velocity to be relative to the new destination angles
+	4	Converts player's angles(yaw) and velocity to be relative to the new destination angles
+	8   Same as 4 but also preserves pitch
 */
 void target_teleporter_use(gentity_t *self, gentity_t *other, gentity_t *activator)
 {
@@ -645,6 +646,12 @@ void target_teleporter_use(gentity_t *self, gentity_t *other, gentity_t *activat
 	}
 
 	if (self->spawnflags & 4)
+	{
+		TeleportPlayerKeepAngles_Clank(activator, other, dest->s.origin, dest->s.angles);
+		return;
+	}
+
+	if (self->spawnflags & 8)
 	{
 		TeleportPlayerKeepAngles(activator, other, dest->s.origin, dest->s.angles);
 		return;

--- a/src/game/g_trigger.cpp
+++ b/src/game/g_trigger.cpp
@@ -387,7 +387,8 @@ spawnflags:
 	1	Sets destination angles and resets velocity
 	2	Sets destination angles and converts velocity to match destination direction,
 		so we are now moving same way as our teleporter_dest angle is pointing at
-	4	Converts player's angles and velocity to be relative to the new destination angles
+	4	Converts player's angles(yaw) and velocity to be relative to the new destination angles
+	8   Same as 4 but also preserves pitch
 */
 void trigger_teleporter_touch(gentity_t *self, gentity_t *other, trace_t *trace)
 {
@@ -421,6 +422,12 @@ void trigger_teleporter_touch(gentity_t *self, gentity_t *other, trace_t *trace)
 	}
 
 	if (self->spawnflags & 4)
+	{
+		TeleportPlayerKeepAngles_Clank(other, self, dest->s.origin, dest->s.angles);
+		return;
+	}
+
+	if (self->spawnflags & 8)
 	{
 		TeleportPlayerKeepAngles(other, self, dest->s.origin, dest->s.angles);
 		return;


### PR DESCRIPTION
- teleporter's spawnflag 4 now preserves pitch and works correctly with spawnflag 1 (reset speed)
- trigger_teleporter now supports same spawnflags as target_teleporter
