### PR TITLE
Remove binocular sway, add spectator zooming

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -2236,7 +2236,7 @@ static void CG_DrawCrosshair(void)
 	}
 
 	// using binoculars
-	if (cg.zoomedBinoc)
+	if (cg.zoomedBinoc && cg.snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR)
 	{
 		CG_DrawBinocReticle();
 		return;
@@ -2258,7 +2258,7 @@ static void CG_DrawCrosshair(void)
 
 	// weapons that get no reticle
 	case WP_NONE:       // no weapon, no crosshair
-		if (cg.zoomedBinoc)
+		if (cg.zoomedBinoc && cg.snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR)
 		{
 			CG_DrawBinocReticle();
 		}
@@ -3982,6 +3982,12 @@ static void CG_DrawFlashZoomTransition(void)
 	int    fadeTime;
 
 	if (!cg.snap)
+	{
+		return;
+	}
+
+	// ETJump: no transition for spectator zoom
+	if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR)
 	{
 		return;
 	}

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -592,6 +592,11 @@ static void CG_ZoomSway(void)
 		return;
 	}
 
+	if (cg.zoomedBinoc)
+	{
+		return;
+	}
+
 	spreadfrac = (float)cg.snap->ps.aimSpreadScale / 255.0;
 
 	phase                       = cg.time / 1000.0 * ZOOM_PITCH_FREQUENCY * M_PI * 2;

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -172,6 +172,11 @@ namespace ETJump
 			return;
 		}
 
+		if (cg.zoomedBinoc || cg.zoomedScope)
+		{
+			return;
+		}
+
 		a = Numeric::clamp(etj_CGazAlpha.value, 0.0f, 1.0f);
 		color[3] = a;
 		y = etj_CGazY.integer > 0 ? etj_CGazY.integer % 480 : 0;

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -88,6 +88,11 @@ namespace ETJump
 			return;
 		}
 
+		if (cg.zoomedBinoc || cg.zoomedScope)
+		{
+			return;
+		}
+
 		// get correct speed scaling
 		scale = PM_CalcScale(ps);
 

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -6687,7 +6687,8 @@ void PmoveSingle(pmove_t *pmove)
 
 	if (pm->cmd.wbuttons & WBUTTON_ZOOM && pm->ps->stats[STAT_HEALTH] >= 0 && !(pm->ps->weaponDelay))
 	{
-		if (pm->ps->stats[STAT_KEYS] & (1 << INV_BINOCS))      // (SA) binoculars are an inventory item (inventory==keys)
+		// ETJump: allow zooming in via binoculars while in spec
+		if (pm->ps->stats[STAT_KEYS] & (1 << INV_BINOCS) || pm->ps->persistant[PERS_TEAM] == TEAM_SPECTATOR)      // (SA) binoculars are an inventory item (inventory==keys)
 		{
 			if (!BG_IsScopedWeapon(pm->ps->weapon) &&       // don't allow binocs if using the sniper scope
 			    !BG_PlayerMounted(pm->ps->eFlags) &&        // or if mounted on a weapon


### PR DESCRIPTION
* Removed sway from binoculars
* Added binocular-like zoom for spectator, without binocular reticle drawing
* CGaz/snaphud is no longer drawn when zooming with binoculars or scoped weapons