### PR TITLE
Fix the demo playback bug

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1249,6 +1249,8 @@ typedef struct
 	vec3_t etjLastJumpPos;
 
 	int pronePressTime;		// No prone print delay: when client last pressed prone
+
+	bool requiresEntityTypeAdjustment; // ETJump 2.3.0 specific hack
 } cg_t;
 
 #define NUM_FUNNEL_SPRITES  21

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -5,6 +5,7 @@
 *
 */
 
+#include <cstring>
 
 #include "cg_local.h"
 #include "cg_mainext.h"
@@ -3701,6 +3702,16 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
 	cgs.demoCam.noclip = qfalse;
 
 	InitGame();
+
+	if (cg.demoPlayback)
+	{
+		// Marks the right 2.3.0 version to perform the entity type adjustement hack
+		char* pakBaseName = strchr(Info_ValueForKey(CG_ConfigString(CS_SYSTEMINFO), "sv_referencedPakNames"), '/') + 1;
+		if (!Q_strncmp(pakBaseName, "etjump-2_3_0-RC4 ", 17) || !Q_strncmp(pakBaseName, "etjump-2_3_0 ", 13))
+		{
+			cg.requiresEntityTypeAdjustment = true;
+		}
+	}	
 
 	ETJump::isInitialized = true;
 

--- a/src/cgame/cg_snapshot.cpp
+++ b/src/cgame/cg_snapshot.cpp
@@ -519,7 +519,28 @@ static snapshot_t *CG_ReadNextSnapshot(void)
 				}
 #endif // SAVEGAME_SUPPORT
 			}
-//
+			
+			// ETJump: This whole block is pretty hacky, but it fixes the bug,
+			// that was introduced in 2.3.0, which made some old demos unplayable
+			// due to the introduced shifting in the entityType_t. This code
+			// just tries to remap everything back, when necessary. This is perfomed
+			// for all new snapshots (so should roughly run just 20 times a second).
+			if (cg.requiresEntityTypeAdjustment)
+			{
+				for (int i = 0; i < dest->numEntities; i++)
+				{
+					entityState_t *es = &dest->entities[i];
+					// ET_VELOCITY_PUSH_TRIGGER = 9 in 2.3.0, so we should remap it to the current position
+					if (es->eType == 9) {
+						es->eType = ET_VELOCITY_PUSH_TRIGGER;
+					}
+					// shifting back all eTypes in demo, so it would match the current enum order
+					else if (es->eType > 9) {
+						es->eType = static_cast<entityType_t>(es->eType - 1);
+					}
+				}
+			}
+
 			return dest;
 		}
 
@@ -649,5 +670,4 @@ void CG_ProcessSnapshots(void)
 	{
 		CG_Error("CG_ProcessSnapshots: cg.nextSnap->serverTime <= cg.time");
 	}
-
 }

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -1498,7 +1498,6 @@ typedef enum
 	ET_PORTAL,
 	ET_SPEAKER,
 	ET_PUSH_TRIGGER,
-	ET_VELOCITY_PUSH_TRIGGER,
 	ET_TELEPORT_TRIGGER,
 	ET_INVISIBLE,
 	ET_CONCUSSIVE_TRIGGER,  // JPW NERVE trigger for concussive dust particles
@@ -1582,7 +1581,9 @@ typedef enum
 
 	ET_WOLF_OBJECTIVE,
 
-	ET_EVENTS               // any of the EV_* events can be added freestanding
+	ET_VELOCITY_PUSH_TRIGGER, // ETJump
+
+	ET_EVENTS,              // any of the EV_* events can be added freestanding
 	                        // by setting eType to ET_EVENTS + eventNum
 	                        // this avoids having to set eFlags and eventNum
 } entityType_t;


### PR DESCRIPTION
Older demos were not working on a newer etjump version, due to the introduced shifting in the entityType_t we have made to add a new entity type in the game.
This patch reorders entityType_t enum to allow older demos to be played again, and also adds 2.3.0 specific hack, to remap demo entity types to match the fixed enum order.

closes #396