### PR TITLE
Fix altscoreboard 3 header text scaling

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -142,6 +142,17 @@ void CG_Text_PaintChar_Ext(float x, float y, float w, float h, float scalex, flo
 	w *= scalex;
 	h *= scaley;
 	CG_AdjustFrom640(&x, &y, &w, &h);
+
+	if (w < 1)
+	{
+		w = 1;
+	}
+
+	if (h < 1)
+	{
+		h = 1;
+	}
+
 	trap_R_DrawStretchPic(x, y, w, h, s, t, s2, t2, hShader);
 }
 


### PR DESCRIPTION
`CG_Text_PaintChar_Ext` now always sets width & height to at least 1px.