### PR TITLE
Phasing (nonsolid/solid brushes per client)

### DIFF
--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(cgame MODULE
 	"etj_timerun_view.cpp"
 	"etj_trickjump_lines.cpp"
 	"etj_utilities.cpp"
+	"etj_phasing.cpp"
 	"../game/bg_animation.cpp"
 	"../game/bg_animgroup.cpp"
 	"../game/bg_character.cpp"

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -22,6 +22,7 @@
 #include "cg_public.h"
 #include "../ui/ui_shared.h"
 #include "etj_awaited_command_handler.h"
+#include "etj_phasing.h"
 
 #define MAX_LOCATIONS       256
 #define POWERUP_BLINKS      5
@@ -4008,6 +4009,7 @@ namespace ETJump
 	extern std::shared_ptr<AutoDemoRecorder> autoDemoRecorder;
 	extern std::shared_ptr<EventLoop> eventLoop;
 	extern std::shared_ptr<PlayerEventsHandler> playerEventsHandler;
+	extern std::shared_ptr<PhaseRemapper> phaseRemapper;
 	void addRealLoopingSound(const vec3_t origin, const vec3_t velocity, sfxHandle_t sfx, int range, int volume, int soundTime);
 	void addLoopingSound(const vec3_t origin, const vec3_t velocity, sfxHandle_t sfx, int volume, int soundTime);
 	bool hideMeCheck(int entityNum);
@@ -4015,6 +4017,7 @@ namespace ETJump
 	void setPhaseMask(pmove_t* pm);
 	void onPlayerRespawn(qboolean revived);
 	void runFrameEnd();
+	void phaseRemap(int eFlags);
 	void DrawCGazHUD();
 	void DrawSnapHUD();
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4012,6 +4012,7 @@ namespace ETJump
 	void addLoopingSound(const vec3_t origin, const vec3_t velocity, sfxHandle_t sfx, int volume, int soundTime);
 	bool hideMeCheck(int entityNum);
 	int checkExtraTrace(int value);
+	void setPhaseMask(pmove_t* pm);
 	void onPlayerRespawn(qboolean revived);
 	void runFrameEnd();
 	void DrawCGazHUD();

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1010,6 +1010,20 @@ namespace ETJump
 		}
 	}
 
+	void setPhaseMask(pmove_t* pm)
+	{
+		// phase brushes always nonsolid for specs
+		if (pm->ps->pm_type == PM_SPECTATOR)
+		{
+			SETBIT(pm->tracemask, CONTENTS_PHASE_A, 0);
+			SETBIT(pm->tracemask, CONTENTS_PHASE_B, 0);
+			return;
+		}
+
+		SETBIT(pm->tracemask, CONTENTS_PHASE_A, pm->ps->eFlags & EF_PHASE_A);
+		SETBIT(pm->tracemask, CONTENTS_PHASE_B, pm->ps->eFlags & EF_PHASE_B);
+	}
+
 	// General purpose etj_hideMe check for cgame events
 	bool hideMeCheck(int entityNum)
 	{

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -28,6 +28,7 @@
 #include "etj_event_loop.h"
 #include "etj_autodemo_recorder.h"
 #include "etj_player_events_handler.h"
+#include "etj_phasing.h"
 
 displayContextDef_t cgDC;
 
@@ -112,6 +113,7 @@ namespace ETJump
 	std::shared_ptr<AutoDemoRecorder> autoDemoRecorder;
 	std::shared_ptr<EventLoop> eventLoop;
 	std::shared_ptr<PlayerEventsHandler> playerEventsHandler;
+	std::shared_ptr<PhaseRemapper> phaseRemapper;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -3774,6 +3776,7 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
 	ETJump::renderables.push_back(std::unique_ptr<ETJump::IRenderable>(keySetSystem));
 	ETJump::initDrawKeys(keySetSystem);
 	ETJump::autoDemoRecorder = std::make_shared<ETJump::AutoDemoRecorder>();
+	ETJump::phaseRemapper = std::make_shared<ETJump::PhaseRemapper>();
 
 	CG_Printf("done\n");
 	CG_Printf("ETJump initialized.\n");

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1015,13 +1015,13 @@ namespace ETJump
 		// phase brushes always nonsolid for specs
 		if (pm->ps->pm_type == PM_SPECTATOR)
 		{
-			SETBIT(pm->tracemask, CONTENTS_PHASE_A, 0);
-			SETBIT(pm->tracemask, CONTENTS_PHASE_B, 0);
+			SETBITIF(pm->tracemask, CONTENTS_PHASE_A, 0);
+			SETBITIF(pm->tracemask, CONTENTS_PHASE_B, 0);
 			return;
 		}
 
-		SETBIT(pm->tracemask, CONTENTS_PHASE_A, pm->ps->eFlags & EF_PHASE_A);
-		SETBIT(pm->tracemask, CONTENTS_PHASE_B, pm->ps->eFlags & EF_PHASE_B);
+		SETBITIF(pm->tracemask, CONTENTS_PHASE_A, pm->ps->eFlags & EF_PHASE_A);
+		SETBITIF(pm->tracemask, CONTENTS_PHASE_B, pm->ps->eFlags & EF_PHASE_B);
 	}
 
 	// General purpose etj_hideMe check for cgame events

--- a/src/cgame/cg_mainext.cpp
+++ b/src/cgame/cg_mainext.cpp
@@ -447,6 +447,11 @@ namespace ETJump
 		awaitedCommandHandler->runFrame();
 		eventLoop->run();
 	}
+
+	void phaseRemap(int eFlags)
+	{
+		phaseRemapper->update(eFlags);
+	}
 }
 
 qboolean CG_displaybyname()

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -689,6 +689,8 @@ void CG_RunLerpFrameRate(clientInfo_t *ci, lerpFrame_t *lf, int newAnimation, ce
 	// Ridah, make sure the animation speed is updated when possible
 	anim = lf->animation;
 
+#if 0 
+	// etjump: flag never set for players
 	// check for forcing last frame
 	if (cent->currentState.eFlags & EF_FORCE_END_FRAME
 	    // xkan, 12/27/2002 - In SP, corpse also stays at the last frame (of the death animation)
@@ -701,6 +703,7 @@ void CG_RunLerpFrameRate(clientInfo_t *ci, lerpFrame_t *lf, int newAnimation, ce
 		lf->backlerp      = 0;
 		return;
 	}
+#endif
 
 	if (anim->moveSpeed && lf->oldFrameSnapshotTime)
 	{

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -445,17 +445,18 @@ static void CG_InterpolatePlayerState(qboolean grabAngles)
 		cmdNum = trap_GetCurrentCmdNumber();
 		trap_GetUserCmd(cmdNum, &cmd);
 
-		// rain - added tracemask
-		if (cg_ghostPlayers.integer == 1)
-		{
-			PM_UpdateViewAngles(out, &cg.pmext, &cmd, CG_Trace, MASK_PLAYERSOLID & ~CONTENTS_BODY);
+		int mask = cg_ghostPlayers.integer == 1
+			? MASK_PLAYERSOLID & ~CONTENTS_BODY
+			: MASK_PLAYERSOLID;
+
+		if (out->eFlags == EF_PHASE_A) {
+			mask |= CONTENTS_PHASE_A;
 		}
-		else
-		{
-			PM_UpdateViewAngles(out, &cg.pmext, &cmd, CG_Trace, MASK_PLAYERSOLID);
+		if (out->eFlags == EF_PHASE_B) {
+			mask |= CONTENTS_PHASE_B;
 		}
 
-
+		PM_UpdateViewAngles(out, &cg.pmext, &cmd, CG_Trace, mask);
 	}
 
 	// if the next frame is a teleport, we can't lerp to it
@@ -1058,6 +1059,8 @@ void CG_PredictPlayerState(void)
 	{
 		cg_pmove.tracemask = MASK_PLAYERSOLID;
 	}
+	
+	ETJump::setPhaseMask(&cg_pmove);
 
 	if ((cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR) || (cg.snap->ps.pm_flags & PMF_LIMBO))     // JPW NERVE limbo
 	{

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -738,8 +738,7 @@ static void CG_TouchTriggerPrediction(void)
 			{
 				BG_TouchJumpPad(&cg.predictedPlayerState, ent);
 			}
-
-			if (ent->eType == ET_VELOCITY_PUSH_TRIGGER)
+			else if (ent->eType == ET_VELOCITY_PUSH_TRIGGER)
 			{
 				BG_TouchVelocityJumpPad(&cg.predictedPlayerState, ent);
 			}

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -449,12 +449,7 @@ static void CG_InterpolatePlayerState(qboolean grabAngles)
 			? MASK_PLAYERSOLID & ~CONTENTS_BODY
 			: MASK_PLAYERSOLID;
 
-		if (out->eFlags == EF_PHASE_A) {
-			mask |= CONTENTS_PHASE_A;
-		}
-		if (out->eFlags == EF_PHASE_B) {
-			mask |= CONTENTS_PHASE_B;
-		}
+		mask |= (out->eFlags & (EF_PHASE_A | EF_PHASE_B));
 
 		PM_UpdateViewAngles(out, &cg.pmext, &cmd, CG_Trace, mask);
 	}

--- a/src/cgame/cg_spawn.cpp
+++ b/src/cgame/cg_spawn.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "cg_local.h"
+#include "etj_phasing.h"
 
 qboolean CG_SpawnString(const char *key, const char *defaultString, char **out)
 {
@@ -542,6 +543,8 @@ void SP_worldspawn(void)
 		CG_SpawnString(va("text%i", i), "", &s);
 		Q_strncpyz(cg.deformText[i], s, sizeof(cg.deformText[0]));
 	}
+
+	ETJump::PhaseRemapper::initialize();
 }
 
 /*

--- a/src/cgame/cg_spawn.cpp
+++ b/src/cgame/cg_spawn.cpp
@@ -5,7 +5,6 @@
 */
 
 #include "cg_local.h"
-#include "etj_phasing.h"
 
 qboolean CG_SpawnString(const char *key, const char *defaultString, char **out)
 {

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -2279,6 +2279,8 @@ void CG_DrawActiveFrame(int serverTime, stereoFrame_t stereoView, qboolean demoP
 			DEBUGTIME
 
 			CG_DrawActiveFrameExt();
+
+			ETJump::phaseRemap(cg.snap->ps.eFlags);
 		}
 
 		// Rafael mg42

--- a/src/cgame/etj_phasing.cpp
+++ b/src/cgame/etj_phasing.cpp
@@ -61,6 +61,7 @@ void ETJump::PhaseRemapper::initialize()
 
 void ETJump::PhaseRemapper::update(int eFlags)
 {
+	// do remaps only if there are any, and active state changed from last check
 	if (!_anyRemaps)
 	{
 		return;
@@ -70,9 +71,7 @@ void ETJump::PhaseRemapper::update(int eFlags)
 
 	if (_isActiveA != a)
 	{
-		_isActiveA = a;
-
-		if (a)
+		if (_isActiveA = a)
 		{
 			// remap
 			for (auto& shader : _remapsA)
@@ -94,9 +93,7 @@ void ETJump::PhaseRemapper::update(int eFlags)
 
 	if (_isActiveB != b)
 	{
-		_isActiveB = b;
-
-		if (b)
+		if (_isActiveB = b)
 		{
 			// remap
 			for (auto& shader : _remapsB)

--- a/src/cgame/etj_phasing.cpp
+++ b/src/cgame/etj_phasing.cpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <string>
+#include <boost/algorithm/string.hpp>
+#include "etj_phasing.h"
+#include "cg_local.h"
+
+// init static members
+std::vector<ETJump::RemapPair> ETJump::PhaseRemapper::_remapsA = std::vector<RemapPair>();
+std::vector<ETJump::RemapPair> ETJump::PhaseRemapper::_remapsB = std::vector<RemapPair>();
+bool ETJump::PhaseRemapper::_anyRemaps = false;
+
+void ETJump::PhaseRemapper::initialize()
+{
+	char* buffer;
+	const std::string keyBase = "phaseremap";
+	const std::string separator = ";";
+
+	for (auto& ab : { "a", "b" })
+	{
+		for (int i = 0; i < ETJump::PhaseRemapper::maxRemaps; i++)
+		{
+			const auto key = keyBase + ab + std::to_string(i + 1);
+
+			// spawnstrings must be in order, most maps dont have any so exit early
+			if (!CG_SpawnString(key.c_str(), "", &buffer))
+			{
+				break;
+			}
+
+			const auto value = std::string(buffer);
+
+			std::vector<std::string> shaders;
+			std::string container;
+			boost::split(shaders, value, boost::is_any_of(separator));
+
+			if (shaders.size() != 2)
+			{
+				CG_Error("Malformed %s value: %s\n", key.c_str(), buffer);
+				continue;
+			}
+
+			RemapPair rmp = { shaders.at(0), shaders.at(1) };
+
+			if (!trap_R_RegisterShader(rmp.to.c_str()))
+			{
+				CG_Error("Failed to register shader: %s\n", rmp.to.c_str());
+				continue;
+			}
+
+			(ab[0] == 'a' ? _remapsA : _remapsB).push_back(rmp);
+		}
+	}
+
+	_anyRemaps = _remapsA.size() != 0 || _remapsB.size() != 0;
+	_remapsA.shrink_to_fit();
+	_remapsB.shrink_to_fit();
+}
+
+void ETJump::PhaseRemapper::update(int eFlags)
+{
+	if (!_anyRemaps)
+	{
+		return;
+	}
+
+	bool a = (eFlags & EF_PHASE_A) == EF_PHASE_A;
+
+	if (_isActiveA != a)
+	{
+		_isActiveA = a;
+
+		if (a)
+		{
+			// remap
+			for (auto& shader : _remapsA)
+			{
+				trap_R_RemapShader(shader.from.c_str(), shader.to.c_str(), "0");
+			}
+		}
+		else
+		{
+			// restore
+			for (auto& shader : _remapsA)
+			{
+				trap_R_RemapShader(shader.from.c_str(), shader.from.c_str(), "0");
+			}
+		}
+	}
+
+	bool b = (eFlags & EF_PHASE_B) == EF_PHASE_B;
+
+	if (_isActiveB != b)
+	{
+		_isActiveB = b;
+
+		if (b)
+		{
+			// remap
+			for (auto& shader : _remapsB)
+			{
+				trap_R_RemapShader(shader.from.c_str(), shader.to.c_str(), "0");
+			}
+		}
+		else
+		{
+			// restore
+			for (auto& shader : _remapsB)
+			{
+				trap_R_RemapShader(shader.from.c_str(), shader.from.c_str(), "0");
+			}
+		}
+	}
+}
+
+ETJump::PhaseRemapper::PhaseRemapper() : _isActiveA(false), _isActiveB(false)
+{
+}
+
+ETJump::PhaseRemapper::~PhaseRemapper()
+{
+}

--- a/src/cgame/etj_phasing.h
+++ b/src/cgame/etj_phasing.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <tuple>
+#include <vector>
+
+namespace ETJump
+{
+	typedef struct RemapPair {
+		std::string from;
+		std::string to;
+	};
+
+	class PhaseRemapper
+	{
+	public:
+		static const int maxRemaps = 32;
+		static void initialize();
+
+		PhaseRemapper();
+		~PhaseRemapper();
+
+		void update(int eFlags);
+
+	private:
+		static std::vector<RemapPair> _remapsA;
+		static std::vector<RemapPair> _remapsB;
+		static bool _anyRemaps;
+
+		bool _isActiveA;
+		bool _isActiveB;
+	};
+}

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -38,13 +38,13 @@ namespace ETJump
 		// phase brushes always nonsolid for specs
 		if (pm->ps->pm_type == PM_SPECTATOR)
 		{
-			SETBIT(pm->tracemask, CONTENTS_PHASE_A, 0);
-			SETBIT(pm->tracemask, CONTENTS_PHASE_B, 0);
+			SETBITIF(pm->tracemask, CONTENTS_PHASE_A, 0);
+			SETBITIF(pm->tracemask, CONTENTS_PHASE_B, 0);
 			return;
 		}
 
-		SETBIT(pm->tracemask, CONTENTS_PHASE_A, pm->ps->eFlags & EF_PHASE_A);
-		SETBIT(pm->tracemask, CONTENTS_PHASE_B, pm->ps->eFlags & EF_PHASE_B);
+		SETBITIF(pm->tracemask, CONTENTS_PHASE_A, pm->ps->eFlags & EF_PHASE_A);
+		SETBITIF(pm->tracemask, CONTENTS_PHASE_B, pm->ps->eFlags & EF_PHASE_B);
 	}
 
 	static void gibStuckPlayer()

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -1009,10 +1009,10 @@ static qboolean PM_CheckProne(void)
 	{
 		if (trace.fraction != 1.0f)
 		{
-			pm->ps->eFlags &= ~EF_PRONE;
-			pm->ps->eFlags &= ~EF_PRONE_MOVING;
-			return qfalse;
-		}
+		pm->ps->eFlags &= ~EF_PRONE;
+		pm->ps->eFlags &= ~EF_PRONE_MOVING;
+		return qfalse;
+	}
 	}
 
 	if (!(pm->ps->eFlags & EF_PRONE))

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -30,6 +30,21 @@ namespace ETJump
 	{
 		return pm->pmext->proneTime - pm->pmext->jumpTime == PRONE_JUMP_DELAY_TIME;
 	}
+
+
+	static void setPlayerPhaseMask()
+	{
+		// phase brushes always nonsolid for specs
+		if (pm->ps->pm_type == PM_SPECTATOR)
+		{
+			SETBIT(pm->tracemask, CONTENTS_PHASE_A, 0);
+			SETBIT(pm->tracemask, CONTENTS_PHASE_B, 0);
+			return;
+		}
+
+		SETBIT(pm->tracemask, CONTENTS_PHASE_A, pm->ps->eFlags & EF_PHASE_A);
+		SETBIT(pm->tracemask, CONTENTS_PHASE_B, pm->ps->eFlags & EF_PHASE_B);
+	}
 }
 
 // JPW NERVE -- stuck this here so it can be seen client & server side
@@ -6605,6 +6620,8 @@ void PmoveSingle(pmove_t *pmove)
 		pm->tracemask  &= ~CONTENTS_BODY;   // corpses can fly through bodies
 		pm->ps->eFlags &= ~EF_ZOOMING;
 	}
+
+	ETJump::setPlayerPhaseMask();
 
 	// ETJump: no activate lean
 	if (pm->noActivateLean)

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -50,25 +50,17 @@ namespace ETJump
 
 	static void gibStuckPlayer()
 	{
-		if (!(pm->shared & BG_LEVEL_PHASE_GIBSOLID))
-		{
-			return;
-		}
-		if (pm->ps->stats[STAT_HEALTH] <= 0)
-		{
-			return;
-		}
-		if (!pm->pmext->stuckTime)
-		{
-			return;
-		}
-		if ((pm->cmd.serverTime - pm->pmext->stuckTime) < ALLSOLID_GIB_TIME)
+		if (!(pm->shared & BG_LEVEL_PHASE_GIBSOLID) ||
+			pm->ps->stats[STAT_HEALTH] <= 0 ||
+			!pm->pmext->stuckTime ||
+			(pm->cmd.serverTime - pm->pmext->stuckTime) < ALLSOLID_GIB_TIME)
 		{
 			return;
 		}
 
 		trace_t trace;
 
+		// checks if allsolid is true even when checking only single content flag
 		auto checkTrace = [trace](int contentFlag) mutable
 		{
 			pm->trace(&trace, pm->ps->origin, pm->mins, pm->maxs, pm->ps->origin, pm->ps->clientNum, contentFlag);

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -695,6 +695,7 @@ typedef enum
 #define EF_DEAD             0x00000001      // don't draw a foe marker over players with EF_DEAD
 #define EF_NONSOLID_BMODEL  0x00000002      // bmodel is visible, but not solid
 #define EF_FORCE_END_FRAME  EF_NONSOLID_BMODEL  // force client to end of current animation (after loading a savegame)
+#define EF_PHASE_A          EF_NONSOLID_BMODEL // etjump: hijacked
 #define EF_TELEPORT_BIT     0x00000004      // toggled every time the origin abruptly changes
 #define EF_READY            0x00000008      // player is ready
 
@@ -718,6 +719,7 @@ typedef enum
 #define EF_MOUNTEDTANK      EF_TAGCONNECT   // Gordon: duplicated for clarity
 
 #define EF_FAKEBMODEL       0x00010000      // Gordon: freed
+#define EF_PHASE_B          EF_FAKEBMODEL   // etjump: hijacked
 #define EF_PATH_LINK        0x00020000      // Gordon: linking trains together
 #define EF_ZOOMING          0x00040000      // client is zooming
 #define EF_PRONE            0x00080000      // player is prone

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -697,7 +697,7 @@ typedef enum
 #define EF_DEAD             0x00000001      // don't draw a foe marker over players with EF_DEAD
 #define EF_NONSOLID_BMODEL  0x00000002      // bmodel is visible, but not solid
 #define EF_FORCE_END_FRAME  EF_NONSOLID_BMODEL  // force client to end of current animation (after loading a savegame)
-#define EF_PHASE_A          EF_NONSOLID_BMODEL // etjump: hijacked
+#define EF_PHASE_A          EF_NONSOLID_BMODEL // etjump: player collides with DONOTENTER_LARGE
 #define EF_TELEPORT_BIT     0x00000004      // toggled every time the origin abruptly changes
 #define EF_READY            0x00000008      // player is ready
 
@@ -721,7 +721,7 @@ typedef enum
 #define EF_MOUNTEDTANK      EF_TAGCONNECT   // Gordon: duplicated for clarity
 
 #define EF_FAKEBMODEL       0x00010000      // Gordon: freed
-#define EF_PHASE_B          EF_FAKEBMODEL   // etjump: hijacked
+#define EF_PHASE_B          EF_FAKEBMODEL   // etjump: player collides with MONSTERCLIP
 #define EF_PATH_LINK        0x00020000      // Gordon: linking trains together
 #define EF_ZOOMING          0x00040000      // client is zooming
 #define EF_PRONE            0x00080000      // player is prone

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -553,6 +553,8 @@ typedef struct
 	qboolean releasedFire;
 	float noclipScale;
 	bool isJumpLand;
+
+	int stuckTime;
 } pmoveExt_t;   // data used both in client and server - store it here
                 // instead of playerstate to prevent different engine versions of playerstate between XP and MP
 

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2620,6 +2620,8 @@ const int BG_LEVEL_NO_FALLDAMAGE = 1 << 3;
 const int BG_LEVEL_NO_FALLDAMAGE_FORCE = 1 << 4;
 // Prone is disabled
 const int BG_LEVEL_NO_PRONE = 1 << 5;
+// gib players stuck in phase brush
+const int BG_LEVEL_PHASE_GIBSOLID = 1 << 6;
 
 #endif // __BG_PUBLIC_H__
 

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -415,8 +415,7 @@ void PhaseDisplaced(gentity_t* ent)
 {
 	if (ent->client && (level.phaseOptions & PHASEOPT_RESETONLOAD))
 	{
-		ent->client->ps.eFlags &= ~EF_PHASE_A;
-		ent->client->ps.eFlags &= ~EF_PHASE_B;
+		ent->client->ps.eFlags &= ~(EF_PHASE_A | EF_PHASE_A);
 	}
 }
 

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -411,6 +411,15 @@ void InterruptRun(gentity_t *ent)
 	game.timerun->interrupt(ClientNum(ent));
 }
 
+void PhaseDisplaced(gentity_t* ent)
+{
+	if (ent->client && (level.phaseOptions & PHASEOPT_RESETONLOAD))
+	{
+		ent->client->ps.eFlags &= ~EF_PHASE_A;
+		ent->client->ps.eFlags &= ~EF_PHASE_B;
+	}
+}
+
 void G_increaseCallvoteCount(const char *mapName)
 {
 	game.mapStatistics->increaseCallvoteCount(mapName);

--- a/src/game/etj_save_system.cpp
+++ b/src/game/etj_save_system.cpp
@@ -254,6 +254,12 @@ void ETJump::SaveSystem::load(gentity_t *ent)
 		return;
 	}
 
+	if (client->sess.sessionTeam == TEAM_SPECTATOR)
+	{
+		CPTo(ent, "^7You can not ^3load ^7as a spectator.");
+		return;
+	}
+
 	if ((client->sess.deathrunFlags & static_cast<int>(DeathrunFlags::Active)) && (client->sess.deathrunFlags & static_cast<int>(DeathrunFlags::NoSave)))
 		{
 		CPTo(ent, "^3Load ^7is disabled for this death run.");
@@ -287,12 +293,6 @@ void ETJump::SaveSystem::load(gentity_t *ent)
 		}
 	}
 
-	if (client->sess.sessionTeam == TEAM_SPECTATOR)
-	{
-		CPTo(ent, "^7You can not ^3load ^7as a spectator.");
-		return;
-	}
-
 	auto validSave = getValidTeamSaveForSlot(ent, client->sess.sessionTeam, slot);
 	if (validSave)
 	{
@@ -302,6 +302,7 @@ void ETJump::SaveSystem::load(gentity_t *ent)
 		{
 			InterruptRun(ent);
 		}
+		PhaseDisplaced(ent);
 		teleportPlayer(ent, validSave);
 	}
 	else
@@ -428,6 +429,7 @@ void ETJump::SaveSystem::loadBackupPosition(gentity_t *ent)
 		{
 			InterruptRun(ent);
 		}
+		PhaseDisplaced(ent);
 		teleportPlayer(ent, pos);
 	}
 	else

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1326,6 +1326,8 @@ void ClientThink_real(gentity_t *ent)
 		}
 	}
 
+	ETJump::setPhaseMask(&pm);
+
 	//DHM - Nerve :: We've gone back to using normal bbox traces
 	//pm.trace = trap_Trace;
 	pm.pointcontents = trap_PointContents;

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2304,8 +2304,8 @@ void ClientSpawn(gentity_t *ent, qboolean revived)
 		ent->clipmask = MASK_PLAYERSOLID;
 	}
 
-	SETBIT(ent->clipmask, CONTENTS_PHASE_B, ent->client->ps.eFlags & EF_PHASE_A);
-	SETBIT(ent->clipmask, CONTENTS_PHASE_B, ent->client->ps.eFlags & EF_PHASE_B);
+	SETBITIF(ent->clipmask, CONTENTS_PHASE_B, ent->client->ps.eFlags & EF_PHASE_A);
+	SETBITIF(ent->clipmask, CONTENTS_PHASE_B, ent->client->ps.eFlags & EF_PHASE_B);
 
 	// DHM - Nerve :: Init to -1 on first spawn;
 	if (!revived)

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2221,6 +2221,13 @@ void ClientSpawn(gentity_t *ent, qboolean revived)
 	flags |= (client->ps.eFlags & EF_VOTED);
 	// clear everything but the persistant data
 
+	// preserve phases on spawn unless specified in map
+	if (!(level.phaseOptions & PHASEOPT_RESETONDEATH))
+	{
+		flags |= (ent->client->ps.eFlags & EF_PHASE_A);
+		flags |= (ent->client->ps.eFlags & EF_PHASE_B);
+	}
+
 	ent->s.eFlags &= ~EF_MOUNTEDTANK;
 
 	saved     = client->pers;

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2297,6 +2297,9 @@ void ClientSpawn(gentity_t *ent, qboolean revived)
 		ent->clipmask = MASK_PLAYERSOLID;
 	}
 
+	SETBIT(ent->clipmask, CONTENTS_PHASE_B, ent->client->ps.eFlags & EF_PHASE_A);
+	SETBIT(ent->clipmask, CONTENTS_PHASE_B, ent->client->ps.eFlags & EF_PHASE_B);
+
 	// DHM - Nerve :: Init to -1 on first spawn;
 	if (!revived)
 	{

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2224,8 +2224,7 @@ void ClientSpawn(gentity_t *ent, qboolean revived)
 	// preserve phases on spawn unless specified in map
 	if (!(level.phaseOptions & PHASEOPT_RESETONDEATH))
 	{
-		flags |= (ent->client->ps.eFlags & EF_PHASE_A);
-		flags |= (ent->client->ps.eFlags & EF_PHASE_B);
+		flags |= (ent->client->ps.eFlags & (EF_PHASE_A | EF_PHASE_B));
 	}
 
 	ent->s.eFlags &= ~EF_MOUNTEDTANK;

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -3951,6 +3951,20 @@ namespace ETJump
 			ent->client->sess.spectatorClient = ClientNum(traceEnt);
 		}
 	}
+
+	void setPhaseMask(pmove_t* pm)
+	{
+		// phase brushes always nonsolid for specs
+		if (pm->ps->pm_type == PM_SPECTATOR)
+		{
+			SETBIT(pm->tracemask, CONTENTS_PHASE_A, 0);
+			SETBIT(pm->tracemask, CONTENTS_PHASE_B, 0);
+			return;
+		}
+
+		SETBIT(pm->tracemask, CONTENTS_PHASE_A, pm->ps->eFlags & EF_PHASE_A);
+		SETBIT(pm->tracemask, CONTENTS_PHASE_B, pm->ps->eFlags & EF_PHASE_B);
+	}
 }
 
 /*

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -3957,13 +3957,13 @@ namespace ETJump
 		// phase brushes always nonsolid for specs
 		if (pm->ps->pm_type == PM_SPECTATOR)
 		{
-			SETBIT(pm->tracemask, CONTENTS_PHASE_A, 0);
-			SETBIT(pm->tracemask, CONTENTS_PHASE_B, 0);
+			SETBITIF(pm->tracemask, CONTENTS_PHASE_A, 0);
+			SETBITIF(pm->tracemask, CONTENTS_PHASE_B, 0);
 			return;
 		}
 
-		SETBIT(pm->tracemask, CONTENTS_PHASE_A, pm->ps->eFlags & EF_PHASE_A);
-		SETBIT(pm->tracemask, CONTENTS_PHASE_B, pm->ps->eFlags & EF_PHASE_B);
+		SETBITIF(pm->tracemask, CONTENTS_PHASE_A, pm->ps->eFlags & EF_PHASE_A);
+		SETBITIF(pm->tracemask, CONTENTS_PHASE_B, pm->ps->eFlags & EF_PHASE_B);
 	}
 }
 

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -4588,6 +4588,7 @@ void Cmd_Goto_f(gentity_t *ent)
 		return;
 	}
 
+	PhaseDisplaced(ent);
 	VectorCopy(other->client->ps.origin, ent->client->ps.origin);
 	VectorClear(ent->client->ps.velocity);
 	trap_SendServerCommand(ClientNum(ent), va("cpm \"%s^7 -> %s\n\"", ent->client->pers.netname, other->client->pers.netname));

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1370,6 +1370,11 @@ typedef struct
 	bool noFallDamage;
 	bool noProne;
 
+	int phaseOptions;
+#define PHASEOPT_RESETONDEATH 1
+#define PHASEOPT_RESETONLOAD 2
+#define PHASEOPT_GIBALLSOLID 4
+
 	int portalEnabled;         //Feen: PGM - Enabled/Disabled by map key
 	qboolean portalSurfaces;
 
@@ -2769,6 +2774,9 @@ void StopTimer(const char *runName, gentity_t *ent);
 void TimerunConnectNotify(gentity_t *ent);
 
 void InterruptRun(gentity_t *ent);
+
+// resets phasing on load/goto if worldspawn flag is set
+void PhaseDisplaced(gentity_t* ent);
 
 void RunFrame(int levelTime);
 const char *G_MatchOneMap(const char *arg);

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1800,6 +1800,7 @@ void G_LeaveTank(gentity_t *ent, qboolean position);
 namespace ETJump
 {
 	void longRangeActivate(gentity_t *ent);
+	void setPhaseMask(pmove_t *pm);
 }
 
 // g_script.c

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -471,6 +471,7 @@ void SP_trigger_tracker(gentity_t *self);
 void SP_target_set_health(gentity_t *self);
 void SP_target_deathrun_start(gentity_t *self);
 void SP_target_deathrun_checkpoint(gentity_t *self);
+void SP_target_phase(gentity_t* self);
 
 // TJL trigger
 void SP_target_tjlclear(gentity_t *self);
@@ -719,6 +720,7 @@ spawn_t spawns[] =
 	{"target_set_health", SP_target_set_health },
 	{"target_deathrun_start", SP_target_deathrun_start},
 	{"target_deathrun_checkpoint", SP_target_deathrun_checkpoint},
+	{"target_phasing", SP_target_phase},
 	{ "target_displaytjl",			 SP_target_tjldisplay			},
 	{ "target_cleartjl",			 SP_target_tjlclear				},
 	{ 0,                             0                              }
@@ -1154,6 +1156,20 @@ namespace ETJump{
 		trap_Cvar_Set("shared", va("%d", shared.integer));
 		G_Printf("Prone is %s.\n", level.noProne ? "disabled" : "enabled");
 	}
+
+	static void initPhasing()
+	{
+		auto value = 0;
+		G_SpawnInt("phasing", "0", &value);
+
+		level.phaseOptions = value;
+
+		G_Printf(
+			"Phasing is %s on death and %s on load/goto. Players are %s when stuck inside.\n",
+			(value & PHASEOPT_RESETONDEATH) ? "reset" : "preserved",
+			(value & PHASEOPT_RESETONLOAD) ? "reset" : "preserved",
+			(value & PHASEOPT_GIBALLSOLID) ? "gibbed" : "not gibbed");
+	}
 }
 
 
@@ -1335,6 +1351,7 @@ void SP_worldspawn(void)
 	ETJump::initStrictSaveLoad();
 	ETJump::initNoFallDamage();
 	ETJump::initNoProne();
+	ETJump::initPhasing();
 
 	level.mapcoordsValid = qfalse;
 	if (G_SpawnVector2D("mapcoordsmins", "-128 128", level.mapcoordsMins) &&    // top left

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -1159,16 +1159,19 @@ namespace ETJump{
 
 	static void initPhasing()
 	{
-		auto value = 0;
-		G_SpawnInt("phasing", "0", &value);
+		auto phaseFlags = 0;
+		G_SpawnInt("phasing", "0", &phaseFlags);
 
-		level.phaseOptions = value;
+		level.phaseOptions = phaseFlags;
+
+		SETBITIF(shared.integer, BG_LEVEL_PHASE_GIBSOLID, phaseFlags & PHASEOPT_GIBALLSOLID);
+		trap_Cvar_Set("shared", va("%d", shared.integer));
 
 		G_Printf(
 			"Phasing is %s on death and %s on load/goto. Players are %s when stuck inside.\n",
-			(value & PHASEOPT_RESETONDEATH) ? "reset" : "preserved",
-			(value & PHASEOPT_RESETONLOAD) ? "reset" : "preserved",
-			(value & PHASEOPT_GIBALLSOLID) ? "gibbed" : "not gibbed");
+			(phaseFlags & PHASEOPT_RESETONDEATH) ? "reset" : "preserved",
+			(phaseFlags & PHASEOPT_RESETONLOAD) ? "reset" : "preserved",
+			(phaseFlags & PHASEOPT_GIBALLSOLID) ? "gibbed" : "not gibbed");
 	}
 }
 

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -720,7 +720,7 @@ spawn_t spawns[] =
 	{"target_set_health", SP_target_set_health },
 	{"target_deathrun_start", SP_target_deathrun_start},
 	{"target_deathrun_checkpoint", SP_target_deathrun_checkpoint},
-	{"target_phasing", SP_target_phase},
+	{ "target_phase", SP_target_phase },
 	{ "target_displaytjl",			 SP_target_tjldisplay			},
 	{ "target_cleartjl",			 SP_target_tjlclear				},
 	{ 0,                             0                              }

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -2310,6 +2310,110 @@ void SP_target_interrupt_timerun(gentity_t *self)
 	self->use = target_interrupt_timerun;
 }
 
+const int TARGETPHASE_A_ON  = 1 << 0;
+const int TARGETPHASE_A_OFF = 1 << 1;
+const int TARGETPHASE_A_TGL = 1 << 2;
+const int TARGETPHASE_B_ON  = 1 << 3;
+const int TARGETPHASE_B_OFF = 1 << 4;
+const int TARGETPHASE_B_TGL = 1 << 5;
+void use_target_phase(gentity_t* ent, gentity_t* other, gentity_t* activator) {
+	if (!activator || !activator->client)
+	{
+		return;
+	}
+
+	if (!ent->count)
+	{
+		Com_Printf("^1Error: nonfunctional target_phase\n");
+		return;
+	}
+
+	if (ent->count & TARGETPHASE_A_ON)
+	{
+		activator->client->ps.eFlags |= EF_PHASE_A;
+	}
+	else if (ent->count & TARGETPHASE_A_OFF)
+	{
+		activator->client->ps.eFlags &= ~EF_PHASE_A;
+	}
+	else if (ent->count & TARGETPHASE_A_TGL)
+	{
+		activator->client->ps.eFlags ^= EF_PHASE_A;
+	}
+
+	if (ent->count & TARGETPHASE_B_ON)
+	{
+		activator->client->ps.eFlags |= EF_PHASE_B;
+	}
+	else if (ent->count & TARGETPHASE_B_OFF)
+	{
+		activator->client->ps.eFlags &= ~EF_PHASE_B;
+	}
+	else if (ent->count & TARGETPHASE_B_TGL)
+	{
+		activator->client->ps.eFlags ^= EF_PHASE_B;
+	}
+}
+
+void SP_target_phase(gentity_t* self)
+{
+	int flags = 0;
+
+	char* phasea = NULL;
+	if (G_SpawnString("phasea", "", &phasea))
+	{
+		if (!Q_stricmp(phasea, "on"))
+		{
+			flags |= TARGETPHASE_A_ON;
+		}
+		else if (!Q_stricmp(phasea, "off"))
+		{
+			flags |= TARGETPHASE_A_OFF;
+		}
+		else if (!Q_stricmp(phasea, "toggle"))
+		{
+			flags |= TARGETPHASE_A_TGL;
+		}
+		else
+		{
+			Com_Printf("^3Invalid phase A setting, defaulting to none: %s\n", phasea);
+		}
+	}
+
+	char* phaseb = NULL;
+	if (G_SpawnString("phaseb", "", &phaseb))
+	{
+		if (!Q_stricmp(phaseb, "on"))
+		{
+			flags |= TARGETPHASE_B_ON;
+		}
+		else if (!Q_stricmp(phaseb, "off"))
+		{
+			flags |= TARGETPHASE_B_OFF;
+		}
+		else if (!Q_stricmp(phaseb, "toggle"))
+		{
+			flags |= TARGETPHASE_B_TGL;
+		}
+		else
+		{
+			Com_Printf("^3Invalid phase B setting, defaulting to none: ^3%s\n", phaseb);
+		}
+	}
+
+	if (flags)
+	{
+		self->count = flags;
+	}
+	else
+	{
+		Com_Printf("^1Error: Nonfunctional target_phase defined");
+	}
+
+	// TODO: activate this entity's targets
+	self->use = use_target_phase;
+}
+
 // target_set_health
 // Sets the health of the target to the specified value.
 // spawnflags

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -2356,6 +2356,11 @@ void use_target_phase(gentity_t* ent, gentity_t* other, gentity_t* activator) {
 	{
 		activator->client->ps.eFlags ^= EF_PHASE_B;
 	}
+
+	if (ent->target)
+	{
+		G_UseTargets(ent, ent->activator);
+	}
 }
 
 void SP_target_phase(gentity_t* self)
@@ -2413,7 +2418,6 @@ void SP_target_phase(gentity_t* self)
 		Com_Printf("^1Error: Nonfunctional target_phase defined\n");
 	}
 
-	// TODO: activate this entity's targets
 	self->use = use_target_phase;
 }
 

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -2310,21 +2310,24 @@ void SP_target_interrupt_timerun(gentity_t *self)
 	self->use = target_interrupt_timerun;
 }
 
-const int TARGETPHASE_A_ON  = 1 << 0;
+const int TARGETPHASE_A_ON = 1 << 0;
 const int TARGETPHASE_A_OFF = 1 << 1;
 const int TARGETPHASE_A_TGL = 1 << 2;
-const int TARGETPHASE_B_ON  = 1 << 3;
+const int TARGETPHASE_B_ON = 1 << 3;
 const int TARGETPHASE_B_OFF = 1 << 4;
 const int TARGETPHASE_B_TGL = 1 << 5;
 void use_target_phase(gentity_t* ent, gentity_t* other, gentity_t* activator) {
-	if (!activator || !activator->client)
+	if (!activator ||
+		!activator->client ||
+		activator->client->sess.sessionTeam == TEAM_SPECTATOR)
 	{
 		return;
 	}
 
 	if (!ent->count)
 	{
-		Com_Printf("^1Error: nonfunctional target_phase\n");
+		auto clientNum = ClientNum(activator);
+		Printer::SendConsoleMessage(clientNum, "^1Error: Nonfunctional target_phase defined");
 		return;
 	}
 
@@ -2397,7 +2400,7 @@ void SP_target_phase(gentity_t* self)
 		}
 		else
 		{
-			Com_Printf("^3Invalid phase B setting, defaulting to none: ^3%s\n", phaseb);
+			Com_Printf("^3Invalid phase B setting, defaulting to none: %s\n", phaseb);
 		}
 	}
 
@@ -2407,7 +2410,7 @@ void SP_target_phase(gentity_t* self)
 	}
 	else
 	{
-		Com_Printf("^1Error: Nonfunctional target_phase defined");
+		Com_Printf("^1Error: Nonfunctional target_phase defined\n");
 	}
 
 	// TODO: activate this entity's targets

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -568,6 +568,9 @@ extern vec3_t axisDefault[3];
 
 #define IS_NAN(x) (((*(int *)&x) & nanmask) == nanmask)
 
+// sets bitfield f's bit b on or off depending on condition c
+#define SETBIT(f, b, c) if (c) { f |= b; } else { f &= ~b; }
+
 float Q_fabs(float f);
 float Q_rsqrt(float f);         // reciprocal square root
 

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -569,7 +569,7 @@ extern vec3_t axisDefault[3];
 #define IS_NAN(x) (((*(int *)&x) & nanmask) == nanmask)
 
 // sets bitfield f's bit b on or off depending on condition c
-#define SETBIT(f, b, c) if (c) { f |= b; } else { f &= ~b; }
+#define SETBITIF(f, b, c) if (c) { f |= b; } else { f &= ~b; }
 
 float Q_fabs(float f);
 float Q_rsqrt(float f);         // reciprocal square root

--- a/src/game/surfaceflags.h
+++ b/src/game/surfaceflags.h
@@ -10,6 +10,41 @@
 
 // these definitions also need to be in q_shared.h!
 
+// CONTENTS_SOLID              0x00000001 - vanilla
+//                             0x00000002 - unknown
+// CONTENTS_LIGHTGRID          0x00000004 - compiler
+// CONTENTS_LAVA               0x00000008 - vanilla
+// CONTENTS_SLIME              0x00000010 - vanilla
+// CONTENTS_WATER              0x00000020 - vanilla
+// CONTENTS_FOG                0x00000040 - vanilla
+// CONTENTS_MISSILECLIP        0x00000080 - vanilla
+// CONTENTS_ITEM               0x00000100 - vanilla
+//                             0x00000200 - unknown
+//                             0x00000400 - unknown
+//                             0x00000800 - unknown
+//                             0x00001000 - unknown
+//                             0x00002000 - unknown
+// CONTENTS_MOVER              0x00004000 - vanilla
+// CONTENTS_AREAPORTAL         0x00008000 - vanilla
+// CONTENTS_PLAYERCLIP         0x00010000 - vanilla
+// CONTENTS_MONSTERCLIP        0x00020000 - etjump: phase brush b
+// CONTENTS_TELEPORTER         0x00040000 - UNUSED (not recognized by q3map2)
+// CONTENTS_NOPORTAL           0x00080000 - etjump: portalgun
+// CONTENTS_NOSAVE             0x00100000 - etjump: nosave
+// CONTENTS_DONOTENTER         0x00200000 - etjump: noprone
+// CONTENTS_DONOTENTER_LARGE   0x00400000 - etjump: phase brush a
+//                             0x00800000 - unknown
+// CONTENTS_ORIGIN             0x01000000 - compiler
+// CONTENTS_BODY               0x02000000 - vanilla
+// CONTENTS_CORPSE             0x04000000 - vanilla
+// CONTENTS_DETAIL             0x08000000 - compiler
+// CONTENTS_STRUCTURAL         0x10000000 - compiler
+// CONTENTS_TRANSLUCENT        0x20000000 - compiler
+// CONTENTS_TRIGGER            0x40000000 - vanilla
+// CONTENTS_NODROP             0x80000000 - vanilla
+
+// unknown and compiler contents could probably be used if they are applied during for brush entities.
+
 #define CONTENTS_SOLID              0x00000001
 #define CONTENTS_LIGHTGRID          0x00000004
 #define CONTENTS_LAVA               0x00000008
@@ -22,12 +57,14 @@
 #define CONTENTS_AREAPORTAL         0x00008000
 #define CONTENTS_PLAYERCLIP         0x00010000
 #define CONTENTS_MONSTERCLIP        0x00020000
+const int CONTENTS_PHASE_B =        0x00020000;
 #define CONTENTS_TELEPORTER         0x00040000  //NOT USED EITHER....
 #define CONTENTS_NOPORTAL           0x00080000  // Feen: PGM - Contents formerly known as CONTENTS_JUMPPAD - Used for 'emancipation grid'
 #define CONTENTS_NOSAVE             0x00100000  // CONTENTS_NOSAVE
 #define CONTENTS_DONOTENTER         0x00200000	// Aciz: renamed back to original, was renamed to CONTENTS_NOSAVERESET but never used anywhere.
 const int CONTENTS_NOPRONE =        0x00200000;
 #define CONTENTS_DONOTENTER_LARGE   0x00400000  
+const int CONTENTS_PHASE_A =        0x00400000;
 #define CONTENTS_ORIGIN             0x01000000  // removed before bsping an entity
 #define CONTENTS_BODY               0x02000000  // should never be on a brush, only in game
 #define CONTENTS_CORPSE             0x04000000
@@ -72,7 +109,7 @@ const int CONTENTS_NOPRONE =        0x00200000;
 #define SURF_MONSLICK_S			0x40000000
 */
 
-//Feen: New ETJump Surfaces...
+//Feen: New ETJump Surfaces...   200000000
 #define SURF_PORTALGATE         0x08000000  //Feen: I hereby declare these's SURF's in the name of ETJump!
 #define SURF_MONSLICK_N         0x10000000  //ETJump: SURF_NOJUMPDELAY
 #define SURF_MONSLICK_E         0x20000000  //Zero: I hereby declare this SURF as a portalable/unportalable surface (depends on level.portalSurfaces)


### PR DESCRIPTION
- Repurposes the following contentparams: `donotenterlarge`, `monsterclip`
- Repurposes the following eFlags for players:
  - `EF_FAKE_MODEL`, was never used for player entities
  - `EF_FORCE_END_FRAME` was only used in deprecated singleplayer code
- Adds entity `target_phase` to control phase A and phase B states
- Adds bitfield worldspawn key `phasing` with the following options:
  - `1` Removes phase flags from player on death/team change
  - `2` Removes phase flags from player on load/goto
  - `4` Gibs player if they are stuck inside phase brush for over 250ms
- Adds worldspawn keys `phaseremapXN` there `X` is `a` or `b`, and `N` is a number from 1 to 32, for clientside remapping of shaders depending on phase flags.
  - Example key/value: `phaseremapa1` `textures/mymap/a_nonsolid;textures/mymap/a_solid`
  - More remaps than 32 could probably be made as there doesn't seem to be an engine limit to that