### PR TITLE
Fix rename exploit

### DIFF
--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -3045,7 +3045,7 @@ static void CG_ServerCommand(void)
 
 
 
-		trap_SendConsoleCommand(va("set name %s\n", line));
+		trap_Cvar_Set("name", line);
 		return;
 	}
 


### PR DESCRIPTION
Fix being able to pass other client commands through `!rename` command.

closes #515 