### PR TITLE
increase g_alloc mempool size

### DIFF
--- a/src/game/g_mem.cpp
+++ b/src/game/g_mem.cpp
@@ -7,7 +7,7 @@
 
 // Ridah, increased this (fixes Dan's crash)
 
-#define POOLSIZE    (4 * 1024 * 1024)
+#define POOLSIZE    (16 * 1024 * 1024)
 
 static char memoryPool[POOLSIZE];
 static int  allocPoint;


### PR DESCRIPTION
On 64bit mod binary, map script related structures are requiring more space because of different pointer size, hence during complex mapscript parsing it's quite easy to run into allocation limits.

closes #652