### PR TITLE
Fix hex color parser bug

### DIFF
--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -90,7 +90,7 @@ static void parseRGBAValuedColorString(const std::string colorString, vec4_t &co
 static void parseHexValuedColorString(const std::string &token, vec4_t &color)
 {
 	auto colorValue = std::stoll(token, nullptr, 16);
-	auto channelCount = (colorValue >> 24 ? 1 : 0) + (colorValue >> 16 ? 1 : 0) + (colorValue >> 8 ? 1 : 0) + 1;
+	auto channelCount = ((token.size() - 1) >> 1) + 1;
 	auto maxShift = 8 * channelCount;
 	for (auto i = 0; i < channelCount; i++)
 	{

--- a/src/tests/color_string_parser_tests.cpp
+++ b/src/tests/color_string_parser_tests.cpp
@@ -308,3 +308,30 @@ TEST_F(ColorStringParsingTests, parseColorString_ShouldParse_MaliciousColorStrin
 	parseColorString(colorString, outColor);
 	ASSERT_TRUE(Vector4Compare(outColor, expectedColor));
 }
+
+TEST_F(ColorStringParsingTests, parseColorString_ShouldParse_GreenHexValue)
+{
+	const std::string colorString{ "0x00ff00" };
+	vec4_t expectedColor{ 0.0, 1.f, 0.0, 1.0f };
+	vec4_t outColor;
+	parseColorString(colorString, outColor);
+	ASSERT_TRUE(Vector4Compare(outColor, expectedColor));
+}
+
+TEST_F(ColorStringParsingTests, parseColorString_ShouldParse_BlueHexValue)
+{
+	const std::string colorString{ "0x0000ff" };
+	vec4_t expectedColor{ 0.0, 0.f, 1.0, 1.0f };
+	vec4_t outColor;
+	parseColorString(colorString, outColor);
+	ASSERT_TRUE(Vector4Compare(outColor, expectedColor));
+}
+
+TEST_F(ColorStringParsingTests, parseColorString_ShouldParse_EmptyHexValue)
+{
+	const std::string colorString{ "0x" };
+	vec4_t expectedColor{ 0.0, 0.f, 0.0, 1.0f };
+	vec4_t outColor;
+	parseColorString(colorString, outColor);
+	ASSERT_TRUE(Vector4Compare(outColor, expectedColor));
+}


### PR DESCRIPTION
Channel count was not correct. Cases such `0x00FF` or `0x0000FF` were interpreted as single channeled, hence parsing went all wrong.

refs #229