### PR TITLE
Fix CGaz 2 crash on very high speeds

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -3439,13 +3439,13 @@ static void CG_DrawCGazHUD(void)
 			scx + right, scy - forward, color2);
 
 		vel_size /= 5;
-		DrawLine(scx, scy,
-			scx + vel_size * sin(vel_relang),
-			scy - vel_size * cos(vel_relang), color1);
 		if (vel_size > SCREEN_HEIGHT / 2)
 		{
 			vel_size = SCREEN_HEIGHT / 2;
 		}
+		DrawLine(scx, scy,
+			scx + vel_size * sin(vel_relang),
+			scy - vel_size * cos(vel_relang), color1);
 		vel_size /= 2;
 		DrawLine(scx, scy,
 			scx + vel_size * sin(vel_relang + per_angle),


### PR DESCRIPTION
Fixes a crash where using CGaz 2 & reaching over 83884088ups would crash the game.

Closes #416 