### PR TITLE
Fix setoffset incorrect Z value

### DIFF
--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -1103,7 +1103,7 @@ namespace ETJump
 
 		// reset speed
 		VectorClear(ent->client->ps.velocity);
-		TeleportPlayer(ent, origin, angles);
+		DirectTeleport(ent, origin, angles);
 	}
 
 	void interruptRun(gentity_t *ent)

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1610,6 +1610,7 @@ void TeleportPlayer(gentity_t *player, vec3_t origin, vec3_t angles);
 void TeleportPlayerExt(gentity_t *player, vec3_t origin, vec3_t angles);
 void TeleportPlayerKeepAngles_Clank(gentity_t *player, gentity_t *trigger, vec3_t origin, vec3_t angles);
 void TeleportPlayerKeepAngles(gentity_t *player, gentity_t *trigger, vec3_t origin, vec3_t angles);
+void DirectTeleport(gentity_t *player, vec3_t origin, vec3_t angles);
 void PortalTeleport(gentity_t *player, vec3_t origin, vec3_t angles);   //Feen: PGM
 void mg42_fire(gentity_t *other);
 void mg42_stopusing(gentity_t *self);

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -481,6 +481,31 @@ void TeleportPlayerKeepAngles(gentity_t *player, gentity_t *trigger, vec3_t orig
 	TeleportPlayer(player, newOrigin, newViewAngles);
 }
 
+// ETJump: teleports player in specific origin with specific angles, 
+//         preserves players velocity(direction) but without origin[2] shift.
+//         Used by setoffset to avoid origin[2] shift.
+void DirectTeleport(gentity_t *player, vec3_t origin, vec3_t angles)
+{
+	VectorCopy(origin, player->client->ps.origin);
+
+	// toggle the teleport bit so the client knows to not lerp
+	player->client->ps.eFlags ^= EF_TELEPORT_BIT;
+
+	// set angles
+	SetClientViewAngle(player, angles);
+
+	// save results of pmove
+	BG_PlayerStateToEntityState(&player->client->ps, &player->s, qtrue);
+
+	// use the precise origin for linking
+	VectorCopy(player->client->ps.origin, player->r.currentOrigin);
+
+	if (player->client->sess.sessionTeam != TEAM_SPECTATOR)
+	{
+		trap_LinkEntity(player);
+	}
+}
+
 /*
 =================================================================================
 


### PR DESCRIPTION
Fixes `setoffset` always setting +1 to Z origin due to using `TeleportPlayer` function which shifts Z origin by 1 unit.