### PR TITLE
Fix portalgun pickup issues

### DIFF
--- a/src/game/g_items.cpp
+++ b/src/game/g_items.cpp
@@ -694,6 +694,13 @@ int Pickup_Weapon(gentity_t *ent, gentity_t *other)
 			return 0;
 		}
 
+		// if we're touching portalgun, don't mess around with weapon switching/dropping
+		if (ent->item->giTag == WP_PORTAL_GUN)
+		{
+			COM_BitSet(other->client->ps.weapons, ent->item->giTag);
+			return -1;
+		}
+
 		// See if we can pick it up
 		if (G_CanPickupWeapon(static_cast<weapon_t>(ent->item->giTag), other))
 		{
@@ -914,7 +921,7 @@ void Touch_Item_Auto(gentity_t *ent, gentity_t *other, trace_t *trace)
 ===============
 Touch_Item_Give
 
-Called by target_give entity to make sure clients are always given items, regardless of conditions
+Called by target_give entity and weapon_portalgun_touch to make sure clients are always given items, regardless of conditions
 ===============
 */
 
@@ -1044,9 +1051,13 @@ void Touch_Item(gentity_t *ent, gentity_t *other, trace_t *trace)
 	// picked up items still stay around, they just don't
 	// draw anything.  This allows respawnable items
 	// to be placed on movers.
-	ent->r.svFlags |= SVF_NOCLIENT;
-	ent->flags     |= FL_NODRAW;
-	ent->r.contents = 0;
+	// ETJump: portalgun never disappears
+	if (ent->item->giTag != WP_PORTAL_GUN)
+	{
+		ent->r.svFlags |= SVF_NOCLIENT;
+		ent->flags |= FL_NODRAW;
+		ent->r.contents = 0;
+	}
 
 	// ZOID
 	// A negative respawn times means to never respawn this item (but don't

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -645,15 +645,8 @@ void weapon_portalgun_touch(gentity_t *self, gentity_t *other, trace_t *trace)
 		return;
 	}
 
-	//Add the gun...
-	COM_BitSet(other->client->ps.weapons, WP_PORTAL_GUN);
-
-	other->client->ps.ammoclip[BG_FindClipForWeapon(WP_PORTAL_GUN)] = 0;
-	other->client->ps.ammo[BG_FindAmmoForWeapon(WP_PORTAL_GUN)]     = 1;
-
-	other->client->ps.weapon = WP_PORTAL_GUN;
-
-
+	// Forcing pickup through same function as target_give uses
+	Touch_Item_Give(self, other, trace);
 }
 
 //Just to fix a bug...


### PR DESCRIPTION
This fixes multiple issues with portalgun pickups:
* Player no longer does an unnecessary weapon switch animation when picking up a portalgun
* Pickup now plays a pickup sound
* Pickup now displays a popup message `Picked up a portalgun` like all other item pickups