### PR TITLE
Fix duplicate popup indicator coloring

### DIFF
--- a/src/cgame/cg_popupmessages.cpp
+++ b/src/cgame/cg_popupmessages.cpp
@@ -481,7 +481,7 @@ void CG_DrawPMItems(void)
 
 	// show repeats counter
 	if (cg_pmWaitingList->repeats > 1) {
-		msg = va("%s (x%d)", cg_pmWaitingList->message, cg_pmWaitingList->repeats);
+		msg = va("%s^9(x%d)", cg_pmWaitingList->message, cg_pmWaitingList->repeats);
 	}
 	else {
 		msg = (char*)&cg_pmWaitingList->message;


### PR DESCRIPTION
The counter for duplicate popups wasn't resetting color and would be colored with any color the popup ended with. Colored it grey, and removed a phantom whitespace.