### PR TITLE
fixed deathrun code broadcasted empty messages

### DIFF
--- a/src/game/etj_deathrun_system.h
+++ b/src/game/etj_deathrun_system.h
@@ -114,6 +114,12 @@ namespace ETJump
 		 */
 		std::string getEndMessage() const;
 		static std::string getMessageFormat(PrintLocation location);
+		/**
+		* Checks if run is active for player
+		* @param clientNum ID of the activating player
+		* @returns is run active for player
+		*/
+		bool isActive(int clientNum);
 	private:
 		struct RunStatus
 		{
@@ -125,12 +131,6 @@ namespace ETJump
 			std::vector<bool> checkpointStatuses;
 			bool active;
 		};
-		/**
-		 * Checks if run is active for player
-		 * @param clientNum ID of the activating player
-		 * @returns is run active for player
-		 */
-		bool isActive(int clientNum);
 		/**
 		 * Resets run score and starts a new run
 		 * @param clientNum activating player ID

--- a/src/game/g_combat.cpp
+++ b/src/game/g_combat.cpp
@@ -789,17 +789,20 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int 
 	}
 
 	auto clientNum = ClientNum(self);
-	auto score = ETJump::deathrunSystem->hitEnd(clientNum);
-	self->client->sess.deathrunFlags = 0;
-	auto fmt = ETJump::DeathrunSystem::getMessageFormat(ETJump::deathrunSystem->getPrintLocation());
-	auto message = ETJump::deathrunSystem->getEndMessage();
-	boost::replace_all(message, "[n]", self->client->pers.netname);
-	boost::replace_all(message, "[s]", std::to_string(score));
-	auto affectedPlayers = Utilities::getSpectators(clientNum);
-	affectedPlayers.push_back(clientNum);
-	for (const auto & c : affectedPlayers)
+	if (ETJump::deathrunSystem->isActive(clientNum))
 	{
-		trap_SendServerCommand(c, va(fmt.c_str(), message.c_str()));
+		auto score = ETJump::deathrunSystem->hitEnd(clientNum);
+		self->client->sess.deathrunFlags = 0;
+		auto fmt = ETJump::DeathrunSystem::getMessageFormat(ETJump::deathrunSystem->getPrintLocation());
+		auto message = ETJump::deathrunSystem->getEndMessage();
+		boost::replace_all(message, "[n]", self->client->pers.netname);
+		boost::replace_all(message, "[s]", std::to_string(score));
+		auto affectedPlayers = Utilities::getSpectators(clientNum);
+		affectedPlayers.push_back(clientNum);
+		for (const auto & c : affectedPlayers)
+		{
+			trap_SendServerCommand(c, va(fmt.c_str(), message.c_str()));
+		}
 	}
 }
 


### PR DESCRIPTION
fixes this https://bt.etjump.com/T160
if deathrun is not active, deathrun system broadcast empty messages on each player death