### PR TITLE
Disable await for timeruns

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@
   * `callvote map` now lists matched maps if more than one match was found
 * added `await` command. Works similar to `wait` except doesn't interrupt other user actions
   * syntax: `await <frames> <command1> | <command2> | <command3>...`
+  * `await` is not available during timeruns, and command queue is cleared on timerun starts
 * added new color parsing support for crosshair
 * fixed a bug in color parser which interpreted hex colors with `00` as single channeled color
 * fixed an old etmain bug where changing crosshair via console would not instantly update crosshair preview in menu

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -3686,6 +3686,7 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
 	}, bind(&ETJump::OperatingSystem::getHwid, ETJump::operatingSystem),
 		ETJump::serverCommandsHandler
 	);
+	ETJump::playerEventsHandler = std::make_shared<ETJump::PlayerEventsHandler>();
     ETJump::awaitedCommandHandler = std::make_shared<ETJump::AwaitedCommandHandler>(
         ETJump::consoleCommandsHandler,
         trap_SendConsoleCommand,
@@ -3694,7 +3695,6 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
             Com_Printf(text);
         }
     );
-	ETJump::playerEventsHandler = std::make_shared<ETJump::PlayerEventsHandler>();
 	ETJump::eventLoop = std::make_shared<ETJump::EventLoop>();
 
 	////////////////////////////////////////////////////////////////

--- a/src/cgame/etj_awaited_command_handler.cpp
+++ b/src/cgame/etj_awaited_command_handler.cpp
@@ -1,7 +1,17 @@
+#include "cg_local.h"
+
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
+
 #include "etj_awaited_command_handler.h"
 #include "etj_client_commands_handler.h"
 #include "../game/etj_string_utilities.h"
 #include "etj_inline_command_parser.h"
+#include "etj_player_events_handler.h"
 
 
 ETJump::AwaitedCommandHandler::AwaitedCommandHandler(
@@ -16,8 +26,22 @@ ETJump::AwaitedCommandHandler::AwaitedCommandHandler(
     _awaitedCommands.clear();
     _consoleCommandsHandler->subscribe("await", [this](const std::vector<std::string>& args)
     {
+		if(cgs.clientinfo->timerunActive)
+		{
+			message("^3Error: ^7cannot use ^3await ^7during timeruns.");
+			return;
+		}
         this->awaitCommand(args);
     });
+
+	playerEventsHandler->subscribe("timerun:start", [&](const std::vector<std::string>& args)
+	{
+		if (_awaitedCommands.size())
+		{
+			CG_AddPMItem(PM_MESSAGE, "^7Timerun started, ^3await ^7queue cleared.", cgs.media.stopwatchIcon);
+			_awaitedCommands.clear();
+		}
+	});
 }
 
 ETJump::AwaitedCommandHandler::~AwaitedCommandHandler()


### PR DESCRIPTION
Don't allow it to be used during timeruns, and clear any queued commands when timerun starts.

Closes #461 