### PR TITLE
Fix speclock was sending update to wrong client

### DIFF
--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -1601,14 +1601,14 @@ namespace ETJump
 			gent.client->sess.timerunActive ? 1 : 0
 		);
 
-		trap_GetConfigstring(CS_PLAYERS + gent.client->ps.clientNum, oldcs, sizeof(oldcs));
+		trap_GetConfigstring(CS_PLAYERS + ClientNum(&gent), oldcs, sizeof(oldcs));
 
 		if (Q_stricmp(oldcs, newcs) == 0)
 		{
 			return false;
 		}
 
-		trap_SetConfigstring(CS_PLAYERS + gent.client->ps.clientNum, newcs);
+		trap_SetConfigstring(CS_PLAYERS + ClientNum(&gent), newcs);
 
 		return true;
 	}


### PR DESCRIPTION
While spectating, `ps->clientNum` is set to a number of the spectated client (and the whole ps), which caused the issue because user info update, upon speclocking, was sent to the spectated client.
closes #440 
related #312