### PR TITLE
Z-rotation anticheat

### DIFF
--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -5797,7 +5797,8 @@ void PM_UpdateViewAngles(playerState_t *ps, pmoveExt_t *pmext, usercmd_t *cmd, v
 	VectorCopy(ps->viewangles, oldViewAngles);
 
 	// circularly clamp the angles with deltas
-	for (i = 0 ; i < 3 ; i++)
+	//for (i = 0 ; i < 3 ; i++)		// Disable ROLL adjustment by client
+	for (i = 0; i < 2; i++)
 	{
 		temp = cmd->angles[i] + ps->delta_angles[i];
 		if (i == PITCH)

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -2043,6 +2043,12 @@ void target_startTimer_use(gentity_t *self, gentity_t *other, gentity_t *activat
 		return;
 	}
 
+	if (activator->client->ps.viewangles[ROLL] != 0)
+	{
+		trap_SendServerCommand(ClientNum(activator), va("cp \"^3WARNING: ^7Timerun was not started. Z-rotation detected!"));
+		return;
+	}
+
 	activator->client->sess.runSpawnflags = self->spawnflags;
 
 	// disable timer if pmove is not fixed


### PR DESCRIPTION
* Clients can no longer rotate z-view at all
* Timeruns won't start if clients z-view is rotated (by teleporter with `angles` for example)