### PR TITLE
Add cvars to hold commands to be executed on runtime events

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2591,6 +2591,8 @@ extern vmCvar_t etj_touchPickupWeapons;
 extern vmCvar_t etj_autoLoad;
 extern vmCvar_t etj_uphillSteps;
 extern vmCvar_t etj_chatLineWidth;
+extern vmCvar_t etj_onRunStart;
+extern vmCvar_t etj_onRunEnd;
 
 //
 // cg_main.c

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -540,6 +540,8 @@ vmCvar_t etj_uphillSteps;
 vmCvar_t etj_quickFollow;
 vmCvar_t etj_chatLineWidth;
 vmCvar_t etj_loopedSounds;
+vmCvar_t etj_onRunStart;
+vmCvar_t etj_onRunEnd;
 
 typedef struct
 {
@@ -920,6 +922,8 @@ cvarTable_t cvarTable[] =
 	{ &etj_uphillSteps, "etj_uphillSteps", "1", CVAR_ARCHIVE },
 	{ &etj_chatLineWidth, "etj_chatLineWidth", "62", CVAR_ARCHIVE },
 	{ &etj_loopedSounds, "etj_loopedSounds", "1", CVAR_ARCHIVE },
+	{ &etj_onRunStart, "etj_onRunStart", "", CVAR_ARCHIVE },
+	{ &etj_onRunEnd, "etj_onRunEnd", "", CVAR_ARCHIVE },
 };
 
 

--- a/src/cgame/cg_mainext.cpp
+++ b/src/cgame/cg_mainext.cpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <memory>
 
-
 static std::unique_ptr<Timerun> timerun;
 static std::unique_ptr<ETJump::TimerunView> timerunView;
 
@@ -52,6 +51,24 @@ void InitGame()
 	}
 }
 
+namespace ETJump
+{
+	void execCmdOnRunStart()
+	{
+		if (etj_onRunStart.string[0])
+		{
+			trap_SendConsoleCommand(va("%s\n", etj_onRunStart.string));
+		}
+	}
+	void execCmdOnRunEnd()
+	{
+		if (etj_onRunEnd.string[0])
+		{
+			trap_SendConsoleCommand(va("%s\n", etj_onRunEnd.string));
+		}
+	}
+}
+
 /**
  * Extended CG_ServerCommand function. Checks whether server
  * sent command matches to any defined here. If no match is found
@@ -69,6 +86,7 @@ qboolean CG_ServerCommandExt(const char *cmd)
 		std::string runName        = CG_Argv(2);
 		auto        previousRecord = atoi(CG_Argv(3));
 		timerun->startTimerun(runName, startTime, previousRecord);
+		ETJump::execCmdOnRunStart();
 		return qtrue;
 	}
 	// timerun_start_spec clientNum{integer} runStartTime{integer} runName{string}
@@ -91,6 +109,7 @@ qboolean CG_ServerCommandExt(const char *cmd)
 	if (command == "timerun_interrupt")
 	{
 		timerun->interrupt();
+		ETJump::execCmdOnRunEnd();
 		return qtrue;
 	}
 	// timerun_stop completionTime{integer}
@@ -98,6 +117,7 @@ qboolean CG_ServerCommandExt(const char *cmd)
 	{
 		auto completionTime = atoi(CG_Argv(1));
 		timerun->stopTimerun(completionTime);
+		ETJump::execCmdOnRunEnd();
 		return qtrue;
 	}
 	// timerun_stop_spec clientNum{integer} completionTime{integer} runName{string}

--- a/src/game/etj_timerun.cpp
+++ b/src/game/etj_timerun.cpp
@@ -355,7 +355,7 @@ void Timerun::interrupt(int clientNum)
 {
 	Player *player = _players[clientNum].get();
 
-	if (player == nullptr)
+	if (player == nullptr || !player->racing)
 	{
 		return;
 	}


### PR DESCRIPTION
* added `etj_onRunStart`, `etj_onRunEnd` cvars which can hold sequence of commands to be executed once run events occur

close #298 