### PR TITLE
Add unload command

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -1695,6 +1695,7 @@ void CG_InitConsoleCommands(void)
 	trap_AddCommand("save");
 	trap_AddCommand("load");
 	trap_AddCommand("backup");
+	trap_AddCommand("unload");
 	trap_AddCommand("goto");
 	trap_AddCommand("call");
 	trap_AddCommand("nogoto");

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -95,6 +95,12 @@ bool Save(gentity_t *ent, Arguments argv)
 	return true;
 }
 
+bool Unload(gentity_t *ent, Arguments argv)
+{
+	ETJump::saveSystem->unload(ent);
+	return true;
+}
+
 bool ListInfo(gentity_t *ent, Arguments argv)
 {
 	if (argv->size() != 2)
@@ -2238,6 +2244,7 @@ Commands::Commands()
 	commands_["backup"] = ClientCommands::BackupLoad;
 	commands_["save"]   = ClientCommands::Save;
 	commands_["load"]   = ClientCommands::Load;
+	commands_["unload"] = ClientCommands::Unload;
 //    commands_["race"] = ClientCommands::Race;
 	commands_["listinfo"] = ClientCommands::ListInfo;
 	commands_["records"]  = ClientCommands::Records;

--- a/src/game/etj_save_system.h
+++ b/src/game/etj_save_system.h
@@ -74,9 +74,11 @@ namespace ETJump
 
 			SavePosition alliesSavedPositions[MAX_SAVED_POSITIONS];
 			boost::circular_buffer<SavePosition> alliesBackupPositions;
+			SavePosition alliesLastLoadPosition;
 
 			SavePosition axisSavedPositions[MAX_SAVED_POSITIONS];
 			boost::circular_buffer<SavePosition> axisBackupPositions;
+			SavePosition axisLastLoadPosition;
 
 			// contains a couple of extra positions for TEAM_SPEC and TEAM_FREE,
 			// but simplifies the accessing code
@@ -91,6 +93,11 @@ namespace ETJump
 			SavePosition alliesSavedPositions[MAX_SAVED_POSITIONS];
 			// Axis saved positions at the time of disconnect
 			SavePosition axisSavedPositions[MAX_SAVED_POSITIONS];
+
+			// Last load positions
+			SavePosition axisLastLoadPosition;
+			SavePosition alliesLastLoadPosition;
+
 
 			// So called "map ident"
 			int progression;
@@ -114,6 +121,12 @@ namespace ETJump
 
 		// Loads backup position
 		void loadBackupPosition(gentity_t *ent);
+
+		// UnLoad - revert last "load" command
+		void unload(gentity_t* ent);
+
+		// Saves last position client loaded from
+		void saveLastLoadPos(gentity_t* ent);
 
 		// resets all clients positions
 		void reset();
@@ -146,6 +159,8 @@ namespace ETJump
 		void restoreStanceFromSave(gentity_t *ent, SavePosition *pos);
 
 		SavePosition* getValidTeamSaveForSlot(gentity_t *ent, team_t team, int slot);
+		
+		SavePosition* getValidTeamUnloadPos(gentity_t* ent, team_t team);
 
 		// All clients' save related data
 		Client _clients[MAX_CLIENTS];


### PR DESCRIPTION
`/unload` - undo last load command and teleport to position you loaded from previously. Some restrictions:

* cannot be used if save is not available
* cannot be used during timeruns
* cannot unload into areas where you cannot use `save`
* only __1__ unload slot thats overwritten on every successful load

closes #544 