### PR TITLE
add deformvertex text support

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -6436,6 +6436,11 @@ void CG_DrawActive(stereoFrame_t stereoView)
 
 	if (!(cg.limboEndCinematicTime > cg.time && cg.showGameView))
 	{
+		for (int i = 0; i < MAX_RENDER_STRINGS; i++)
+		{
+			Q_strncpyz(cg.refdef_current->text[i], cg.deformText[i], sizeof(cg.refdef_current->text[0]));
+		}
+
 		trap_R_RenderScene(cg.refdef_current);
 	}
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1251,6 +1251,8 @@ typedef struct
 	int pronePressTime;		// No prone print delay: when client last pressed prone
 
 	bool requiresEntityTypeAdjustment; // ETJump 2.3.0 specific hack
+
+	char deformText[MAX_RENDER_STRINGS][MAX_RENDER_STRING_LENGTH];
 } cg_t;
 
 #define NUM_FUNNEL_SPRITES  21

--- a/src/cgame/cg_spawn.cpp
+++ b/src/cgame/cg_spawn.cpp
@@ -536,6 +536,12 @@ void SP_worldspawn(void)
 	{
 		cgs.media.thirtySecondSound_a = -1;
 	}
+
+	for (int i = 0; i < MAX_RENDER_STRINGS; i++)
+	{
+		CG_SpawnString(va("text%i", i), "", &s);
+		Q_strncpyz(cg.deformText[i], s, sizeof(cg.deformText[0]));
+	}
 }
 
 /*


### PR DESCRIPTION
`deformVertex text` isn't quite documented, but it works as follows:
1) make a shader with a charset texture(you can use gfx/2d/hudchars.tga)
2) add `deformVertex text0` directive
3) add epair in worldspawn, that will hold the string for a text0: `text0 "example text"`
you can have up to 8 string buffers per scene, strings can be up to 32 chars long