### PR TITLE
Fix team follow bug

### DIFF
--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1777,15 +1777,18 @@ void SpectatorClientEndFrame(gentity_t *ent)
 			}
 			else
 			{
-
 				// drop them to free spectators unless they are dedicated camera followers
 				if (ent->client->sess.spectatorClient >= 0)
 				{
 					ent->client->sess.spectatorState = SPECTATOR_FREE;
 					ClientBegin(ent->client - level.clients);
 				}
-
 			}
+		}
+		else
+		{
+			ent->client->sess.spectatorState = SPECTATOR_FREE;
+			ClientBegin(ent->client - level.clients);
 		}
 	}
 


### PR DESCRIPTION
If spectated player leave and no other players left to follow you would start receiving an incorrect player state or non at all.