### PR TITLE
Fix last jump speed inaccuracy

### DIFF
--- a/src/cgame/cg_drawCHS.cpp
+++ b/src/cgame/cg_drawCHS.cpp
@@ -430,7 +430,8 @@ static void CG_CHS_PlaneAngleZ(char *buf, int size)
 
 static void CG_CHS_LastJumpSpeed(char* buf, int size)
 {
-	Com_sprintf(buf, size, "%.0f", cg.lastJumpSpeed);
+	playerState_t* ps = CG_CHS_GetPlayerState();
+	Com_sprintf(buf, size, "%d", ps->stats[STAT_JUMP_SPEED]);
 }
 
 typedef struct

--- a/src/cgame/cg_drawCHS.cpp
+++ b/src/cgame/cg_drawCHS.cpp
@@ -431,7 +431,7 @@ static void CG_CHS_PlaneAngleZ(char *buf, int size)
 static void CG_CHS_LastJumpSpeed(char* buf, int size)
 {
 	playerState_t* ps = CG_CHS_GetPlayerState();
-	Com_sprintf(buf, size, "%d", ps->stats[STAT_JUMP_SPEED]);
+	Com_sprintf(buf, size, "%d", ps->persistant[PERS_JUMP_SPEED]);
 }
 
 typedef struct

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -2112,7 +2112,6 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 	case EV_JUMP:
 		DEBUGNAME("EV_JUMP");
 		VectorCopy(cent->lerpOrigin, cg.etjLastJumpPos);
-		cg.lastJumpSpeed = sqrt(cg.predictedPlayerState.velocity[0] * cg.predictedPlayerState.velocity[0] + cg.predictedPlayerState.velocity[1] * cg.predictedPlayerState.velocity[1]);
 		trap_S_StartSound(NULL, es->number, CHAN_VOICE, CG_CustomSound(es->number, "*jump1.wav"));
 		break;
 	case EV_TAUNT:

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1258,8 +1258,6 @@ typedef struct
 
 	char deformText[MAX_RENDER_STRINGS][MAX_RENDER_STRING_LENGTH];
 	qboolean gridInitDone;
-
-	float lastJumpSpeed;
 } cg_t;
 
 #define NUM_FUNNEL_SPRITES  21

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -913,7 +913,7 @@ static qboolean PM_CheckJump(void)
 	}
 
 	// store horizontal speed for CHS 55
-	pm->ps->stats[STAT_JUMP_SPEED] = sqrt(pm->ps->velocity[0] * pm->ps->velocity[0] + pm->ps->velocity[1] * pm->ps->velocity[1]);
+	pm->ps->persistant[PERS_JUMP_SPEED] = sqrt(pm->ps->velocity[0] * pm->ps->velocity[0] + pm->ps->velocity[1] * pm->ps->velocity[1]);
 
 	return qtrue;
 }

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -912,6 +912,9 @@ static qboolean PM_CheckJump(void)
 		pm->ps->pm_flags |= PMF_BACKWARDS_JUMP;
 	}
 
+	// store horizontal speed for CHS 55
+	pm->ps->stats[STAT_JUMP_SPEED] = sqrt(pm->ps->velocity[0] * pm->ps->velocity[0] + pm->ps->velocity[1] * pm->ps->velocity[1]);
+
 	return qtrue;
 }
 

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -662,9 +662,7 @@ typedef enum
 	// setup - keys pressed (high byte contains buttons, low byte contains wbuttons)
 	STAT_USERCMD_BUTTONS,
 	// setup - keys pressed (see UMOVE_* for flags)
-	STAT_USERCMD_MOVE,
-	// ETJump: last jump speed
-	STAT_JUMP_SPEED
+	STAT_USERCMD_MOVE
 } statIndex_t;
 
 // player_state->persistant[] indexes
@@ -682,7 +680,8 @@ typedef enum
 	// these were added for single player awards tracking
 
 	PERS_REVIVE_COUNT,
-	PERS_BLEH_2,
+	//PERS_BLEH_2,
+	PERS_JUMP_SPEED,                // ETJump: last jump speed
 	PERS_BLEH_3,
 	PERS_BLEH_4,
 

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -662,7 +662,9 @@ typedef enum
 	// setup - keys pressed (high byte contains buttons, low byte contains wbuttons)
 	STAT_USERCMD_BUTTONS,
 	// setup - keys pressed (see UMOVE_* for flags)
-	STAT_USERCMD_MOVE
+	STAT_USERCMD_MOVE,
+	// ETJump: last jump speed
+	STAT_JUMP_SPEED
 } statIndex_t;
 
 // player_state->persistant[] indexes


### PR DESCRIPTION
Events are processed few frames after `commandTime`, which caused last jump speed to be slightly inaccurate because the value was taken few frames after jump was processed in pmove. This caused issue where jumping at the very last few frames on ramps would print the speed after you lost some due to hitting the ramp.

The new ~stat `STAT_JUMP_SPEED`~ pers `PERS_JUMP_SPEED` can be later utilized to generate a jump speed list, which is planned.

Thanks @suburbski for reporting this issue!

@isRyven I want to double check before merging this that adding a new stat is fine, I don't imagine it being a problem since we have already added some there? `MAX_STATS` is 16, there are now 11 fields.

refs #603 