### PR TITLE
Make command listeners handling non blocking

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -1589,12 +1589,15 @@ qboolean CG_ConsoleCommand(void)
 		trap_Argv(i, buf, sizeof(buf));
 		arguments.push_back(buf);
 	}
-	if (ETJump::consoleCommandsHandler->check(command, arguments))
+	
+	bool found = ETJump::consoleCommandsHandler->check(command, arguments);
+
+	if (CG_ConsoleCommandExt(cmd))
 	{
 		return qtrue;
 	}
 
-	return CG_ConsoleCommandExt(cmd);
+	return found ? qtrue : qfalse;
 }
 
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -3079,16 +3079,15 @@ static void CG_ServerCommand(void)
 		trap_Argv(i, buf, sizeof(buf));
 		arguments.push_back(buf);
 	}
-	if (ETJump::serverCommandsHandler->check(cmd, arguments))
-	{
-		return;
-	}
+
+	bool found = ETJump::serverCommandsHandler->check(cmd, arguments);
 
 	if (CG_ServerCommandExt(cmd))
 	{
 		return;
 	}
 
+	if (found) return;
 
 	CG_Printf("Unknown client game command: %s\n", cmd);
 }


### PR DESCRIPTION
This allows other etjump command handlers (mainext) to react on commands.
And yeah that should be refactored in future.