### PR TITLE
Disallow WP_MORTAR_SET in timeruns

### DIFF
--- a/src/game/etj_utilities.cpp
+++ b/src/game/etj_utilities.cpp
@@ -107,6 +107,7 @@ void Utilities::startRun(int clientNum)
 		WP_SATCHEL_DET,
 		WP_SATCHEL,
 		WP_MORTAR,
+		WP_MORTAR_SET,
 		WP_GPG40,
 		WP_LANDMINE,
 		WP_FLAMETHROWER,


### PR DESCRIPTION
Remove WP_MORTAR_SET when starting a timerun. Could be exploited in very specific circumstances.