### PR TITLE
Fix hideme + freecam in demos

### DIFF
--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -2113,7 +2113,7 @@ void CG_Player(centity_t *cent)
 			return;
 		}
 
-		if (ci->hideMe)
+		if (!cg.demoPlayback && ci->hideMe)
 		{
 			return;
 		}


### PR DESCRIPTION
Make yourself visible in demo playback when entering freecam mode, if demo was recorded with `etj_hideMe 1`. Does NOT make other players in demo who had `etj_hideMe 1` visible, only yourself.