### PR TITLE
noise + outspeed keys for teleports

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -62,6 +62,10 @@
   * __2__ pickup any touched weapons
   * functionality relies on having `cg_autoactivate 1`
 * fixed `movie_changeFovBasedOnSpeed` toggle not working
+* added `noise` key for target_teleporter and trigger_teleport, plays only to client
+* added `outspeed` key for target_teleporter and trigger_teleport
+  * sets fixed speed at which player exits teleport
+  * value __0__ does NOT reset speed, instead ignores the key (default)
 
 
 # ETJump 2.2.0

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -562,6 +562,8 @@ struct gentity_s
 
 	int tjlLineNumber;
 	char *tjlLineName;
+
+	int outSpeed;
 };
 
 // Ridah

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -650,6 +650,20 @@ void target_teleporter_use(gentity_t *self, gentity_t *other, gentity_t *activat
 	{
 		return;
 	}
+
+	if (self->outSpeed > 0)
+	{
+		VectorNormalize(activator->client->ps.velocity);  // normalize velocity 
+		VectorScale(activator->client->ps.velocity, self->outSpeed, activator->client->ps.velocity); // scale it up again
+		activator->client->ps.pm_time = 160;        // hold time
+		activator->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;
+	}
+
+	if (self->noise_index)
+	{
+		G_AddEvent(activator, EV_GENERAL_SOUND, self->noise_index);
+	}
+
 	dest = G_PickTarget(self->target);
 	if (!dest)
 	{
@@ -690,10 +704,17 @@ The activator will be teleported away.
 */
 void SP_target_teleporter(gentity_t *self)
 {
+	char *s;
+
 	if (!self->targetname)
 	{
 		G_Printf("untargeted %s at %s\n", self->classname, vtos(self->s.origin));
 	}
+
+	G_SpawnString("noise", "", &s);
+	self->noise_index = G_SoundIndex(s);
+
+	G_SpawnInt("outspeed", "0", &self->outSpeed);
 
 	self->use = target_teleporter_use;
 }


### PR DESCRIPTION
- Noise only plays sound to the client, it's not global
- Outspeed sets fixed speed at which player exits teleport
- Does not change angles, so original ET teleport behavior is kept, spawnflags 2 can be used to apply outspeed to angle of destination