### PR TITLE
fix openal bug on goldrush

### DIFF
--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -3535,6 +3535,12 @@ void CG_AttachBitsToTank(centity_t *tank, refEntity_t *mg42base, refEntity_t *mg
 		mg42gun->hModel = cgs.media.hMountedMG42;
 	}
 
+	// entity was not received yet, ignore
+	if (tank->currentState.number == 0)
+	{
+		return;
+	}
+
 	if (!CG_AddCEntity_Filter(tank))
 	{
 		return;


### PR DESCRIPTION
Tank entity was processed way before it was received, which caused bug on goldrush where player sounds were played from a distance on openAL backend. This only affected client with id 0.