### PR TITLE
Fix NJD not always saving jumpTime

### DIFF
--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -1670,9 +1670,9 @@ static void PM_WalkMove(void)
 			{
 				pm->pmext->sprintTime = 0;
 			}
-
-			pm->pmext->jumpTime = pm->cmd.serverTime;
 		}
+
+		pm->pmext->jumpTime = pm->cmd.serverTime;
 
 		// JPW NERVE
 		pm->ps->jumpTime = pm->cmd.serverTime;  // Arnout: NOTE : TEMP DEBUG


### PR DESCRIPTION
In cases where you jump from an NJD surface to another NJD surface within regular jump delay time (so jump delay would normally occur), `jumpTime` wasn't updated. This made it possible to perform NJD -> NJD -> non-NJD jump combinations and not have jump delay on non-NJD surface.