### PR TITLE
Enhance etpro scripting

### DIFF
--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -713,7 +713,7 @@ typedef enum
 #define EF_TAGCONNECT       0x00008000      // connected to another entity via tag
 #define EF_MOUNTEDTANK      EF_TAGCONNECT   // Gordon: duplicated for clarity
 
-#define EF_FAKEBMODEL       0x00010000      // Gordon: freed
+#define EF_FAKEBMODEL       0x00010000      // ETJump: used
 #define EF_PATH_LINK        0x00020000      // Gordon: linking trains together
 #define EF_ZOOMING          0x00040000      // client is zooming
 #define EF_PRONE            0x00080000      // player is prone

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1397,6 +1397,7 @@ qboolean    G_SpawnVector2DExt(const char *key, const char *defaultString, float
 void        G_SpawnEntitiesFromString(void);
 char *G_NewString(const char *string);
 // Ridah
+gentity_t *G_SpawnGEntityFromSpawnVars();
 qboolean G_CallSpawn(gentity_t *ent);
 // done.
 char *G_AddSpawnVarToken(const char *string);

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1475,6 +1475,9 @@ qboolean G_IsWeaponDisabled(gentity_t *ent, weapon_t weapon);
 void    G_TeamCommand(team_t team, char *cmd);
 void    G_KillBox(gentity_t *ent);
 gentity_t *G_Find(gentity_t *from, int fieldofs, const char *match);
+gentity_t *G_FindInt(gentity_t *from, int fieldofs, int match);
+gentity_t *G_FindFloat(gentity_t *from, int fieldofs, float match);
+gentity_t *G_FindVector(gentity_t *from, int fieldofs, const vec3_t match);
 gentity_t *G_FindByTargetname(gentity_t *from, const char *match);
 gentity_t *G_FindByTargetnameFast(gentity_t *from, const char *match, int hash);
 gentity_t *G_PickTarget(char *targetname);
@@ -2738,6 +2741,31 @@ void InterruptRun(gentity_t *ent);
 void RunFrame(int levelTime);
 const char *G_MatchOneMap(const char *arg);
 
+//
+// fields are needed for spawning from the entity string
+//
+typedef enum
+{
+	F_INT,
+	F_FLOAT,
+	F_LSTRING,          // string on disk, pointer in memory, TAG_LEVEL
+	F_GSTRING,          // string on disk, pointer in memory, TAG_GAME
+	F_VECTOR,
+	F_ANGLEHACK,
+	F_ENTITY,           // index on disk, pointer in memory
+	F_ITEM,             // index on disk, pointer in memory
+	F_CLIENT,           // index on disk, pointer in memory
+	F_IGNORE
+} fieldtype_t;
+
+typedef struct
+{
+	const char *name;
+	int ofs;
+	fieldtype_t type;
+	int flags;
+} field_t;
+
 ///////////////////////////////////////////////////////////////////////////////
 // ETJump global systems
 ///////////////////////////////////////////////////////////////////////////////
@@ -2752,6 +2780,7 @@ namespace ETJump
 	extern std::shared_ptr<ETJump::SaveSystem> saveSystem;
 	extern std::shared_ptr<Session> session;
 	extern std::shared_ptr<Database> database;
+	void devPrintf(const std::string &text); // devmap printf
 }
 
 

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -35,6 +35,14 @@ namespace ETJump
 	std::shared_ptr<SaveSystem> saveSystem;
 	std::shared_ptr<Database> database;
 	std::shared_ptr<Session> session;
+
+	void devPrintf(const std::string &text)
+	{
+		if (g_cheats.integer)
+		{
+			trap_Printf(text.c_str());
+		}
+	}
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -666,7 +674,6 @@ void QDECL G_Error(const char *fmt, ...)
 }
 //bani
 void QDECL G_Error(const char *fmt, ...);
-
 
 #define CH_KNIFE_DIST       48  // from g_weapon.c
 #define CH_LADDER_DIST      100

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -3433,47 +3433,27 @@ void G_TempTraceIgnorePlayersAndBodies(void)
 	}
 }
 
-//QUAKED func_fakebrush (1 0 0) ?
 /*
-scriptName "bugfix1"
-classname "func_fakebrush"
-origin "1072 -1824 502"
-contents 1  // CONTENTS_SOLID
-mins "-180 -150 -10"
-maxs "180 150 10"
+	ETPro mapscript fakebrush allows the limited ability to spawn brush entities
+	create
+	{
+	   scriptName "bugfix1"
+	   classname "func_fakebrush"
+	   origin "3632 -4313 881"
+	   contents 65536  // CONTENTS_PLAYERCLIP
+	   mins "-40 -1 -20"
+	   maxs "40 1 10"
+	}
 */
 void SP_func_fakebrush(gentity_t *ent)
 {
-	// all this values should be already set in G_ParseField but make sure they
-	// were really found
-	if (!G_SpawnVector("origin", "1 0 0", ent->s.origin))
-	{
-		G_Error("'func_fakebrush' does not have an origin\n");
-	}
-	if (!G_SpawnInt("contents", "1", &ent->r.contents))
-	{
-		G_Error("'func_fakebrush' does not have contents\n");
-	}
-	if (!G_SpawnVector("mins", "0 0 0", ent->r.mins))
-	{
-		G_Error("'func_fakebrush' does not have mins\n");
-	}
-	if (!G_SpawnVector("maxs", "0 0 0", ent->r.maxs))
-	{
-		G_Error("'func_fakebrush' does not have maxs\n");
-	}
-
-	ent->clipmask = ent->r.contents;
-
 	G_SetOrigin(ent, ent->s.origin);
 	G_SetAngle(ent, ent->s.angles);
 
-	// rape origin2 and angles2 to save mins and maxs for client prediction
+	// ETJump: reusing origin2, anlges2 to store fakebrush bbox
 	VectorCopy(ent->r.mins, ent->s.origin2);
 	VectorCopy(ent->r.maxs, ent->s.angles2);
 	ent->s.eFlags |= EF_FAKEBMODEL;
-
-	ent->s.eType = ET_GENERAL;
 
 	trap_LinkEntity(ent);
 }

--- a/src/game/g_mover.cpp
+++ b/src/game/g_mover.cpp
@@ -4564,6 +4564,13 @@ func_explosive_use
 void func_explosive_use(gentity_t *self, gentity_t *other, gentity_t *activator)
 {
 	G_Script_ScriptEvent(self, "death", "");   // JPW NERVE used to trigger script stuff for MP
+	
+	// make the parent (trigger) die too
+	if (self->parent && Q_stricmp(self->scriptName, self->parent->scriptName))
+	{
+		G_Script_ScriptEvent(self->parent, "death", "");
+	}
+
 	func_explosive_explode(self, self, other, self->damage, 0);
 }
 
@@ -4783,7 +4790,11 @@ void SP_func_explosive(gentity_t *ent)
 	char *type;
 	char *cursorhint;
 
-	trap_SetBrushModel(ent, ent->model);
+	if (ent->model)
+	{
+		trap_SetBrushModel(ent, ent->model);
+	}
+
 	InitExplosive(ent);
 
 	if (ent->spawnflags & EXPLOSIVE_START_INVIS)    // start invis

--- a/src/game/g_mover.cpp
+++ b/src/game/g_mover.cpp
@@ -4799,7 +4799,14 @@ void SP_func_explosive(gentity_t *ent)
 
 	if (ent->spawnflags & EXPLOSIVE_START_INVIS)    // start invis
 	{
-		ent->use = func_explosive_spawn;
+		if (ent->s.eFlags & EF_FAKEBMODEL)
+		{
+			ent->use = func_explosive_use;
+		}
+		else
+		{
+			ent->use = func_explosive_spawn;
+		}
 		trap_UnlinkEntity(ent);
 	}
 	else if (ent->targetname)

--- a/src/game/g_script.cpp
+++ b/src/game/g_script.cpp
@@ -117,6 +117,7 @@ qboolean G_ScriptAction_ConstructibleDuration(gentity_t *ent, char *params) ;
 //bani
 qboolean etpro_ScriptAction_SetValues(gentity_t *ent, char *params);
 qboolean G_ScriptAction_Create(gentity_t *ent, char *params);
+qboolean G_ScriptAction_Delete(gentity_t *ent, char *params);
 
 // these are the actions that each event can call
 g_script_stack_action_t gScriptActions[] =
@@ -199,6 +200,7 @@ g_script_stack_action_t gScriptActions[] =
 	{ "killplayer", G_ScriptAction_KillPlayer },
 
 	{ "create",                         G_ScriptAction_Create                        },
+	{ "delete", G_ScriptAction_Delete },
 
 	// Gordon: going for longest silly script command ever here :) (sets a model for a brush to one stolen from a func_brushmodel
 	{ "setmodelfrombrushmodel",         G_ScriptAction_SetModelFromBrushmodel        },
@@ -655,7 +657,10 @@ void G_Script_ScriptParse(gentity_t *ent)
 
 				// Ikkyo - Parse for {}'s if this is a set command
 				// parse for {}'s if this is a set or create command
-				if (!Q_stricmp(action->actionString, "set") || !Q_stricmp(action->actionString, "create"))
+				if (
+					!Q_stricmp(action->actionString, "set") || 
+					!Q_stricmp(action->actionString, "create") || 
+					!Q_stricmp(action->actionString, "delete"))
 				{
 					token = COM_Parse(&pScript);
 					if (token[0] != '{')

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -9,6 +9,15 @@
 #include "../game/g_local.h"
 #include "../game/q_shared.h"
 
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
+
+#include "etj_string_utilities.h"
+
 /*
 Contains the code to handle the various commands available with an event script.
 
@@ -4868,4 +4877,174 @@ qboolean G_ScriptAction_Create(gentity_t *ent, char *params)
 	trap_LinkEntity(create);
 
 	return qtrue;
+}
+
+extern field_t fields[];
+
+/*
+=============
+G_ScriptAction_Delete
+Delete entities that match all the criteria provided in "params"
+
+// remove radar main door
+delete 
+{
+	classname trigger_objective_info
+	scriptname maindoor1_trig
+}
+delete 
+{
+	classname func_explosive
+	scriptname maindoor1
+}
+
+=============
+*/
+qboolean G_ScriptAction_Delete(gentity_t *ent, char *params)
+{
+	gentity_t *found = NULL;
+	char      *token;
+	char      *p = params;
+	char      key[MAX_TOKEN_CHARS], value[MAX_TOKEN_CHARS];
+	int       i;
+	int       pass[MAX_GENTITIES];      // number of matching criteria for each entity
+	int       count = 0;            // number of key/value pairs in params
+	int       deleted = 0;            // number of deleted entities
+	qboolean  terminate = qfalse;
+	int       valueInt;
+	float     valueFloat;
+	vec3_t    valueVector;
+
+	// params can contain more than 1 key/value pair,
+	// We must check if the entity equals all of these pairs
+	// before we delete it..
+	for (i = MAX_CLIENTS; i < MAX_GENTITIES; ++i)
+	{
+		pass[i] = 0;
+	}
+
+	while (!terminate)
+	{
+		// strip key/value from the params..
+		token = COM_ParseExt(&p, qfalse);
+
+		// are there tokes in the params?..
+		if (!token[0])
+		{
+			break;
+		}
+
+		strcpy(key, token);
+
+		token = COM_ParseExt(&p, qfalse);
+		if (!token[0])
+		{
+			ETJump::devPrintf(ETJump::stringFormat("^3WARNING: G_ScriptAction_Delete(): key \"%s\" has no value\n", key));
+			continue;
+		}
+
+		strcpy(value, token);
+
+		// does the field exist?..
+		for (i = 0; fields[i].name; ++i)
+			if (!Q_stricmp(fields[i].name, key))
+			{
+				break;
+			}
+		if (!fields[i].name)
+		{
+			ETJump::devPrintf(ETJump::stringFormat("^3WARNING: G_ScriptAction_Delete(): non-existing key \"%s\"\n", key));
+			continue;
+		}
+
+		// we have a key/value pair to search for..
+		count++;
+
+		// start searching from the first entity..
+		found = NULL;
+
+		// check key's datatype..
+		switch (fields[i].type)
+		{
+		case F_INT:
+			valueInt = atoi(value);
+			// find all entities with the given key/value..
+			while ((found = G_FindInt(found, fields[i].ofs, valueInt)) != NULL)
+			{
+				pass[found->s.number]++;
+			}
+			break;
+
+		case F_FLOAT:
+			valueFloat = (float)atof(value);
+			while ((found = G_FindFloat(found, fields[i].ofs, valueFloat)) != NULL)
+			{
+				pass[found->s.number]++;
+			}
+			break;
+
+		case F_LSTRING:
+		case F_GSTRING:
+			while ((found = G_Find(found, fields[i].ofs, value)) != NULL)
+			{
+				pass[found->s.number]++;
+			}
+			break;
+
+		case F_VECTOR:
+			sscanf(value, "%f %f %f", &valueVector[0], &valueVector[1], &valueVector[2]);
+			while ((found = G_FindVector(found, fields[i].ofs, valueVector)) != NULL)
+			{
+				pass[found->s.number]++;
+			}
+			break;
+
+		case F_ANGLEHACK:
+			valueVector[0] = 0;
+			valueVector[1] = (float)atof(value);
+			valueVector[2] = 0;
+			while ((found = G_FindVector(found, fields[i].ofs, valueVector)) != NULL)
+			{
+				pass[found->s.number]++;
+			}
+			break;
+
+		case F_ENTITY:
+		case F_ITEM:
+		case F_CLIENT:
+		case F_IGNORE:
+		default:
+			// It's certain the test will fail now, so just abort..
+			ETJump::devPrintf(ETJump::stringFormat("^3WARNING: G_ScriptAction_Delete(): invalid key \"%s\"\n", key));
+			terminate = qtrue;
+			break;
+		}
+	}
+
+	// did we find any key/value pairs in the params at all?..
+	if (count == 0)
+	{
+		return qfalse;
+	}
+
+	// now delete the entities that passed all tests..
+	for (i = MAX_GENTITIES - 1; i >= MAX_CLIENTS; i--)
+		if (pass[i] == count)
+		{
+			deleted++;
+			ETJump::devPrintf(ETJump::stringFormat(
+				"^2G_ScriptAction_Delete(): \"%s\" entity %i removed (%s)\n", g_entities[i].classname, i, params));
+			G_FreeEntity(&g_entities[i]);
+		}
+
+	// did we actually delete any entity?..
+	if (deleted > 0)
+	{
+		return qtrue;
+	}
+	else
+	{
+		ETJump::devPrintf(ETJump::stringFormat("^3WARNING: G_ScriptAction_Delete(): no entities found (%s)\n", params));
+	}
+	return qfalse;
 }

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -77,33 +77,6 @@ qboolean    G_SpawnVector2DExt(const char *key, const char *defaultString, float
 	return present;
 }
 
-
-
-//
-// fields are needed for spawning from the entity string
-//
-typedef enum
-{
-	F_INT,
-	F_FLOAT,
-	F_LSTRING,          // string on disk, pointer in memory, TAG_LEVEL
-	F_GSTRING,          // string on disk, pointer in memory, TAG_GAME
-	F_VECTOR,
-	F_ANGLEHACK,
-	F_ENTITY,           // index on disk, pointer in memory
-	F_ITEM,             // index on disk, pointer in memory
-	F_CLIENT,           // index on disk, pointer in memory
-	F_IGNORE
-} fieldtype_t;
-
-typedef struct
-{
-	const char *name;
-	int ofs;
-	fieldtype_t type;
-	int flags;
-} field_t;
-
 field_t fields[] =
 {
 	{ "classname",    FOFS(classname),      F_LSTRING   },

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -185,6 +185,17 @@ field_t fields[] =
 
 	{ "damageparent", FOFS(damageparent),   F_LSTRING   },
 
+	// ETJump: ETPro mapscripting support
+	{ "eflags", FOFS(s.eFlags), F_INT },
+	{ "svflags", FOFS(r.svFlags), F_INT },
+	{ "maxs", FOFS(r.maxs), F_VECTOR },
+	{ "mins", FOFS(r.mins), F_VECTOR },
+	{ "contents", FOFS(r.contents), F_INT },
+	{ "clipmask", FOFS(clipmask), F_INT },
+	{ "count2", FOFS(count2), F_INT },
+	{ "baseAngle", FOFS(s.apos.trBase), F_VECTOR },
+	{ "baseOrigin", FOFS(s.pos.trBase), F_VECTOR },
+
 	{ NULL }
 };
 
@@ -894,7 +905,7 @@ Spawn an entity and fill in all of the level fields from
 level.spawnVars[], then call the class specfic spawn function
 ===================
 */
-void G_SpawnGEntityFromSpawnVars(void)
+gentity_t *G_SpawnGEntityFromSpawnVars()
 {
 	int       i;
 	gentity_t *ent;
@@ -913,7 +924,7 @@ void G_SpawnGEntityFromSpawnVars(void)
 	if (i)
 	{
 		G_FreeEntity(ent);
-		return;
+		return nullptr;
 	}
 
 	// allowteams handling
@@ -956,6 +967,8 @@ void G_SpawnGEntityFromSpawnVars(void)
 
 	// RF, try and move it into the bot entities if possible
 	//	BotCheckBotGameEntity( ent );
+
+	return ent;
 }
 /*
 ====================

--- a/src/game/g_trigger.cpp
+++ b/src/game/g_trigger.cpp
@@ -209,36 +209,10 @@ void SP_trigger_multiple(gentity_t *ent)
 	trap_LinkEntity(ent);
 }
 
+// ETJump: obsolete, use SP_trigger_multiple instead
 void SP_trigger_multiple_ext(gentity_t *ent)
 {
-	G_SpawnFloat("wait", "0.5", &ent->wait);
-	G_SpawnFloat("random", "0", &ent->random);
-	if (!G_SpawnVector("mins", "0 0 0", ent->r.mins))
-	{
-		G_Error("'trigger_multiple_ext' does not have mins\n");
-	}
-	if (!G_SpawnVector("maxs", "0 0 0", ent->r.maxs))
-	{
-		G_Error("'trigger_multiple_ext' does not have maxs\n");
-	}
-
-	if (ent->random >= ent->wait && ent->wait >= 0)
-	{
-		ent->random = ent->wait - (FRAMETIME * 0.001f);
-		G_Printf("trigger_multiple_ext has random >= wait\n");
-	}
-
-	ent->touch   = Touch_Multi;
-	ent->use     = Use_Multi;
-	ent->s.eType = ET_TRIGGER_MULTIPLE;
-
-	InitTrigger(ent);
-
-#ifdef VISIBLE_TRIGGERS
-	ent->r.svFlags &= ~SVF_NOCLIENT;
-#endif // VISIBLE_TRIGGERS
-
-	trap_LinkEntity(ent);
+	SP_trigger_multiple(ent);
 }
 
 /*

--- a/src/game/g_utils.cpp
+++ b/src/game/g_utils.cpp
@@ -211,7 +211,7 @@ gentity_t *G_Find(gentity_t *from, int fieldofs, const char *match)
 		{
 			continue;
 		}
-		s = *(char **) ((byte *)from + fieldofs);
+		s = *reinterpret_cast<char **>(reinterpret_cast<byte *>(from) + fieldofs);
 		if (!s)
 		{
 			continue;
@@ -224,6 +224,109 @@ gentity_t *G_Find(gentity_t *from, int fieldofs, const char *match)
 
 	return NULL;
 }
+
+/*
+	Like G_Find, but searches for integer values.
+*/
+gentity_t *G_FindInt(gentity_t *from, int fieldofs, int match)
+{
+	int       i;
+	gentity_t *max = &g_entities[level.num_entities];
+
+	if (!from)
+	{
+		from = g_entities;
+	}
+	else
+	{
+		from++;
+	}
+
+	for (; from < max; from++)
+	{
+		if (!from->inuse)
+		{
+			continue;
+		}
+		i = *reinterpret_cast<int *>(reinterpret_cast<byte *>(from) + fieldofs);
+		if (i == match)
+		{
+			return from;
+		}
+	}
+
+	return NULL;
+}
+
+/*
+	Like G_Find, but searches for float values..
+*/
+gentity_t *G_FindFloat(gentity_t *from, int fieldofs, float match)
+{
+	float     f;
+	gentity_t *max = &g_entities[level.num_entities];
+
+	if (!from)
+	{
+		from = g_entities;
+	}
+	else
+	{
+		from++;
+	}
+
+	for (; from < max; from++)
+	{
+		if (!from->inuse)
+		{
+			continue;
+		}
+		f = *reinterpret_cast<float *>(reinterpret_cast<byte *>(from) + fieldofs);
+		if (f == match)
+		{
+			return from;
+		}
+	}
+
+	return NULL;
+}
+
+/*
+	Like G_Find, but searches for vector values..
+*/
+gentity_t *G_FindVector(gentity_t *from, int fieldofs, const vec3_t match)
+{
+	vec3_t    vec;
+	gentity_t *max = &g_entities[level.num_entities];
+
+	if (!from)
+	{
+		from = g_entities;
+	}
+	else
+	{
+		from++;
+	}
+
+	for (; from < max; from++)
+	{
+		if (!from->inuse)
+		{
+			continue;
+		}
+		vec[0] = *reinterpret_cast<vec_t *>(reinterpret_cast<byte *>(from) + fieldofs + 0);
+		vec[1] = *reinterpret_cast<vec_t *>(reinterpret_cast<byte *>(from) + fieldofs + 4);
+		vec[2] = *reinterpret_cast<vec_t *>(reinterpret_cast<byte *>(from) + fieldofs + 8);
+
+		if (vec[0] == match[0] && vec[1] == match[1] && vec[2] == match[2])
+		{
+			return from;
+		}
+	}
+
+	return NULL;
+}
+
 
 /*
 =============


### PR DESCRIPTION
This pr should add proper support for etpro scripting commands:
- revamped `create` command and extended supported spawnvars
- cleaned up fakebrush

- [x] Add `delete` scripting command, to delete entities based on spawnvars (port from ETLegacy)