### PR TITLE
Fixed chat newline intolerance

### DIFF
--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -1758,7 +1758,7 @@ static void CG_RemoveChatEscapeChar(char *text)
 	l = 0;
 	for (i = 0; text[i]; i++)
 	{
-		if (text[i] == '\x19')
+		if (text[i] == '\x19' || text[i] == '\n')
 		{
 			continue;
 		}

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -2633,7 +2633,7 @@ void Cmd_CallVote_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue)
 
 	if (level.time - ent->client->lastVoteTime < 1000 * g_voteCooldown.integer)
 	{
-		CP(va("chat \"^3callvote:^7 you must wait %d more seconds to vote again.\"",
+		CP(va("chat \"^3callvote:^7 you must wait %d more seconds to vote again.\n\"",
 			g_voteCooldown.integer - ((level.time - ent->client->lastVoteTime) / 1000)));
 		return;
 	}


### PR DESCRIPTION
Was printing undefined character in the chat if newline was encountered. 
Which is also the case for other non-alpha characters, we probably should handle the range at some point. Maybe in the new chat widget.
related #166