### PR TITLE
Fix weapon swap handling on timerun start

### DIFF
--- a/src/game/bg_misc.cpp
+++ b/src/game/bg_misc.cpp
@@ -2941,6 +2941,15 @@ bool BG_WeaponDisallowedInTimeruns(int weap)
 	}
 }
 
+bool BG_WeaponHasAmmo(playerState_t *ps, int weap)
+{
+	if (ps->ammo[BG_FindAmmoForWeapon(static_cast<weapon_t>(weap))] || ps->ammoclip[BG_FindClipForWeapon(static_cast<weapon_t>(weap))])
+	{
+		return true;
+	}
+	return false;
+}
+
 /*
 ============
 BG_PlayerTouchesItem

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -1639,6 +1639,7 @@ qboolean BG_CanUseWeapon(int classNum, int teamNum, weapon_t weapon);
 qboolean    BG_CanItemBeGrabbed(const entityState_t *ent, const playerState_t *ps, int *skill, int teamNum);
 qboolean    BG_WeaponIsExplosive(int weap);
 bool BG_WeaponDisallowedInTimeruns(int weap);
+bool BG_WeaponHasAmmo(playerState_t *ps, int weap);
 
 
 // content masks

--- a/src/game/etj_utilities.h
+++ b/src/game/etj_utilities.h
@@ -104,7 +104,7 @@ namespace Utilities {
 	 */
 	void toConsole(gentity_t *ent, std::string message);
 
-	void RemovePlayerWeapons(int clientNum, const std::vector<int>& weapons);
+	void RemovePlayerWeapons(int clientNum);
 };
 
 

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -2566,13 +2566,11 @@ void target_init_use(gentity_t *self, gentity_t *other, gentity_t *activator)
 		// if we have ammo: primary > seconday > knife
 		if (activator->client->ps.weapon == WP_PORTAL_GUN)
 		{
-			if (activator->client->ps.ammo[BG_FindAmmoForWeapon(static_cast<weapon_t>(activator->client->sess.playerWeapon))] ||
-				activator->client->ps.ammoclip[BG_FindClipForWeapon(static_cast<weapon_t>(activator->client->sess.playerWeapon))])
+			if (BG_WeaponHasAmmo(&activator->client->ps, activator->client->sess.playerWeapon))
 			{
 				activator->client->ps.weapon = activator->client->sess.playerWeapon;
 			}
-			else if (activator->client->ps.ammo[BG_FindAmmoForWeapon(static_cast<weapon_t>(activator->client->sess.playerWeapon2))] ||
-				activator->client->ps.ammoclip[BG_FindClipForWeapon(static_cast<weapon_t>(activator->client->sess.playerWeapon2))])
+			else if (BG_WeaponHasAmmo(&activator->client->ps, activator->client->sess.playerWeapon2))
 			{
 				activator->client->ps.weapon = activator->client->sess.playerWeapon2;
 			}


### PR DESCRIPTION
Covert ops weapons were not handled properly when starting a timerun with a disallowed weapon equipped. Also some refactoring for checking which weapons to remove when a timerun starts.