### PR TITLE
Unlock cg_centertime

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -597,7 +597,7 @@ cvarTable_t cvarTable[] =
 	{ &cg_gun_x,                    "cg_gunX",                     "0",                      CVAR_ARCHIVE             },
 	{ &cg_gun_y,                    "cg_gunY",                     "0",                      CVAR_ARCHIVE             },
 	{ &cg_gun_z,                    "cg_gunZ",                     "0",                      CVAR_ARCHIVE             },
-	{ &cg_centertime,               "cg_centertime",               "5",                      CVAR_CHEAT               }, // DHM - Nerve :: changed from 3 to 5
+	{ &cg_centertime,               "cg_centertime",               "5",                      CVAR_ARCHIVE             }, // DHM - Nerve :: changed from 3 to 5
 	{ &cg_runpitch,                 "cg_runpitch",                 "0.002",                  CVAR_ARCHIVE             },
 	{ &cg_runroll,                  "cg_runroll",                  "0.005",                  CVAR_ARCHIVE             },
 	{ &cg_bobup,                    "cg_bobup",                    "0",                      CVAR_ARCHIVE             },


### PR DESCRIPTION
Unlock `cg_centertime`, no reason to have it locked.