### PR TITLE
Add popup hiding

### DIFF
--- a/src/cgame/cg_popupmessages.cpp
+++ b/src/cgame/cg_popupmessages.cpp
@@ -438,7 +438,7 @@ void CG_DrawPMItems(void)
 	float        y         = 360;
 	char         *msg;
 
-	if (cg_numPopups.value <= 0)
+	if (cg_numPopups.integer <= 0)
 	{
 		return;
 	}


### PR DESCRIPTION
Previously `etj_numPopups` __0__ would still display 1 popup, and setting `etj_popupStayTime` and `etj_popupFadeTime` to __0__ would still flash popups for a frame or so (more evident on lower fps). Latter is not fixed, but I don't see necessary to do it since with this you can just disable them completely.