### PR TITLE
Re-enable cvarListUndefined with initialisation

### DIFF
--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -3437,18 +3437,15 @@ const char *Item_Multi_Setting(itemDef_t *item)
 				}
 			}
 		}
+		if (multiPtr->undefinedStr)
+		{
+			return multiPtr->undefinedStr;
+		}
 		if (multiPtr->count == 0)
 		{
 			return "None Defined";
 		}
 	}
-	
-	// ignore cvarListUndefined as it's almost never used and easily forgotten
-	/*
-	if (multiPtr->undefinedStr)
-	{
-		return multiPtr->undefinedStr;
-	}*/
 
 	return "Custom";
 }
@@ -7010,14 +7007,17 @@ void Item_ValidateTypeData(itemDef_t *item)
 	else if (item->type == ITEM_TYPE_MULTI || item->type == ITEM_TYPE_CHECKBOX || item->type == ITEM_TYPE_TRICHECKBOX)
 	{
 		item->typeData = UI_Alloc(sizeof(multiDef_t));
+		memset(item->typeData, 0, sizeof(multiDef_t));
 	}
 	else if (item->type == ITEM_TYPE_MODEL)
 	{
 		item->typeData = UI_Alloc(sizeof(modelDef_t));
+		memset(item->typeData, 0, sizeof(modelDef_t));
 	}
 	else if (item->type == ITEM_TYPE_MENUMODEL)
 	{
 		item->typeData = UI_Alloc(sizeof(modelDef_t));
+		memset(item->typeData, 0, sizeof(modelDef_t));
 	}
 }
 
@@ -8033,6 +8033,7 @@ qboolean ItemParse_cvarStrList(itemDef_t *item, int handle)
 	multiPtr         = (multiDef_t *)item->typeData;
 	multiPtr->count  = 0;
 	multiPtr->strDef = qtrue;
+	multiPtr->undefinedStr = NULL;
 
 	if (!trap_PC_ReadToken(handle, &token))
 	{
@@ -8095,6 +8096,7 @@ qboolean ItemParse_cvarFloatList(itemDef_t *item, int handle)
 	multiPtr         = (multiDef_t *)item->typeData;
 	multiPtr->count  = 0;
 	multiPtr->strDef = qfalse;
+	multiPtr->undefinedStr = NULL;
 
 	if (!trap_PC_ReadToken(handle, &token))
 	{


### PR DESCRIPTION
Proper fix for #616, allows to leave cvarListUndefined unset in menu files without undefined behaviour