### PR TITLE
add cvar to always get an overbounce

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -3569,6 +3569,10 @@ static qboolean CG_IsOverBounce(float vel, float initHeight,
                                 float finalHeight, float rintv,
                                 float psec, int gravity)
 {
+	if (etj_forceOb.integer != 0) {
+		return qtrue;
+	}
+
 	float a, b, c;
 	float n1;
 	//float			n2;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2497,6 +2497,7 @@ extern vmCvar_t etj_fireteamAlpha;
 extern vmCvar_t etj_logBanner;
 extern vmCvar_t cg_weaponSound;
 
+extern vmCvar_t etj_forceOb;
 extern vmCvar_t cg_noclipScale;
 extern vmCvar_t cg_drawSlick;
 extern vmCvar_t cg_slickX;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -448,6 +448,7 @@ vmCvar_t etj_fireteamAlpha;
 vmCvar_t etj_logBanner;
 vmCvar_t cg_weaponSound;
 vmCvar_t cg_noclipScale;
+vmCvar_t etj_forceOb;
 
 vmCvar_t cg_drawSlick;
 vmCvar_t cg_slickX;
@@ -957,6 +958,7 @@ cvarTable_t cvarTable[] =
 	{ &etj_ad_stopDelay, "etj_ad_stopDelay", "2000", CVAR_ARCHIVE },
 	{ &etj_ad_targetPath, "etj_ad_targetPath", "autodemo", CVAR_ARCHIVE },
 	{ &etj_chatScale, "etj_chatScale", "1.0", CVAR_ARCHIVE },
+	{ &etj_forceOb, "etj_forceOb", "0", CVAR_ARCHIVE },
 };
 
 
@@ -1105,7 +1107,7 @@ void CG_UpdateCvars(void)
 					cv->vmCvar == &cg_hideMe || cv->vmCvar == &cg_noclipScale ||
 					cv->vmCvar == &etj_enableTimeruns || cv->vmCvar == &etj_noActivateLean ||
 					cv->vmCvar == &etj_touchPickupWeapons || cv->vmCvar == &etj_autoLoad ||
-					cv->vmCvar == &etj_quickFollow
+					cv->vmCvar == &etj_quickFollow || cv->vmCvar == &etj_forceOb
 				    )
 				{
 					fSetFlags = qtrue;
@@ -1164,7 +1166,7 @@ void CG_setClientFlags(void)
 	}
 
 	cg.pmext.bAutoReload = (cg_autoReload.integer > 0) ? qtrue : qfalse;
-	trap_Cvar_Set("cg_uinfo", va("%d %d %d %d %f %d",
+	trap_Cvar_Set("cg_uinfo", va("%d %d %d %d %f %d %d",
 	                             // Client Flags
 	                             (
 	                                 ((cg_autoReload.integer > 0) ? CGF_AUTORELOAD : 0) |
@@ -1191,7 +1193,8 @@ void CG_setClientFlags(void)
 	                             int_cl_maxpackets.integer,
 	                             com_maxfps.integer,
 	                             cg_noclipScale.value,
-	                             etj_touchPickupWeapons.integer
+	                             etj_touchPickupWeapons.integer,
+								 etj_forceOb.integer
 	                             ));
 
 }

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -958,7 +958,7 @@ cvarTable_t cvarTable[] =
 	{ &etj_ad_stopDelay, "etj_ad_stopDelay", "2000", CVAR_ARCHIVE },
 	{ &etj_ad_targetPath, "etj_ad_targetPath", "autodemo", CVAR_ARCHIVE },
 	{ &etj_chatScale, "etj_chatScale", "1.0", CVAR_ARCHIVE },
-	{ &etj_forceOb, "etj_forceOb", "0", CVAR_ARCHIVE },
+	{ &etj_forceOb, "etj_forceOb", "0", CVAR_CHEAT },
 };
 
 

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -1088,6 +1088,8 @@ void CG_PredictPlayerState(void)
 		cg.pmext.noclipScale = cg_noclipScale.value;
 	}
 
+	cg.pmext.forceObEnabled = etj_forceOb.integer != 0;
+
 	memcpy(&oldpmext[current & CMD_MASK], &cg.pmext, sizeof(pmoveExt_t));
 
 	// if we don't have the commands right after the snapshot, we

--- a/src/cgame/etj_overbounce_watcher.cpp
+++ b/src/cgame/etj_overbounce_watcher.cpp
@@ -172,6 +172,10 @@ bool ETJump::OverbounceWatcher::isOverbounce(float vel, float currentHeight,
                                              float finalHeight, float rintv,
                                              float psec, int gravity)
 {
+	if (etj_forceOb.integer != 0) {
+		return qtrue;
+	}
+
 	float a, b, c;
 	float n1;
 	float hn;
@@ -199,12 +203,8 @@ bool ETJump::OverbounceWatcher::isOverbounce(float vel, float currentHeight,
 
 bool ETJump::OverbounceWatcher::surfaceAllowsOverbounce(trace_t* trace)
 {
-	if (cg_pmove.shared & BG_LEVEL_NO_OVERBOUNCE)
-	{
-		return ((trace->surfaceFlags & SURF_OVERBOUNCE) != 0);
-	}
-	else
-	{
-		return !((trace->surfaceFlags & SURF_OVERBOUNCE) != 0);
-	}
+	auto worldspawnKey = (cg_pmove.shared & BG_LEVEL_NO_OVERBOUNCE) != 0;
+	auto surfaceParm = (trace->surfaceFlags & SURF_OVERBOUNCE) != 0;
+
+	return worldspawnKey == surfaceParm;
 }

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -1803,10 +1803,11 @@ static void PM_WalkMove(void)
 
 	// With a real overbounce, PM_WalkMove is called while client still has their Z speed.
 	// Simulate this by using cached Z velocity.
-	if (pm->pmext->forceObZVelocity != 0) {
+	if (pm->pmext->forceObEnabled && pm->pmext->forceObZVelocity != 0) {
 		pm->ps->velocity[2] += pm->pmext->forceObZVelocity;
-		pm->pmext->forceObZVelocity = 0;
 	}
+	
+	pm->pmext->forceObZVelocity = 0;
 
 	vel = VectorLength(pm->ps->velocity);
 

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -552,6 +552,9 @@ typedef struct
 	qboolean releasedFire;
 	float noclipScale;
 	bool isJumpLand;
+
+	bool forceObEnabled;
+	float forceObZVelocity;
 } pmoveExt_t;   // data used both in client and server - store it here
                 // instead of playerstate to prevent different engine versions of playerstate between XP and MP
 

--- a/src/game/etj_save_system.cpp
+++ b/src/game/etj_save_system.cpp
@@ -725,6 +725,7 @@ void ETJump::SaveSystem::teleportPlayer(gentity_t* ent, SavePosition* pos)
 	}
 
 	client->ps.pm_time = 1; // Crashland + instant load bug fix.
+	client->pmext.forceObZVelocity = 0;
 }
 
 ETJump::SaveSystem::SaveSystem(const std::shared_ptr<Session> session) :

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1270,6 +1270,8 @@ void ClientThink_real(gentity_t *ent)
 		client->pmext.noclipScale = client->pers.noclipScale;
 	}
 
+	client->pmext.forceObEnabled = client->pers.forceOverbounce;
+
 	if (client->speedScale)                 // Goalitem speed scale
 	{
 		client->ps.speed *= (client->speedScale * 0.01);

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -1665,13 +1665,14 @@ void ClientUserinfoChanged(int clientNum)
 	// TODO: Check for hardware info spoofing
 
 	s = Info_ValueForKey(userinfo, "cg_uinfo");
-	sscanf(s, "%i %i %i %i %f %i",
+	sscanf(s, "%i %i %i %i %f %i %i",
 	       &client->pers.clientFlags,
 	       &client->pers.clientTimeNudge,
 	       &client->pers.clientMaxPackets,
 	       &client->pers.maxFPS,
 	       &client->pers.noclipScale,
-	       &client->pers.touchPickupWeapons);
+	       &client->pers.touchPickupWeapons,
+		   &client->pers.forceOverbounce);
 
 	client->pers.autoActivate      = (client->pers.clientFlags & CGF_AUTOACTIVATE) ? PICKUP_TOUCH : PICKUP_ACTIVATE;
 	client->pers.predictItemPickup = ((client->pers.clientFlags & CGF_PREDICTITEMS) != 0) ? qtrue : qfalse;

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -903,6 +903,7 @@ typedef struct
 
 	int hideMe;
 	float noclipScale;
+	bool forceOverbounce;
 
 	qboolean enableTimeruns;
 

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -113,6 +113,8 @@ void TeleportPlayer(gentity_t *player, vec3_t origin, vec3_t angles)
 	VectorCopy(origin, player->client->ps.origin);
 	player->client->ps.origin[2] += 1;
 
+	player->client->pmext.forceObZVelocity = 0;
+
 	// spit the player out
 /*	AngleVectors( angles, player->client->ps.velocity, NULL, NULL );
     VectorScale( player->client->ps.velocity, 400, player->client->ps.velocity );


### PR DESCRIPTION
- add cheat protected toggle cvar `etj_forceOb`
- add forced OB handling for DrawOB and OBwatcher
- clean up some checks for combined worldspawn/surfaceparm settings (`nooverbounce` and `nofalldamage`)