### PR TITLE
Fix unintended vote logic behavior change

### DIFF
--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -3314,7 +3314,7 @@ void CheckVote(void)
 	auto numConnectedClients = level.numConnectedClients;
 
 	auto validVotingClients = getNumValidVoters();
-	auto requiredClients = validVotingClients / 100.0f * requiredPercentage;
+	int requiredClients = validVotingClients * requiredPercentage / 100;
 
 	auto voter = g_entities + level.voteInfo.voter_cn;
 	if (level.voteInfo.voter_team != voter->client->sess.sessionTeam)


### PR DESCRIPTION
No idea why this approach didn't cause issues before, but the vote passing logic is now same as in etmain (fully integer based).

closes #552 