### PR TITLE
Replace etj_weaponSound with etj_weaponVolume

### DIFF
--- a/assets/ui/etjump_settings_1.menu
+++ b/assets/ui/etjump_settings_1.menu
@@ -84,7 +84,8 @@ menuDef {
         MULTI				(316, SUBW_CONSOLE_Y + 44, 276, 8, "Console color:", 0.2, 8, "etj_consoleColor", cvarStrList { "White"; "white"; "Yellow"; "yellow"; "Red"; "red"; "Green"; "green"; "Blue"; "blue"; "Magenta"; "magenta"; "Cyan"; "cyan"; "Orange"; "orange"; "Light Blue"; "0xa0c0ff"; "Medium Blue"; "mdblue"; "Light Red"; "0xffc0a0"; "Medium Red"; "mdred"; "Light Green"; "0xa0ffc0"; "Medium Green"; "mdgreen"; "Dark Green"; "dkgreen"; "Medium Cyan"; "mdcyan"; "Medium Yellow"; "mdyellow"; "Medium Orange"; "mdorange"; "Light Grey"; "ltgrey"; "Medium Grey"; "mdgrey"; "Dark Grey"; "dkgrey"; "Black"; "black" }, "Sets console color when console shader is disabled (vid_restart required)\netj_consoleColor")
 
     SUBWINDOW(308, 284, 292, 64, "SOUNDS")
-        YESNO				(316, SUBW_SOUNDS_Y + 20, 276, 8, "Weapon sounds:", 0.2, 8, "etj_weaponSound", "Enable weapon sounds\netj_weaponSounds")
+        CVARFLOATLABEL		(316, SUBW_SOUNDS_Y + 20, 276, 8, "etj_weaponVolume", 0.2, ITEM_ALIGN_RIGHT, 276, 8)
+        SLIDER      		(316, SUBW_SOUNDS_Y + 20, 276, 8, "Weapon sound volume:", 0.2, 8, etj_weaponVolume 1 0 5 0.1, "Scale weapon sound volume\netj_weaponVolume")
         YESNO				(316, SUBW_SOUNDS_Y + 32, 276, 8, "Looped sounds:", 0.2, 8, "etj_loopedSounds", "Play looping sounds on map\netj_loopedSounds")
         YESNO				(316, SUBW_SOUNDS_Y + 44, 276, 8, "Uphill step sounds:", 0.2, 8, "etj_uphillSteps", "Enable stepsounds on very low impact speeds\netj_uphillSteps")
 

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -2292,7 +2292,6 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 // jpw
 
 	case EV_NOAMMO:
-		if (!etj_weaponSound.integer) break;
 	case EV_WEAPONSWITCHED:
 		DEBUGNAME("EV_NOAMMO");
 		if ((es->weapon != WP_GRENADE_LAUNCHER) &&
@@ -2306,7 +2305,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		    (es->weapon != WP_AMMO) &&
 		    (es->weapon != WP_MEDKIT)) //Feen: PGM
 		{
-			trap_S_StartSound(NULL, es->number, CHAN_AUTO, cgs.media.noAmmoSound);
+			trap_S_StartSoundVControl(NULL, es->number, CHAN_AUTO, cgs.media.noAmmoSound, DEFAULT_VOLUME * etj_weaponVolume.value);
 		}
 
 		if (es->number == cg.snap->ps.clientNum && (

--- a/src/cgame/cg_flamethrower.cpp
+++ b/src/cgame/cg_flamethrower.cpp
@@ -1386,12 +1386,6 @@ void CG_UpdateFlamethrowerSounds(void)
 	flameChunk_t *f, *trav; // , *lastSoundFlameChunk=NULL; // TTimo: unused
 	#define MIN_BLOW_VOLUME     30
 
-	// Mute sounds if weapon sounds are disabled
-	if (etj_weaponSound.integer <= 0)
-	{
-		return;
-	}
-
 	// draw each of the headFlameChunk's
 	f = headFlameChunks;
 	while (f)
@@ -1402,16 +1396,16 @@ void CG_UpdateFlamethrowerSounds(void)
 			// blow/ignition sound
 			if (centFlameStatus[f->ownerCent].blowVolume * 255.0 > MIN_BLOW_VOLUME)
 			{
-				trap_S_AddLoopingSound(f->org, vec3_origin, cgs.media.flameBlowSound, (int)(255.0 * centFlameStatus[f->ownerCent].blowVolume), 0); // JPW NERVE
+				trap_S_AddLoopingSound(f->org, vec3_origin, cgs.media.flameBlowSound, (int)(255.0 * centFlameStatus[f->ownerCent].blowVolume) * etj_weaponVolume.value, 0); // JPW NERVE
 			}
 			else
 			{
-				trap_S_AddLoopingSound(f->org, vec3_origin, cgs.media.flameBlowSound, MIN_BLOW_VOLUME, 0);   // JPW NERVE
+				trap_S_AddLoopingSound(f->org, vec3_origin, cgs.media.flameBlowSound, MIN_BLOW_VOLUME * etj_weaponVolume.value, 0);   // JPW NERVE
 			}
 
 			if (centFlameStatus[f->ownerCent].streamVolume)
 			{
-				trap_S_AddLoopingSound(f->org, vec3_origin, cgs.media.flameStreamSound, (int)(255.0 * centFlameStatus[f->ownerCent].streamVolume), 0);     // JPW NERVE
+				trap_S_AddLoopingSound(f->org, vec3_origin, cgs.media.flameStreamSound, (int)(255.0 * centFlameStatus[f->ownerCent].streamVolume) * etj_weaponVolume.value, 0);     // JPW NERVE
 			}
 
 			centFlameInfo[f->ownerCent].lastSoundUpdate = cg.time;
@@ -1423,7 +1417,7 @@ void CG_UpdateFlamethrowerSounds(void)
 			// update the sound volume
 			if (trav->blueLife + 100 < (cg.time - trav->timeStart))
 			{
-				trap_S_AddLoopingSound(trav->org, vec3_origin, cgs.media.flameSound, (int)(255.0 * (0.2 * (trav->size / FLAME_MAX_SIZE))), 0);
+				trap_S_AddLoopingSound(trav->org, vec3_origin, cgs.media.flameSound, (int)(255.0 * (0.2 * (trav->size / FLAME_MAX_SIZE))) * etj_weaponVolume.value, 0);
 			}
 		}
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2525,7 +2525,7 @@ extern vmCvar_t etj_fireteamAlpha;
 
 #define CONLOG_BANNERPRINT 1
 extern vmCvar_t etj_logBanner;
-extern vmCvar_t etj_weaponSound;
+extern vmCvar_t etj_weaponVolume;
 
 extern vmCvar_t etj_noclipScale;
 extern vmCvar_t etj_drawSlick;
@@ -3362,6 +3362,7 @@ void        trap_R_ClearDecals(void);
 
 // normal sounds will have their volume dynamically changed as their entity
 // moves and the listener moves
+constexpr int DEFAULT_VOLUME = 127;
 void        trap_S_StartSound(vec3_t origin, int entityNum, int entchannel, sfxHandle_t sfx);
 void        trap_S_StartSoundVControl(vec3_t origin, int entityNum, int entchannel, sfxHandle_t sfx, int volume);
 void        trap_S_StartSoundEx(vec3_t origin, int entityNum, int entchannel, sfxHandle_t sfx, int flags);

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -449,7 +449,7 @@ vmCvar_t etj_fireteamPosY;
 vmCvar_t etj_fireteamAlpha;
 
 vmCvar_t etj_logBanner;
-vmCvar_t etj_weaponSound;
+vmCvar_t etj_weaponVolume;
 vmCvar_t etj_noclipScale;
 
 vmCvar_t etj_drawSlick;
@@ -875,7 +875,7 @@ cvarTable_t cvarTable[] =
 	{ &etj_fireteamAlpha,           "etj_fireteamAlpha",           "1.0",                    CVAR_ARCHIVE             },
 	
 	{ &etj_logBanner,               "etj_logBanner",               "1",                      CVAR_ARCHIVE             },
-	{ &etj_weaponSound,              "etj_weaponSound",             "1",                      CVAR_ARCHIVE             },
+	{ &etj_weaponVolume,              "etj_weaponVolume",             "1.0",                      CVAR_ARCHIVE             },
 	{ &etj_noclipScale,              "etj_noclipScale",             "1",                      CVAR_ARCHIVE             },
 	{ &etj_drawSlick,                "etj_drawSlick",               "1",                      CVAR_ARCHIVE             },
 	{ &etj_slickX,                   "etj_slickX",                  "304",                    CVAR_ARCHIVE             },

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -5736,8 +5736,7 @@ void CG_FireWeapon(centity_t *cent)
         firesound = &cg_weapons[ WP_MEDKIT ].flashSound[0];
     }*/
 
-	// Zero: don't play sound if etj_weaponSound is set to 0
-	if (!(cent->currentState.eFlags & EF_ZOOMING) && etj_weaponSound.integer)   // JPW NERVE -- don't play sounds or eject brass if zoomed in
+	if (!(cent->currentState.eFlags & EF_ZOOMING))   // JPW NERVE -- don't play sounds or eject brass if zoomed in
 	{   // play a sound
 		for (c = 0 ; c < 4 ; c++)
 		{
@@ -5751,7 +5750,7 @@ void CG_FireWeapon(centity_t *cent)
 			c = rand() % c;
 			if (firesound[c])
 			{
-				trap_S_StartSound(NULL, ent->number, CHAN_WEAPON, firesound[c]);
+				trap_S_StartSoundVControl(NULL, ent->number, CHAN_WEAPON, firesound[c], DEFAULT_VOLUME * etj_weaponVolume.value);
 
 				if (fireEchosound && fireEchosound[c])   // check for echo
 				{
@@ -5767,7 +5766,7 @@ void CG_FireWeapon(centity_t *cent)
 					if (gdist > 512 && gdist < 4096)     // temp dist.  TODO: use numbers that are weapon specific
 					{   // use gorg as the new sound origin
 						VectorMA(cg.refdef_current->vieworg, 64, norm, gorg);   // sound-on-a-stick
-						trap_S_StartSoundEx(gorg, ent->number, CHAN_WEAPON, fireEchosound[c], SND_NOCUT);
+						trap_S_StartSoundExVControl(gorg, ent->number, CHAN_WEAPON, fireEchosound[c], SND_NOCUT, DEFAULT_VOLUME * etj_weaponVolume.value);
 					}
 				}
 			}


### PR DESCRIPTION
Replaces `etj_weaponSound` toggle with `etj_weaponVolume` to allow scaling weapon sound volume instead of purely toggling them.

closes #430 