### PR TITLE
Give fops binocs, disable arty unless cheats are enabled

### DIFF
--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -868,12 +868,9 @@ void SetWolfSpawnWeapons(gclient_t *client)
 	// Zero: CTF: if CTF give no other weapons than knife
 	if (g_weapons.integer)
 	{
-		if (pc != PC_FIELDOPS)
+		if (AddWeaponToPlayer(client, WP_BINOCULARS, 1, 0, qfalse))
 		{
-			if (AddWeaponToPlayer(client, WP_BINOCULARS, 1, 0, qfalse))
-			{
-				client->ps.stats[STAT_KEYS] |= (1 << INV_BINOCS);
-			}
+			client->ps.stats[STAT_KEYS] |= (1 << INV_BINOCS);
 		}
 		// Engineer gets dynamite
 		if (pc == PC_ENGINEER)

--- a/src/game/g_weapon.cpp
+++ b/src/game/g_weapon.cpp
@@ -4923,7 +4923,8 @@ void FireWeapon(gentity_t *ent)
 		aimSpreadScale = 1.0;
 	}
 
-	if ((ent->client->ps.eFlags & EF_ZOOMING) && (ent->client->ps.stats[STAT_KEYS] & (1 << INV_BINOCS)))
+	// ETJump: only allow calling artillery if cheats are enabled
+	if ((ent->client->ps.eFlags & EF_ZOOMING) && (ent->client->ps.stats[STAT_KEYS] & (1 << INV_BINOCS)) && g_cheats.integer)
 	{
 		if (ent->client->sess.playerType == PC_FIELDOPS)
 		{


### PR DESCRIPTION
* Field Ops now spawn with binoculars too
* Calling artillery is only possible if cheats are enabled (didn't disable it fully because you can get airstrike canisters and binoculars with `give all` anyway)