### PR TITLE
fixed func_static, target_speaker

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -2564,7 +2564,6 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 	case EV_POPUP:
 	case EV_GIVEPAGE:
 		break;
-
 	case EV_GENERAL_SOUND:
 		DEBUGNAME("EV_GENERAL_SOUND");
 		// Ridah, check for a sound script
@@ -2613,6 +2612,11 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		trap_S_StartSoundVControl(NULL, es->number, CHAN_VOICE, sound, 255);
 	}
 	break;
+	case EV_GENERAL_CLIENT_SOUND_VOLUME:
+		if (cg.snap->ps.clientNum != es->teamNum)
+		{
+			break;
+		}
 	case EV_GENERAL_SOUND_VOLUME:
 	{
 		int sound  = es->eventParm;

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -1062,6 +1062,7 @@ typedef enum
 	EV_GRENADE_BOUNCE,      // eventParm will be the soundindex
 	EV_GENERAL_SOUND,
 	EV_GENERAL_SOUND_VOLUME,
+	EV_GENERAL_CLIENT_SOUND_VOLUME, // ETJump: play sound from the specific entity to the client
 	EV_GLOBAL_SOUND,        // no attenuation
 	EV_GLOBAL_CLIENT_SOUND, // DHM - Nerve :: no attenuation, only plays for specified client
 	EV_GLOBAL_TEAM_SOUND,   // no attenuation, team only

--- a/src/game/g_mover.cpp
+++ b/src/game/g_mover.cpp
@@ -3798,7 +3798,7 @@ void Static_Pain(gentity_t *ent, gentity_t *attacker, int damage, vec3_t point)
 
 	if (level.time > ent->wait + ent->delay + rand() % 1000 + 500)
 	{
-		G_UseTargets(ent, NULL);
+		G_UseTargets(ent, attacker);
 		ent->wait = level.time;
 	}
 

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -233,7 +233,8 @@ void Use_Target_Speaker(gentity_t *ent, gentity_t *other, gentity_t *activator)
 	{
 		if (ent->spawnflags & 8)
 		{
-			G_AddEvent(activator, EV_GENERAL_SOUND_VOLUME, ent->noise_index);
+			G_AddEvent(ent, EV_GENERAL_CLIENT_SOUND_VOLUME, ent->noise_index);
+			ent->s.teamNum = ClientNum(activator);
 		}
 		else if (ent->spawnflags & 4)
 		{
@@ -268,11 +269,11 @@ void target_speaker_multiple(gentity_t *ent)
 
 }
 
+
 void SP_target_speaker(gentity_t *ent)
 {
 	char buffer[MAX_QPATH];
 	char *s;
-
 	G_SpawnFloat("wait", "0", &ent->wait);
 	G_SpawnFloat("random", "0", &ent->random);
 


### PR DESCRIPTION
https://bt.etjump.com/T82

fixed: func_static -> spawnflag 2(PAIN) triggering linked entities that expect
activator to be set would crash the game (eg. teleporter, identity)

fixed: target_speaker -> spawnflag 8(ACTIVATOR) didn't play sound to the
activator due to lack of volume(since volume is stored in field that player entities use for own needs, unlike other entities)