### PR TITLE
Fix target_give

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -78,6 +78,7 @@
 * added spawnflag __1__ `persistent` to target_scale_velocity
   * scales activators velocity permanently by amount of `scale`
   * scaling can be reset with `/kill` or by triggering another `target_scale_velocity` with `scale` __1__
+* added `target_give` support
 
 # ETJump 2.2.0
 

--- a/src/game/g_items.cpp
+++ b/src/game/g_items.cpp
@@ -909,6 +909,21 @@ void Touch_Item_Auto(gentity_t *ent, gentity_t *other, trace_t *trace)
 	}
 }
 
+
+/*
+===============
+Touch_Item_Give
+
+Called by target_give entity to make sure clients are always given items, regardless of conditions
+===============
+*/
+
+void Touch_Item_Give(gentity_t *ent, gentity_t *other, trace_t *trace)
+{
+	ent->active = qtrue;
+	Touch_Item(ent, other, trace);
+}
+
 /*
 ===============
 Touch_Item

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1447,6 +1447,8 @@ void G_DropWeapon(gentity_t *ent, weapon_t weapon);
 // Touch_Item_Auto is bound by the rules of autoactivation (if cg_autoactivate is 0, only touch on "activate")
 void Touch_Item_Auto(gentity_t *ent, gentity_t *other, trace_t *trace);
 
+void Touch_Item_Give(gentity_t *ent, gentity_t *other, trace_t *trace);	// Called by target_give
+
 void Prop_Break_Sound(gentity_t *ent);
 void Spawn_Shard(gentity_t *ent, gentity_t *inflictor, int quantity, int type);
 

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -38,7 +38,7 @@ void Use_Target_Give(gentity_t *ent, gentity_t *other, gentity_t *activator)
 		{
 			continue;
 		}
-		Touch_Item(t, activator, &trace);
+		Touch_Item_Give(t, activator, &trace);
 
 		// make sure it isn't going to respawn or show any events
 		t->nextthink = 0;


### PR DESCRIPTION
`target_give` was not functional in ET since it never set the targeted items to active, therefore players didn't pick them up.