### PR TITLE
Rename cg/player code references to etj

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -568,10 +568,10 @@ static float CG_DrawSpeed(float y)
 
 	thistime = trap_Milliseconds();
 
-	if (thistime > (lasttime + cg_speedinterval.integer))
+	if (thistime > (lasttime + etj_speedinterval.integer))
 	{
 
-		if (cg_speedXYonly.integer)
+		if (etj_speedXYonly.integer)
 		{
 			speed = sqrt(cg.predictedPlayerState.velocity[0] * cg.predictedPlayerState.velocity[0] + cg.predictedPlayerState.velocity[1] * cg.predictedPlayerState.velocity[1]);
 		}
@@ -590,12 +590,12 @@ static float CG_DrawSpeed(float y)
 
 	}
 
-	switch (cg_drawspeed.integer)
+	switch (etj_drawspeed.integer)
 	{
 	default:
 	case 1:
 		// kw: swapped 1 and 2 to match etpro's b_speedunit
-		switch (cg_speedunit.integer)
+		switch (etj_speedunit.integer)
 		{
 		default:
 		case 0:
@@ -614,7 +614,7 @@ static float CG_DrawSpeed(float y)
 		break;
 
 	case 2:
-		switch (cg_speedunit.integer)
+		switch (etj_speedunit.integer)
 		{
 		default:
 		case 0:
@@ -656,7 +656,7 @@ float CG_DrawTime(float y)
 	trap_RealTime(&tm);
 	displayTime[0] = '\0';
 
-	if (cg_drawClock.integer == 1)
+	if (etj_drawClock.integer == 1)
 	{
 		Q_strcat(displayTime, sizeof(displayTime),
 		         va("%d:%02d", tm.tm_hour, tm.tm_min));
@@ -806,7 +806,7 @@ static void CG_DrawUpperRight(void)
 	    y = CG_DrawTimer( y );
 	}*/
 
-	if (cg_drawClock.integer)
+	if (etj_drawClock.integer)
 	{
 		y = CG_DrawTime(y);
 	}
@@ -816,7 +816,7 @@ static void CG_DrawUpperRight(void)
 		y = CG_DrawFPS(y);
 	}
 
-	if (cg_drawspeed.integer)
+	if (etj_drawspeed.integer)
 	{
 		y = CG_DrawSpeed(y);
 	}
@@ -906,8 +906,8 @@ static void CG_DrawTeamInfo(void)
 
 		for (i = cgs.teamChatPos - 1; i >= cgs.teamLastChatPos; i--)
 		{
-			auto linePosX = CHATLOC_TEXT_X + cg_chatPosX.value;
-			auto linePosY = CHATLOC_Y + cg_chatPosY.value - (cgs.teamChatPos - i - 1) * lineHeight - 1;
+			auto linePosX = CHATLOC_TEXT_X + etj_chatPosX.value;
+			auto linePosY = CHATLOC_Y + etj_chatPosY.value - (cgs.teamChatPos - i - 1) * lineHeight - 1;
 
 			if (linePosY <= 0 || linePosY >= 480 + lineHeight)
 			{
@@ -936,12 +936,12 @@ static void CG_DrawTeamInfo(void)
 				hcolor[2] = 0;
 			}
 
-			chatbgalpha = Numeric::clamp(cg_chatBackgroundAlpha.value, 0.0f, 1.0f);
+			chatbgalpha = Numeric::clamp(etj_chatBackgroundAlpha.value, 0.0f, 1.0f);
 
 			hcolor[3] = chatbgalpha * alphapercent;
 
 			trap_R_SetColor(hcolor);
-			CG_DrawPic(CHATLOC_X + cg_chatPosX.value, CHATLOC_Y + cg_chatPosY.value - (cgs.teamChatPos - i) * lineHeight, chatWidth, lineHeight, cgs.media.teamStatusBar);
+			CG_DrawPic(CHATLOC_X + etj_chatPosX.value, CHATLOC_Y + etj_chatPosY.value - (cgs.teamChatPos - i) * lineHeight, chatWidth, lineHeight, cgs.media.teamStatusBar);
 
 			hcolor[0] = hcolor[1] = hcolor[2] = 1.0;
 			hcolor[3] = alphapercent * textAlpha;
@@ -965,8 +965,8 @@ static void CG_DrawTeamInfo(void)
 				{
 					float flagScaleX = 12.0f * chatScale;
 					float flagScaleY = 9.0f * chatScale;
-					float flagPosX = (CHATLOC_TEXT_X + cg_chatPosX.value) - (13 * chatScale);
-					float flagPosY = (CHATLOC_Y + cg_chatPosY.value - (cgs.teamChatPos - i - 1) * lineHeight) - (9 * chatScale);
+					float flagPosX = (CHATLOC_TEXT_X + etj_chatPosX.value) - (13 * chatScale);
+					float flagPosY = (CHATLOC_Y + etj_chatPosY.value - (cgs.teamChatPos - i - 1) * lineHeight) - (9 * chatScale);
 					CG_DrawPic(flagPosX, flagPosY, flagScaleX, flagScaleY, flag);
 				}
 
@@ -2733,7 +2733,7 @@ static void CG_DrawCrosshairNames(void)
 	}
 	else 
 	{
-		if ((cg_hide.integer == 1 && dist < cg_hideDistance.integer) || cg_hide.integer == 2)
+		if ((etj_hide.integer == 1 && dist < etj_hideDistance.integer) || etj_hide.integer == 2)
 		{
 			return;
 		}
@@ -3260,7 +3260,7 @@ static void CG_DrawOB(void)
 	vec3_t        start, end;
 	float         x;
 
-	if (!cg_drawOB.integer || cg_thirdPerson.integer)
+	if (!etj_drawOB.integer || cg_thirdPerson.integer)
 	{
 		return;
 	}
@@ -3343,7 +3343,7 @@ static void CG_DrawOB(void)
 
 		// don't predict sticky ob if there is an ob already or if the sticky
 		// ob detection isn't requested
-		if (b || cg_drawOB.integer != 2)
+		if (b || etj_drawOB.integer != 2)
 		{
 			return;
 		}
@@ -3385,7 +3385,7 @@ static void CG_DrawSlick(void)
 	const float   minWalkNormal = 0.7;
 	float         x;
 
-	if (!cg_drawSlick.integer)
+	if (!etj_drawSlick.integer)
 	{
 		return;
 	}
@@ -3394,7 +3394,7 @@ static void CG_DrawSlick(void)
 
 	playerState_t *ps = ETJump::getValidPlayerState();
 
-	x = cg_slickX.value;
+	x = etj_slickX.value;
 
 	ETJump_AdjustPosition(&x);
 
@@ -3406,7 +3406,7 @@ static void CG_DrawSlick(void)
 	if ((trace.fraction != 1.0 && trace.surfaceFlags & SURF_SLICK) ||
 	    (trace.plane.normal[2] > 0 && trace.plane.normal[2] < minWalkNormal))
 	{
-		CG_DrawStringExt(x, cg_slickY.integer, "S", colorWhite, qfalse, qtrue, TINYCHAR_WIDTH, TINYCHAR_HEIGHT, 0);
+		CG_DrawStringExt(x, etj_slickY.integer, "S", colorWhite, qfalse, qtrue, TINYCHAR_WIDTH, TINYCHAR_HEIGHT, 0);
 	}
 }
 
@@ -5188,7 +5188,7 @@ static void CG_DrawPlayerStatus(void)
 		}
 	}
 	
-	if (cg_HUD_weaponIcon.integer)
+	if (etj_HUD_weaponIcon.integer)
 	{
 		// Draw ammo
 		weap = CG_PlayerAmmoValue(&value, &value2, &value3);
@@ -5214,7 +5214,7 @@ static void CG_DrawPlayerStatus(void)
 
 
 // ==
-	if (cg_HUD_healthBar.integer)
+	if (etj_HUD_healthBar.integer)
 	{
 		rect.x = 24;
 		rect.y = 480 - 92;
@@ -5225,7 +5225,7 @@ static void CG_DrawPlayerStatus(void)
 // ==
 
 // ==
-	if (cg_HUD_fatigueBar.integer)
+	if (etj_HUD_fatigueBar.integer)
 	{
 		rect.x = 4;
 		rect.y = 480 - 92;
@@ -5236,7 +5236,7 @@ static void CG_DrawPlayerStatus(void)
 // ==
 
 // ==
-	if (cg_HUD_chargeBar.integer)
+	if (etj_HUD_chargeBar.integer)
 	{
 		rect.x = SCREEN_WIDTH - 16;
 		rect.y = 480 - 92;
@@ -5330,7 +5330,7 @@ static void CG_DrawPlayerStats(void)
 	float w;
 	vec_t *clr;
 
-	if (cg_HUD_playerHealth.integer)
+	if (etj_HUD_playerHealth.integer)
 	{
 		str = va("%i", cg.snap->ps.stats[STAT_HEALTH]);
 		w   = CG_Text_Width_Ext(str, 0.25f, 0, &cgs.media.limboFont1);
@@ -5346,7 +5346,7 @@ static void CG_DrawPlayerStats(void)
 	ps = &cg.snap->ps;
 	ci = &cgs.clientinfo[ps->clientNum];
 
-	if (cg_HUD_xpInfo.integer)
+	if (etj_HUD_xpInfo.integer)
 	{
 
 		for (i = 0; i < 3; i++)
@@ -5531,9 +5531,9 @@ void CG_DrawDemoRecording(void)
 void CG_DrawSpectatorInfo(void)
 {
 	int i = 0;
-	int y = player_spectatorInfoY.integer;
+	int y = etj_spectatorInfoY.integer;
 
-	if (player_drawSpectatorInfo.integer == 0)
+	if (etj_drawSpectatorInfo.integer == 0)
 	{
 		return;
 	}
@@ -5561,7 +5561,7 @@ void CG_DrawSpectatorInfo(void)
 		{
 			if (cg.scores[i].followedClient == cg.snap->ps.clientNum)
 			{
-				float x = player_spectatorInfoX.integer;
+				float x = etj_spectatorInfoX.integer;
 				ETJump_AdjustPosition(&x);
 				// spectating me
 				ETJump::DrawSmallString(x, y, va("%s", cgs.clientinfo[cg.scores[i].client].name), 1);
@@ -5656,7 +5656,7 @@ static void CG_Draw2D(void)
 
 			if (cg.snap->ps.stats[STAT_HEALTH] > 0)
 			{
-				if (cg_HUD_playerHead.integer)
+				if (etj_HUD_playerHead.integer)
 				{
 					CG_DrawPlayerStatusHead();
 				}

--- a/src/cgame/cg_drawCHS.cpp
+++ b/src/cgame/cg_drawCHS.cpp
@@ -609,7 +609,7 @@ void CG_DrawCHS(void)
 	align_t CHS2Align = ALIGN_LEFT;
 
 	// CHS1
-	if (cg_drawCHS1.integer)
+	if (etj_drawCHS1.integer)
 	{
 		x = (SCREEN_WIDTH / 2) - 1;
 		y = (SCREEN_HEIGHT / 2) - 1;
@@ -619,36 +619,36 @@ void CG_DrawCHS(void)
 		 *   6     4
 		 *      5
 		 */
-		CG_CHS_DrawSingleInfo(x, y - 20, cg_CHS1Info1.integer, qfalse, ALIGN_CENTER);
-		CG_CHS_DrawSingleInfo(x + 10, y - 10, cg_CHS1Info2.integer, qfalse, ALIGN_LEFT);
-		CG_CHS_DrawSingleInfo(x + 20, y, cg_CHS1Info3.integer, qfalse, ALIGN_LEFT);
-		CG_CHS_DrawSingleInfo(x + 10, y + 10, cg_CHS1Info4.integer, qfalse, ALIGN_LEFT);
-		CG_CHS_DrawSingleInfo(x, y + 20, cg_CHS1Info5.integer, qfalse, ALIGN_CENTER);
-		CG_CHS_DrawSingleInfo(x - 10, y + 10, cg_CHS1Info6.integer, qfalse, ALIGN_RIGHT);
-		CG_CHS_DrawSingleInfo(x - 20, y, cg_CHS1Info7.integer, qfalse, ALIGN_RIGHT);
-		CG_CHS_DrawSingleInfo(x - 10, y - 10, cg_CHS1Info8.integer, qfalse, ALIGN_RIGHT);
+		CG_CHS_DrawSingleInfo(x, y - 20, etj_CHS1Info1.integer, qfalse, ALIGN_CENTER);
+		CG_CHS_DrawSingleInfo(x + 10, y - 10, etj_CHS1Info2.integer, qfalse, ALIGN_LEFT);
+		CG_CHS_DrawSingleInfo(x + 20, y, etj_CHS1Info3.integer, qfalse, ALIGN_LEFT);
+		CG_CHS_DrawSingleInfo(x + 10, y + 10, etj_CHS1Info4.integer, qfalse, ALIGN_LEFT);
+		CG_CHS_DrawSingleInfo(x, y + 20, etj_CHS1Info5.integer, qfalse, ALIGN_CENTER);
+		CG_CHS_DrawSingleInfo(x - 10, y + 10, etj_CHS1Info6.integer, qfalse, ALIGN_RIGHT);
+		CG_CHS_DrawSingleInfo(x - 20, y, etj_CHS1Info7.integer, qfalse, ALIGN_RIGHT);
+		CG_CHS_DrawSingleInfo(x - 10, y - 10, etj_CHS1Info8.integer, qfalse, ALIGN_RIGHT);
 	}
 
 	// CHS2
-	if (cg_drawCHS2.integer)
+	if (etj_drawCHS2.integer)
 	{
 		float chs2OffsetX = ETJump_AdjustPosition(etj_CHS2PosX.value);
 		x = 30 + chs2OffsetX;
 		y = (SCREEN_HEIGHT / 2) + 40 + etj_CHS2PosY.value;
 
-		if (cg_drawCHS2.integer > 1) {
+		if (etj_drawCHS2.integer > 1) {
 			CHS2Align = ALIGN_RIGHT;
 			x = SCREEN_WIDTH - 30 + chs2OffsetX;
 		}
 
-		CG_CHS_DrawSingleInfo(x, y +  0, cg_CHS2Info1.integer, qtrue, CHS2Align);
-		CG_CHS_DrawSingleInfo(x, y + 10, cg_CHS2Info2.integer, qtrue, CHS2Align);
-		CG_CHS_DrawSingleInfo(x, y + 20, cg_CHS2Info3.integer, qtrue, CHS2Align);
-		CG_CHS_DrawSingleInfo(x, y + 30, cg_CHS2Info4.integer, qtrue, CHS2Align);
-		CG_CHS_DrawSingleInfo(x, y + 40, cg_CHS2Info5.integer, qtrue, CHS2Align);
-		CG_CHS_DrawSingleInfo(x, y + 50, cg_CHS2Info6.integer, qtrue, CHS2Align);
-		CG_CHS_DrawSingleInfo(x, y + 60, cg_CHS2Info7.integer, qtrue, CHS2Align);
-		CG_CHS_DrawSingleInfo(x, y + 70, cg_CHS2Info8.integer, qtrue, CHS2Align);
+		CG_CHS_DrawSingleInfo(x, y +  0, etj_CHS2Info1.integer, qtrue, CHS2Align);
+		CG_CHS_DrawSingleInfo(x, y + 10, etj_CHS2Info2.integer, qtrue, CHS2Align);
+		CG_CHS_DrawSingleInfo(x, y + 20, etj_CHS2Info3.integer, qtrue, CHS2Align);
+		CG_CHS_DrawSingleInfo(x, y + 30, etj_CHS2Info4.integer, qtrue, CHS2Align);
+		CG_CHS_DrawSingleInfo(x, y + 40, etj_CHS2Info5.integer, qtrue, CHS2Align);
+		CG_CHS_DrawSingleInfo(x, y + 50, etj_CHS2Info6.integer, qtrue, CHS2Align);
+		CG_CHS_DrawSingleInfo(x, y + 60, etj_CHS2Info7.integer, qtrue, CHS2Align);
+		CG_CHS_DrawSingleInfo(x, y + 70, etj_CHS2Info8.integer, qtrue, CHS2Align);
 	}
 }
 

--- a/src/cgame/cg_edv.cpp
+++ b/src/cgame/cg_edv.cpp
@@ -228,7 +228,7 @@ void CG_EDV_RunInput(void)
 	/* Create pmext for cam movement */
 	memset(&edv_pmext, 0, sizeof(edv_pmext));
 	edv_pmext.sprintTime = SPRINTTIME;
-	edv_pmext.noclipScale = cg_noclipScale.value;
+	edv_pmext.noclipScale = etj_noclipScale.value;
 
 	/* Fill in pmove stuff */
 	cg_pmove.ps = &edv_ps;

--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -2621,7 +2621,7 @@ static void CG_PortalGate(centity_t *cent)
 
 
 	//Check if player wants to see other player portals
-	if (!cg_viewPlayerPortals.integer)
+	if (!etj_viewPlayerPortals.integer)
 	{
 		//We don't want to see other player portals
 		//so let's only render our portal...
@@ -2632,8 +2632,8 @@ static void CG_PortalGate(centity_t *cent)
 		}
 	}
 
-	// if cg_viewPlayerPortals is 2, only show others portals when we're speccing
-	if (cg_viewPlayerPortals.integer == 2)
+	// if etj_viewPlayerPortals is 2, only show others portals when we're speccing
+	if (etj_viewPlayerPortals.integer == 2)
 	{
 		if (cgs.clientinfo[cg.clientNum].team != TEAM_SPECTATOR)
 		{

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -168,7 +168,7 @@ static void CG_ItemPickup(int itemNum)
 	int wpbank_cur, wpbank_pickup;
 
 	itemid = bg_itemlist[itemNum].giTag;
-	if (cg_itemPickupText.integer)
+	if (etj_itemPickupText.integer)
 	{
 		CG_AddPMItem(PM_MESSAGE, va("Picked up %s", CG_PickupItemText(itemNum)), cgs.media.pmImages[PM_MESSAGE]);
 	}
@@ -2168,7 +2168,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 
 			if (event == EV_ITEM_PICKUP) // not quiet
 			{
-				if (cg_itemPickupText.integer)
+				if (etj_itemPickupText.integer)
 				{
 					// powerups and team items will have a separate global sound, this one
 					// will be played at prediction time
@@ -2292,7 +2292,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 // jpw
 
 	case EV_NOAMMO:
-		if (!cg_weaponSound.integer) break;
+		if (!etj_weaponSound.integer) break;
 	case EV_WEAPONSWITCHED:
 		DEBUGNAME("EV_NOAMMO");
 		if ((es->weapon != WP_GRENADE_LAUNCHER) &&

--- a/src/cgame/cg_flamethrower.cpp
+++ b/src/cgame/cg_flamethrower.cpp
@@ -1387,7 +1387,7 @@ void CG_UpdateFlamethrowerSounds(void)
 	#define MIN_BLOW_VOLUME     30
 
 	// Mute sounds if weapon sounds are disabled
-	if (cg_weaponSound.integer <= 0)
+	if (etj_weaponSound.integer <= 0)
 	{
 		return;
 	}

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2400,10 +2400,10 @@ extern vmCvar_t cl_waveoffset;
 extern vmCvar_t cg_recording_statusline;
 
 extern vmCvar_t cg_ghostPlayers;
-extern vmCvar_t cg_hide;
-extern vmCvar_t cg_hideDistance;
-extern vmCvar_t cg_hideMe;
-extern vmCvar_t cg_nofatigue;
+extern vmCvar_t etj_hide;
+extern vmCvar_t etj_hideDistance;
+extern vmCvar_t etj_hideMe;
+extern vmCvar_t etj_nofatigue;
 extern vmCvar_t com_maxfps;
 extern vmCvar_t com_hunkmegs;
 
@@ -2420,7 +2420,7 @@ extern vmCvar_t etj_CGaz5Color3;
 extern vmCvar_t etj_CGaz5Color4;
 extern vmCvar_t etj_CGaz5Fov;
 
-extern vmCvar_t cg_drawOB;
+extern vmCvar_t etj_drawOB;
 // Aciz: movable drawOB
 extern vmCvar_t etj_OBX;
 extern vmCvar_t etj_OBY;
@@ -2430,23 +2430,23 @@ extern vmCvar_t etj_keysX;
 extern vmCvar_t etj_keysY;
 extern vmCvar_t etj_keysShadow;
 extern vmCvar_t etj_keysColor;
-extern vmCvar_t cg_loadviewangles;
+extern vmCvar_t etj_loadviewangles;
 // forty - speedometer
-extern vmCvar_t cg_drawspeed;
-extern vmCvar_t cg_speedinterval;
-extern vmCvar_t cg_speedXYonly;
-extern vmCvar_t cg_speedunit;
+extern vmCvar_t etj_drawspeed;
+extern vmCvar_t etj_speedinterval;
+extern vmCvar_t etj_speedXYonly;
+extern vmCvar_t etj_speedunit;
 extern pmove_t  cg_pmove;
 // Cheat cvars
 extern vmCvar_t cl_yawspeed;
 extern vmCvar_t cl_freelook;
-extern vmCvar_t cg_drawClock;
-extern vmCvar_t cg_drawSpeed2;
-extern vmCvar_t cg_speedX;
-extern vmCvar_t cg_speedY;
+extern vmCvar_t etj_drawClock;
+extern vmCvar_t etj_drawSpeed2;
+extern vmCvar_t etj_speedX;
+extern vmCvar_t etj_speedY;
 extern vmCvar_t etj_speedSize;
-extern vmCvar_t cg_speedColor;
-extern vmCvar_t cg_speedAlpha;
+extern vmCvar_t etj_speedColor;
+extern vmCvar_t etj_speedAlpha;
 extern vmCvar_t etj_speedShadow;
 extern vmCvar_t etj_drawMaxSpeed;
 extern vmCvar_t etj_maxSpeedX;
@@ -2456,10 +2456,10 @@ extern vmCvar_t etj_speedColorUsesAccel;
 
 extern vmCvar_t cg_adminpassword;
 extern vmCvar_t cg_username;
-extern vmCvar_t cg_popupTime;
-extern vmCvar_t cg_popupStayTime;
-extern vmCvar_t cg_popupFadeTime;
-extern vmCvar_t cg_numPopups;
+extern vmCvar_t etj_popupTime;
+extern vmCvar_t etj_popupStayTime;
+extern vmCvar_t etj_popupFadeTime;
+extern vmCvar_t etj_numPopups;
 extern vmCvar_t etj_HUD_popup;
 extern vmCvar_t etj_popupGrouped;
 extern vmCvar_t etj_popupShadow;
@@ -2468,36 +2468,36 @@ extern vmCvar_t etj_popupPosX;
 extern vmCvar_t etj_popupPosY;
 
 //Feen: PGM client cvars
-extern vmCvar_t cg_viewPlayerPortals;         //Enable/Disable viewing other player portals
+extern vmCvar_t etj_viewPlayerPortals;         //Enable/Disable viewing other player portals
 //TODO: May add cvars to allow players to override portal colors
-//		when cg_viewPlayerPortals is set to 0 (disabled)
+//		when etj_viewPlayerPortals is set to 0 (disabled)
 
-extern vmCvar_t cg_chatPosX;
-extern vmCvar_t cg_chatPosY;
-extern vmCvar_t cg_chatBackgroundAlpha;
+extern vmCvar_t etj_chatPosX;
+extern vmCvar_t etj_chatPosY;
+extern vmCvar_t etj_chatBackgroundAlpha;
 extern vmCvar_t etj_chatFlags;
 extern vmCvar_t etj_chatShadow;
 extern vmCvar_t etj_chatAlpha;
 
 // crosshair stats
-extern vmCvar_t cg_drawCHS1;
-extern vmCvar_t cg_CHS1Info1;
-extern vmCvar_t cg_CHS1Info2;
-extern vmCvar_t cg_CHS1Info3;
-extern vmCvar_t cg_CHS1Info4;
-extern vmCvar_t cg_CHS1Info5;
-extern vmCvar_t cg_CHS1Info6;
-extern vmCvar_t cg_CHS1Info7;
-extern vmCvar_t cg_CHS1Info8;
-extern vmCvar_t cg_drawCHS2;
-extern vmCvar_t cg_CHS2Info1;
-extern vmCvar_t cg_CHS2Info2;
-extern vmCvar_t cg_CHS2Info3;
-extern vmCvar_t cg_CHS2Info4;
-extern vmCvar_t cg_CHS2Info5;
-extern vmCvar_t cg_CHS2Info6;
-extern vmCvar_t cg_CHS2Info7;
-extern vmCvar_t cg_CHS2Info8;
+extern vmCvar_t etj_drawCHS1;
+extern vmCvar_t etj_CHS1Info1;
+extern vmCvar_t etj_CHS1Info2;
+extern vmCvar_t etj_CHS1Info3;
+extern vmCvar_t etj_CHS1Info4;
+extern vmCvar_t etj_CHS1Info5;
+extern vmCvar_t etj_CHS1Info6;
+extern vmCvar_t etj_CHS1Info7;
+extern vmCvar_t etj_CHS1Info8;
+extern vmCvar_t etj_drawCHS2;
+extern vmCvar_t etj_CHS2Info1;
+extern vmCvar_t etj_CHS2Info2;
+extern vmCvar_t etj_CHS2Info3;
+extern vmCvar_t etj_CHS2Info4;
+extern vmCvar_t etj_CHS2Info5;
+extern vmCvar_t etj_CHS2Info6;
+extern vmCvar_t etj_CHS2Info7;
+extern vmCvar_t etj_CHS2Info8;
 // chs2 position
 extern vmCvar_t etj_CHS2PosX;
 extern vmCvar_t etj_CHS2PosY;
@@ -2507,15 +2507,15 @@ extern vmCvar_t etj_CHSAlpha;
 extern vmCvar_t etj_CHSColor;
 extern vmCvar_t etj_CHSUseFeet;
 
-extern vmCvar_t cg_itemPickupText;
+extern vmCvar_t etj_itemPickupText;
 
-extern vmCvar_t cg_HUD_chargeBar;
-extern vmCvar_t cg_HUD_fatigueBar;
-extern vmCvar_t cg_HUD_healthBar;
-extern vmCvar_t cg_HUD_playerHead;
-extern vmCvar_t cg_HUD_playerHealth;
-extern vmCvar_t cg_HUD_weaponIcon;
-extern vmCvar_t cg_HUD_xpInfo;
+extern vmCvar_t etj_HUD_chargeBar;
+extern vmCvar_t etj_HUD_fatigueBar;
+extern vmCvar_t etj_HUD_healthBar;
+extern vmCvar_t etj_HUD_playerHead;
+extern vmCvar_t etj_HUD_playerHealth;
+extern vmCvar_t etj_HUD_weaponIcon;
+extern vmCvar_t etj_HUD_xpInfo;
 extern vmCvar_t etj_HUD_fireteam;
 
 extern vmCvar_t etj_fireteamPosX;
@@ -2524,28 +2524,28 @@ extern vmCvar_t etj_fireteamAlpha;
 
 #define CONLOG_BANNERPRINT 1
 extern vmCvar_t etj_logBanner;
-extern vmCvar_t cg_weaponSound;
+extern vmCvar_t etj_weaponSound;
 
-extern vmCvar_t cg_noclipScale;
-extern vmCvar_t cg_drawSlick;
-extern vmCvar_t cg_slickX;
-extern vmCvar_t cg_slickY;
+extern vmCvar_t etj_noclipScale;
+extern vmCvar_t etj_drawSlick;
+extern vmCvar_t etj_slickX;
+extern vmCvar_t etj_slickY;
 
 // Alternative scoreboard
-extern vmCvar_t cg_altScoreboard;
+extern vmCvar_t etj_altScoreboard;
 
-extern vmCvar_t player_drawSpectatorInfo;
-extern vmCvar_t player_spectatorInfoX;
-extern vmCvar_t player_spectatorInfoY;
+extern vmCvar_t etj_drawSpectatorInfo;
+extern vmCvar_t etj_spectatorInfoX;
+extern vmCvar_t etj_spectatorInfoY;
 
-extern vmCvar_t player_drawRunTimer;
-extern vmCvar_t player_runTimerX;
-extern vmCvar_t player_runTimerY;
+extern vmCvar_t etj_drawRunTimer;
+extern vmCvar_t etj_runTimerX;
+extern vmCvar_t etj_runTimerY;
 extern vmCvar_t etj_runTimerShadow;
 extern vmCvar_t etj_runTimerAutoHide;
 extern vmCvar_t etj_runTimerInactiveColor;
 
-extern vmCvar_t player_drawMessageTime;
+extern vmCvar_t etj_drawMessageTime;
 
 extern vmCvar_t movie_changeFovBasedOnSpeed;
 extern vmCvar_t movie_fovMinSpeed;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -325,10 +325,10 @@ vmCvar_t cl_wavefilename;
 vmCvar_t cl_waveoffset;
 vmCvar_t cg_recording_statusline;
 vmCvar_t cg_ghostPlayers;
-vmCvar_t cg_hide;
-vmCvar_t cg_hideDistance;
-vmCvar_t cg_hideMe;
-vmCvar_t cg_nofatigue;
+vmCvar_t etj_hide;
+vmCvar_t etj_hideDistance;
+vmCvar_t etj_hideMe;
+vmCvar_t etj_nofatigue;
 vmCvar_t com_maxfps;
 vmCvar_t com_hunkmegs;
 
@@ -345,7 +345,7 @@ vmCvar_t etj_CGaz5Color3;
 vmCvar_t etj_CGaz5Color4;
 vmCvar_t etj_CGaz5Fov;
 
-vmCvar_t cg_drawOB;
+vmCvar_t etj_drawOB;
 //Aciz: movable drawOB
 vmCvar_t etj_OBX;
 vmCvar_t etj_OBY;
@@ -355,26 +355,26 @@ vmCvar_t etj_keysX;
 vmCvar_t etj_keysY;
 vmCvar_t etj_keysSize;
 vmCvar_t etj_keysShadow;
-vmCvar_t cg_loadviewangles;
+vmCvar_t etj_loadviewangles;
 
 // forty - speedometer
-vmCvar_t cg_drawspeed;
-vmCvar_t cg_speedinterval;
-vmCvar_t cg_speedXYonly;
-vmCvar_t cg_speedunit;
+vmCvar_t etj_drawspeed;
+vmCvar_t etj_speedinterval;
+vmCvar_t etj_speedXYonly;
+vmCvar_t etj_speedunit;
 
 // Cheat cvars
 vmCvar_t cl_yawspeed;
 vmCvar_t cl_freelook;
 
-vmCvar_t cg_drawClock;
+vmCvar_t etj_drawClock;
 
-vmCvar_t cg_drawSpeed2;
-vmCvar_t cg_speedX;
-vmCvar_t cg_speedY;
+vmCvar_t etj_drawSpeed2;
+vmCvar_t etj_speedX;
+vmCvar_t etj_speedY;
 vmCvar_t etj_speedSize;
-vmCvar_t cg_speedColor;
-vmCvar_t cg_speedAlpha;
+vmCvar_t etj_speedColor;
+vmCvar_t etj_speedAlpha;
 vmCvar_t etj_speedShadow;
 vmCvar_t etj_drawMaxSpeed;
 vmCvar_t etj_maxSpeedX;
@@ -385,10 +385,10 @@ vmCvar_t etj_speedColorUsesAccel;
 vmCvar_t cg_adminpassword;
 vmCvar_t cg_username;
 
-vmCvar_t cg_popupTime;
-vmCvar_t cg_popupStayTime;
-vmCvar_t cg_popupFadeTime;
-vmCvar_t cg_numPopups;
+vmCvar_t etj_popupTime;
+vmCvar_t etj_popupStayTime;
+vmCvar_t etj_popupFadeTime;
+vmCvar_t etj_numPopups;
 
 vmCvar_t etj_HUD_popup;
 vmCvar_t etj_popupGrouped;
@@ -398,34 +398,34 @@ vmCvar_t etj_popupPosX;
 vmCvar_t etj_popupPosY;
 
 //Feen: PGM client cvars
-vmCvar_t cg_viewPlayerPortals;            //Enable/Disable viewing other player portals
+vmCvar_t etj_viewPlayerPortals;            //Enable/Disable viewing other player portals
 
-vmCvar_t cg_chatPosX;
-vmCvar_t cg_chatPosY;
-vmCvar_t cg_chatBackgroundAlpha;
+vmCvar_t etj_chatPosX;
+vmCvar_t etj_chatPosY;
+vmCvar_t etj_chatBackgroundAlpha;
 vmCvar_t etj_chatFlags;
 vmCvar_t etj_chatShadow;
 vmCvar_t etj_chatAlpha;
 
 // crosshair stats
-vmCvar_t cg_drawCHS1;
-vmCvar_t cg_CHS1Info1;
-vmCvar_t cg_CHS1Info2;
-vmCvar_t cg_CHS1Info3;
-vmCvar_t cg_CHS1Info4;
-vmCvar_t cg_CHS1Info5;
-vmCvar_t cg_CHS1Info6;
-vmCvar_t cg_CHS1Info7;
-vmCvar_t cg_CHS1Info8;
-vmCvar_t cg_drawCHS2;
-vmCvar_t cg_CHS2Info1;
-vmCvar_t cg_CHS2Info2;
-vmCvar_t cg_CHS2Info3;
-vmCvar_t cg_CHS2Info4;
-vmCvar_t cg_CHS2Info5;
-vmCvar_t cg_CHS2Info6;
-vmCvar_t cg_CHS2Info7;
-vmCvar_t cg_CHS2Info8;
+vmCvar_t etj_drawCHS1;
+vmCvar_t etj_CHS1Info1;
+vmCvar_t etj_CHS1Info2;
+vmCvar_t etj_CHS1Info3;
+vmCvar_t etj_CHS1Info4;
+vmCvar_t etj_CHS1Info5;
+vmCvar_t etj_CHS1Info6;
+vmCvar_t etj_CHS1Info7;
+vmCvar_t etj_CHS1Info8;
+vmCvar_t etj_drawCHS2;
+vmCvar_t etj_CHS2Info1;
+vmCvar_t etj_CHS2Info2;
+vmCvar_t etj_CHS2Info3;
+vmCvar_t etj_CHS2Info4;
+vmCvar_t etj_CHS2Info5;
+vmCvar_t etj_CHS2Info6;
+vmCvar_t etj_CHS2Info7;
+vmCvar_t etj_CHS2Info8;
 // chs2 position
 vmCvar_t etj_CHS2PosX;
 vmCvar_t etj_CHS2PosY;
@@ -435,15 +435,15 @@ vmCvar_t etj_CHSAlpha;
 vmCvar_t etj_CHSColor;
 vmCvar_t etj_CHSUseFeet;
 
-vmCvar_t cg_itemPickupText;
+vmCvar_t etj_itemPickupText;
 
-vmCvar_t cg_HUD_chargeBar;
-vmCvar_t cg_HUD_fatigueBar;
-vmCvar_t cg_HUD_healthBar;
-vmCvar_t cg_HUD_playerHead;
-vmCvar_t cg_HUD_playerHealth;
-vmCvar_t cg_HUD_weaponIcon;
-vmCvar_t cg_HUD_xpInfo;
+vmCvar_t etj_HUD_chargeBar;
+vmCvar_t etj_HUD_fatigueBar;
+vmCvar_t etj_HUD_healthBar;
+vmCvar_t etj_HUD_playerHead;
+vmCvar_t etj_HUD_playerHealth;
+vmCvar_t etj_HUD_weaponIcon;
+vmCvar_t etj_HUD_xpInfo;
 vmCvar_t etj_HUD_fireteam;
 
 vmCvar_t etj_fireteamPosX;
@@ -451,27 +451,27 @@ vmCvar_t etj_fireteamPosY;
 vmCvar_t etj_fireteamAlpha;
 
 vmCvar_t etj_logBanner;
-vmCvar_t cg_weaponSound;
-vmCvar_t cg_noclipScale;
+vmCvar_t etj_weaponSound;
+vmCvar_t etj_noclipScale;
 
-vmCvar_t cg_drawSlick;
-vmCvar_t cg_slickX;
-vmCvar_t cg_slickY;
+vmCvar_t etj_drawSlick;
+vmCvar_t etj_slickX;
+vmCvar_t etj_slickY;
 
-vmCvar_t cg_altScoreboard;
+vmCvar_t etj_altScoreboard;
 
-vmCvar_t player_drawSpectatorInfo;
-vmCvar_t player_spectatorInfoX;
-vmCvar_t player_spectatorInfoY;
+vmCvar_t etj_drawSpectatorInfo;
+vmCvar_t etj_spectatorInfoX;
+vmCvar_t etj_spectatorInfoY;
 
-vmCvar_t player_drawRunTimer;
-vmCvar_t player_runTimerX;
-vmCvar_t player_runTimerY;
+vmCvar_t etj_drawRunTimer;
+vmCvar_t etj_runTimerX;
+vmCvar_t etj_runTimerY;
 vmCvar_t etj_runTimerShadow;
 vmCvar_t etj_runTimerAutoHide;
 vmCvar_t etj_runTimerInactiveColor;
 
-vmCvar_t player_drawMessageTime;
+vmCvar_t etj_drawMessageTime;
 
 vmCvar_t movie_changeFovBasedOnSpeed;
 vmCvar_t movie_fovMinSpeed;
@@ -763,15 +763,15 @@ cvarTable_t cvarTable[] =
 	{ &cg_recording_statusline,     "cg_recording_statusline",     "9",                      CVAR_ARCHIVE             },
 
 	{ &cg_ghostPlayers,             "",                            "0",                      0                        },
-	{ &cg_hide,                     "etj_hide",                    "1",                      CVAR_ARCHIVE             },
-	{ &cg_hideDistance,             "etj_hideDistance",            "128",                    CVAR_ARCHIVE             },
-	{ &cg_hideMe,                   "etj_hideMe",                  "0",                      CVAR_ARCHIVE             },
-	{ &cg_nofatigue,                "etj_nofatigue",               "1",                      CVAR_ARCHIVE             },
+	{ &etj_hide,                     "etj_hide",                    "1",                      CVAR_ARCHIVE             },
+	{ &etj_hideDistance,             "etj_hideDistance",            "128",                    CVAR_ARCHIVE             },
+	{ &etj_hideMe,                   "etj_hideMe",                  "0",                      CVAR_ARCHIVE             },
+	{ &etj_nofatigue,                "etj_nofatigue",               "1",                      CVAR_ARCHIVE             },
 	{ &com_maxfps,                  "com_maxfps",                  "76",                     CVAR_ARCHIVE             },
 	{ &com_hunkmegs,                "com_hunkmegs",                "128",                    CVAR_ARCHIVE             },
 
 	{ &etj_drawCGaz,                 "etj_drawCGaz",                "0",                      CVAR_ARCHIVE             },
-	{ &cg_drawOB,                   "etj_drawOB",                  "0",                      CVAR_ARCHIVE             },
+	{ &etj_drawOB,                   "etj_drawOB",                  "0",                      CVAR_ARCHIVE             },
 	{ &etj_OBX,                     "etj_OBX",                     "320",                    CVAR_ARCHIVE             },
 	{ &etj_OBY,                     "etj_OBY",                     "220",                    CVAR_ARCHIVE             },
 	{ &etj_CGazY,                    "etj_CGazY",                   "260",                    CVAR_ARCHIVE             },
@@ -794,18 +794,18 @@ cvarTable_t cvarTable[] =
 	{ &etj_keysX,                   "etj_keysX",                   "610",                    CVAR_ARCHIVE             },
 	{ &etj_keysY,                   "etj_keysY",                   "220",                    CVAR_ARCHIVE             },
 	{ &etj_keysShadow,              "etj_keysShadow",              "0",                      CVAR_ARCHIVE             },
-	{ &cg_loadviewangles,           "etj_loadviewangles",          "1",                      CVAR_ARCHIVE             },
-	{ &cg_drawspeed,                "etj_drawspeed",               "1",                      CVAR_ARCHIVE             },
-	{ &cg_speedXYonly,              "etj_speedXYonly",             "1",                      CVAR_ARCHIVE             },
-	{ &cg_speedinterval,            "etj_speedinterval",           "100",                    CVAR_ARCHIVE             },
-	{ &cg_speedunit,                "etj_speedunit",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_drawClock,                "etj_drawClock",               "1",                      CVAR_ARCHIVE             },
-	{ &cg_drawSpeed2,               "etj_drawSpeed2",              "1",                      CVAR_ARCHIVE             },
-	{ &cg_speedX,                   "etj_speedX",                  "320",                    CVAR_ARCHIVE             },
-	{ &cg_speedY,                   "etj_speedY",                  "340",                    CVAR_ARCHIVE             },
+	{ &etj_loadviewangles,           "etj_loadviewangles",          "1",                      CVAR_ARCHIVE             },
+	{ &etj_drawspeed,                "etj_drawspeed",               "1",                      CVAR_ARCHIVE             },
+	{ &etj_speedXYonly,              "etj_speedXYonly",             "1",                      CVAR_ARCHIVE             },
+	{ &etj_speedinterval,            "etj_speedinterval",           "100",                    CVAR_ARCHIVE             },
+	{ &etj_speedunit,                "etj_speedunit",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_drawClock,                "etj_drawClock",               "1",                      CVAR_ARCHIVE             },
+	{ &etj_drawSpeed2,               "etj_drawSpeed2",              "1",                      CVAR_ARCHIVE             },
+	{ &etj_speedX,                   "etj_speedX",                  "320",                    CVAR_ARCHIVE             },
+	{ &etj_speedY,                   "etj_speedY",                  "340",                    CVAR_ARCHIVE             },
 	{ &etj_speedSize,               "etj_speedSize",               "3",                      CVAR_ARCHIVE             },
-	{ &cg_speedColor,               "etj_speedColor",              "White",                  CVAR_ARCHIVE             },
-	{ &cg_speedAlpha,               "etj_speedAlpha",              "1.0",                    CVAR_ARCHIVE             },
+	{ &etj_speedColor,               "etj_speedColor",              "White",                  CVAR_ARCHIVE             },
+	{ &etj_speedAlpha,               "etj_speedAlpha",              "1.0",                    CVAR_ARCHIVE             },
 	{ &etj_speedShadow,             "etj_speedShadow",             "0",                      CVAR_ARCHIVE             },
 	{ &etj_drawMaxSpeed,            "etj_drawMaxSpeed",            "0",                      CVAR_ARCHIVE             },
 	{ &etj_maxSpeedX,               "etj_maxSpeedX",               "320",                    CVAR_ARCHIVE             },
@@ -813,10 +813,10 @@ cvarTable_t cvarTable[] =
 	{ &etj_maxSpeedDuration,        "etj_maxSpeedDuration",        "2000",                   CVAR_ARCHIVE             },
 	{ &etj_speedColorUsesAccel,     "etj_speedColorUsesAccel",     "0",                      CVAR_ARCHIVE             },
 
-	{ &cg_popupTime,                "etj_popupTime",               "1000",                   CVAR_ARCHIVE             },
-	{ &cg_popupStayTime,            "etj_popupStayTime",           "2000",                   CVAR_ARCHIVE             },
-	{ &cg_popupFadeTime,            "etj_popupFadeTime",           "2500",                   CVAR_ARCHIVE             },
-	{ &cg_numPopups,                "etj_numPopups",               "5",                      CVAR_ARCHIVE             },
+	{ &etj_popupTime,                "etj_popupTime",               "1000",                   CVAR_ARCHIVE             },
+	{ &etj_popupStayTime,            "etj_popupStayTime",           "2000",                   CVAR_ARCHIVE             },
+	{ &etj_popupFadeTime,            "etj_popupFadeTime",           "2500",                   CVAR_ARCHIVE             },
+	{ &etj_numPopups,                "etj_numPopups",               "5",                      CVAR_ARCHIVE             },
 	
 	{ &etj_HUD_popup,               "etj_HUD_popup",               "1",                      CVAR_ARCHIVE             },
 	{ &etj_popupGrouped,            "etj_popupGrouped",            "1",                      CVAR_ARCHIVE             },
@@ -826,33 +826,33 @@ cvarTable_t cvarTable[] =
 	{ &etj_popupPosY,               "etj_popupPosY",               "0",                      CVAR_ARCHIVE             },
 
 	
-	{ &cg_viewPlayerPortals,        "etj_viewPlayerPortals",       "1",                      CVAR_ARCHIVE             }, //Feen: PGM - View other player portals
-	{ &cg_chatPosX,                 "etj_chatPosX",                "0",                      CVAR_ARCHIVE             },
-	{ &cg_chatPosY,                 "etj_chatPosY",                "0",                      CVAR_ARCHIVE             },
-	{ &cg_chatBackgroundAlpha,      "etj_chatBackgroundAlpha",     "0.33",                   CVAR_ARCHIVE             },
+	{ &etj_viewPlayerPortals,        "etj_viewPlayerPortals",       "1",                      CVAR_ARCHIVE             }, //Feen: PGM - View other player portals
+	{ &etj_chatPosX,                 "etj_chatPosX",                "0",                      CVAR_ARCHIVE             },
+	{ &etj_chatPosY,                 "etj_chatPosY",                "0",                      CVAR_ARCHIVE             },
+	{ &etj_chatBackgroundAlpha,      "etj_chatBackgroundAlpha",     "0.33",                   CVAR_ARCHIVE             },
 	{ &etj_chatFlags,               "etj_chatFlags",               "1",                      CVAR_ARCHIVE             },
 	{ &etj_chatShadow,              "etj_chatShadow",              "0",                      CVAR_ARCHIVE             },
 	{ &etj_chatAlpha,               "etj_chatAlpha",               "1.0",                    CVAR_ARCHIVE             },
 
 	// crosshair stats
-	{ &cg_drawCHS1,                 "etj_drawCHS1",                "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS1Info1,                "etj_CHS1Info1",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS1Info2,                "etj_CHS1Info2",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS1Info3,                "etj_CHS1Info3",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS1Info4,                "etj_CHS1Info4",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS1Info5,                "etj_CHS1Info5",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS1Info6,                "etj_CHS1Info6",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS1Info7,                "etj_CHS1Info7",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS1Info8,                "etj_CHS1Info8",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_drawCHS2,                 "etj_drawCHS2",                "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS2Info1,                "etj_CHS2Info1",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS2Info2,                "etj_CHS2Info2",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS2Info3,                "etj_CHS2Info3",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS2Info4,                "etj_CHS2Info4",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS2Info5,                "etj_CHS2Info5",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS2Info6,                "etj_CHS2Info6",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS2Info7,                "etj_CHS2Info7",               "0",                      CVAR_ARCHIVE             },
-	{ &cg_CHS2Info8,                "etj_CHS2Info8",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_drawCHS1,                 "etj_drawCHS1",                "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS1Info1,                "etj_CHS1Info1",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS1Info2,                "etj_CHS1Info2",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS1Info3,                "etj_CHS1Info3",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS1Info4,                "etj_CHS1Info4",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS1Info5,                "etj_CHS1Info5",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS1Info6,                "etj_CHS1Info6",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS1Info7,                "etj_CHS1Info7",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS1Info8,                "etj_CHS1Info8",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_drawCHS2,                 "etj_drawCHS2",                "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS2Info1,                "etj_CHS2Info1",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS2Info2,                "etj_CHS2Info2",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS2Info3,                "etj_CHS2Info3",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS2Info4,                "etj_CHS2Info4",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS2Info5,                "etj_CHS2Info5",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS2Info6,                "etj_CHS2Info6",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS2Info7,                "etj_CHS2Info7",               "0",                      CVAR_ARCHIVE             },
+	{ &etj_CHS2Info8,                "etj_CHS2Info8",               "0",                      CVAR_ARCHIVE             },
 	{ &etj_CHS2PosX,                "etj_CHS2PosX",                "0",                      CVAR_ARCHIVE             },
 	{ &etj_CHS2PosY,                "etj_CHS2PosY",                "0",                      CVAR_ARCHIVE             },
 	{ &etj_CHSShadow,               "etj_CHSShadow",               "0",                      CVAR_ARCHIVE             },
@@ -860,14 +860,14 @@ cvarTable_t cvarTable[] =
 	{ &etj_CHSColor,                "etj_CHSColor",                "1.0 1.0 1.0",            CVAR_ARCHIVE             },
 	{ &etj_CHSUseFeet,              "etj_CHSUseFeet",              "0",                      CVAR_ARCHIVE             },
 
-	{ &cg_itemPickupText,           "etj_itemPickupText",          "1",                      CVAR_ARCHIVE             },
-	{ &cg_HUD_chargeBar,            "etj_HUD_chargeBar",           "1",                      CVAR_ARCHIVE             },
-	{ &cg_HUD_fatigueBar,           "etj_HUD_fatigueBar",          "1",                      CVAR_ARCHIVE             },
-	{ &cg_HUD_healthBar,            "etj_HUD_healthBar",           "1",                      CVAR_ARCHIVE             },
-	{ &cg_HUD_playerHead,           "etj_HUD_playerHead",          "0",                      CVAR_ARCHIVE             },
-	{ &cg_HUD_playerHealth,         "etj_HUD_playerHealth",        "0",                      CVAR_ARCHIVE             },
-	{ &cg_HUD_weaponIcon,           "etj_HUD_weaponIcon",          "1",                      CVAR_ARCHIVE             },
-	{ &cg_HUD_xpInfo,               "etj_HUD_xpInfo",              "0",                      CVAR_ARCHIVE             },
+	{ &etj_itemPickupText,           "etj_itemPickupText",          "1",                      CVAR_ARCHIVE             },
+	{ &etj_HUD_chargeBar,            "etj_HUD_chargeBar",           "1",                      CVAR_ARCHIVE             },
+	{ &etj_HUD_fatigueBar,           "etj_HUD_fatigueBar",          "1",                      CVAR_ARCHIVE             },
+	{ &etj_HUD_healthBar,            "etj_HUD_healthBar",           "1",                      CVAR_ARCHIVE             },
+	{ &etj_HUD_playerHead,           "etj_HUD_playerHead",          "0",                      CVAR_ARCHIVE             },
+	{ &etj_HUD_playerHealth,         "etj_HUD_playerHealth",        "0",                      CVAR_ARCHIVE             },
+	{ &etj_HUD_weaponIcon,           "etj_HUD_weaponIcon",          "1",                      CVAR_ARCHIVE             },
+	{ &etj_HUD_xpInfo,               "etj_HUD_xpInfo",              "0",                      CVAR_ARCHIVE             },
 	{ &etj_HUD_fireteam,            "etj_HUD_fireteam",            "1",                      CVAR_ARCHIVE             },
 	// fireteam
 	{ &etj_fireteamPosX,            "etj_fireteamPosX",            "0",                      CVAR_ARCHIVE             },
@@ -875,23 +875,23 @@ cvarTable_t cvarTable[] =
 	{ &etj_fireteamAlpha,           "etj_fireteamAlpha",           "1.0",                    CVAR_ARCHIVE             },
 	
 	{ &etj_logBanner,               "etj_logBanner",               "1",                      CVAR_ARCHIVE             },
-	{ &cg_weaponSound,              "etj_weaponSound",             "1",                      CVAR_ARCHIVE             },
-	{ &cg_noclipScale,              "etj_noclipScale",             "1",                      CVAR_ARCHIVE             },
-	{ &cg_drawSlick,                "etj_drawSlick",               "1",                      CVAR_ARCHIVE             },
-	{ &cg_slickX,                   "etj_slickX",                  "304",                    CVAR_ARCHIVE             },
-	{ &cg_slickY,                   "etj_slickY",                  "220",                    CVAR_ARCHIVE             },
-	{ &cg_altScoreboard,            "etj_altScoreboard",           "0",                      CVAR_ARCHIVE             },
-	{ &player_drawSpectatorInfo,    "etj_drawSpectatorInfo",       "0",                      CVAR_ARCHIVE             },
-	{ &player_spectatorInfoX,       "etj_spectatorInfoX",          "320",                    CVAR_ARCHIVE             },
-	{ &player_spectatorInfoY,       "etj_spectatorInfoY",          "40",                     CVAR_ARCHIVE             },
-	{ &player_drawRunTimer,         "etj_drawRunTimer",            "1",                      CVAR_ARCHIVE             },
-	{ &player_runTimerX,            "etj_runTimerX",               "320",                    CVAR_ARCHIVE             },
-	{ &player_runTimerY,            "etj_runTimerY",               "360",                    CVAR_ARCHIVE             },
+	{ &etj_weaponSound,              "etj_weaponSound",             "1",                      CVAR_ARCHIVE             },
+	{ &etj_noclipScale,              "etj_noclipScale",             "1",                      CVAR_ARCHIVE             },
+	{ &etj_drawSlick,                "etj_drawSlick",               "1",                      CVAR_ARCHIVE             },
+	{ &etj_slickX,                   "etj_slickX",                  "304",                    CVAR_ARCHIVE             },
+	{ &etj_slickY,                   "etj_slickY",                  "220",                    CVAR_ARCHIVE             },
+	{ &etj_altScoreboard,            "etj_altScoreboard",           "0",                      CVAR_ARCHIVE             },
+	{ &etj_drawSpectatorInfo,    "etj_drawSpectatorInfo",       "0",                      CVAR_ARCHIVE             },
+	{ &etj_spectatorInfoX,       "etj_spectatorInfoX",          "320",                    CVAR_ARCHIVE             },
+	{ &etj_spectatorInfoY,       "etj_spectatorInfoY",          "40",                     CVAR_ARCHIVE             },
+	{ &etj_drawRunTimer,         "etj_drawRunTimer",            "1",                      CVAR_ARCHIVE             },
+	{ &etj_runTimerX,            "etj_runTimerX",               "320",                    CVAR_ARCHIVE             },
+	{ &etj_runTimerY,            "etj_runTimerY",               "360",                    CVAR_ARCHIVE             },
 	{ &etj_runTimerShadow,          "etj_runTimerShadow",          "0",                      CVAR_ARCHIVE             },
 	{ &etj_runTimerAutoHide,        "etj_runTimerAutoHide",        "1",                      CVAR_ARCHIVE             },
 	{ &etj_runTimerInactiveColor, "etj_runTimerInactiveColor", "mdgrey", CVAR_ARCHIVE },
 
-	{ &player_drawMessageTime,      "etj_drawMessageTime",         "2",                      CVAR_ARCHIVE             },
+	{ &etj_drawMessageTime,      "etj_drawMessageTime",         "2",                      CVAR_ARCHIVE             },
 
 	{ &movie_changeFovBasedOnSpeed, "movie_changeFovBasedOnSpeed", "0",                      CVAR_ARCHIVE             },
 	{ &movie_fovMinSpeed,           "movie_fovMinSpeed",           "400",                    CVAR_ARCHIVE             },
@@ -1127,10 +1127,10 @@ void CG_UpdateCvars(void)
 					cv->vmCvar == &int_cl_timenudge || cv->vmCvar == &int_cl_maxpackets ||
 					cv->vmCvar == &cg_autoactivate || cv->vmCvar == &cg_predictItems ||
 					cv->vmCvar == &pmove_fixed || cv->vmCvar == &com_maxfps ||
-					cv->vmCvar == &cg_nofatigue || cv->vmCvar == &etj_drawCGaz ||
+					cv->vmCvar == &etj_nofatigue || cv->vmCvar == &etj_drawCGaz ||
 					cv->vmCvar == &cl_yawspeed || cv->vmCvar == &cl_freelook ||
-					cv->vmCvar == &int_m_pitch || cv->vmCvar == &cg_loadviewangles ||
-					cv->vmCvar == &cg_hideMe || cv->vmCvar == &cg_noclipScale ||
+					cv->vmCvar == &int_m_pitch || cv->vmCvar == &etj_loadviewangles ||
+					cv->vmCvar == &etj_hideMe || cv->vmCvar == &etj_noclipScale ||
 					cv->vmCvar == &etj_enableTimeruns || cv->vmCvar == &etj_noActivateLean ||
 					cv->vmCvar == &etj_touchPickupWeapons || cv->vmCvar == &etj_autoLoad ||
 					cv->vmCvar == &etj_quickFollow || cv->vmCvar == &etj_drawSnapHUD
@@ -1199,13 +1199,13 @@ void CG_setClientFlags(void)
 	                                 ((cg_autoAction.integer & AA_STATSDUMP) ? CGF_STATSDUMP : 0) |
 	                                 ((cg_autoactivate.integer > 0) ? CGF_AUTOACTIVATE : 0) |
 	                                 ((cg_predictItems.integer > 0) ? CGF_PREDICTITEMS : 0) |
-	                                 ((cg_nofatigue.integer > 0) ? CGF_NOFATIGUE : 0) |
+	                                 ((etj_nofatigue.integer > 0) ? CGF_NOFATIGUE : 0) |
 	                                 ((pmove_fixed.integer > 0) ? CGF_PMOVEFIXED : 0) |
 	                                 ((etj_drawCGaz.integer > 0) ? CGF_CGAZ : 0) |
 	                                 ((cl_yawspeed.integer > 0 || (int_m_pitch.value < 0.01 && int_m_pitch.value > -0.01) ||
 	                                   cl_freelook.integer == 0) ? CGF_CHEATCVARSON : 0) |
-	                                 ((cg_loadviewangles.integer > 0) ? CGF_LOADVIEWANGLES : 0) |
-									 ((cg_hideMe.integer > 0) ? CGF_HIDEME : 0) |
+	                                 ((etj_loadviewangles.integer > 0) ? CGF_LOADVIEWANGLES : 0) |
+									 ((etj_hideMe.integer > 0) ? CGF_HIDEME : 0) |
 									 ((etj_enableTimeruns.integer > 0) ? CGF_ENABLE_TIMERUNS : 0) |
 									 ((etj_noActivateLean.integer > 0) ? CGF_NOACTIVATELEAN : 0) |
 									 ((etj_autoLoad.integer > 0) ? CGF_AUTO_LOAD : 0) |
@@ -1219,7 +1219,7 @@ void CG_setClientFlags(void)
 	                             // MaxPackets
 	                             int_cl_maxpackets.integer,
 	                             com_maxfps.integer,
-	                             cg_noclipScale.value,
+	                             etj_noclipScale.value,
 	                             etj_touchPickupWeapons.integer
 	                             ));
 

--- a/src/cgame/cg_newDraw.cpp
+++ b/src/cgame/cg_newDraw.cpp
@@ -350,7 +350,7 @@ void CG_DrawPlayerWeaponIcon(rectDef_t *rect, qboolean drawHighlighted, int alig
 	}
 
 
-	if (cg_HUD_weaponIcon.integer && icon)
+	if (etj_HUD_weaponIcon.integer && icon)
 	{
 		float x, y, w, h;
 

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -2106,22 +2106,22 @@ void CG_Player(centity_t *cent)
 	{
 
 		vec_t playerDist = Distance(cgsnap->lerpOrigin, cent->lerpOrigin);
-		int transZone = cg_hideDistance.integer + etj_hideFadeRange.integer;
+		int transZone = etj_hideDistance.integer + etj_hideFadeRange.integer;
 
 		// Hide players at close range
-		if (cg_hide.integer && ci->clientNum != cg.snap->ps.clientNum && playerDist < cg_hideDistance.integer)
+		if (etj_hide.integer && ci->clientNum != cg.snap->ps.clientNum && playerDist < etj_hideDistance.integer)
 		{
 			return;
 		}
 
-		if (cg_hide.integer && ci->clientNum != cg.snap->ps.clientNum && playerDist < transZone) {
+		if (etj_hide.integer && ci->clientNum != cg.snap->ps.clientNum && playerDist < transZone) {
 
 			float diff = (transZone - playerDist) / etj_hideFadeRange.integer;
 			cg.currentTransparencyValue = etj_playerOpacity.value - (etj_playerOpacity.value * diff);
 
 		}
 
-		if (cg_hide.integer && ci->clientNum != cg.snap->ps.clientNum && cg.currentTransparencyValue <= 0) {
+		if (etj_hide.integer && ci->clientNum != cg.snap->ps.clientNum && cg.currentTransparencyValue <= 0) {
 			return;
 		}
 

--- a/src/cgame/cg_playerstate.cpp
+++ b/src/cgame/cg_playerstate.cpp
@@ -273,7 +273,7 @@ void CG_Respawn(qboolean revived)
 	// clear pmext
 	memset(&cg.pmext, 0, sizeof(cg.pmext));
 
-	cg.pmext.noclipScale = (cg_noclipScale.value);
+	cg.pmext.noclipScale = (etj_noclipScale.value);
 	cg.pmext.bAutoReload = (cg_autoReload.integer > 0) ? qtrue : qfalse;
 
 	cg.pmext.sprintTime = SPRINTTIME;

--- a/src/cgame/cg_popupmessages.cpp
+++ b/src/cgame/cg_popupmessages.cpp
@@ -84,8 +84,8 @@ void CG_InitPM(void)
 }
 
 /*
-Replaced these with cg_popupTime,
-cg_popupFadeTime & cg_popupStayTime
+Replaced these with etj_popupTime,
+etj_popupFadeTime & etj_popupStayTime
 #define PM_FADETIME 2500
 #define PM_WAITTIME 2000
 */
@@ -95,7 +95,7 @@ cg_popupFadeTime & cg_popupStayTime
 
 int CG_TimeForPopup(popupMessageType_t type)
 {
-	return cg_popupTime.integer;
+	return etj_popupTime.integer;
 }
 
 int CG_TimeForBigPopup(popupMessageBigType_t type)
@@ -131,7 +131,7 @@ void CG_UpdatePMLists(void)
 			}
 			else
 			{
-				if (cg.time > t + cg_popupStayTime.integer + cg_popupFadeTime.integer)
+				if (cg.time > t + etj_popupStayTime.integer + etj_popupFadeTime.integer)
 				{
 					// we're gone completely
 					cg_pmWaitingList = NULL;
@@ -150,7 +150,7 @@ void CG_UpdatePMLists(void)
 	lastItem = NULL;
 	while (listItem)
 	{
-		int t = (CG_TimeForPopup(listItem->type) + listItem->time + cg_popupStayTime.integer + cg_popupFadeTime.integer);
+		int t = (CG_TimeForPopup(listItem->type) + listItem->time + etj_popupStayTime.integer + etj_popupFadeTime.integer);
 		if (cg.time > t)
 		{
 			// nuke this, and everything below it (though there shouldn't BE anything below us anyway)
@@ -200,7 +200,7 @@ void CG_UpdatePMLists(void)
 			}
 			else
 			{
-				if (cg.time > t + cg_popupStayTime.integer + cg_popupFadeTime.integer)
+				if (cg.time > t + etj_popupStayTime.integer + etj_popupFadeTime.integer)
 				{
 					// we're gone completely
 					cg_pmWaitingListBig = NULL;
@@ -447,7 +447,7 @@ void CG_DrawPMItems(void)
 		return;
 	}
 
-	if (cg_numPopups.integer <= 0)
+	if (etj_numPopups.integer <= 0)
 	{
 		return;
 	}
@@ -487,10 +487,10 @@ void CG_DrawPMItems(void)
 		msg = (char*)&cg_pmWaitingList->message;
 	}
 
-	t = cg_pmWaitingList->time + CG_TimeForPopup(cg_pmWaitingList->type) + cg_popupStayTime.integer;
+	t = cg_pmWaitingList->time + CG_TimeForPopup(cg_pmWaitingList->type) + etj_popupStayTime.integer;
 	if (cg.time > t)
 	{
-		colourText[3] = colour[3] = (1 - ((cg.time - t) / (float)cg_popupFadeTime.integer)) * textAlpha;
+		colourText[3] = colour[3] = (1 - ((cg.time - t) / (float)etj_popupFadeTime.integer)) * textAlpha;
 	}
 	else {
 		colourText[3] = colour[3] = textAlpha;
@@ -507,14 +507,14 @@ void CG_DrawPMItems(void)
 
 	CG_Text_Paint_Ext(x + size + 2 - x_off, y + 12, 0.2f, 0.2f, colourText, msg, 0, 0, textStyle, &cgs.media.limboFont2);
 
-	for (i = 0; i < cg_numPopups.integer - 1 && listItem; i++, listItem = listItem->next)
+	for (i = 0; i < etj_numPopups.integer - 1 && listItem; i++, listItem = listItem->next)
 	{
 		y -= size + 2;
 
-		t = listItem->time + CG_TimeForPopup(listItem->type) + cg_popupStayTime.integer;
+		t = listItem->time + CG_TimeForPopup(listItem->type) + etj_popupStayTime.integer;
 		if (cg.time > t)
 		{
-			colourText[3] = colour[3] = (1 - ((cg.time - t) / (float)cg_popupFadeTime.integer)) * textAlpha;
+			colourText[3] = colour[3] = (1 - ((cg.time - t) / (float)etj_popupFadeTime.integer)) * textAlpha;
 		}
 		else
 		{

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -1075,17 +1075,17 @@ void CG_PredictPlayerState(void)
 	// rain - fill in the current cmd with the latest prediction from
 	// cg.pmext (#166)
 
-	if (cg_noclipScale.value < 0.1)
+	if (etj_noclipScale.value < 0.1)
 	{
 		cg.pmext.noclipScale = 0.1;
 	}
-	else if (cg_noclipScale.value > 20)
+	else if (etj_noclipScale.value > 20)
 	{
 		cg.pmext.noclipScale = 20;
 	}
 	else
 	{
-		cg.pmext.noclipScale = cg_noclipScale.value;
+		cg.pmext.noclipScale = etj_noclipScale.value;
 	}
 
 	memcpy(&oldpmext[current & CMD_MASK], &cg.pmext, sizeof(pmoveExt_t));

--- a/src/cgame/cg_scoreboard.cpp
+++ b/src/cgame/cg_scoreboard.cpp
@@ -1162,19 +1162,19 @@ qboolean CG_DrawScoreboard(void)
 		fade = fadeColor[3];
 	}
 
-	if (cg_altScoreboard.integer == 1)
+	if (etj_altScoreboard.integer == 1)
 	{
 		CG_DrawAltScoreboard(fade);
 		return qtrue;
 	}
 	
-	if (cg_altScoreboard.integer == 2)
+	if (etj_altScoreboard.integer == 2)
 	{
 		CG_DrawAltScoreboard2(fade);
 		return qtrue;
 	}
 
-	if (cg_altScoreboard.integer == 3)
+	if (etj_altScoreboard.integer == 3)
 	{
 		CG_DrawAltScoreboard3(fade);
 		return qtrue;

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -1631,13 +1631,13 @@ void CG_VoiceChatLocal(int mode, qboolean voiceOnly, int clientNum, int color, v
 				chat = vsay->custom;
 			}
 
-			if (player_drawMessageTime.integer)
+			if (etj_drawMessageTime.integer)
 			{
 				if (cg.clientNum == clientNum)
 				{
 					msgColor = "^g";
 				}
-				if (player_drawMessageTime.integer == 2)
+				if (etj_drawMessageTime.integer == 2)
 				{
 					msgTime = va("%s[%02d:%02d:%02d]^7 ", msgColor, t.tm_hour, t.tm_min, t.tm_sec);
 				}
@@ -2438,13 +2438,13 @@ const char *CG_AddChatModifications(char *text, int clientNum)
 		}
 	}
 
-	if (player_drawMessageTime.integer)
+	if (etj_drawMessageTime.integer)
 	{
 		if (cg.clientNum == clientNum)
 		{
 			msgColor = "^g";
 		}
-		if (player_drawMessageTime.integer == 2)
+		if (etj_drawMessageTime.integer == 2)
 		{
 			Q_strcat(message, sizeof(message), va("%s[%02d:%02d:%02d]^7 ", msgColor, t.tm_hour, t.tm_min, t.tm_sec));
 		}

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -5736,8 +5736,8 @@ void CG_FireWeapon(centity_t *cent)
         firesound = &cg_weapons[ WP_MEDKIT ].flashSound[0];
     }*/
 
-	// Zero: don't play sound if cg_weaponSound is set to 0
-	if (!(cent->currentState.eFlags & EF_ZOOMING) && cg_weaponSound.integer)   // JPW NERVE -- don't play sounds or eject brass if zoomed in
+	// Zero: don't play sound if etj_weaponSound is set to 0
+	if (!(cent->currentState.eFlags & EF_ZOOMING) && etj_weaponSound.integer)   // JPW NERVE -- don't play sounds or eject brass if zoomed in
 	{   // play a sound
 		for (c = 0 ; c < 4 ; c++)
 		{

--- a/src/cgame/etj_maxspeed.cpp
+++ b/src/cgame/etj_maxspeed.cpp
@@ -51,14 +51,14 @@ ETJump::DisplayMaxSpeed::DisplayMaxSpeed(EntityEventsHandler* entityEventsHandle
 		_animationStartTime = cg.time;
 	});
 
-	parseColor(cg_speedColor.string, _color);
-	cvarUpdateHandler->subscribe(&cg_speedColor, [&](const vmCvar_t *cvar)
+	parseColor(etj_speedColor.string, _color);
+	cvarUpdateHandler->subscribe(&etj_speedColor, [&](const vmCvar_t *cvar)
 	{
-		parseColor(cg_speedColor.string, _color);
+		parseColor(etj_speedColor.string, _color);
 	});
-	cvarUpdateHandler->subscribe(&cg_speedAlpha, [&](const vmCvar_t *cvar)
+	cvarUpdateHandler->subscribe(&etj_speedAlpha, [&](const vmCvar_t *cvar)
 	{
-		parseColor(cg_speedColor.string, _color);
+		parseColor(etj_speedColor.string, _color);
 	});
 }
 
@@ -70,7 +70,7 @@ ETJump::DisplayMaxSpeed::~DisplayMaxSpeed()
 void ETJump::DisplayMaxSpeed::parseColor(const std::string& color, vec4_t& out)
 {
 	parseColorString(color, out);
-	out[3] *= cg_speedAlpha.value;
+	out[3] *= etj_speedAlpha.value;
 }
 
 void ETJump::DisplayMaxSpeed::beforeRender()

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -34,7 +34,7 @@ constexpr float ACCEL_FOR_SOLID_COLOR      = 100;
 
 ETJump::DisplaySpeed::DisplaySpeed()
 {
-	parseColor(cg_speedColor.string, _color);
+	parseColor(etj_speedColor.string, _color);
 	checkShadow();
 	startListeners();
 }
@@ -44,19 +44,19 @@ ETJump::DisplaySpeed::~DisplaySpeed() {}
 void ETJump::DisplaySpeed::parseColor(const std::string& color, vec4_t& out)
 {
 	parseColorString(color, out);
-	out[3] *= cg_speedAlpha.value;
+	out[3] *= etj_speedAlpha.value;
 }
 
 void ETJump::DisplaySpeed::startListeners()
 {
-	cvarUpdateHandler->subscribe(&cg_speedColor, [&](const vmCvar_t *cvar)
+	cvarUpdateHandler->subscribe(&etj_speedColor, [&](const vmCvar_t *cvar)
 	{
-		parseColor(cg_speedColor.string, _color);
+		parseColor(etj_speedColor.string, _color);
 	});
 
-	cvarUpdateHandler->subscribe(&cg_speedAlpha, [&](const vmCvar_t *cvar)
+	cvarUpdateHandler->subscribe(&etj_speedAlpha, [&](const vmCvar_t *cvar)
 	{
-		parseColor(cg_speedColor.string, _color);
+		parseColor(etj_speedColor.string, _color);
 	});
 
 	cvarUpdateHandler->subscribe(&etj_speedShadow, [&](const vmCvar_t *cvar)
@@ -106,13 +106,13 @@ void ETJump::DisplaySpeed::render() const
 	}
 
 	float size = 0.1f * etj_speedSize.integer;
-	float x = cg_speedX.integer;
-	float y = cg_speedY.integer;
+	float x = etj_speedX.integer;
+	float y = etj_speedY.integer;
 	ETJump_AdjustPosition(&x);
 
 	auto status = getStatus();
 	float w = CG_Text_Width_Ext(status.c_str(), size, 0, &cgs.media.limboFont2) / 2;
-	if (cg_drawSpeed2.integer == 8)
+	if (etj_drawSpeed2.integer == 8)
 	{
 		w = 0;
 	}
@@ -149,7 +149,7 @@ void ETJump::DisplaySpeed::render() const
 std::string ETJump::DisplaySpeed::getStatus() const
 {
 	float speed = sqrt(cg.predictedPlayerState.velocity[0] * cg.predictedPlayerState.velocity[0] + cg.predictedPlayerState.velocity[1] * cg.predictedPlayerState.velocity[1]);
-	switch (cg_drawSpeed2.integer)
+	switch (etj_drawSpeed2.integer)
 	{
 	case 2: return stringFormat("%.0f %.0f", speed, _maxSpeed);
 	case 3: return stringFormat("%.0f ^z%.0f", speed, _maxSpeed);
@@ -166,7 +166,7 @@ std::string ETJump::DisplaySpeed::getStatus() const
 
 bool ETJump::DisplaySpeed::canSkipDraw() const
 {
-	return !cg_drawSpeed2.integer || cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time;
+	return !etj_drawSpeed2.integer || cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time;
 }
 
 void ETJump::DisplaySpeed::popOldStoredSpeeds()

--- a/src/cgame/etj_timerun_view.cpp
+++ b/src/cgame/etj_timerun_view.cpp
@@ -93,7 +93,7 @@ void ETJump::TimerunView::draw()
 	auto run = currentRun();
 
 	auto hasTimerun = (cg.demoPlayback && run->running) || cg.hasTimerun;
-	if (player_drawRunTimer.integer == 0 || !hasTimerun)
+	if (etj_drawRunTimer.integer == 0 || !hasTimerun)
 	{
 		return;
 	}
@@ -162,8 +162,8 @@ void ETJump::TimerunView::draw()
 		% millis).str();
 
 	auto textWidth = CG_Text_Width_Ext(text.c_str(), 0.3, 0, &cgs.media.limboFont1) / 2;
-	auto x = player_runTimerX.value;
-	auto y = player_runTimerY.integer;
+	auto x = etj_runTimerX.value;
+	auto y = etj_runTimerY.integer;
 
 	// timer fading/hiding routine
 	ETJump_AdjustPosition(&x);
@@ -235,8 +235,8 @@ void ETJump::TimerunView::pastRecordAnimation(vec4_t *color, const char* text, i
 	vec4_t toColor;
 	vec4_t incolor;
 
-	auto x = player_runTimerX.value;
-	auto y = player_runTimerY.value;
+	auto x = etj_runTimerX.value;
+	auto y = etj_runTimerY.value;
 
 	ETJump_AdjustPosition(&x);
 


### PR DESCRIPTION
While the transition from cg/player -> etj cvars was made, the code references were still left to the original cvar names. This PR should change all of those to correspond to the real cvar name.