### PR TITLE
Add option to disable quickfollow hint

### DIFF
--- a/etjump/ui/etjump_settings_1.menu
+++ b/etjump/ui/etjump_settings_1.menu
@@ -29,7 +29,7 @@ menuDef {
         YESNO(16, 124, 276, 8, "Auto load:", 0.2, 8, "etj_autoLoad", "Automatically load to latest saved position when joining team\netj_autoLoad")
         YESNO(16, 136, 276, 8, "Real FOV:", 0.2, 8, "etj_realFov", "Take aspect ratio into account when calculating FOV\netj_realFov")
         YESNO(16, 148, 276, 8, "No +activate lean:", 0.2, 8, "etj_noActivateLean", "Disable leaning when +activate is held\netj_noActivateLean")
-        YESNO(16, 160, 276, 8, "Quick follow:", 0.2, 8, "etj_quickFollow", "Spectate other players by aiming and pressing +activate\netj_quickFollow")
+        MULTI(16, 160, 276, 8, "Quick follow:", 0.2, 8, "etj_quickFollow", cvarFloatList { "No" 0 "Yes" 1 "Yes + draw hint" 2 }, "Spectate other players by aiming and pressing +activate\netj_quickFollow")
         CVARFLOATLABEL(16, 172, 276, 8, "etj_noclipScale", 0.2, ITEM_ALIGN_RIGHT, 276, 8)
         SLIDER(16, 172, 276, 8, "Noclip scale:", 0.2, 8, etj_noclipScale 1 0 10 0.2, "Scales the speed of noclip\netj_noclipScale")
         MULTI(16, 184, 276, 8, "Auto weapon pickup:", 0.2, 8, "etj_touchPickupWeapons", cvarFloatList { "No" 0 "Own + Spawned" 1 "All" 2 }, "Automatically pickup weapons when touching them\netj_touchPickupWeapons")

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -916,7 +916,7 @@ cvarTable_t cvarTable[] =
 	{ &etj_drawLeaves, "etj_drawLeaves", "1", CVAR_ARCHIVE },
 	{ &etj_touchPickupWeapons, "etj_touchPickupWeapons", "0", CVAR_ARCHIVE },
 	{ &etj_autoLoad, "etj_autoLoad", "1", CVAR_ARCHIVE },
-	{ &etj_quickFollow, "etj_quickFollow", "1", CVAR_ARCHIVE },
+	{ &etj_quickFollow, "etj_quickFollow", "2", CVAR_ARCHIVE },
 	{ &etj_drawProneIndicator, "etj_drawProneIndicator", "3", CVAR_ARCHIVE },
 	{ &etj_proneIndicatorX, "etj_proneIndicatorX", "615", CVAR_ARCHIVE },
 	{ &etj_proneIndicatorY, "etj_proneIndicatorY", "338", CVAR_ARCHIVE },

--- a/src/cgame/etj_quick_follow_drawable.cpp
+++ b/src/cgame/etj_quick_follow_drawable.cpp
@@ -29,7 +29,7 @@ void ETJump::QuickFollowDrawer::render() const
 
 bool ETJump::QuickFollowDrawer::canSkipDraw() const
 {
-	if (etj_quickFollow.integer  < 1 || cg.crosshairClientNum > MAX_CLIENTS)
+	if (etj_quickFollow.integer < 2 || cg.crosshairClientNum > MAX_CLIENTS)
 	{
 		return true;
 	}


### PR DESCRIPTION
Added option __2__ to `etj_quickFollow` that now draws the hint for following players. This is a new default, __1__ just enables the functionality without drawing the hint text.