### PR TITLE
Add etj_extraTrace

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include "etj_client_commands_handler.h"
 #include "etj_inline_command_parser.h"
+#include "../game/etj_string_utilities.h"
 
 void CG_TargetCommand_f(void)
 {
@@ -1374,6 +1375,37 @@ void CG_IncrementVar_f(void)
 	trap_Cvar_Set(CG_Argv(1), va("%f", value));
 }
 
+struct extraTraceListOptions
+{
+	const int bitmaskValue;
+	const char *description;
+};
+
+extraTraceListOptions extraTraceList[]
+{
+	{ 1 << ETJump::OB_DETECTOR, "OB detector" },
+	{ 1 << ETJump::SLICK_DETECTOR, "Slick detector" },
+	{ 1 << ETJump::NJD_DETECTOR, "No jump delay detector" },
+	{ 1 << ETJump::CHS_10_11, "CHS 10-11" },
+	{ 1 << ETJump::CHS_12, "CHS 12" },
+	{ 1 << ETJump::CHS_13_15, "CHS 13-15" },
+	{ 1 << ETJump::CHS_16, "CHS 16" },
+	{ 1 << ETJump::CHS_53, "CHS 53" },
+};
+
+void CG_ExtraTrace_f(void)
+{
+	std::string listPrint{ "Bitmask values for ^3etj_extraTrace^7:\n" };
+
+	for (auto traceList : extraTraceList)
+	{
+		std::string listValues = ETJump::stringFormat("  ^3%d ^7= %s\n", traceList.bitmaskValue, traceList.description);
+		listPrint += (listValues);
+	}
+
+	CG_Printf(listPrint.c_str());
+}
+
 typedef struct
 {
 	const char *cmd;
@@ -1505,6 +1537,7 @@ static consoleCommand_t commands[] =
 
 	{ "mod_information", CG_ModInformation_f },
 	{ "incrementVar", CG_IncrementVar_f },
+	{ "extraTrace", CG_ExtraTrace_f },
 };
 
 

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -3611,7 +3611,6 @@ static void CG_DrawOB(void)
 	float         h0, t;
 	trace_t       trace;
 	vec3_t        start, end;
-	playerState_t *ps;
 	float         x;
 
 	if (!cg_drawOB.integer || cg_thirdPerson.integer)
@@ -3619,15 +3618,9 @@ static void CG_DrawOB(void)
 		return;
 	}
 
-	if (cg.snap->ps.clientNum != cg.clientNum)
-	{
-		ps = &cg.snap->ps;
-	}
-	else
-	{
-		// use predictedPlayerState if not spectating
-		ps = &cg.predictedPlayerState;
-	}
+	int traceContents = ETJump::checkExtraTrace(ETJump::OB_DETECTOR);
+
+	playerState_t *ps = ETJump::getValidPlayerState();
 
 	psec    = pmove_msec.integer / 1000.0;
 	gravity = ps->gravity;
@@ -3652,7 +3645,7 @@ static void CG_DrawOB(void)
 		end[2] -= 131072;
 
 		CG_Trace(&trace, start, vec3_origin, vec3_origin, end, ps->clientNum,
-		         CONTENTS_SOLID);
+		         traceContents);
 
 		if (trace.fraction != 1.0 && trace.plane.type == 2)
 		{
@@ -3674,7 +3667,7 @@ static void CG_DrawOB(void)
 	VectorMA(start, 131072, cg.refdef.viewaxis[0], end);
 
 	CG_Trace(&trace, start, vec3_origin, vec3_origin, end, ps->clientNum,
-	         CONTENTS_SOLID);
+	         traceContents);
 
 	if (trace.fraction != 1.0 && trace.plane.type == 2)
 	{
@@ -3740,25 +3733,19 @@ static void CG_DrawOB(void)
 
 static void CG_DrawSlick(void)
 {
-	playerState_t *ps = NULL;
 	trace_t       trace;
 	vec3_t        start, end;
 	const float   minWalkNormal = 0.7;
 	float         x;
+
 	if (!cg_drawSlick.integer)
 	{
 		return;
 	}
 
-	if (cg.snap->ps.clientNum != cg.clientNum)
-	{
-		ps = &cg.snap->ps;
-	}
-	else
-	{
-		// use predictedPlayerState if not spectating
-		ps = &cg.predictedPlayerState;
-	}
+	int traceContents = ETJump::checkExtraTrace(ETJump::SLICK_DETECTOR);
+
+	playerState_t *ps = ETJump::getValidPlayerState();
 
 	x = cg_slickX.value;
 
@@ -3767,7 +3754,7 @@ static void CG_DrawSlick(void)
 	VectorCopy(cg.refdef.vieworg, start);
 	VectorMA(start, 8192, cg.refdef.viewaxis[0], end);
 
-	CG_Trace(&trace, start, NULL, NULL, end, ps->clientNum, CONTENTS_SOLID);
+	CG_Trace(&trace, start, NULL, NULL, end, ps->clientNum, traceContents);
 
 	if ((trace.fraction != 1.0 && trace.surfaceFlags & SURF_SLICK) ||
 	    (trace.plane.normal[2] > 0 && trace.plane.normal[2] < minWalkNormal))
@@ -3783,19 +3770,29 @@ static void CG_DrawJumpDelay(void)
 	vec3_t start, end;
 	float x = etj_noJumpDelayX.integer;
 	float y = etj_noJumpDelayY.integer;
+
 	if (!etj_drawNoJumpDelay.integer)
 	{
 		return;
 	}
+
+	int traceContents = ETJump::checkExtraTrace(ETJump::NJD_DETECTOR);
+
+	playerState_t *ps = ETJump::getValidPlayerState();
+
 	ETJump_AdjustPosition(&x);
 	VectorCopy(cg.refdef.vieworg, start);
 	VectorMA(start, 8192, cg.refdef.viewaxis[0], end);
-	CG_Trace(&trace, start, nullptr, nullptr, end, cg.snap->ps.clientNum, CONTENTS_SOLID);
+
+	CG_Trace(&trace, start, nullptr, nullptr, end, ps->clientNum, traceContents);
+
 	if (trace.surfaceFlags & SURF_NOJUMPDELAY)
 	{
-		if (shared.integer & BG_LEVEL_NO_JUMPDELAY) {
+		if (shared.integer & BG_LEVEL_NO_JUMPDELAY)
+		{
 			CG_DrawStringExt(x, y, "D", colorWhite, qfalse, qtrue, TINYCHAR_WIDTH, TINYCHAR_HEIGHT, 0);
-		} else
+		}
+		else
 		{
 			CG_DrawStringExt(x, y, "ND", colorWhite, qfalse, qtrue, TINYCHAR_WIDTH, TINYCHAR_HEIGHT, 0);
 		}

--- a/src/cgame/cg_drawCHS.cpp
+++ b/src/cgame/cg_drawCHS.cpp
@@ -23,7 +23,7 @@ static playerState_t *CG_CHS_GetPlayerState(void)
 	}
 }
 
-static void CG_CHS_ViewTrace(trace_t *trace)
+static void CG_CHS_ViewTrace(trace_t *trace, int traceContents)
 {
 	playerState_t *ps = CG_CHS_GetPlayerState();
 	vec3_t        start, end;
@@ -31,7 +31,7 @@ static void CG_CHS_ViewTrace(trace_t *trace)
 	VectorCopy(cg.refdef.vieworg, start);
 	VectorMA(start, 131072, cg.refdef.viewaxis[0], end);
 	CG_Trace(trace, start, vec3_origin, vec3_origin, end, ps->clientNum,
-	         CONTENTS_SOLID);
+	         traceContents);
 }
 
 static void CG_CHS_Speed(char *buf, int size)
@@ -69,7 +69,9 @@ static void CG_CHS_Distance_XY(char *buf, int size)
 	playerState_t *ps = CG_CHS_GetPlayerState();
 	trace_t       trace;
 
-	CG_CHS_ViewTrace(&trace);
+	int traceContents = ETJump::checkExtraTrace(ETJump::CHS_10_11);
+
+	CG_CHS_ViewTrace(&trace, traceContents);
 
 	if (trace.fraction != 1.0)
 	{
@@ -88,7 +90,9 @@ static void CG_CHS_Distance_Z(char *buf, int size)
 	playerState_t *ps = CG_CHS_GetPlayerState();
 	trace_t       trace;
 
-	CG_CHS_ViewTrace(&trace);
+	int traceContents = ETJump::checkExtraTrace(ETJump::CHS_10_11);
+
+	CG_CHS_ViewTrace(&trace, traceContents);
 
 	if (trace.fraction != 1.0)
 	{
@@ -105,7 +109,9 @@ static void CG_CHS_Distance_XYZ(char *buf, int size)
 	playerState_t *ps = CG_CHS_GetPlayerState();
 	trace_t       trace;
 
-	CG_CHS_ViewTrace(&trace);
+	int traceContents = ETJump::checkExtraTrace(ETJump::CHS_12);
+
+	CG_CHS_ViewTrace(&trace, traceContents);
 
 	if (trace.fraction != 1.0)
 	{
@@ -121,7 +127,9 @@ static void CG_CHS_Distance_ViewXYZ(char *buf, int size)
 {
 	trace_t trace;
 
-	CG_CHS_ViewTrace(&trace);
+	int traceContents = ETJump::checkExtraTrace(ETJump::CHS_13_15);
+
+	CG_CHS_ViewTrace(&trace, traceContents);
 
 	if (trace.fraction != 1.0)
 	{
@@ -139,7 +147,9 @@ static void CG_CHS_Distance_XY_Z_XYZ(char *buf, int size)
 	playerState_t *ps = CG_CHS_GetPlayerState();
 	trace_t       trace;
 
-	CG_CHS_ViewTrace(&trace);
+	int traceContents = ETJump::checkExtraTrace(ETJump::CHS_13_15);
+
+	CG_CHS_ViewTrace(&trace, traceContents);
 
 	if (trace.fraction != 1.0)
 	{
@@ -160,7 +170,9 @@ static void CG_CHS_Distance_XY_Z_ViewXYZ(char *buf, int size)
 	playerState_t *ps = CG_CHS_GetPlayerState();
 	trace_t       trace;
 
-	CG_CHS_ViewTrace(&trace);
+	int traceContents = ETJump::checkExtraTrace(ETJump::CHS_13_15);
+
+	CG_CHS_ViewTrace(&trace, traceContents);
 
 	if (trace.fraction != 1.0)
 	{
@@ -180,7 +192,9 @@ static void CG_CHS_Look_XYZ(char *buf, int size)
 {
 	trace_t trace;
 
-	CG_CHS_ViewTrace(&trace);
+	int traceContents = ETJump::checkExtraTrace(ETJump::CHS_16);
+
+	CG_CHS_ViewTrace(&trace, traceContents);
 
 	if (trace.fraction != 1.0)
 	{
@@ -375,7 +389,9 @@ static void CG_CHS_PlaneAngleZ(char *buf, int size)
 {
 	trace_t trace;
 
-	CG_CHS_ViewTrace(&trace);
+	int traceContents = ETJump::checkExtraTrace(ETJump::CHS_53);
+
+	CG_CHS_ViewTrace(&trace, traceContents);
 
 	float vec_x = trace.plane.normal[0];
 	float vec_y = trace.plane.normal[1];

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3942,6 +3942,18 @@ namespace ETJump
 	void addRealLoopingSound(const vec3_t origin, const vec3_t velocity, sfxHandle_t sfx, int range, int volume, int soundTime);
 	void addLoopingSound(const vec3_t origin, const vec3_t velocity, sfxHandle_t sfx, int volume, int soundTime);
 	bool hideMeCheck(int entityNum);
+	int checkExtraTrace(int value);
+
+	enum extraTraceOptions {
+		OB_DETECTOR,
+		SLICK_DETECTOR,
+		NJD_DETECTOR,
+		CHS_10_11,
+		CHS_12,
+		CHS_13_15,
+		CHS_16,
+		CHS_53,
+	};
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -547,6 +547,7 @@ vmCvar_t etj_onRunEnd;
 vmCvar_t etj_lagometerX;
 vmCvar_t etj_lagometerY;
 vmCvar_t etj_spectatorVote;
+vmCvar_t etj_extraTrace;
 
 typedef struct
 {
@@ -740,7 +741,7 @@ cvarTable_t cvarTable[] =
 	{ &cg_drawCGaz,                 "etj_drawCGaz",                "0",                      CVAR_ARCHIVE             },
 	{ &cg_drawOB,                   "etj_drawOB",                  "0",                      CVAR_ARCHIVE             },
 	{ &etj_OBX,                     "etj_OBX",                     "320",                    CVAR_ARCHIVE             },
-	{ &etj_OBY,                     "etj_OBY",                     "220",                    CVAR_ARCHIVE },
+	{ &etj_OBY,                     "etj_OBY",                     "220",                    CVAR_ARCHIVE             },
 	{ &cg_CGazY,                    "etj_CGazY",                   "260",                    CVAR_ARCHIVE             },
 	{ &cg_CGazHeight,               "etj_CGazHeight",              "20",                     CVAR_ARCHIVE             },
 	{ &cg_CGazWidth,                "etj_CGazWidth",               "300",                    CVAR_ARCHIVE             },
@@ -931,6 +932,7 @@ cvarTable_t cvarTable[] =
 	{ &etj_lagometerX, "etj_lagometerX", "0", CVAR_ARCHIVE },
 	{ &etj_lagometerY, "etj_lagometerY", "0", CVAR_ARCHIVE },
 	{ &etj_spectatorVote, "", "0", 0 },
+	{ &etj_extraTrace, "etj_extraTrace", "0", CVAR_ARCHIVE },
 };
 
 
@@ -968,6 +970,17 @@ namespace ETJump
 			}
 		}
 		return false;
+	}
+
+	// Get correct trace contents depending on etj_extraTrace value
+	int checkExtraTrace(int value)
+	{
+		if (etj_extraTrace.integer & 1 << value)
+		{
+			return CONTENTS_SOLID | CONTENTS_PLAYERCLIP;
+		}
+
+		return CONTENTS_SOLID;
 	}
 }
 


### PR DESCRIPTION
`etj_extraTrace` - bitmask cvar that allows toggling playerclip tracing for OB, slick and NJD detectors, as well as few CHS functions.

* 0 = off
* 1 = OB detector
* 2 = Slick detector
* 4 = NJD detector
* 8 = CHS 10-11
* 16 = CHS 12
* 32 = CHS 13-15
* 64 = CHS 16
* 128 = CHS 53

The list above can be printed to console with `extraTrace` command.

Also a small fix to NJD detector always using snapshots for traces.

Closes #389 