### PR TITLE
Prevent etj_CGazAlpha from affecting CGaz 5

### DIFF
--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -509,7 +509,6 @@ namespace ETJump
 			{
 				vec4_t color;
 				parseColorString(etj_CGaz5Color1.string, color);
-				color[3] = a;
 				CG_FillAngleYaw_Ext(-d_min, +d_min, yaw, y, h, fov, color);
 			}
 
@@ -517,7 +516,6 @@ namespace ETJump
 			{
 				vec4_t color;
 				parseColorString(etj_CGaz5Color2.string, color);
-				color[3] = a;
 				CG_FillAngleYaw_Ext(+d_min, +d_opt, yaw, y, h, fov, color);
 				CG_FillAngleYaw_Ext(-d_opt, -d_min, yaw, y, h, fov, color);
 			}
@@ -526,7 +524,6 @@ namespace ETJump
 			{
 				vec4_t color;
 				parseColorString(etj_CGaz5Color3.string, color);
-				color[3] = a;
 				CG_FillAngleYaw_Ext(+d_opt, +d_max_cos, yaw, y, h, fov, color);
 				CG_FillAngleYaw_Ext(-d_max_cos, -d_opt, yaw, y, h, fov, color);
 			}
@@ -535,7 +532,6 @@ namespace ETJump
 			{
 				vec4_t color;
 				parseColorString(etj_CGaz5Color4.string, color);
-				color[3] = a;
 				CG_FillAngleYaw_Ext(+d_max_cos, +d_max, yaw, y, h, fov, color);
 				CG_FillAngleYaw_Ext(-d_max, -d_max_cos, yaw, y, h, fov, color);
 			}


### PR DESCRIPTION
Since all color elements of CGaz 5 can be changed individually, it's better to allow per-color alpha control via the RGBA color value of each individual color, rather than with a single cvar, like it is with the two colors of CGaz 2.