### PR TITLE
Remove useless spam protection print from team command

### DIFF
--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -1882,7 +1882,6 @@ void Cmd_Team_f(gentity_t *ent)
 
 	if (ClientIsFlooding(ent))
 	{
-		CP("print \"^1Spam protection: ^7command team ignored.\n\"");
 		return;
 	}
 


### PR DESCRIPTION
This print shouldn't ever print (in fact, the whole `ClientIsFlooding` block should never execute) since the command isn't executed in the first place if flood protection kicks in. However it seems that it does sometimes as seen here, so keeping the 2nd flood protection check still in.

![image](https://user-images.githubusercontent.com/14221121/110016060-42a45b80-7d2d-11eb-919d-be3d7e303078.png)
