### PR TITLE
Timerun debugging changes

### DIFF
--- a/src/game/etj_utilities.cpp
+++ b/src/game/etj_utilities.cpp
@@ -94,7 +94,7 @@ void Utilities::startRun(int clientNum)
 	}
 
 	// If we are debugging, just exit here
-	if (Utilities::isDebugging())
+	if (g_debugTimeruns.integer > 0)
 	{
 		return;
 	}
@@ -322,19 +322,4 @@ std::vector<std::string> Utilities::getMaps()
 	}
 
 	return std::move(maps);
-}
-
-bool Utilities::isDebugging()
-{
-	if (g_debugTimeruns.integer > 0)
-	{
-		return true;
-	}
-	
-	if (g_debugTrackers.integer > 0)
-	{
-		return true;
-	}
-
-	return false;
 }

--- a/src/game/etj_utilities.h
+++ b/src/game/etj_utilities.h
@@ -85,11 +85,6 @@ namespace Utilities {
 	void toConsole(gentity_t *ent, std::string message);
 
 	void RemovePlayerWeapons(int clientNum, const std::vector<int>& weapons);
-
-	/**
-	* Check if debugging cvars are enabled for timeruns
-	*/
-	bool isDebugging();
 };
 
 

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -18,7 +18,6 @@
 #include "etj_save_system.h"
 #include "etj_entity_utilities.h"
 #include "etj_string_utilities.h"
-#include "etj_utilities.h"
 
 
 void BotDebug(int clientNum);
@@ -826,7 +825,7 @@ void Cmd_God_f(gentity_t *ent)
 	char     *name;
 	qboolean godAll = qfalse;
 
-	if (ent->client->sess.timerunActive && !(Utilities::isDebugging()))
+	if (ent->client->sess.timerunActive && g_debugTimeruns.integer <= 0)
 	{
 		CP("cp \"You cannot use cheats while timerun is active.\n\"");
 		return;
@@ -1013,7 +1012,7 @@ namespace ETJump
 			return{ false, "^7Non-player entities cannot use ^3%s^7.\n" };
 		}
 
-		if (ent->client->sess.timerunActive && !(Utilities::isDebugging()))
+		if (ent->client->sess.timerunActive && g_debugTimeruns.integer <= 0)
 		{
 			return{ false, "^7Cannot use ^3%s ^7while timer is running.\n" };
 		}

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -2051,7 +2051,7 @@ void target_startTimer_use(gentity_t *self, gentity_t *other, gentity_t *activat
 	}
 
 	// We don't need any of these checks if we are debugging
-	if (!(Utilities::isDebugging()))
+	if (g_debugTimeruns.integer <= 0)
 	{
 		if (activator->client->noclip || activator->flags == FL_GODMODE)
 		{


### PR DESCRIPTION
Separated `g_debugTrackers` from `g_debugTimeruns` - not sure what my logic was here when I made this, but the end result was that `g_debugTrackers` was just a more feature-rich version of `g_debugTimeruns`. Cheats during timeruns now actually require timerun debugging to be enabled instead of tracker debugging.