### PR TITLE
Early out CGaz 2 if not moving

### DIFF
--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -265,6 +265,10 @@ namespace ETJump
 		// Dzikie Weze's 2D-CGaz
 		if (etj_drawCGaz.integer == 2)
 		{
+			if (VectorLengthSquared2(ps->velocity) == 0)
+			{
+				return;
+			}
 
 			parseColorString(etj_CGazColor1.string, color1);
 			parseColorString(etj_CGazColor2.string, color2);


### PR DESCRIPTION
CGaz 2 was unnecessarily going through it's calculations when nothing was actually drawn.