### PR TITLE
added acceleration based speed2 color

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2423,6 +2423,7 @@ extern vmCvar_t etj_drawMaxSpeed;
 extern vmCvar_t etj_maxSpeedX;
 extern vmCvar_t etj_maxSpeedY;
 extern vmCvar_t etj_maxSpeedDuration;
+extern vmCvar_t etj_speedColorUsesAccel;
 
 extern vmCvar_t cg_adminpassword;
 extern vmCvar_t cg_username;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -376,6 +376,7 @@ vmCvar_t etj_drawMaxSpeed;
 vmCvar_t etj_maxSpeedX;
 vmCvar_t etj_maxSpeedY;
 vmCvar_t etj_maxSpeedDuration;
+vmCvar_t etj_speedColorUsesAccel;
 
 vmCvar_t cg_adminpassword;
 vmCvar_t cg_username;
@@ -789,6 +790,7 @@ cvarTable_t cvarTable[] =
 	{ &etj_maxSpeedX,               "etj_maxSpeedX",               "320",                    CVAR_ARCHIVE             },
 	{ &etj_maxSpeedY,               "etj_maxSpeedY",               "320",                    CVAR_ARCHIVE             },
 	{ &etj_maxSpeedDuration,        "etj_maxSpeedDuration",        "2000",                   CVAR_ARCHIVE             },
+	{ &etj_speedColorUsesAccel,     "etj_speedColorUsesAccel",     "0",                      CVAR_ARCHIVE             },
 
 	{ &cg_popupTime,                "etj_popupTime",               "1000",                   CVAR_ARCHIVE             },
 	{ &cg_popupStayTime,            "etj_popupStayTime",           "2000",                   CVAR_ARCHIVE             },

--- a/src/cgame/etj_speed_drawable.h
+++ b/src/cgame/etj_speed_drawable.h
@@ -2,11 +2,19 @@
 #include "etj_irenderable.h"
 #include "cg_local.h"
 #include <string>
+#include <list>
 
 namespace ETJump
 {
 	class DisplaySpeed : public IRenderable
 	{
+		struct StoredSpeed
+		{
+			int time;
+			float speed;
+		};
+
+		std::list<StoredSpeed> _storedSpeeds;
 		float _maxSpeed{ 0 };
 		vec4_t _color;
 		bool _shouldDrawShadow{ false };
@@ -16,6 +24,8 @@ namespace ETJump
 		void startListeners();
 		std::string getStatus() const;
 		bool canSkipDraw() const;
+		void popOldStoredSpeeds();
+		float calcAvgAccel() const;
 	public:
 		DisplaySpeed();
 		~DisplaySpeed();


### PR DESCRIPTION
Here's the pull request for the acceleration based speed2 color that I talked to Aciz about yesterday. 

The idea simply is that if you enable the setting `etj_speedColorUsesAccel`, `etj_drawSpeed2`'s color will be white when there is no acceleration and it gradually changes to green or red based on how much your speed has increased or decreased respectively.

I haven't done extensive testing with it, I've only jumped a few gammas to make sure it's working.