### PR TITLE
Add spawnflags 1 to trigger_savereset

### DIFF
--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1757,7 +1757,7 @@ void target_savereset_use(gentity_t *self, gentity_t *other, gentity_t *activato
 	{
 		ETJump::saveSystem->resetSavedPositions(activator);
 
-		if (!self->spawnflags & 1)
+		if (!(self->spawnflags & 1))
 		{
 			CPx(activator - g_entities, "cp \"^7 Your saves were removed.\n\"");
 		}

--- a/src/game/g_trigger.cpp
+++ b/src/game/g_trigger.cpp
@@ -604,7 +604,10 @@ void trigger_savereset_touch(gentity_t *self, gentity_t *other, trace_t *trace)
 
 	ETJump::saveSystem->resetSavedPositions(other);
 
-	CPx(other - g_entities, "cp \"^7 Your saves were removed.\n\"");
+	if (!(self->spawnflags & 1))
+	{
+		CPx(other - g_entities, "cp \"^7 Your saves were removed.\n\"");
+	}
 }
 
 void savereset_think(gentity_t *ent)


### PR DESCRIPTION
`spawnflags 1` __SILENT__ -  don't print text when removing saves. This was already added for `target_savereset` but honestly I forgot that a trigger version existed.