### PR TITLE
improve etlegacy server browser integration

### DIFF
--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -293,6 +293,16 @@ vmCvar_t g_debugTimeruns;
 vmCvar_t g_spectatorVote;
 vmCvar_t g_enableVote;
 
+// ETLegacy server browser integration 
+// os support - this SERVERINFO cvar specifies supported client operating systems on server
+vmCvar_t g_oss; //   0 - vanilla/unknown/ET:L auto setup
+                //   1 - Windows
+                //   2 - Linux
+                //   4 - Linux 64
+                //   8 - Mac OS X
+                //  16 - Android
+                //  32 - Raspberry Pi
+
 cvarTable_t gameCvarTable[] =
 {
 	// don't override the cheat state set by the system
@@ -545,7 +555,7 @@ cvarTable_t gameCvarTable[] =
 	{ &g_debugTimeruns, "g_debugTimeruns", "0", CVAR_ARCHIVE | CVAR_LATCH },
 	{ &g_spectatorVote, "g_spectatorVote", "0", CVAR_ARCHIVE | CVAR_SERVERINFO },
 	{ &g_enableVote, "g_enableVote", "1", CVAR_ARCHIVE },
-
+	{ &g_oss, "g_oss", "15", CVAR_SERVERINFO | CVAR_LATCH, 0, qfalse, qfalse },
 };
 
 // bk001129 - made static to avoid aliasing


### PR DESCRIPTION
Added `g_oss` cvar to improve the integration with the legacy's server browser, which allows to sort by the supported client architecture.

Reference https://github.com/etlegacy/etlegacy/pull/1687#issuecomment-903086780