### PR TITLE
Make sqlite threadsafe again

### DIFF
--- a/deps/sqlite/CMakeLists.txt
+++ b/deps/sqlite/CMakeLists.txt
@@ -2,4 +2,4 @@ add_library(libsqlite OBJECT sqlite3.c)
 target_include_directories(libsqlite 
     SYSTEM INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_compile_definitions(libsqlite 
-    PUBLIC SQLITE_THREADSAFE=0 SQLITE_OMIT_LOAD_EXTENSION SQLITE_HAVE_ISNAN)
+    PUBLIC SQLITE_THREADSAFE=1 SQLITE_OMIT_LOAD_EXTENSION SQLITE_HAVE_ISNAN)


### PR DESCRIPTION
Since we might be running concurrent async operations on database, it makes total sense to enable threadsafety.