### PR TITLE
Add snaphud

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,6 +95,7 @@ file(GLOB CGAME_SRC
 	"cgame/etj_overbounce_watcher.cpp"
 	"cgame/etj_player_events_handler.cpp"
 	"cgame/etj_quick_follow_drawable.cpp"
+	"cgame/etj_snaphud.cpp"
 	"cgame/etj_speed_drawable.cpp"
 	"cgame/etj_trickjump_lines.cpp"
 	"cgame/etj_utilities.cpp"

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -5719,6 +5719,7 @@ static void CG_Draw2D(void)
 			CG_DrawNewCompass();
 			CG_DrawFollow();
 			ETJump::DrawCGazHUD();
+			ETJump::DrawSnapHUD();
 			CG_DrawOB();
 			CG_DrawSlick();
 			CG_DrawJumpDelay();

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -76,6 +76,25 @@ void CG_FillRectGradient(float x, float y, float width, float height, const floa
 	trap_R_SetColor(NULL);
 }
 
+/*
+==============
+CG_FillAngleYaw
+==============
+*/
+void CG_FillAngleYaw(float start, float end, float viewangle, float y, float height, const float* color)
+{
+	float x, width, fovscale;
+
+	fovscale = tan(DEG2RAD(cg.refdef.fov_x / 2));
+	x = SCREEN_WIDTH / 2 + tan(DEG2RAD(viewangle + start)) / fovscale * SCREEN_WIDTH / 2;
+	width = fabs(SCREEN_WIDTH * (tan(DEG2RAD(viewangle + end)) - tan(DEG2RAD(viewangle + start))) / (fovscale * 2)) + 1;
+
+	trap_R_SetColor(color);
+	CG_AdjustFrom640(&x, &y, &width, &height);
+	trap_R_DrawStretchPic(x, y, width, height, 0, 0, 0, 0, cgs.media.whiteShader);
+	trap_R_SetColor(NULL);
+}
+
 
 /*
 ==============

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2686,6 +2686,7 @@ void CG_Letterbox(float xsize, float ysize, qboolean center);
 //
 void CG_AdjustFrom640(float *x, float *y, float *w, float *h);
 void CG_FillRect(float x, float y, float width, float height, const float *color);
+void CG_FillAngleYaw(float start, float end, float viewangle, float y, float height, const float* color);
 void CG_HorizontalPercentBar(float x, float y, float width, float height, float percent);
 void CG_DrawPic(float x, float y, float width, float height, qhandle_t hShader);
 void CG_DrawPicST(float x, float y, float width, float height, float s0, float t0, float s1, float t1, qhandle_t hShader);

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2614,6 +2614,13 @@ extern vmCvar_t etj_ad_targetPath;
 
 extern vmCvar_t etj_chatScale;
 
+// Snaphud
+extern vmCvar_t etj_drawSnapHUD;
+extern vmCvar_t etj_snapHUDOffsetY;
+extern vmCvar_t etj_snapHUDHeight;
+extern vmCvar_t etj_snapHUDColor1;
+extern vmCvar_t etj_snapHUDColor2;
+
 //
 // cg_main.c
 //
@@ -3968,6 +3975,7 @@ namespace ETJump
 	void onPlayerRespawn(qboolean revived);
 	void runFrameEnd();
 	void DrawCGazHUD();
+	void DrawSnapHUD();
 
 	enum extraTraceOptions {
 		OB_DETECTOR,

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -567,6 +567,13 @@ vmCvar_t etj_ad_targetPath;
 
 vmCvar_t etj_chatScale;
 
+// Snaphud
+vmCvar_t etj_drawSnapHUD;
+vmCvar_t etj_snapHUDOffsetY;
+vmCvar_t etj_snapHUDHeight;
+vmCvar_t etj_snapHUDColor1;
+vmCvar_t etj_snapHUDColor2;
+
 typedef struct
 {
 	vmCvar_t *vmCvar;
@@ -959,6 +966,12 @@ cvarTable_t cvarTable[] =
 	{ &etj_ad_stopDelay, "etj_ad_stopDelay", "2000", CVAR_ARCHIVE },
 	{ &etj_ad_targetPath, "etj_ad_targetPath", "autodemo", CVAR_ARCHIVE },
 	{ &etj_chatScale, "etj_chatScale", "1.0", CVAR_ARCHIVE },
+	// Snaphud
+	{ &etj_drawSnapHUD, "etj_drawSnapHUD", "0", CVAR_ARCHIVE },
+	{ &etj_snapHUDOffsetY, "etj_snapHUDOffsetY", "0", CVAR_ARCHIVE },
+	{ &etj_snapHUDHeight, "etj_snapHUDHeight", "10", CVAR_ARCHIVE },
+	{ &etj_snapHUDColor1, "etj_snapHUDColor1", "0.02 0.1 0.02 0.4", CVAR_ARCHIVE },
+	{ &etj_snapHUDColor2, "etj_snapHUDColor2", "0.05 0.05 0.05 0.1", CVAR_ARCHIVE },
 };
 
 

--- a/src/cgame/cgame.vcxproj
+++ b/src/cgame/cgame.vcxproj
@@ -317,6 +317,7 @@
     <ClCompile Include="etj_overbounce_watcher.cpp" />
     <ClCompile Include="etj_player_events_handler.cpp" />
     <ClCompile Include="etj_quick_follow_drawable.cpp" />
+    <ClCompile Include="etj_snaphud.cpp" />
     <ClCompile Include="etj_speed_drawable.cpp" />
     <ClCompile Include="etj_timerun_view.cpp" />
     <ClCompile Include="etj_trickjump_lines.cpp" />
@@ -364,6 +365,7 @@
     <ClInclude Include="etj_player_events_handler.h" />
     <ClInclude Include="etj_quick_follow_drawable.h" />
     <ClInclude Include="etj_rotation_matrix.hpp" />
+    <ClInclude Include="etj_snaphud.h" />
     <ClInclude Include="etj_speed_drawable.h" />
     <ClInclude Include="etj_timerun_view.h" />
     <ClInclude Include="etj_trickjump_lines.hpp" />

--- a/src/cgame/cgame.vcxproj.filters
+++ b/src/cgame/cgame.vcxproj.filters
@@ -290,6 +290,9 @@
     <ClCompile Include="etj_cgaz.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="etj_snaphud.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\game\bg_classes.h">
@@ -434,6 +437,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="etj_cgaz.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="etj_snaphud.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -90,20 +90,6 @@ namespace ETJump
 		snapZones[snapCount] = snapZones[0] + 90;
 	}
 
-	void CG_FillAngleYaw(float start, float end, float viewangle, float y, float height, const float* color)
-	{
-		float x, width, fovscale;
-
-		fovscale = tan(DEG2RAD(cg.refdef.fov_x / 2));
-		x = SCREEN_WIDTH / 2 + tan(DEG2RAD(viewangle + start)) / fovscale * SCREEN_WIDTH / 2;
-		width = fabs(SCREEN_WIDTH * (tan(DEG2RAD(viewangle + end)) - tan(DEG2RAD(viewangle + start))) / (fovscale * 2)) + 1;
-
-		trap_R_SetColor(color);
-		CG_AdjustFrom640(&x, &y, &width, &height);
-		trap_R_DrawStretchPic(x, y, width, height, 0, 0, 0, 0, cgs.media.whiteShader);
-		trap_R_SetColor(NULL);
-	}
-
 	// FIXME: share this with cgaz
 	static float PM_CalcScale(playerState_t* ps)
 	{

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -5,6 +5,44 @@
 
 namespace ETJump
 {
+	constexpr int SNAPHUD_MAXZONES{ 128 };
+	float snapSpeed;
+	float snapZones[SNAPHUD_MAXZONES];
+	int snapCount;
+
+	static int QDECL sortSnapZones(const void* a, const void* b)
+	{
+		return *(float*)a - *(float*)b;
+	}
+
+	// FIXME: share this with cgaz
+	static float PM_CalcScale(playerState_t* ps)
+	{
+		// based on PM_CmdScale from bg_pmove.c
+		float scale = ps->stats[STAT_USERCMD_BUTTONS] & (BUTTON_SPRINT << 8) && cg.pmext.sprintTime > 50 ? ps->sprintSpeedScale : ps->runSpeedScale;
+		return scale;
+	}
+
+	static void UpdateSnapHUDSettings(float speed)
+	{
+		float step;
+
+		snapSpeed = speed;
+		speed /= 125;
+		snapCount = 0;
+
+		for (step = floor(speed + 0.5) - 0.5; step > 0 && snapCount < SNAPHUD_MAXZONES - 2; step--)
+		{
+			snapZones[snapCount] = RAD2DEG(acos(step / speed));
+			snapCount++;
+			snapZones[snapCount] = RAD2DEG(asin(step / speed));
+			snapCount++;
+		}
+
+		qsort(snapZones, snapCount, sizeof(snapZones[0]), sortSnapZones);
+		snapZones[snapCount] = snapZones[0] + 90;
+	}
+
 	void DrawSnapHUD(void)
 	{
 		float scale;
@@ -68,38 +106,5 @@ namespace ETJump
 			CG_FillAngleYaw(snapZones[i] + 90, snapZones[i + 1] + 90, yaw, y, h, color[colorID]);
 			colorID ^= 1;
 		}
-	}
-
-	void UpdateSnapHUDSettings(float speed)
-	{
-		float step;
-
-		snapSpeed = speed;
-		speed /= 125;
-		snapCount = 0;
-
-		for (step = floor(speed + 0.5) - 0.5; step > 0 && snapCount < SNAPHUD_MAXZONES - 2; step--)
-		{
-			snapZones[snapCount] = RAD2DEG(acos(step / speed));
-			snapCount++;
-			snapZones[snapCount] = RAD2DEG(asin(step / speed));
-			snapCount++;
-		}
-
-		qsort(snapZones, snapCount, sizeof(snapZones[0]), sortSnapZones);
-		snapZones[snapCount] = snapZones[0] + 90;
-	}
-
-	// FIXME: share this with cgaz
-	static float PM_CalcScale(playerState_t* ps)
-	{
-		// based on PM_CmdScale from bg_pmove.c
-		float scale = ps->stats[STAT_USERCMD_BUTTONS] & (BUTTON_SPRINT << 8) && cg.pmext.sprintTime > 50 ? ps->sprintSpeedScale : ps->runSpeedScale;
-		return scale;
-	}
-
-	static int QDECL sortSnapZones(const void* a, const void* b)
-	{
-		return *(float*)a - *(float*)b;
 	}
 }

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -33,7 +33,7 @@ namespace ETJump
 		scale = PM_CalcScale(ps);
 
 		// check whether snapSpeed needs to be updated
-		speed = ps->speed * scale;
+		speed = cg.snap->ps.speed * scale;
 		if (speed != snapSpeed)
 		{
 			UpdateSnapHUDSettings(speed);

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -1,0 +1,119 @@
+#include "etj_snaphud.h"
+#include "etj_utilities.h"
+
+// Snaphud implementation based on iodfe
+
+namespace ETJump
+{
+	void DrawSnapHUD(void)
+	{
+		float scale;
+		float speed;
+		float y, h;
+		float yaw;
+		vec4_t color[2];
+		int colorID = 0;
+		playerState_t* ps;
+		usercmd_t cmd;
+		int cmdNum;
+
+		ps = &cg.predictedPlayerState;
+
+		if (!etj_drawSnapHUD.integer)
+		{
+			return;
+		}
+
+		if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR)
+		{
+			return;
+		}
+
+		// get correct speed scaling
+		scale = PM_CalcScale(ps);
+
+		// check whether snapSpeed needs to be updated
+		speed = ps->speed * scale;
+		if (speed != snapSpeed)
+		{
+			UpdateSnapHUDSettings(speed);
+		}
+
+		// apply correct yaw offset for different strafe styles,
+		// or if no keys are pressed
+		yaw = cg.predictedPlayerState.viewangles[YAW];
+
+		cmdNum = trap_GetCurrentCmdNumber();
+		trap_GetUserCmd(cmdNum, &cmd);
+
+		if (cmd.forwardmove != 0 && cmd.rightmove != 0)
+		{
+			yaw += 45;
+		}
+		else if (cmd.forwardmove == 0 && cmd.rightmove == 0)
+		{
+			yaw += 45;
+		}
+
+		// draw snaphud
+		h = etj_snapHUDHeight.value;
+		y = 240 + etj_snapHUDOffsetY.value;
+
+		parseColorString(etj_snapHUDColor1.string, color[0]);
+		parseColorString(etj_snapHUDColor2.string, color[1]);
+
+		for (int i = 0; i < snapCount; i++)
+		{
+			CG_FillAngleYaw(snapZones[i], snapZones[i + 1], yaw, y, h, color[colorID]);
+			CG_FillAngleYaw(snapZones[i] + 90, snapZones[i + 1] + 90, yaw, y, h, color[colorID]);
+			colorID ^= 1;
+		}
+	}
+
+	void UpdateSnapHUDSettings(float speed)
+	{
+		float step;
+
+		snapSpeed = speed;
+		speed /= 125;
+		snapCount = 0;
+
+		for (step = floor(speed + 0.5) - 0.5; step > 0 && snapCount < SNAPHUD_MAXZONES - 2; step--)
+		{
+			snapZones[snapCount] = RAD2DEG(acos(step / speed));
+			snapCount++;
+			snapZones[snapCount] = RAD2DEG(asin(step / speed));
+			snapCount++;
+		}
+
+		qsort(snapZones, snapCount, sizeof(snapZones[0]), sortSnapZones);
+		snapZones[snapCount] = snapZones[0] + 90;
+	}
+
+	void CG_FillAngleYaw(float start, float end, float viewangle, float y, float height, const float* color)
+	{
+		float x, width, fovscale;
+
+		fovscale = tan(DEG2RAD(cg.refdef.fov_x / 2));
+		x = SCREEN_WIDTH / 2 + tan(DEG2RAD(viewangle + start)) / fovscale * SCREEN_WIDTH / 2;
+		width = fabs(SCREEN_WIDTH * (tan(DEG2RAD(viewangle + end)) - tan(DEG2RAD(viewangle + start))) / (fovscale * 2)) + 1;
+
+		trap_R_SetColor(color);
+		CG_AdjustFrom640(&x, &y, &width, &height);
+		trap_R_DrawStretchPic(x, y, width, height, 0, 0, 0, 0, cgs.media.whiteShader);
+		trap_R_SetColor(NULL);
+	}
+
+	// FIXME: share this with cgaz
+	static float PM_CalcScale(playerState_t* ps)
+	{
+		// based on PM_CmdScale from bg_pmove.c
+		float scale = ps->stats[STAT_USERCMD_BUTTONS] & (BUTTON_SPRINT << 8) && cg.pmext.sprintTime > 50 ? ps->sprintSpeedScale : ps->runSpeedScale;
+		return scale;
+	}
+
+	static int QDECL sortSnapZones(const void* a, const void* b)
+	{
+		return *(float*)a - *(float*)b;
+	}
+}

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -4,13 +4,5 @@
 
 namespace ETJump
 {
-	constexpr int SNAPHUD_MAXZONES{ 128 };
-	float snapSpeed;
-	float snapZones[SNAPHUD_MAXZONES];
-	int snapCount;
-
 	void DrawSnapHUD();
-	void UpdateSnapHUDSettings(float speed);
-	static float PM_CalcScale(playerState_t* ps);
-	static int QDECL sortSnapZones(const void* a, const void* b);
 }

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "cg_local.h"
+
+namespace ETJump
+{
+	constexpr int SNAPHUD_MAXZONES{ 128 };
+	float snapSpeed;
+	float snapZones[SNAPHUD_MAXZONES];
+	int snapCount;
+
+	void DrawSnapHUD();
+	void UpdateSnapHUDSettings(float speed);
+	void CG_FillAngleYaw(float start, float end, float viewangle, float y, float height, const float* color);
+	static float PM_CalcScale(playerState_t* ps);
+	static int QDECL sortSnapZones(const void* a, const void* b);
+}

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -11,7 +11,6 @@ namespace ETJump
 
 	void DrawSnapHUD();
 	void UpdateSnapHUDSettings(float speed);
-	void CG_FillAngleYaw(float start, float end, float viewangle, float y, float height, const float* color);
 	static float PM_CalcScale(playerState_t* ps);
 	static int QDECL sortSnapZones(const void* a, const void* b);
 }


### PR DESCRIPTION
* `etj_drawSnapHUD` - toggle snaphud
* `etj_snapHUDOffsetY` - Y offset for snaphud position
* `etj_snapHUDHeight` - height of the snaphud
* `etj_snapHUDColor1` - 1st RGBA color of snapzones
* `etj_snapHUDColor2` - 2nd RGBA color of snapzones

Menu entries are not included for now, will probably have to add another menu file.

This should be followed with implementation of DeFRaG cgaz, since it's the one that really lets the snaphud shine.