### PR TITLE
Fix uncrustify config

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -376,8 +376,8 @@ align_with_tabs                          = false	    # false/true
 # Whether to bump out to the next tab when aligning
 align_on_tabstop                         = false    # false/true
 
-# Whether to left-align numbers
-align_number_left                        = false    # false/true
+# Whether to right-align numbers
+align_number_right                       = true    # false/true
 
 # Align variable definitions in prototypes and functions
 align_func_params                        = false    # false/true


### PR DESCRIPTION
`align_number_left` was renamed to `align_number_right`

refs #642 