### PR TITLE
Add constantLight support

### DIFF
--- a/src/game/g_mover.cpp
+++ b/src/game/g_mover.cpp
@@ -1863,13 +1863,50 @@ so the movement delta can be calculated
 void InitMover(gentity_t *ent)
 {
 	vec3_t move;
-	float  distance;
+	float distance;
+	float light;
+	vec3_t color;
+	qboolean lightSet, colorSet;
 
 	// if the "model2" key is set, use a seperate model
 	// for drawing, but clip against the brushes
 	if (ent->model2)
 	{
 		ent->s.modelindex2 = G_ModelIndex(ent->model2);
+	}
+
+	// if the "color" or "light" keys are set, setup constantLight
+	lightSet = G_SpawnFloat("light", "100", &light);
+	colorSet = G_SpawnVector("color", "1 1 1", color);
+	if (lightSet || colorSet)
+	{
+		int		r, g, b, i;
+
+		r = color[0] * 255;
+		if (r > 255)
+		{
+			r = 255;
+		}
+
+		g = color[1] * 255;
+		if (g > 255)
+		{
+			g = 255;
+		}
+
+		b = color[2] * 255;
+		if (b > 255)
+		{
+			b = 255;
+		}
+
+		i = light / 4;
+		if (i > 255)
+		{
+			i = 255;
+		}
+
+		ent->s.constantLight = r | (g << 8) | (b << 16) | (i << 24);
 	}
 
 	// JOSEPH 1-26-00


### PR DESCRIPTION
Piece of code that was removed from ET, allows various brush entities (eg. `func_static`, `func_door_rotating`) to emit light by setting "light" and "color" keys. These lights are dynamic and do not contribute to lightmaps.