### PR TITLE
fixed savestrictload

### DIFF
--- a/src/game/etj_save.h
+++ b/src/game/etj_save.h
@@ -19,11 +19,19 @@ public:
 	static const int MAX_SAVED_POSITIONS  = 3;
 	static const int MAX_BACKUP_POSITIONS = 3;
 
+	enum SaveStance
+	{
+		Stand,
+		Crouch,
+		Prone
+	};
+
 	struct SavePosition
 	{
 		bool isValid;
 		vec3_t origin;
 		vec3_t vangles;
+		SaveStance stance;
 	};
 
 	struct Client
@@ -35,6 +43,8 @@ public:
 
 		SavePosition axisSavedPositions[MAX_SAVED_POSITIONS];
 		boost::circular_buffer<SavePosition> axisBackupPositions;
+
+
 	};
 
 	struct DisconnectedClient
@@ -52,9 +62,9 @@ public:
 
 	enum class SaveLoadRestrictions
 	{
-		Crouch = 1 << 0,
-		Prone = 1 << 1,
-		Move = 1 << 2,
+		Default = 0,
+		Stance = 1 << 0,
+		Move = 1 << 1
 	};
 
 	// Saves current position

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -10,6 +10,8 @@
 #include <unordered_map>
 
 #include "g_local.h"
+#include "etj_save.h"
+
 qboolean G_SpawnStringExt(const char *key, const char *defaultString, char **out, const char *file, int line)
 {
 	int i;
@@ -1084,11 +1086,10 @@ namespace ETJump{
 		G_Printf("Save is %s.\n", level.noSave ? "disabled" : "enabled");
 	}
 	
-	std::unordered_map<std::string, int> allowedStrictValues {
-		{ "default", 0 },
-		{ "crouch", 1 << 0 },
-		{ "prone", 1 << 1 },
-		{ "move", 1 << 2 },
+	std::unordered_map<std::string, SaveSystem::SaveLoadRestrictions> allowedStrictValues {
+		{ "default", SaveSystem::SaveLoadRestrictions::Default },
+		{ "stance", SaveSystem::SaveLoadRestrictions::Stance },
+		{ "move", SaveSystem::SaveLoadRestrictions::Move },
 	};
  
 	static void initStrictSaveLoad()
@@ -1107,10 +1108,11 @@ namespace ETJump{
 			while (str >> token)
 			{
 				boost::algorithm::to_lower(token);
-				value |= allowedStrictValues[token]; // else 0
+				value |= static_cast<int>(allowedStrictValues[token]); // else 0
 			}
 		}
 		level.saveLoadRestrictions = value;
+		G_Printf("Save restrictions are %s.\n", value ? "enabled" : "disabled");
 	}
 }
 


### PR DESCRIPTION
fixed behavior for `strictsaveload`  worldspawn key:

`strictsaveload` 0/1/2 bitmask:
**0**: Standard save/load behavior. (alt value: **default**)
**1**: Saves player's stance (standing, crouch, prone) and restores it when loading. Forces view angles for prone. (alt value: **stance**)
**2**: Disables save when moving. (alt value: **move**)
Strings can be combined with white space: `strictsaveload: stance move`