### PR TITLE
Add SILENT spawnflag to target_savereset

### DIFF
--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1756,7 +1756,11 @@ void target_savereset_use(gentity_t *self, gentity_t *other, gentity_t *activato
 	if (activator->client)
 	{
 		ETJump::saveSystem->resetSavedPositions(activator);
-		CPx(activator - g_entities, "cp \"^7 Your saves were removed.\n\"");
+
+		if (!self->spawnflags & 1)
+		{
+			CPx(activator - g_entities, "cp \"^7 Your saves were removed.\n\"");
+		}
 	}
 }
 


### PR DESCRIPTION
Adds spawnflag 1 `SILENT` to `target_savereset` which suppresses the print it normally does. This makes printing other stuff at the same time easier.

Closes #402 