### PR TITLE
Extend etj_popupGrouped to allow printing duplicates in console

### DIFF
--- a/src/cgame/cg_popupmessages.cpp
+++ b/src/cgame/cg_popupmessages.cpp
@@ -303,7 +303,7 @@ void CG_AddPMItem(popupMessageType_t type, const char *message, qhandle_t shader
 	else
 	{
 		listItem->shader = cgs.media.pmImages[type];
-	}	
+	}
 
 	listItem->repeats = 1;
 	


### PR DESCRIPTION
Print duplicate popups in console when `etj_popupGrouped` __1__, group duplicates when `etj_popupGrouped` __2__ (current behavior)

Closes #409 