### PR TITLE
Fix getting stuck in water with nooverbounce

### DIFF
--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -2340,7 +2340,7 @@ static void PM_GroundTrace(void)
 		if (trace.plane.normal[2] == 1 && !((trace.surfaceFlags & SURF_OVERBOUNCE) != 0))
 		{
 			pm->ps->velocity[2] = 0;
-			if (trace.plane.type == 2)
+			if (trace.plane.type == 2 && pm->waterlevel < 2)
 			{
 				auto offset = pm->ps->origin[2] - trace.endpos[2];
 				pm->ps->origin[2] -= offset;
@@ -2351,7 +2351,7 @@ static void PM_GroundTrace(void)
 		if (trace.plane.normal[2] == 1 && ((trace.surfaceFlags & SURF_OVERBOUNCE) != 0))
 		{
 			pm->ps->velocity[2] = 0;
-			if (trace.plane.type == 2)
+			if (trace.plane.type == 2 && pm->waterlevel < 2)
 			{
 				auto offset = pm->ps->origin[2] - trace.endpos[2];
 				pm->ps->origin[2] -= offset;


### PR DESCRIPTION
Fixes getting stuck at the bottom of water brush that's tall enough that you have to swim there when overbounces are disabled.