### PR TITLE
Fix invalid fireteam prompt after leaving fireteam

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -2792,8 +2792,17 @@ static void CG_DrawVote(void)
 
 	if (cgs.autoFireteamEndTime > cg.time && cgs.autoFireteamNum == -1)
 	{
-		line_a = "Make Fireteam private?";
-		line_b = ETJump::stringFormat("Press '%s' for YES, or '%s' for No", str1, str2);
+		// make sure we're still on the fireteam before displaying this prompt
+		if (CG_IsOnFireteam(cg.clientNum))
+		{
+			line_a = "Make Fireteam private?";
+			line_b = ETJump::stringFormat("Press '%s' for YES, or '%s' for No", str1, str2);
+		}
+		// we have left, so reset the timer
+		else
+		{
+			cgs.autoFireteamEndTime = cg.time;
+		}
 	}
 
 	if (cgs.voteTime)

--- a/src/game/g_fireteams.cpp
+++ b/src/game/g_fireteams.cpp
@@ -378,6 +378,10 @@ void G_RemoveClientFromFireteams(int entityNum, qboolean update, qboolean print)
 				}
 				ft->joinOrder[MAX_CLIENTS - 1] = -1;
 
+				// invalidate "Make fireteam private?" prompt response in case we joined
+				// a fireteam and left without responding
+				g_entities[entityNum].client->pers.autofireteamEndTime = level.time;
+
 				break;
 			}
 		}


### PR DESCRIPTION
Hide and invalidate "Make fireteam private?" prompt in case we left the fireteam before responding.

closes #655 