### PR TITLE
Fix entityevents getting wiped too early

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -3893,7 +3893,6 @@ void CG_Shutdown(void)
 		ETJump::serverCommandsHandler = nullptr;
 		ETJump::operatingSystem = nullptr;
 		ETJump::authentication = nullptr;
-		ETJump::entityEventsHandler = nullptr;
 		ETJump::renderables.clear();
 		ETJump::cvarUpdateHandler = nullptr;
 		ETJump::cvarShadows.clear();
@@ -3904,6 +3903,7 @@ void CG_Shutdown(void)
 		ETJump::eventLoop->shutdown();
 		ETJump::eventLoop = nullptr;
 		ETJump::playerEventsHandler = nullptr;
+		ETJump::entityEventsHandler = nullptr;
 
 		ETJump::isInitialized = false;
 	}


### PR DESCRIPTION
`entityEventsHandler` was nulled before renderables, causing crash on renderables which tried to unsubscribe from entityevents.