### PR TITLE
Add spawnflag 1 to target_scale_velocity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -74,6 +74,10 @@
   * `nofalldamage` __1__ = fall damage disabled on all surfaces except on `surfaceparm nodamage`
 * added minimize button for game window (Windows only)
 * added `etj_keysShadow` to draw shadow for keysets
+* added ability to hide popups with `etj_numPopups` __0__
+* added spawnflag __1__ `persistent` to target_scale_velocity
+  * scales activators velocity permanently by amount of `scale`
+  * scaling can be reset with `/kill` or by triggering another `target_scale_velocity` with `scale` __1__
 
 # ETJump 2.2.0
 

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1217,6 +1217,11 @@ void ClientThink_real(gentity_t *ent)
 	// set speed
 	client->ps.speed = G_SPEED;
 
+	if (client->sess.velocityScale)
+	{
+		client->ps.speed *= client->sess.velocityScale;
+	}
+
 	if (client->pers.noclipScale < 1)
 	{
 		client->pmext.noclipScale = 1;

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2473,6 +2473,8 @@ void ClientSpawn(gentity_t *ent, qboolean revived)
 		VectorCopy(client->sess.posBeforeInactivity, ent->r.currentOrigin);
 		client->sess.loadedPosBeforeInactivity = qtrue;
 	}
+
+	client->sess.velocityScale = 1;
 }
 
 void ClearPortals(gentity_t *ent)

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -767,6 +767,8 @@ typedef struct
 #define MAX_PROGRESSION_TRACKERS 50
 	int progression[MAX_PROGRESSION_TRACKERS];
 	int deathrunFlags;
+
+	float velocityScale;
 } clientSession_t;
 
 //

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -2243,11 +2243,13 @@ void SP_target_activate_if_velocity(gentity_t *self)
 
 void target_scale_velocity_use(gentity_t *self, gentity_t *other, gentity_t *activator)
 {
-	int i = 0;
-	for (; i < 3; i++)
+	if (self->spawnflags & 1)
 	{
-		activator->client->ps.velocity[i] *= self->speed;
+		activator->client->sess.velocityScale = self->speed;
+		return;
 	}
+
+	VectorScale(activator->client->ps.velocity, self->speed, activator->client->ps.velocity);
 }
 
 void SP_target_scale_velocity(gentity_t *self)


### PR DESCRIPTION
Can be used to permanently scale activators velocity by amount of `scale`. Reset on respawn or by triggering another `target_scale_velocity` with `scale` __1__