### PR TITLE
Show total number of maps on server on listmaps output

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -1182,6 +1182,8 @@ bool ListMaps(gentity_t *ent, Arguments argv)
 
 	buffer += "\n";
 
+	buffer += (boost::format("\n^zFound ^3%d ^zmaps on the server.\n") % static_cast<int>(maps.size())).str();
+
 	Utilities::toConsole(ent, buffer);
 
 	return true;


### PR DESCRIPTION
`!listmaps` now displays total number of maps found on the server.

![image](https://user-images.githubusercontent.com/14221121/109932303-afd6d300-7cd2-11eb-8da3-71a928cf024f.png)
