### PR TITLE
Fix `g_blockedMaps` string getting lowercased

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -1263,7 +1263,9 @@ bool Map(gentity_t *ent, Arguments argv)
 		return false;
 	}
 
-	if (strstr(Q_strlwr(g_blockedMaps.string), requestedMap.c_str()) != nullptr)
+	MapStatistics mapStats;
+
+	if (strstr(mapStats.getBlockedMapsStr().c_str(), requestedMap.c_str()) != nullptr)
 	{
 		ChatPrintTo(ent, "^3map: ^7" + requestedMap + " cannot be played on this server.");
 		return false;

--- a/src/game/etj_custom_map_votes.cpp
+++ b/src/game/etj_custom_map_votes.cpp
@@ -269,7 +269,9 @@ std::string const CustomMapVotes::RandomMap(std::string const& type)
 
 bool CustomMapVotes::isValidMap(const std::string &mapName)
 {
+	MapStatistics mapStats;
+
 	return	G_MapExists(mapName.c_str()) && 
 			mapName != level.rawmapname &&
-			strstr(Q_strlwr(g_blockedMaps.string), mapName.c_str()) == nullptr;
+			strstr(mapStats.getBlockedMapsStr().c_str(), mapName.c_str()) == nullptr;
 }

--- a/src/game/etj_map_statistics.cpp
+++ b/src/game/etj_map_statistics.cpp
@@ -80,7 +80,7 @@ std::vector<std::string> MapStatistics::getMaps()
 
 	for (auto& map: _maps)
 	{
-		if (map.isOnServer && strstr(Q_strlwr(g_blockedMaps.string), map.name.c_str()) == nullptr)
+		if (map.isOnServer && strstr(getBlockedMapsStr().c_str(), map.name.c_str()) == nullptr)
 		{
 			maps.push_back(map.name);
 		}
@@ -495,11 +495,18 @@ const char *MapStatistics::randomMap() const
 	return mapName;
 }
 
+std::string MapStatistics::getBlockedMapsStr() const
+{
+	std::string blockedMapsStr = g_blockedMaps.string;
+	boost::to_lower(blockedMapsStr);
+	return blockedMapsStr;
+}
+
 bool MapStatistics::isValidMap(const MapInformation* mapInfo) const
 {
 	return	mapInfo != _currentMap &&
 			mapInfo->isOnServer && 
-			strstr(Q_strlwr(g_blockedMaps.string), mapInfo->name.c_str()) == nullptr;
+			strstr(getBlockedMapsStr().c_str(), mapInfo->name.c_str()) == nullptr;
 }
 
 MapStatistics::~MapStatistics()

--- a/src/game/etj_map_statistics.h
+++ b/src/game/etj_map_statistics.h
@@ -72,6 +72,7 @@ public:
 	std::vector<const MapInformation *> getLeastPlayed();
 	std::vector<std::string> getMaps();
 	const std::vector<std::string> *getCurrentMaps();
+	std::string getBlockedMapsStr() const;
 private:
 	std::vector<MapInformation> _maps;
 	std::vector<std::string>    _currentMaps;

--- a/src/game/etj_utilities.cpp
+++ b/src/game/etj_utilities.cpp
@@ -25,6 +25,7 @@
 #include "etj_utilities.h"
 #include "etj_save_system.h"
 #include <boost/algorithm/string.hpp>
+#include "etj_map_statistics.h"
 
 #include "g_local.h"
 
@@ -304,6 +305,7 @@ void Utilities::Error(const std::string& error)
 std::vector<std::string> Utilities::getMaps()
 {
 	std::vector<std::string> maps;
+	MapStatistics mapStats;
 
 	int  i       = 0;
 	int  numDirs = 0;
@@ -325,7 +327,7 @@ std::vector<std::string> Utilities::getMaps()
 		Q_strncpyz(buf, dirPtr, sizeof(buf));
 		boost::to_lower(buf);
 
-		if (strstr(Q_strlwr(g_blockedMaps.string), buf) != nullptr)
+		if (strstr(mapStats.getBlockedMapsStr().c_str(), buf) != nullptr)
 		{
 			continue;
 		}

--- a/src/game/g_vote.cpp
+++ b/src/game/g_vote.cpp
@@ -4,6 +4,7 @@
 #include "g_local.h"
 #include "etj_printer.h"
 #include "etj_string_utilities.h"
+#include "etj_map_statistics.h"
 
 
 
@@ -342,7 +343,9 @@ namespace ETJump
 			return false;
 		}
 
-		if (strstr(Q_strlwr(g_blockedMaps.string), resultedMap.c_str()) != nullptr)
+		MapStatistics mapStats;
+
+		if (strstr(mapStats.getBlockedMapsStr().c_str(), resultedMap.c_str()) != nullptr)
 		{
 			resultedMap = stringFormat("^3callvote: ^7Voting for %s is not allowed.\n", resultedMap);
 			return false;


### PR DESCRIPTION
Get rid of `Q_strlwr` on blocked maps checks and replace them with a function that returns the blocked maps string.