### PR TITLE
fix grid init was skipped in some cases

### DIFF
--- a/src/cgame/cg_commandmap.cpp
+++ b/src/cgame/cg_commandmap.cpp
@@ -227,7 +227,6 @@ void CG_ParseMapEntityInfo(int axis_number, int allied_number)
 	CG_TransformAutomapEntity();
 }
 
-static qboolean gridInitDone = qfalse;
 static vec2_t   gridStartCoord, gridStep;
 
 static void CG_DrawGrid(float x, float y, float w, float h, mapScissor_t *scissor)
@@ -249,7 +248,7 @@ static void CG_DrawGrid(float x, float y, float w, float h, mapScissor_t *scisso
 	dist[0] = cg.mapcoordsMaxs[0] - cg.mapcoordsMins[0];
 	dist[1] = cg.mapcoordsMaxs[1] - cg.mapcoordsMins[1];
 
-	if (!gridInitDone)
+	if (!cg.gridInitDone)
 	{
 		gridStep[0] = 1200.f;
 		gridStep[1] = 1200.f;
@@ -263,7 +262,7 @@ static void CG_DrawGrid(float x, float y, float w, float h, mapScissor_t *scisso
 		gridStartCoord[0] = .5f * ((((cg.mapcoordsMaxs[0] - cg.mapcoordsMins[0]) / gridStep[0]) - ((int)((cg.mapcoordsMaxs[0] - cg.mapcoordsMins[0]) / gridStep[0]))) * gridStep[0]);
 		gridStartCoord[1] = .5f * ((((cg.mapcoordsMins[1] - cg.mapcoordsMaxs[1]) / gridStep[1]) - ((int)((cg.mapcoordsMins[1] - cg.mapcoordsMaxs[1]) / gridStep[1]))) * gridStep[1]);
 
-		gridInitDone = qtrue;
+		cg.gridInitDone = qtrue;
 	}
 
 	if (scissor)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1256,6 +1256,7 @@ typedef struct
 	bool requiresEntityTypeAdjustment; // ETJump 2.3.0 specific hack
 
 	char deformText[MAX_RENDER_STRINGS][MAX_RENDER_STRING_LENGTH];
+	qboolean gridInitDone;
 } cg_t;
 
 #define NUM_FUNNEL_SPRITES  21


### PR DESCRIPTION
Happened because static variable `gridInitDone` was not reset upon each module reload.
Moved the variable in the `cg_t` structure instead, so it would be manually reset on each game init.