### PR TITLE
fix LoadTag returns incorrect tag file number

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2093,7 +2093,7 @@ void    trap_BotFreeClient(int clientNum);
 void    trap_GetUsercmd(int clientNum, usercmd_t *cmd);
 qboolean    trap_GetEntityToken(char *buffer, int bufferSize);
 qboolean trap_GetTag(int clientNum, int tagFileNumber, const char *tagName, orientation_t *orientation);
-qboolean trap_LoadTag(const char *filename);
+int     trap_LoadTag(const char *filename);
 
 int     trap_RealTime(qtime_t *qtime);
 

--- a/src/game/g_syscalls.cpp
+++ b/src/game/g_syscalls.cpp
@@ -359,9 +359,9 @@ qboolean trap_GetTag(int clientNum, int tagFileNumber, const char *tagName, orie
 	return syscall(G_GETTAG, clientNum, tagFileNumber, tagName, orientation) ? qtrue : qfalse;
 }
 
-qboolean trap_LoadTag(const char *filename)
+int trap_LoadTag(const char *filename)
 {
-	return syscall(G_REGISTERTAG, filename) ? qtrue : qfalse;
+	return syscall(G_REGISTERTAG, filename);
 }
 
 // BotLib traps start here


### PR DESCRIPTION
https://bt.etjump.com/T131
Turns out original devs left incorrect return type for trap_LoadTag, which should return tag file number that is referenced in entities, and well, your c++ conversion clamped values to 0 and 1, this made trap_GetTag, that uses these tag file numbers, to fail getting right tag and hence there were no position updates for specific tagged entities.