### PR TITLE
Color folders in replays + up max demo length

### DIFF
--- a/etjump/ui/viewreplay.menu
+++ b/etjump/ui/viewreplay.menu
@@ -53,7 +53,7 @@ menuDef {
 		elementtype		LISTBOX_TEXT
 		elementwidth	200
 		elementheight	12
-		columns			1 0 200 33
+		columns			1 0 200 89
 		visible			1
 		tooltip			"Select the replay to view or delete"
 		

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -4899,7 +4899,7 @@ static void UI_LoadDemos()
         FileSystemObjectInfo objectInfo;
         objectInfo.type = FileSystemObjectType::Folder;
         objectInfo.name = std::string(dirPtr);
-        objectInfo.displayName = objectInfo.name + "/";
+        objectInfo.displayName = "^7" + objectInfo.name + "/";
         if (objectInfo.name != "." && objectInfo.name != "..")
         {
             directories.push_back(objectInfo);


### PR DESCRIPTION
Color folders in replays menu white to stand out more, and increase the character limit to draw demo name to max the menu can show.