### PR TITLE
Fix banner system crashes server

### DIFF
--- a/src/game/etj_banner_system.cpp
+++ b/src/game/etj_banner_system.cpp
@@ -31,6 +31,11 @@ void ETJump::BannerSystem::check(int levelTime)
 		return;
 	}
 
+	if (_options.messages.size() == 0)
+	{
+		return;
+	}
+
 	auto message = _options.messages[_bannerIdx];
 
 	switch (_options.location)


### PR DESCRIPTION
In case where g_banner1-5 cvars were all empty, would lead to server crash on map loading.