### PR TITLE
fix broken callvote map partial matching when there is a single match

### DIFF
--- a/src/game/g_vote.cpp
+++ b/src/game/g_vote.cpp
@@ -331,6 +331,10 @@ namespace ETJump
 			}
 			resultedMap += "\n";
 			return false;
+		} 
+		else if (resultedMap.empty()) 
+		{
+			resultedMap = matchedMaps[0];
 		}
 
 		if (resultedMap == level.rawmapname)


### PR DESCRIPTION
Partial matching on single match wasn't working at all.

closes #485 