### PR TITLE
Fix quickfollowing hidden players + speclock text

### DIFF
--- a/src/cgame/etj_quick_follow_drawable.cpp
+++ b/src/cgame/etj_quick_follow_drawable.cpp
@@ -21,7 +21,7 @@ void ETJump::QuickFollowDrawer::render() const
 	}
 
 	auto binding = BindingFromName("+activate");
-	auto hintText = cgs.clientinfo[cg.crosshairClientNum].specLocked ? "^9Speclocked" : stringFormat("^9[%s] to follow", binding);
+	auto hintText = stringFormat("^9[%s] to follow", binding);
 	float w = DrawStringWidth(cgs.clientinfo[cg.crosshairClientNum].name, 0.23f);
 	auto offx = SCREEN_CENTER_X - w / 2;
 	DrawString(offx, 182 + 10, 0.16f, 0.16f, color, qfalse, hintText.c_str(), 0, ITEM_TEXTSTYLE_SHADOWED);

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -3889,6 +3889,29 @@ tryagain:
 
 namespace ETJump
 {
+	bool allowQuickFollow(gentity_t *ent, gentity_t *traceEnt)
+	{
+		if (!ETJump::isPlayer(traceEnt))
+		{
+			return false;
+		}
+		if (!G_AllowFollow(ent, traceEnt))
+		{
+			auto clientNum = ClientNum(ent);
+			std::string specLockMsg = ETJump::stringFormat("%s is speclocked.", traceEnt->client->pers.netname);
+			Printer::SendLeftMessage(clientNum, specLockMsg);
+			return false;
+		}
+		if (!ent->client->pers.quickFollow)
+		{
+			return false;
+		}
+		if (traceEnt->client->pers.hideMe)
+		{
+			return false;
+		}
+		return true;
+	}
 	
 	void longRangeActivate(gentity_t *ent)
 	{
@@ -3911,7 +3934,7 @@ namespace ETJump
 
 		traceEnt = &g_entities[tr.entityNum];
 
-		if (ETJump::isPlayer(traceEnt) && G_AllowFollow(ent, traceEnt) && ent->client->pers.quickFollow && !(traceEnt->client->pers.hideMe))
+		if (ETJump::allowQuickFollow(ent, traceEnt))
 		{
 			if (ent->client->sess.sessionTeam != TEAM_SPECTATOR)
 			{


### PR DESCRIPTION
* Fix `etj_quickFollow` __2__ drawing hint text on hidden players
* Quick following hidden players is no longer possible
* Trying to quick follow speclocked player now gives a print.