### PR TITLE
Fix portalgun is able to teleport players on timerun start

### DIFF
--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -423,6 +423,12 @@ void    G_TouchTriggers(gentity_t *ent)
 		if (hit->touch)
 		{
 			hit->touch(hit, ent, &trace);
+			// update mins/maxs after portal trigger
+			if (hit->surfaceFlags == SURF_PORTALGATE)
+			{
+				VectorAdd(ent->client->ps.origin, ent->r.mins, mins);
+				VectorAdd(ent->client->ps.origin, ent->r.maxs, maxs);
+			}
 		}
 
 		if ((ent->r.svFlags & SVF_BOT) && (ent->touch))

--- a/src/game/g_weapon.cpp
+++ b/src/game/g_weapon.cpp
@@ -4008,17 +4008,12 @@ void Weapon_Portal_Fire(gentity_t *ent, int PortalNumber)
 	tent->s.otherEntityNum2 = ent->s.number;
 	//END - Rail
 
-
-
-
 	portal            = G_Spawn();
 	portal->classname = "portal_gate";
-
 
 	//Assign ent to player as well as the portal type..
 	if (PortalNumber == 1)
 	{
-
 		portal->s.eType = ET_PORTAL_BLUE; //Portal 1
 
 		portal->linkedPortal = ent->portalRed;
@@ -4029,11 +4024,9 @@ void Weapon_Portal_Fire(gentity_t *ent, int PortalNumber)
 
 		//Assign to client
 		ent->portalBlue = portal;
-
 	}
 	else
 	{
-
 		portal->s.eType = ET_PORTAL_RED; //Portal 2
 
 		portal->linkedPortal = ent->portalBlue;
@@ -4044,10 +4037,7 @@ void Weapon_Portal_Fire(gentity_t *ent, int PortalNumber)
 
 		//Assign to client
 		ent->portalRed = portal;
-
 	}
-
-
 
 	//Set origin (obviously)
 	G_SetOrigin(portal, t_endpos);
@@ -4068,9 +4058,6 @@ void Weapon_Portal_Fire(gentity_t *ent, int PortalNumber)
 
 		VectorSet(portal->r.mins, -P_DEPTH, -P_WIDTH, -P_HEIGHT);  //(P_DEPTH, P_WIDTH, P_HEIGHT)
 		VectorSet(portal->r.maxs, P_DEPTH, P_WIDTH, P_HEIGHT);
-
-
-
 	}
 	else if (t_portalAngles[PITCH] == -0)  //Vertical Portals (On walls)
 	{
@@ -4091,8 +4078,6 @@ void Weapon_Portal_Fire(gentity_t *ent, int PortalNumber)
 			VectorSet(portal->r.maxs, P_DEPTH, P_HEIGHT, P_WIDTH);
 
 		}
-
-
 	}
 	else   //Slanted (not quite vertical) portals get the largest bbox...
 	{
@@ -4101,8 +4086,6 @@ void Weapon_Portal_Fire(gentity_t *ent, int PortalNumber)
 
 		VectorSet(portal->r.mins, -P_DEPTH, -P_WIDTH, -P_HEIGHT);  //(P_DEPTH, P_WIDTH, P_HEIGHT)
 		VectorSet(portal->r.maxs, P_DEPTH, P_WIDTH, P_HEIGHT);
-
-
 	}
 
 	//end new bbox code
@@ -4140,10 +4123,7 @@ void Weapon_Portal_Fire(gentity_t *ent, int PortalNumber)
 	vectoangles(tr.plane.normal, portal->s.angles); //NOTE: RE-Enable angles...
 	vectoangles(tr.plane.normal, portal->r.currentAngles);
 
-
 	trap_LinkEntity(portal);
-
-
 }
 
 


### PR DESCRIPTION
All triggers are checked on a hit using same coordinates, if portal trigger runs before `startTimer`, then it teleports player on a new destination, while coordinates used for a hittest will remain old, so any next trigger will still assume player did not instantly move anywhere. So we should just update coordinates after portalling, so next triggers will be tested against new player position.

closes #299