### PR TITLE
Fix func_static + doors

### DIFF
--- a/src/game/g_mover.cpp
+++ b/src/game/g_mover.cpp
@@ -3840,7 +3840,14 @@ void Static_Pain(gentity_t *ent, gentity_t *attacker, int damage, vec3_t point)
 
 	if (level.time > ent->wait + ent->delay + rand() % 1000 + 500)
 	{
-		G_UseTargets(ent, attacker);
+		if (ent->spawnflags & 8)
+		{
+			G_UseTargets(ent, attacker);
+		}
+		else
+		{
+			G_UseTargets(ent, NULL);
+		}
 		ent->wait = level.time;
 	}
 


### PR DESCRIPTION
This disables `func_static` with `PAIN` spawnflag sending activator data by default as it made it unable to open doors due to `key` always being set to __-1__ on targeted doors. The activator data is now only being sent with spawnflag __8__