### PR TITLE
Fix timerun prints on runs over 1 hour

### DIFF
--- a/src/cgame/cg_timerun.cpp
+++ b/src/cgame/cg_timerun.cpp
@@ -116,16 +116,13 @@ Timerun::Time Timerun::createTimeFromTimestamp(int timestamp)
 {
 	int millis = timestamp;
 
-	int hours = millis / static_cast<int>(Time::Duration::Hour);
-	millis -= hours * static_cast<int>(Time::Duration::Hour);
-
 	int minutes = millis / static_cast<int>(Time::Duration::Minute);
 	millis -= minutes * static_cast<int>(Time::Duration::Minute);
 
 	int seconds = millis / static_cast<int>(Time::Duration::Second);
 	millis -= seconds * static_cast<int>(Time::Duration::Second);
 
-	return{ hours, minutes, seconds, millis, timestamp };
+	return{ minutes, seconds, millis, timestamp };
 }
 
 std::string Timerun::createCompletionMessage(clientInfo_t& player, std::string& runName, int completionTime, int previousTime)

--- a/src/cgame/cg_timerun.h
+++ b/src/cgame/cg_timerun.h
@@ -119,10 +119,8 @@ private:
 		{
 			Millisecond = 1,
 			Second = 1000,
-			Minute = 60 * 1000,
-			Hour = 60 * 60 * 1000
+			Minute = 60 * 1000
 		};
-		int hours;
 		int minutes;
 		int seconds;
 		int ms;


### PR DESCRIPTION
Removes hours calculations from timerun timestamps on cgame side, we don't need them anyway, makes more sense to just display pure minutes.

closes #575 