### PR TITLE
Fix connection interrupted icon position

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -1216,8 +1216,8 @@ static void CG_DrawDisconnect(void)
 		return;
 	}
 
-	x = SCREEN_WIDTH - 48;
-	y = 480 - 200;
+	x = SCREEN_WIDTH - 48 + ETJump_AdjustPosition(etj_lagometerX.value);
+	y = 480 - 200 + etj_lagometerY.value;
 
 	CG_DrawPic(x, y, 48, 48, cgs.media.disconnectIcon);
 }
@@ -1250,7 +1250,7 @@ static void CG_DrawLagometer(void)
 	// draw the graph
 	//
 	x = SCREEN_WIDTH - 48 + ETJump_AdjustPosition(etj_lagometerX.value);
-	y = 480 - 200 + etj_lagometerY.integer;
+	y = 480 - 200 + etj_lagometerY.value;
 
 	trap_R_SetColor(NULL);
 	CG_DrawPic(x, y, 48, 48, cgs.media.lagometerShader);


### PR DESCRIPTION
Connection interrupted icon drawn on top of lagometer was static and not moving when lagometer was moved.

Also changed `etj_lagometerY` to support float values.

Closes #368 