### PR TITLE
Allow floating point values for etj_speedSize

### DIFF
--- a/src/cgame/etj_maxspeed.cpp
+++ b/src/cgame/etj_maxspeed.cpp
@@ -96,7 +96,7 @@ void ETJump::DisplayMaxSpeed::render() const
 	color[3] *= fade;
 
 	auto size = 0.1f;
-	size *= etj_speedSize.integer;
+	size *= etj_speedSize.value;
 
 	auto str = va("%0.f", _displayMaxSpeed);
 	float w;

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -105,7 +105,7 @@ void ETJump::DisplaySpeed::render() const
 		return;
 	}
 
-	float size = 0.1f * etj_speedSize.integer;
+	float size = 0.1f * etj_speedSize.value;
 	float x = etj_speedX.integer;
 	float y = etj_speedY.integer;
 	ETJump_AdjustPosition(&x);


### PR DESCRIPTION
Size difference between integers is quite big, so allow floating point values for more precise sizing.