### PR TITLE
Fix weapons potentially set at WP_NONE when using team command

### DIFF
--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -1814,8 +1814,9 @@ G_GetDefaultWeaponForClass
 Returns default weapons for class
 =================
 */
-int G_GetDefaultWeaponForClass(gentity_t* ent, char* s, int weapon, bool primary, bool updateclient)
+weapon_t G_GetDefaultWeaponForClass(gentity_t* ent, char* s, bool primary)
 {
+	weapon_t weapon;
 	// sessionTeam isn't set when this is called, so compare against team string
 	if (!Q_stricmp(s, "red") || !Q_stricmp(s, "r") || !Q_stricmp(s, "axis"))
 	{
@@ -1850,11 +1851,6 @@ int G_GetDefaultWeaponForClass(gentity_t* ent, char* s, int weapon, bool primary
 		default:
 			break;
 		}
-	}
-
-	if (updateclient)
-	{
-		ClientUserinfoChanged(ent - g_entities);
 	}
 
 	return weapon;
@@ -1909,11 +1905,11 @@ void Cmd_Team_f(gentity_t *ent)
 	// if weapons are not specified, set default weapons for class
 	if (!w)
 	{
-		w = static_cast<weapon_t>(G_GetDefaultWeaponForClass(ent, s, w, true, true));
+		w = G_GetDefaultWeaponForClass(ent, s, true);
 	}
 	if (!w2)
 	{
-		w2 = static_cast<weapon_t>(G_GetDefaultWeaponForClass(ent, s, w2, false, true));
+		w2 = G_GetDefaultWeaponForClass(ent, s, false);
 	}
 
 	if (!SetTeam(ent, s, qfalse, w, w2, qtrue))

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -1826,7 +1826,7 @@ weapon_t G_GetDefaultWeaponForClass(gentity_t* ent, char* s, bool primary)
 		case PC_MEDIC:
 		case PC_ENGINEER:
 		case PC_FIELDOPS:
-			weapon = primary ? WP_MP40 :  WP_LUGER;			
+			weapon = primary ? WP_MP40 : WP_LUGER;			
 			break;
 		case PC_COVERTOPS:
 			weapon = primary ?  WP_STEN : WP_SILENCER;
@@ -1835,7 +1835,7 @@ weapon_t G_GetDefaultWeaponForClass(gentity_t* ent, char* s, bool primary)
 			break;
 		}
 	}
-	if (!Q_stricmp(s, "blue") || !Q_stricmp(s, "b") || !Q_stricmp(s, "allies"))
+	else if (!Q_stricmp(s, "blue") || !Q_stricmp(s, "b") || !Q_stricmp(s, "allies"))
 	{
 		switch (ent->client->sess.latchPlayerType)
 		{
@@ -1851,6 +1851,10 @@ weapon_t G_GetDefaultWeaponForClass(gentity_t* ent, char* s, bool primary)
 		default:
 			break;
 		}
+	}
+	else
+	{
+		weapon = WP_NONE;
 	}
 
 	return weapon;

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1430,6 +1430,7 @@ void StopFollowing(gentity_t *ent);
 void G_TeamDataForString(const char *teamstr, int clientNum, team_t *team, spectatorState_t *sState, int *specClient);
 qboolean SetTeam(gentity_t *ent, const char *s, qboolean force, weapon_t w1, weapon_t w2, qboolean setweapons);
 void G_SetClientWeapons(gentity_t *ent, weapon_t w1, weapon_t w2, qboolean updateclient);
+int G_GetDefaultWeaponForClass(gentity_t* ent, char *s, char *weapon, bool primary, bool updateclient);
 void Cmd_FollowCycle_f(gentity_t *ent, int dir);
 void Cmd_Kill_f(gentity_t *ent);
 void Cmd_SwapPlacesWithBot_f(gentity_t *ent, int botNum);

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1430,7 +1430,7 @@ void StopFollowing(gentity_t *ent);
 void G_TeamDataForString(const char *teamstr, int clientNum, team_t *team, spectatorState_t *sState, int *specClient);
 qboolean SetTeam(gentity_t *ent, const char *s, qboolean force, weapon_t w1, weapon_t w2, qboolean setweapons);
 void G_SetClientWeapons(gentity_t *ent, weapon_t w1, weapon_t w2, qboolean updateclient);
-int G_GetDefaultWeaponForClass(gentity_t* ent, char *s, char *weapon, bool primary, bool updateclient);
+weapon_t G_GetDefaultWeaponForClass(gentity_t* ent, char *s, bool primary);
 void Cmd_FollowCycle_f(gentity_t *ent, int dir);
 void Cmd_Kill_f(gentity_t *ent);
 void Cmd_SwapPlacesWithBot_f(gentity_t *ent, int botNum);


### PR DESCRIPTION
Not defining weapons when using `team` command leaves them at 0 `(WP_NONE)` which causes mismatch in client session data `client->sess.playerWeapon` & `client->sess.playerWeapon2`