### PR TITLE
fix static panel buttons were not reinitialized on module reload

### DIFF
--- a/src/cgame/cg_debriefing.cpp
+++ b/src/cgame/cg_debriefing.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
+#include <vector>
 
 #include "cg_local.h"
+#include "etj_utilities.h"
 
 team_t CG_Debriefing_FindWinningTeam(void);
 team_t CG_Debriefing_FindOveralWinningTeam(void);
@@ -747,6 +749,7 @@ panel_button_t *debriefPanelButtons[] =
 	NULL
 };
 
+std::vector<panel_button_t> debriefPanelButtonsLayout;
 
 panel_button_t teamDebriefOutcome =
 {
@@ -1047,11 +1050,7 @@ panel_button_t *teamDebriefPanelButtons[] =
 	NULL
 };
 
-
-
-
-
-
+std::vector<panel_button_t> teamDebriefPanelButtonsLayout;
 
 
 
@@ -1325,11 +1324,35 @@ panel_button_t *chatPanelButtons[] =
 	NULL
 };
 
+std::vector<panel_button_t> chatPanelButtonsLayout;
+
+void CG_DebriefingPanel_Setup(std::vector<panel_button_t> &layout, panel_button_t **buttons)
+{
+	panel_button_t *button;
+	for (; *buttons; buttons++)
+	{
+		button = (*buttons);
+		if (button) 
+		{
+			layout.push_back(*button);
+		}
+	}
+}
+
 void CG_ChatPanel_Setup(void)
 {
-	BG_PanelButtonsSetup(chatPanelButtons);
-	BG_PanelButtonsSetup(teamDebriefPanelButtons);
-	BG_PanelButtonsSetup(debriefPanelButtons);
+	debriefPanelButtonsLayout.reserve(ETJump::nelem(debriefPanelButtons) * sizeof(panel_button_t));
+	debriefPanelButtonsLayout.clear();
+	chatPanelButtonsLayout.clear();
+	teamDebriefPanelButtonsLayout.clear();
+
+	CG_DebriefingPanel_Setup(debriefPanelButtonsLayout, debriefPanelButtons);
+	CG_DebriefingPanel_Setup(chatPanelButtonsLayout, chatPanelButtons);
+	CG_DebriefingPanel_Setup(teamDebriefPanelButtonsLayout, teamDebriefPanelButtons);
+
+	BG_PanelButtonsSetupWide(chatPanelButtonsLayout);
+	BG_PanelButtonsSetupWide(teamDebriefPanelButtonsLayout);
+	BG_PanelButtonsSetupWide(debriefPanelButtonsLayout);
 }
 
 void CG_Debriefing_Startup(void)
@@ -1431,8 +1454,8 @@ qboolean CG_Debriefing_Draw(void)
 	switch (cgs.dbMode)
 	{
 	case 1:
-		BG_PanelButtonsRender(teamDebriefPanelButtons);
-		BG_PanelButtonsRender(chatPanelButtons);
+		BG_PanelButtonsRender(teamDebriefPanelButtonsLayout);
+		BG_PanelButtonsRender(chatPanelButtonsLayout);
 
 		CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
 
@@ -1440,7 +1463,7 @@ qboolean CG_Debriefing_Draw(void)
 	case 0:
 		CG_DrawScoreboard();
 
-		BG_PanelButtonsRender(chatPanelButtons);
+		BG_PanelButtonsRender(chatPanelButtonsLayout);
 
 		CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
 		break;
@@ -1452,9 +1475,9 @@ qboolean CG_Debriefing_Draw(void)
 
 		qsort(cgs.dbSortedClients, MAX_CLIENTS, sizeof(int), CG_SortPlayersByXP);
 
-		BG_PanelButtonsRender(debriefPanelButtons);
+		BG_PanelButtonsRender(debriefPanelButtonsLayout);
 
-		BG_PanelButtonsRender(chatPanelButtons);
+		BG_PanelButtonsRender(chatPanelButtonsLayout);
 
 		CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
 		break;
@@ -2071,7 +2094,7 @@ void CG_Debriefing_KeyEvent(int key, qboolean down)
 	switch (cgs.dbMode)
 	{
 	case 1:
-		if (BG_PanelButtonsKeyEvent(key, down, teamDebriefPanelButtons))
+		if (BG_PanelButtonsKeyEvent(key, down, teamDebriefPanelButtonsLayout))
 		{
 			return;
 		}
@@ -2079,14 +2102,14 @@ void CG_Debriefing_KeyEvent(int key, qboolean down)
 	case 0:
 		break;
 	case 2:
-		if (BG_PanelButtonsKeyEvent(key, down, debriefPanelButtons))
+		if (BG_PanelButtonsKeyEvent(key, down, debriefPanelButtonsLayout))
 		{
 			return;
 		}
 		break;
 	}
 
-	if (BG_PanelButtonsKeyEvent(key, down, chatPanelButtons))
+	if (BG_PanelButtonsKeyEvent(key, down, chatPanelButtonsLayout))
 	{
 		return;
 	}

--- a/src/cgame/cg_fireteams.cpp
+++ b/src/cgame/cg_fireteams.cpp
@@ -1,3 +1,4 @@
+#include <vector>
 
 #include "cg_local.h"
 
@@ -91,6 +92,8 @@ panel_button_t *fireteamButtons[] =
 
 	NULL
 };
+
+std::vector<panel_button_t> fireteamButtonsLayout;
 
 const char *ftMenuRootStrings[] =
 {
@@ -910,7 +913,17 @@ void CG_Fireteams_MenuText_Draw(panel_button_t *button)
 
 void CG_Fireteams_Setup(void)
 {
-	BG_PanelButtonsSetup(fireteamButtons);
+	fireteamButtonsLayout.clear();
+
+	for (auto btnptr : fireteamButtons)
+	{
+		if (btnptr) 
+		{
+			fireteamButtonsLayout.push_back(*btnptr);
+		}
+	}
+
+	BG_PanelButtonsSetup(fireteamButtonsLayout);
 }
 
 void CG_Fireteams_KeyHandling(int key, qboolean down)
@@ -923,7 +936,7 @@ void CG_Fireteams_KeyHandling(int key, qboolean down)
 
 void CG_Fireteams_Draw(void)
 {
-	BG_PanelButtonsRender(fireteamButtons);
+	BG_PanelButtonsRender(fireteamButtonsLayout);
 }
 
 void CG_QuickFireteamMessage_f(void);

--- a/src/cgame/cg_limbopanel.cpp
+++ b/src/cgame/cg_limbopanel.cpp
@@ -1,4 +1,7 @@
+#include <vector>
+
 #include "cg_local.h"
+#include "etj_utilities.h"
 
 #define SOUNDEVENT(sound) trap_S_StartLocalSound(sound, CHAN_LOCAL_SOUND)
 
@@ -1017,6 +1020,8 @@ panel_button_t *limboPanelButtons[] =
 
 	NULL,
 };
+
+std::vector<panel_button_t> limboPanelButtonsLayout;
 
 qboolean CG_LimboPanel_BriefingButton_KeyDown(panel_button_t *button, int key)
 {
@@ -2685,7 +2690,6 @@ void CG_LimboPanel_RenderCounter(panel_button_t *button)
 void CG_LimboPanel_Setup(void)
 {
 	panel_button_t   *button;
-	panel_button_t   **buttons = limboPanelButtons;
 	clientInfo_t     *ci       = &cgs.clientinfo[cg.clientNum];
 	bg_playerclass_t *classinfo;
 	int              i;
@@ -2706,9 +2710,9 @@ void CG_LimboPanel_Setup(void)
 		cgs.ccSelectedLayer = CG_CurLayerForZ((int)cg.predictedPlayerEntity.lerpOrigin[2]);
 	}
 
-	for ( ; *buttons; buttons++)
+	for (auto &buttonRef : limboPanelButtonsLayout)
 	{
-		button = (*buttons);
+		button = &buttonRef;
 
 		if (button->onDraw == CG_LimboPanel_RenderCounter)
 		{
@@ -2777,7 +2781,18 @@ void CG_LimboPanel_Setup(void)
 
 void CG_LimboPanel_Init(void)
 {
-	BG_PanelButtonsSetup(limboPanelButtons);
+	limboPanelButtonsLayout.reserve(ETJump::nelem(limboPanelButtons) * sizeof(panel_button_t));
+	limboPanelButtonsLayout.clear();
+
+	for (auto panelBtnPtr : limboPanelButtons)
+	{
+		if (panelBtnPtr) 
+		{
+			limboPanelButtonsLayout.push_back(*panelBtnPtr);
+		}
+	}
+
+	BG_PanelButtonsSetupWide(limboPanelButtonsLayout);
 }
 
 qboolean CG_LimboPanel_Draw(void)
@@ -2786,7 +2801,7 @@ qboolean CG_LimboPanel_Draw(void)
 	panel_button_t        *hilight;
 //	panel_button_t** buttons = limboPanelButtons;
 
-	hilight = BG_PanelButtonsGetHighlightButton(limboPanelButtons);
+	hilight = BG_PanelButtonsGetHighlightButton(limboPanelButtonsLayout);
 	if (hilight && hilight != lastHighlight)
 	{
 		lastHighlight = hilight;
@@ -2804,7 +2819,7 @@ qboolean CG_LimboPanel_Draw(void)
 	CG_FillRect(0, 0, SCREEN_OFFSET_X, 480, sideColor);
 	CG_FillRect(SCREEN_OFFSET_X + 640, 0, SCREEN_OFFSET_X, 480, sideColor);
 
-	BG_PanelButtonsRender(limboPanelButtons);
+	BG_PanelButtonsRender(limboPanelButtonsLayout);
 
 	trap_R_SetColor(NULL);
 	CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
@@ -2839,7 +2854,7 @@ qboolean CG_LimboPanel_Draw(void)
 void CG_LimboPanel_KeyHandling(int key, qboolean down)
 {
 	int b1, b2;
-	if (BG_PanelButtonsKeyEvent(key, down, limboPanelButtons))
+	if (BG_PanelButtonsKeyEvent(key, down, limboPanelButtonsLayout))
 	{
 		return;
 	}

--- a/src/cgame/cg_loadpanel.cpp
+++ b/src/cgame/cg_loadpanel.cpp
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "cg_local.h"
 #include "../ui/ui_shared.h"
 
@@ -209,6 +211,8 @@ panel_button_t *loadpanelButtons[] =
 	NULL,
 };
 
+std::vector<panel_button_t> loadpanelButtonsLayout;
+
 /*
 ================
 CG_DrawConnectScreen
@@ -280,7 +284,17 @@ void CG_DrawConnectScreen(qboolean interactive, qboolean forcerefresh)
 
 		bg_mappic = 0;
 
-		BG_PanelButtonsSetup(loadpanelButtons);
+		loadpanelButtonsLayout.clear();
+
+		for (auto panelBtnPtr : loadpanelButtons)
+		{
+			if (panelBtnPtr) 
+			{
+				loadpanelButtonsLayout.push_back(*panelBtnPtr);
+			}
+		}
+
+		BG_PanelButtonsSetupWide(loadpanelButtonsLayout);
 
 		bg_loadscreeninited = qtrue;
 	}
@@ -289,7 +303,7 @@ void CG_DrawConnectScreen(qboolean interactive, qboolean forcerefresh)
 	vec4_t sideColor = { 0.145f, 0.172f, 0.145f, 1.f };
 	DC->fillRect(0, 0, SCREEN_WIDTH, 480, sideColor);
 
-	BG_PanelButtonsRender(loadpanelButtons);
+	BG_PanelButtonsRender(loadpanelButtonsLayout);
 
 	if (interactive)
 	{
@@ -544,7 +558,7 @@ void CG_LoadPanel_RenderMissionDescriptionText(panel_button_t *button)
 
 void CG_LoadPanel_KeyHandling(int key, qboolean down)
 {
-	if (BG_PanelButtonsKeyEvent(key, down, loadpanelButtons))
+	if (BG_PanelButtonsKeyEvent(key, down, loadpanelButtonsLayout))
 	{
 		return;
 	}

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3983,5 +3983,7 @@ namespace ETJump
 qboolean CG_ConsoleCommandExt(const char *cmd);
 void CG_DrawActiveFrameExt();
 
+extern displayContextDef_t *DC;
+
 #endif // CG_LOCAL_H
 

--- a/src/cgame/cg_sound.cpp
+++ b/src/cgame/cg_sound.cpp
@@ -1,4 +1,5 @@
 // Ridah, cg_sound.c - parsing and use of sound script files
+#include <vector>
 
 #include "cg_local.h"
 
@@ -1060,6 +1061,7 @@ static panel_button_t *speakerInfoButtons[] =
 	NULL
 };
 
+std::vector<panel_button_t> speakerInfoButtonsLayout;
 
 void CG_SpeakerEditor_RenderEdit(panel_button_t *button)
 {
@@ -2001,6 +2003,8 @@ static panel_button_t *speakerEditorButtons[] =
 	NULL
 };
 
+std::vector<panel_button_t> speakerEditorButtonsLayout;
+
 void CG_SpeakerEditorDraw(void)
 {
 	if (!cg.editingSpeakers)
@@ -2091,14 +2095,14 @@ void CG_SpeakerEditorDraw(void)
 		if (editSpeaker)
 		{
 			// render interface
-			BG_PanelButtonsRender(speakerInfoButtons);
+			BG_PanelButtonsRender(speakerInfoButtonsLayout);
 		}
 
 	}
 	else
 	{
 		// render interface
-		BG_PanelButtonsRender(speakerEditorButtons);
+		BG_PanelButtonsRender(speakerEditorButtonsLayout);
 
 		// render cursor
 		trap_R_SetColor(NULL);
@@ -2108,7 +2112,7 @@ void CG_SpeakerEditorDraw(void)
 
 void CG_SpeakerEditor_KeyHandling(int key, qboolean down)
 {
-	if (!BG_PanelButtonsKeyEvent(key, down, speakerEditorButtons))
+	if (!BG_PanelButtonsKeyEvent(key, down, speakerEditorButtonsLayout))
 	{
 		switch (key)
 		{
@@ -2237,8 +2241,27 @@ void CG_ActivateEditSoundMode(void)
 		speakerShader          = trap_R_RegisterShader("gfx/misc/speaker");
 		speakerShaderGrayScale = trap_R_RegisterShader("gfx/misc/speaker_gs");
 
-		BG_PanelButtonsSetup(speakerInfoButtons);
-		BG_PanelButtonsSetup(speakerEditorButtons);
+		speakerInfoButtonsLayout.clear();
+		speakerEditorButtonsLayout.clear();
+
+		for (auto btnptr : speakerInfoButtons)
+		{
+			if (btnptr) 
+			{
+				speakerInfoButtonsLayout.push_back(*btnptr);
+			}
+		}
+
+		for (auto btnptr : speakerEditorButtons)
+		{
+			if (btnptr) 
+			{
+				speakerEditorButtonsLayout.push_back(*btnptr);
+			}
+		}
+
+		BG_PanelButtonsSetup(speakerInfoButtonsLayout);
+		BG_PanelButtonsSetup(speakerEditorButtonsLayout);
 	}
 }
 

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -1,10 +1,11 @@
-#include "etj_utilities.h"
 #include <regex>
 #include <unordered_map>
 #include <sstream>
-#include <boost/algorithm/string.hpp>
-#include "etj_event_loop.h"
 #include <memory>
+#include <boost/algorithm/string.hpp>
+
+#include "etj_utilities.h"
+#include "etj_event_loop.h"
 
 namespace ETJump
 {

--- a/src/cgame/etj_utilities.h
+++ b/src/cgame/etj_utilities.h
@@ -1,14 +1,8 @@
 #pragma once
 #include <string>
-#include "../game/q_shared.h"
 #include <functional>
 
-#ifdef min
-#undef min
-#endif
-#ifdef max
-#undef max
-#endif
+#include "../game/q_shared.h"
 
 namespace ETJump
 {
@@ -18,6 +12,12 @@ namespace ETJump
 	std::string composeShader(const char *name, ShaderStages stages);
 	void parseColorString(const std::string &colorString, vec4_t &color);
 
+	template<typename T, std::size_t N>
+	constexpr std::size_t nelem(T(&)[N]) 
+	{ 
+		return N;
+	}
+	
 #ifdef CGAMEDLL
 
 	int setTimeout(std::function<void()> fun, int delay);

--- a/src/ui/ui_loadpanel.cpp
+++ b/src/ui/ui_loadpanel.cpp
@@ -1,5 +1,11 @@
+#include <vector>
+
 #include "ui_local.h"
 #include "ui_shared.h"
+
+#include "../cgame/etj_utilities.h"
+
+extern displayContextDef_t *DC;
 
 qboolean   bg_loadscreeninited = qfalse;
 fontInfo_t bg_loadscreenfont1;
@@ -131,6 +137,8 @@ panel_button_t *loadpanelButtons[] =
 	NULL,
 };
 
+std::vector<panel_button_t> loadpanelButtonsLayout;
+
 /*
 ================
 CG_DrawConnectScreen
@@ -159,7 +167,17 @@ void UI_DrawLoadPanel(qboolean forcerefresh, qboolean ownerdraw, qboolean uihack
 		trap_R_RegisterFont("ariblk", 27, &bg_loadscreenfont1);
 		trap_R_RegisterFont("courbd", 30, &bg_loadscreenfont2);
 
-		BG_PanelButtonsSetup(loadpanelButtons);
+		loadpanelButtonsLayout.clear();
+
+		for (auto panelBtnPtr : loadpanelButtons)
+		{
+			if (panelBtnPtr) 
+			{
+				loadpanelButtonsLayout.push_back(*panelBtnPtr);
+			}
+		}
+
+		BG_PanelButtonsSetupWide(loadpanelButtonsLayout);
 
 		bg_loadscreeninited = qtrue;
 	}
@@ -169,7 +187,7 @@ void UI_DrawLoadPanel(qboolean forcerefresh, qboolean ownerdraw, qboolean uihack
 	uiInfo.uiDC.fillRect(0, 0, SCREEN_OFFSET_X, 480, sideColor);
 	uiInfo.uiDC.fillRect(SCREEN_OFFSET_X + 640, 0, SCREEN_OFFSET_X, 480, sideColor);
 
-	BG_PanelButtonsRender(loadpanelButtons);
+	BG_PanelButtonsRender(loadpanelButtonsLayout);
 
 	if (forcerefresh)
 	{

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -1,6 +1,8 @@
 //
 // string allocation/managment
 
+#include <vector>
+
 #include "ui_shared.h"
 #include "ui_local.h"   // For CS settings/retrieval
 
@@ -9627,15 +9629,15 @@ qboolean BG_PanelButton_EditClick(panel_button_t *button, int key)
 	return qtrue;
 }
 
-qboolean BG_PanelButtonsKeyEvent(int key, qboolean down, panel_button_t **buttons)
+qboolean BG_PanelButtonsKeyEvent(int key, qboolean down, std::vector<panel_button_t> &buttons)
 {
 	panel_button_t *button;
 
 	if (BG_PanelButtons_GetFocusButton())
 	{
-		for ( ; *buttons; buttons++)
+		for (auto &buttonRef : buttons)
 		{
-			button = (*buttons);
+			button = &buttonRef;
 
 			if (button == BG_PanelButtons_GetFocusButton())
 			{
@@ -9673,9 +9675,9 @@ qboolean BG_PanelButtonsKeyEvent(int key, qboolean down, panel_button_t **button
 
 	if (down)
 	{
-		for ( ; *buttons; buttons++)
+		for (auto &buttonRef : buttons)
 		{
-			button = (*buttons);
+			button = &buttonRef;
 
 			if (button->onKeyDown)
 			{
@@ -9691,9 +9693,9 @@ qboolean BG_PanelButtonsKeyEvent(int key, qboolean down, panel_button_t **button
 	}
 	else
 	{
-		for ( ; *buttons; buttons++)
+		for (auto &buttonRef : buttons)
 		{
-			button = (*buttons);
+			button = &buttonRef;
 
 			if (button->onKeyUp && BG_CursorInRect(&button->rect))
 			{
@@ -9708,50 +9710,49 @@ qboolean BG_PanelButtonsKeyEvent(int key, qboolean down, panel_button_t **button
 	return qfalse;
 }
 
-void BG_PanelButtonsSetup(panel_button_t **buttons)
+void BG_PanelButtonsSetup(std::vector<panel_button_t> &buttons)
 {
-	panel_button_t *button;
-
-	for ( ; *buttons; buttons++)
+	for (auto &button : buttons)
 	{
-		button = (*buttons);
-		button->rect.x += SCREEN_OFFSET_X;
-
-		if (button->shaderNormal)
+		if (button.shaderNormal)
 		{
-			button->hShaderNormal = trap_R_RegisterShaderNoMip(button->shaderNormal);
+			button.hShaderNormal = trap_R_RegisterShaderNoMip(button.shaderNormal);
 		}
 	}
 }
 
-panel_button_t *BG_PanelButtonsGetHighlightButton(panel_button_t **buttons)
+void BG_PanelButtonsSetupWide(std::vector<panel_button_t> &buttons)
 {
-	panel_button_t *button;
-
-	for ( ; *buttons; buttons++)
+	for (auto &button : buttons)
 	{
-		button = (*buttons);
-
-		if (button->onKeyDown && BG_CursorInRect(&button->rect))
+		button.rect.x += SCREEN_OFFSET_X;
+		if (button.shaderNormal)
 		{
-			return button;
+			button.hShaderNormal = trap_R_RegisterShaderNoMip(button.shaderNormal);
+		}
+	}
+}
+
+panel_button_t *BG_PanelButtonsGetHighlightButton(std::vector<panel_button_t> &buttons)
+{
+	for (auto &button : buttons)
+	{
+		if (button.onKeyDown && BG_CursorInRect(&button.rect))
+		{
+			return &button;
 		}
 	}
 
 	return NULL;
 }
 
-void BG_PanelButtonsRender(panel_button_t **buttons)
+void BG_PanelButtonsRender(std::vector<panel_button_t> &buttons)
 {
-	panel_button_t *button;
-
-	for ( ; *buttons; buttons++)
+	for (auto &button : buttons)
 	{
-		button = (*buttons);
-
-		if (button->onDraw)
+		if (button.onDraw)
 		{
-			button->onDraw(button);
+			button.onDraw(&button);
 		}
 	}
 }

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -1,6 +1,7 @@
 #ifndef __UI_SHARED_H
 #define __UI_SHARED_H
 
+#include <vector>
 
 #include "../game/q_shared.h"
 #include "../cgame/tr_types.h"
@@ -620,13 +621,14 @@ struct panel_button_s
 
 void BG_PanelButton_RenderEdit(panel_button_t *button);
 qboolean BG_PanelButton_EditClick(panel_button_t *button, int key);
-qboolean BG_PanelButtonsKeyEvent(int key, qboolean down, panel_button_t **buttons);
-void BG_PanelButtonsSetup(panel_button_t **buttons);
-void BG_PanelButtonsRender(panel_button_t **buttons);
+qboolean BG_PanelButtonsKeyEvent(int key, qboolean down, std::vector<panel_button_t> &buttons);
+void BG_PanelButtonsSetup(std::vector<panel_button_t> &buttons);
+void BG_PanelButtonsSetupWide(std::vector<panel_button_t> &buttons);
+void BG_PanelButtonsRender(std::vector<panel_button_t> &buttons);
 void BG_PanelButtonsRender_Text(panel_button_t *button);
 void BG_PanelButtonsRender_TextExt(panel_button_t *button, const char *text);
 void BG_PanelButtonsRender_Img(panel_button_t *button);
-panel_button_t *BG_PanelButtonsGetHighlightButton(panel_button_t **buttons);
+panel_button_t *BG_PanelButtonsGetHighlightButton(std::vector<panel_button_t> &buttons);
 void BG_PanelButtons_SetFocusButton(panel_button_t *button);
 panel_button_t *BG_PanelButtons_GetFocusButton(void);
 
@@ -637,8 +639,6 @@ void BG_FitTextToWidth_Ext(char *instr, float scale, float w, int size, fontInfo
 
 void AdjustFrom640(float *x, float *y, float *w, float *h);
 void SetupRotatedThing(polyVert_t *verts, vec2_t org, float w, float h, vec_t angle);
-
-extern displayContextDef_t *DC;
 
 #define SCREEN_WIDTH         DC->screenWidth
 #define SCREEN_HEIGHT        DC->screenHeight


### PR DESCRIPTION
This fixes annoying widescreen bug, where certain UI elements were drawn
with accumulated offset.

closes #438