### PR TITLE
Reset jump speeds on save

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -3189,6 +3189,13 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		ETJump::playerEventsHandler->check("load", {});
 		ETJump::QueueJumpSpeedsReset();
 		break;
+	case EV_SAVE:
+		DEBUGNAME("EV_SAVE");
+		if (clientNum == cg.predictedPlayerState.clientNum)
+		{
+			ETJump::QueueJumpSpeedsReset();
+		}
+		break;
 	default:
 		DEBUGNAME("UNKNOWN");
 		break;

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -1148,6 +1148,7 @@ typedef enum
 	EV_PORTAL_TELEPORT,
 	EV_LOAD_TELEPORT,
 	EV_UPHILLSTEP,
+	EV_SAVE,
 	EV_MAX_EVENTS   // just added as an 'endcap'
 } entity_event_t;
 

--- a/src/game/etj_save_system.cpp
+++ b/src/game/etj_save_system.cpp
@@ -222,6 +222,8 @@ void ETJump::SaveSystem::save(gentity_t *ent)
 
 	storePosition(client, pos);
 
+	G_AddEvent(ent, EV_SAVE, 0);
+
 	if (position == 0)
 	{
 		CP(va("cp \"%s\n\"", g_savemsg.string));


### PR DESCRIPTION
Makes sense, it's sort of equivalent in terms on "jump session" with `load`

refs #608 