### PR TITLE
Fix timerun prints

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -129,6 +129,8 @@
   * value indicates characters before line break
   * valid range is 1-200
 * increased chat max height to 64 lines
+* fixed an issue with difference calculations in timerun prints
+* reformatted timerun timer format to `MM:SS.xxx`
 
 # ETJump 2.2.0
 

--- a/src/cgame/cg_timerun.cpp
+++ b/src/cgame/cg_timerun.cpp
@@ -144,30 +144,55 @@ void Timerun::record(int clientNum, std::string runName, int completionTime)
 
 	auto diffMillis  = abs(completionTime - previousTime);
 	auto diffMinutes = diffMillis / 60000;
-	diffMillis -= minutes * 60000;
+	diffMillis -= diffMinutes * 60000;
 	auto diffSeconds = diffMillis / 1000;
 	diffMillis -= diffSeconds * 1000;
 
 	if (previousTime != NO_PREVIOUS_RECORD)
 	{
-		CG_AddPMItem(PM_MESSAGE, (boost::format("^7%s ^7completed ^7%s ^7in %02d:%02d:%03d! ^7(-^2%02d:%02d:%03d^7)")
-		                          % cgs.clientinfo[clientNum].name
-		                          % runName
-		                          % minutes
-		                          % seconds
-		                          % millis
-		                          % diffMinutes
-		                          % diffSeconds
-		                          % diffMillis).str().c_str(), cgs.media.voiceChatShader);
+		if (clientNum == _clientNum)
+		{
+			CG_AddPMItem(PM_MESSAGE, (boost::format("^7You completed ^7%s ^7in %02d:%02d.%03d! (-^2%02d:%02d.%03d^7)")
+				                      % runName
+				                      % minutes
+				                      % seconds
+				                      % millis
+				                      % diffMinutes
+				                      % diffSeconds
+				                      % diffMillis).str().c_str(), cgs.media.voiceChatShader);
+		}
+		else
+		{
+			CG_AddPMItem(PM_MESSAGE, (boost::format("^7%s ^7completed ^7%s ^7in %02d:%02d.%03d! (-^2%02d:%02d.%03d^7)")
+				                      % cgs.clientinfo[clientNum].name
+				                      % runName
+				                      % minutes
+				                      % seconds
+				                      % millis
+				                      % diffMinutes
+				                      % diffSeconds
+				                      % diffMillis).str().c_str(), cgs.media.voiceChatShader);
+		}
 	}
 	else
 	{
-		CG_AddPMItem(PM_MESSAGE, (boost::format("^7%s ^7completed %s in %02d:%02d:%03d!")
-		                          % cgs.clientinfo[clientNum].name
-		                          % runName
-		                          % minutes
-		                          % seconds
-		                          % millis).str().c_str(), cgs.media.voiceChatShader);
+		if (clientNum == _clientNum)
+		{
+			CG_AddPMItem(PM_MESSAGE, (boost::format("^7You completed ^7%s ^7in %02d:%02d.%03d!")
+				                      % runName
+				                      % minutes
+				                      % seconds
+				                      % millis).str().c_str(), cgs.media.voiceChatShader);
+		}
+		else
+		{
+			CG_AddPMItem(PM_MESSAGE, (boost::format("^7%s ^7completed ^7%s ^7in %02d:%02d.%03d!")
+				                      % cgs.clientinfo[clientNum].name
+				                      % runName
+				                      % minutes
+				                      % seconds
+				                      % millis).str().c_str(), cgs.media.voiceChatShader);
+		}
 	}
 }
 
@@ -198,13 +223,13 @@ void Timerun::completion(int clientNum, std::string runName, int completionTime)
 		{
 			auto diffMillis  = abs(completionTime - previousRecord);
 			auto diffMinutes = diffMillis / 60000;
-			diffMillis -= minutes * 60000;
+			diffMillis -= diffMinutes * 60000;
 			auto diffSeconds = diffMillis / 1000;
 			diffMillis -= diffSeconds * 1000;
 
 			if (clientNum == _clientNum)
 			{
-				CG_AddPMItem(PM_MESSAGE, (boost::format("^7You completed ^7%s ^7in %02d:%02d:%03d (+^1%02d:%02d:%03d^7).")
+				CG_AddPMItem(PM_MESSAGE, (boost::format("^7You completed ^7%s ^7in %02d:%02d.%03d. (+^1%02d:%02d.%03d^7)")
 				                          % runName
 				                          % minutes
 				                          % seconds
@@ -215,7 +240,7 @@ void Timerun::completion(int clientNum, std::string runName, int completionTime)
 			}
 			else
 			{
-				CG_AddPMItem(PM_MESSAGE, (boost::format("^7%s ^7completed ^7%s ^7in %02d:%02d:%03d (+^1%02d:%02d:%03d^7).")
+				CG_AddPMItem(PM_MESSAGE, (boost::format("^7%s ^7completed ^7%s ^7in %02d:%02d.%03d. (+^1%02d:%02d.%03d^7)")
 				                          % cgs.clientinfo[clientNum].name
 				                          % runName
 				                          % minutes
@@ -230,7 +255,7 @@ void Timerun::completion(int clientNum, std::string runName, int completionTime)
 		{
 			if (clientNum == _clientNum)
 			{
-				CG_AddPMItem(PM_MESSAGE, (boost::format("^7You completed ^7%s ^7in %02d:%02d:%03d.")
+				CG_AddPMItem(PM_MESSAGE, (boost::format("^7You completed ^7%s ^7in %02d:%02d.%03d!")
 				                          % runName
 				                          % minutes
 				                          % seconds
@@ -238,7 +263,7 @@ void Timerun::completion(int clientNum, std::string runName, int completionTime)
 			}
 			else
 			{
-				CG_AddPMItem(PM_MESSAGE, (boost::format("^7%s ^7completed ^7%s ^7in %02d:%02d:%03d.")
+				CG_AddPMItem(PM_MESSAGE, (boost::format("^7%s ^7completed ^7%s ^7in %02d:%02d.%03d!")
 				                          % cgs.clientinfo[clientNum].name
 				                          % runName
 				                          % minutes

--- a/src/cgame/etj_timerun_view.cpp
+++ b/src/cgame/etj_timerun_view.cpp
@@ -127,7 +127,7 @@ void ETJump::TimerunView::draw()
 	auto seconds = millis / 1000;
 	millis -= seconds * 1000;
 
-	auto text = (boost::format("%02d:%02d:%03d")
+	auto text = (boost::format("%02d:%02d.%03d")
 		% minutes
 		% seconds
 		% millis).str();

--- a/src/game/etj_timerun.cpp
+++ b/src/game/etj_timerun.cpp
@@ -26,7 +26,7 @@ std::string millisToString(int millis)
 	seconds = millis / 1000;
 	millis -= seconds * 1000;
 
-	s = (boost::format("%02d:%02d:%03d") % minutes % seconds % millis).str();
+	s = (boost::format("%02d:%02d.%03d") % minutes % seconds % millis).str();
 
 	return s;
 }


### PR DESCRIPTION
* Fixed difference math when difference was > 1min
* Re-formatted timer to correct format (`MM:SS:xxx` -> `MM:SS.xxx`)
* Unified timerun completion prints