### PR TITLE
Enable and fix more gcc warnings

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -25,8 +25,9 @@ function(create_compiler_opts target)
 		-fPIC
 		-fvisibility=hidden
 		-fdiagnostics-color=always
-		$<IF:$<STREQUAL:${WARN_LEVEL},0>,-w,-Wall>
-		-Wno-comment
+		$<IF:$<STREQUAL:${WARN_LEVEL},0>,-w,-Wall -Wextra -Wpedantic>
+		-Wno-unused-parameter
+		-Wno-missing-field-initializers
 		$<$<CONFIG:Release>:
 			-flto              # link time optimizations
 			-O3                # max optimization 

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -1675,6 +1675,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		{
 			break;
 		}
+		// fall through
 	case EV_FOOTSTEP:
 		DEBUGNAME("EV_FOOTSTEP");
 		if (es->eventParm != FOOTSTEP_TOTAL)
@@ -2476,6 +2477,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		{
 			break;
 		}
+		// fall through
 	case EV_GENERAL_SOUND_VOLUME:
 	{
 		int sound  = es->eventParm;
@@ -2515,6 +2517,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		{
 			break;
 		}
+		// fall through
 	case EV_GLOBAL_SOUND:   // play from the player's head so it never diminishes
 		DEBUGNAME("EV_GLOBAL_SOUND");
 		// Ridah, check for a sound script

--- a/src/cgame/cg_fireteamoverlay.cpp
+++ b/src/cgame/cg_fireteamoverlay.cpp
@@ -92,6 +92,7 @@ void CG_ParseFireteams()
 	const char       *s;
 	const char *p;
 	int        clnts[2];
+	unsigned int tmp;
 
 	// qboolean onFireteam2;
 	// qboolean isLeader2;
@@ -137,9 +138,11 @@ void CG_ParseFireteams()
 
 		s = Info_ValueForKey(p, "c");
 		Q_strncpyz(hexbuffer + 2, s, 9);
-		sscanf(hexbuffer, "%x", &clnts[1]);
+		sscanf(hexbuffer, "%x", &tmp);
+		clnts[1] = static_cast<int>(tmp);
 		Q_strncpyz(hexbuffer + 2, s + 8, 9);
-		sscanf(hexbuffer, "%x", &clnts[0]);
+		sscanf(hexbuffer, "%x", &tmp);
+		clnts[0] = static_cast<int>(tmp);
 
 		for (j = 0; j < MAX_CLIENTS; j++)
 		{

--- a/src/cgame/cg_info.cpp
+++ b/src/cgame/cg_info.cpp
@@ -182,6 +182,7 @@ void CG_DemoClick(int key, qboolean down)
 			CG_RunBinding(key, down);
 			return;
 		}
+		// fall through
 	case K_CTRL:
 	case K_MOUSE4:
 		cgs.fResize = down;
@@ -295,6 +296,7 @@ void CG_DemoClick(int key, qboolean down)
 			CG_RunBinding(key, down);
 			return;
 		}
+		// fall through
 	case K_ESCAPE:
 		if (!down)
 		{
@@ -362,6 +364,7 @@ void CG_DemoClick(int key, qboolean down)
 			}
 			return;
 		}       // Roll over into timescale changes
+		// fall through
 	case K_KP_LEFTARROW:
 		if (!down && cg_timescale.value > 0.1f)
 		{
@@ -385,6 +388,7 @@ void CG_DemoClick(int key, qboolean down)
 			}
 			return;
 		}       // Roll over into timescale changes
+		// fall through
 	case K_KP_RIGHTARROW:
 		if (!down)
 		{

--- a/src/cgame/cg_limbopanel.cpp
+++ b/src/cgame/cg_limbopanel.cpp
@@ -2437,7 +2437,7 @@ int CG_LimboPanel_RenderCounter_NumRollers(panel_button_t *button)
 		case 2:
 			return 3;
 		}
-
+		break;
 	case 2:     // xp
 		if (cg_gameType.integer == GT_WOLF_LMS)
 		{

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -2549,6 +2549,7 @@ void CG_Player(centity_t *cent)
 				{
 					continue;
 				}
+				// fall through
 			case ACC_MOUTH2:            // hat2
 			case ACC_MOUTH3:            // hat3
 

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -229,6 +229,7 @@ void CG_MachineGunEjectBrass(centity_t *cent)
 		case WP_CARBINE:
 		case WP_K43:
 			re->hModel = cgs.media.machinegunBrassModel;
+			// fall through
 		case WP_MP40:
 		case WP_THOMPSON:
 		case WP_STEN:

--- a/src/cgame/etj_cvar_shadow.cpp
+++ b/src/cgame/etj_cvar_shadow.cpp
@@ -34,7 +34,7 @@ CvarShadow::CvarShadow(const vmCvar_t *shadow, std::string target): _shadow(shad
 	{
 		forceCvarSet(cvar);
 	});
-};
+}
 
 CvarShadow::~CvarShadow() {}
 

--- a/src/game/bg_animation.cpp
+++ b/src/game/bg_animation.cpp
@@ -1493,7 +1493,7 @@ int BG_PlayAnim(playerState_t *ps, animModelInfo_t *animModelInfo, int animNum, 
 		{
 			break;
 		}
-
+		// fall through
 	case ANIM_BP_TORSO:
 
 		if ((ps->torsoTimer < 50) || force)

--- a/src/game/bg_misc.cpp
+++ b/src/game/bg_misc.cpp
@@ -3196,6 +3196,7 @@ qboolean BG_CanUseWeapon(int classNum, int teamNum, weapon_t weapon)
 		{
 			return (teamNum == TEAM_ALLIES) ? qtrue : qfalse;
 		}
+		break;
 	case PC_FIELDOPS:
 		// TAT 1/11/2003 - in SP, field op can only use handgun, check after switch below
 		if (isSinglePlayer && teamNum == TEAM_ALLIES)
@@ -5439,16 +5440,19 @@ int BG_simpleHintsCollapse(int hint, int val)
 		{
 			return(0);
 		}
+		break;
 	case HINT_BUILD:
 		if (val > 0)
 		{
 			return(1);
 		}
+		break;
 	case HINT_BREAKABLE:
 		if (val == 0)
 		{
 			return(1);
 		}
+		break;
 	case HINT_DOOR_ROTATING:
 	case HINT_BUTTON:
 	case HINT_MG42:
@@ -5456,11 +5460,15 @@ int BG_simpleHintsCollapse(int hint, int val)
 		{
 			return(2);
 		}
+		break;
 	case HINT_BREAKABLE_DYNAMITE:
 		if (val == 0)
 		{
 			return(3);
 		}
+		break;
+	default:
+		break;
 	}
 
 	return(0);

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -3153,6 +3153,7 @@ void PM_BeginWeaponChange(int oldweapon, int newweapon, qboolean reload)        
 			CrossProduct(axis[0], axis[2], axis[1]);
 			AxisToAngles(axis, pm->pmext->mountedWeaponAngles);
 		}
+		break;
 	case WP_MOBILE_MG42_SET:
 		if (newweapon == weapAlts[oldweapon])
 		{

--- a/src/game/etj_filesystem.h
+++ b/src/game/etj_filesystem.h
@@ -54,4 +54,4 @@ namespace ETJump
 			static std::string sanitizeFolder(std::string path);
 		};
 	};
-};
+}

--- a/src/game/etj_utilities.h
+++ b/src/game/etj_utilities.h
@@ -105,7 +105,7 @@ namespace Utilities {
 	void toConsole(gentity_t *ent, std::string message);
 
 	void RemovePlayerWeapons(int clientNum);
-};
+}
 
 
 #endif //ETJUMP_UTILITIES_H

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -1770,7 +1770,7 @@ void ClientUserinfoChanged(int clientNum)
 	// TODO: Check for hardware info spoofing
 
 	s = Info_ValueForKey(userinfo, "cg_uinfo");
-	sscanf(s, "%i %i %i %i %f %i",
+	sscanf(s, "%u %u %u %u %f %i",
 	       &client->pers.clientFlags,
 	       &client->pers.clientTimeNudge,
 	       &client->pers.clientMaxPackets,

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -1926,6 +1926,12 @@ void Cmd_Team_f(gentity_t *ent)
 	}
 }
 
+// wrapper for Cmd_Team_f
+void Cmd_Team2_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue)
+{
+	Cmd_Team_f(ent);
+}
+
 void Cmd_ResetSetup_f(gentity_t *ent)
 {
 	qboolean changed = qfalse;

--- a/src/game/g_cmds_ext.cpp
+++ b/src/game/g_cmds_ext.cpp
@@ -51,7 +51,7 @@ static const cmd_reference_t aCommandInfo[] =
 	{ "speclist",       qtrue,  qtrue,  Cmd_SpecList_f,        ":^7Lists specinvited players"                                                               },
 	{ "statsall",       qtrue,  qfalse, G_statsall_cmd,        ":^7 Shows weapon accuracy stats for all players"                                            },
 	{ "statsdump",      qtrue,  qtrue,  NULL,                  ":^7 Shows player stats + match info saved locally to a file"                                },
-	{ "team",           qtrue,  qtrue,  (void (*)(gentity_t *, unsigned int, qboolean))Cmd_Team_f, " <b|r|s|none>:^7 Joins a team (b = allies, r = axis, s = spectator)"},
+	{ "team",           qtrue,  qtrue,  Cmd_Team2_f, " <b|r|s|none>:^7 Joins a team (b = allies, r = axis, s = spectator)"},
 	{ "topshots",       qtrue,  qtrue,  G_weaponRankings_cmd,  ":^7 Shows BEST player for each weapon. Add ^3<weapon_ID>^7 to show all stats for a weapon"  },
 	{ "unready",        qtrue,  qfalse, G_ready_cmd,           ":^7 Sets your status to ^5not ready^7 to start a match"                                     },
 	{ "weaponstats",    qtrue,  qfalse, G_weaponStats_cmd,     " [player_ID]:^7 Shows weapon accuracy stats for a player"                                   },

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1723,6 +1723,7 @@ void Cmd_CallVote_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue);
 void Cmd_Follow_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue);
 void Cmd_Say_f(gentity_t *ent, int mode, qboolean arg0, qboolean encoded);
 void Cmd_Team_f(gentity_t *ent);
+void Cmd_Team2_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue);
 void Cmd_SetWeapons_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue);
 void Cmd_SetClass_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue);
 
@@ -2701,7 +2702,6 @@ qboolean G_commandCheck(gentity_t *ent, char *cmd, qboolean fDoAnytime);
 const char *G_SHA1(const char *string);
 char *Q_SayConcatArgs(int start);
 void DecolorString(char *in, char *out);
-char *Q_StrReplace(char *haystack, char *needle, char *newp);
 int Q_SayArgc();
 qboolean Q_SayArgv(int n, char *buffer, int bufferLength);
 

--- a/src/game/g_match.cpp
+++ b/src/game/g_match.cpp
@@ -478,7 +478,7 @@ void G_parseStats(char *pszStatsInfo)
 	const char   *tmp = pszStatsInfo;
 	unsigned int i, dwWeaponMask, dwClientID = atoi(pszStatsInfo);
 
-	if (dwClientID < 0 || dwClientID > MAX_CLIENTS)
+	if (dwClientID > MAX_CLIENTS)
 	{
 		return;
 	}

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -2180,7 +2180,7 @@ qboolean G_ScriptAction_PlayAnim(gentity_t *ent, char *params)
 	}
 
 	return (endtime <= level.time) ? qtrue : qfalse;
-};
+}
 
 /*
 =================

--- a/src/game/q_shared.cpp
+++ b/src/game/q_shared.cpp
@@ -976,6 +976,10 @@ Safe strncpy that ensures a trailing zero
 */
 void Q_strncpyz(char *dest, const char *src, int destsize)
 {
+	if (!dest)
+	{
+		Com_Error(ERR_FATAL, "Q_strncpyz: NULL dest");
+	}
 	if (!src)
 	{
 		Com_Error(ERR_FATAL, "Q_strncpyz: NULL src");
@@ -985,9 +989,7 @@ void Q_strncpyz(char *dest, const char *src, int destsize)
 		Com_Error(ERR_FATAL, "Q_strncpyz: destsize < 1");
 	}
 
-	// replace strncpy with memcpy to silence gcc warning about potentially missing termination string
-	// strncpy(dest, src, destsize - 1);
-	memcpy(dest, src, destsize - 1);
+	strncpy(dest, src, destsize - 1);
 	dest[destsize - 1] = 0;
 }
 
@@ -1622,56 +1624,4 @@ void Info_SetValueForKey(char *s, const char *key, const char *value)
 	}
 
 	strcat(s, newi);
-}
-
-//====================================================================
-
-
-char *Q_StrReplace(char *haystack, char *needle, char *newp)
-{
-	static char final[MAX_STRING_CHARS] = { "" };
-	char        dest[MAX_STRING_CHARS]  = { "" };
-	char        newString[MAX_STRING_CHARS]   = { "" };
-	char        *destp;
-	int         needle_len = 0;
-	int         new_len    = 0;
-
-	if (!*haystack)
-	{
-		return final;
-	}
-	if (!*needle)
-	{
-		Q_strncpyz(final, haystack, sizeof(final));
-		return final;
-	}
-	if (*newp)
-	{
-		Q_strncpyz(newString, newp, sizeof(newString));
-	}
-
-	dest[0]    = '\0';
-	needle_len = strlen(needle);
-	new_len    = strlen(newString);
-	destp      = &dest[0];
-	while (*haystack)
-	{
-		if (!Q_stricmpn(haystack, needle, needle_len))
-		{
-			Q_strcat(dest, sizeof(dest), newString);
-			haystack += needle_len;
-			destp    += new_len;
-			continue;
-		}
-		if (MAX_STRING_CHARS > (strlen(dest) + 1))
-		{
-			*destp   = *haystack;
-			*++destp = '\0';
-		}
-		haystack++;
-	}
-	// tjw: don't work with final return value in case haystack
-	//      was pointing at it.
-	Q_strncpyz(final, dest, sizeof(final));
-	return final;
 }

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -8089,16 +8089,8 @@ const char *UI_FeederItemText(float feederID, int index, int column, qhandle_t *
 							return uiInfo.gameTypes[i].gameTypeShort;
 						}
 					}
-
-					if (i == uiInfo.numGameTypes)
-					{
-						return "???";
-					}
 				}
-				else
-				{
-					return "???";
-				}
+				return "???";
 			case SORT_PING:
 				//if (ping < 0) {
 				if (ping <= 0)

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -523,7 +523,7 @@ qboolean PC_Char_Parse(int handle, char *out);              // NERVE - SMF
 namespace ETJump
 {
 	bool PC_hasFloat(int handle);
-};
+}
 int Menu_Count();
 menuDef_t *Menu_Get(int handle);
 void Menu_New(int handle);


### PR DESCRIPTION
All gcc warnings are now enabled except for unused parameters and missing field initializers. They both output tons of warnings and are not that critical for spotting bugs, therefore keeping them disabled until someone with a lot of free time fixes those.