### PR TITLE
Fix teleport outspeed when player doesn't have any velocity

### DIFF
--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -654,6 +654,10 @@ void target_teleporter_use(gentity_t *self, gentity_t *other, gentity_t *activat
 
 	if (self->outSpeed > 0)
 	{
+		if (VectorCompare(activator->client->ps.velocity, vec3_origin)) // If we don't have any velocity when teleporting, theres nothing to scale from, so let's add some
+		{
+			VectorSet(activator->client->ps.velocity, 0.01, 0.01, 0.0);
+		}
 		VectorNormalize(activator->client->ps.velocity);  // normalize velocity 
 		VectorScale(activator->client->ps.velocity, self->outSpeed, activator->client->ps.velocity); // scale it up again
 	}

--- a/src/game/g_trigger.cpp
+++ b/src/game/g_trigger.cpp
@@ -465,6 +465,10 @@ void trigger_teleporter_touch(gentity_t *self, gentity_t *other, trace_t *trace)
 
 	if (self->outSpeed > 0)
 	{
+		if (VectorCompare(other->client->ps.velocity, vec3_origin)) // If we don't have any velocity when teleporting, theres nothing to scale from, so let's add some
+		{
+			VectorSet(other->client->ps.velocity, 0.01, 0.01, 0.0);
+		}
 		VectorNormalize(other->client->ps.velocity);  // normalize velocity 
 		VectorScale(other->client->ps.velocity, self->outSpeed, other->client->ps.velocity); // scale it up again
 	}


### PR DESCRIPTION
Add some velocity to player in case teleporting with 0 ups on all vectors.