### PR TITLE
Don't reset timescale on demos when subsystems are restarted

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -3810,10 +3810,6 @@ void CG_Shutdown(void)
 	// like closing files or archiving session data
 
 	CG_EventHandling(CGAME_EVENT_NONE, qtrue);
-	if (cg.demoPlayback)
-	{
-		trap_Cvar_Set("timescale", "1");
-	}
 
 	/////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// ETJump shutdown


### PR DESCRIPTION
Don't reset timescale when `CG_Shutdown` is called during demo playback. This is mainly a QOL feature for video making, where you might want to execute configs that require `vid_restart` during demo playback and you have the demo frozen on the spot where you want to start recording. Side effect is that exiting demo playback to main menu no longer resets timescale, but I don't think it's an issue really.