### PR TITLE
Fix CGaz and snaphud calculations on slopes

### DIFF
--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -32,10 +32,8 @@
 
 namespace ETJump
 {
-	void CGaz::UpdateCGaz1(int8_t uCmdScale, usercmd_t cmd)
+	void CGaz::UpdateCGaz1(vec3_t wishvel, int8_t uCmdScale, usercmd_t cmd)
 	{
-		vec3_t wishvel;
-		VectorCopy(pm->pmext->wishvel, wishvel);
 		// set default key combination if no user input
 		if (!cmd.forwardmove && !cmd.rightmove)
 		{
@@ -144,22 +142,25 @@ namespace ETJump
 		// get correct pmove state
 		pm = PmoveUtils::getPmove(cmd);
 
+		// show upmove influence?
+		float scale = etj_CGazTrueness.integer & static_cast<int>(CGazTrueness::CGAZ_JUMPCROUCH)
+			? pm->pmext->scale
+			: pm->pmext->scaleAlt;
+
+		vec3_t wishvel;
+		float wishspeed = PmoveUtils::PM_GetWishspeed(wishvel, scale, cmd, pm->pmext->forward, pm->pmext->right, pm->pmext->up, *ps, pm);
+
 		// set default wishspeed for drawing if no user input
 		if (!cmd.forwardmove && !cmd.rightmove)
 		{
-			pm->pmext->wishspeed = ps->speed * ps->sprintSpeedScale;
-			pm->pmext->wishspeedAlt = ps->speed * ps->sprintSpeedScale;
+			wishspeed = ps->speed * ps->sprintSpeedScale;
 		}
-
-		// show upmove influence?
-		const float wishspeed = etj_CGazTrueness.integer & static_cast<int>(CGazTrueness::CGAZ_JUMPCROUCH)
-			? pm->pmext->wishspeed : pm->pmext->wishspeedAlt;
 
 		switch (etj_drawCGaz.integer)
 		{
 		case 1:
 			UpdateDraw(wishspeed, pm->pmext->accel);
-			UpdateCGaz1(uCmdScale, cmd);
+			UpdateCGaz1(wishvel, uCmdScale, cmd);
 			break;
 		case 2:
 			UpdateDraw(wishspeed, pm->pmext->accel);

--- a/src/cgame/etj_cgaz.h
+++ b/src/cgame/etj_cgaz.h
@@ -69,7 +69,7 @@ namespace ETJump
 		float yaw;
 
 		bool canSkipDraw() const;
-		void UpdateCGaz1(int8_t uCmdScale, usercmd_t cmd);
+		void UpdateCGaz1(vec3_t wishvel, int8_t uCmdScale, usercmd_t cmd);
 		void UpdateCGaz2(void);
 		float GetSlickGravity();
 		void UpdateDraw(float wishspeed, float accel);

--- a/src/cgame/etj_pmove_utils.h
+++ b/src/cgame/etj_pmove_utils.h
@@ -42,7 +42,11 @@ namespace ETJump
 		// returns either sprintSpeedScale or runSpeedScale
 		static float PM_SprintScale(const playerState_t* ps);
 
+		// calculates wishspeed projected onto flat ground plane
+		static float PM_GetWishspeed(vec3_t wishvel, float scale, usercmd_t cmd, vec3_t forward, vec3_t right, vec3_t up, const playerState_t& ps, pmove_t *pm);
+
 		// updates XY wishvel based on cmdScale and angle vectors
+		// projects velocity down to a flat ground plane
 		// Z vector is taken as input for AngleVectors
 		static void PM_UpdateWishvel(vec3_t wishvel, usercmd_t cmd, vec3_t forward, vec3_t right, vec3_t up, const playerState_t& ps);
 	};

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -38,7 +38,7 @@ namespace ETJump
 
 	private:
 		bool canSkipDraw() const;
-		void InitSnaphud(int8_t uCmdScale, usercmd_t cmd);
+		void InitSnaphud(vec3_t wishvel, int8_t uCmdScale, usercmd_t cmd);
 		void UpdateSnapState(void);
 
 		enum class SnapTrueness

--- a/src/cgame/etj_strafe_quality_drawable.cpp
+++ b/src/cgame/etj_strafe_quality_drawable.cpp
@@ -106,7 +106,9 @@ namespace ETJump
 
 		// check whether user input is good
 		const float speed = VectorLength2(ps.velocity);
-		if (speed < pm->pmext->wishspeed)
+		vec3_t wishvel;
+		const float wishspeed = PmoveUtils::PM_GetWishspeed(wishvel, pm->pmext->scale, cmd, pm->pmext->forward, pm->pmext->right, pm->pmext->up, ps, pm);
+		if (speed < wishspeed)
 		{
 			// possibly good frame under ground speed if speed increased
 			// note that without speed increased you could go forward in a

--- a/src/game/bg_local.h
+++ b/src/game/bg_local.h
@@ -53,6 +53,8 @@ extern float pm_waterWadeScale;
 extern float pm_slagSwimScale;
 extern float pm_slagWadeScale;
 
+extern float pm_proneSpeedScale;
+
 extern float pm_accelerate;
 extern float pm_airaccelerate;
 extern float pm_wateraccelerate;

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -1603,7 +1603,7 @@ static void PM_AirMove(void)
 	vec3_t    wishvel;
 	float     fmove, smove;
 	vec3_t    wishdir;
-	float     wishspeed, wishspeedAlt;
+	float     wishspeed;
 	float     scale, scaleAlt;
 	usercmd_t cmd;
 
@@ -1646,13 +1646,11 @@ static void PM_AirMove(void)
 	VectorCopy(wishvel, wishdir);
 	wishspeed  = VectorNormalize(wishdir);
 	wishspeed *= scale;
-	wishspeedAlt = scaleAlt * VectorLength2(wishvel);
 
 	// ETJump: store wishspeed and accel in pmext
-	pm->pmext->wishspeed = wishspeed;
-	pm->pmext->wishspeedAlt = wishspeedAlt;
+	pm->pmext->scale = scale;
+	pm->pmext->scaleAlt = scaleAlt;
 	pm->pmext->accel = pm_airaccelerate;
-	VectorCopy(wishvel, pm->pmext->wishvel);
 	VectorCopy(pm->ps->velocity, pm->pmext->velocity);
 
 	// not on ground, so little effect on velocity
@@ -1703,7 +1701,7 @@ static void PM_WalkMove(void)
 	vec3_t    wishvel;
 	float     fmove, smove;
 	vec3_t    wishdir;
-	float     wishspeed, wishspeedAlt;
+	float     wishspeed;
 	float     scale, scaleAlt;
 	usercmd_t cmd;
 	float     accelerate;
@@ -1775,6 +1773,10 @@ static void PM_WalkMove(void)
 	scale    = PM_CmdScale(&cmd);
 	scaleAlt = PM_CmdScaleAlt(&cmd);
 
+	// ETJump: store values in pmext
+	pm->pmext->scale = scale;
+	pm->pmext->scaleAlt = scaleAlt;
+
 // Ridah, moved this down, so we use the actual movement direction
 	// set the movementDir so clients can rotate the legs for strafing
 //	PM_SetMovementDir();
@@ -1800,7 +1802,6 @@ static void PM_WalkMove(void)
 	VectorCopy(wishvel, wishdir);
 	wishspeed  = VectorNormalize(wishdir);
 	wishspeed *= scale;
-	wishspeedAlt = scaleAlt * VectorLength2(wishvel);
 	
 	// clamp the speed lower if prone
 	if (pm->ps->eFlags & EF_PRONE)
@@ -1808,11 +1809,6 @@ static void PM_WalkMove(void)
 		if (wishspeed > pm->ps->speed * pm_proneSpeedScale)
 		{
 			wishspeed = pm->ps->speed * pm_proneSpeedScale;
-		}
-
-		if (wishspeedAlt > pm->ps->speed * pm_proneSpeedScale)
-		{
-			wishspeedAlt = pm->ps->speed * pm_proneSpeedScale;
 		}
 	}
 	else if (pm->ps->pm_flags & PMF_DUCKED)       // clamp the speed lower if ducking
@@ -1822,11 +1818,6 @@ static void PM_WalkMove(void)
 		if (wishspeed > pm->ps->speed * pm->ps->crouchSpeedScale)
 		{
 			wishspeed = pm->ps->speed * pm->ps->crouchSpeedScale;
-		}
-
-		if (wishspeedAlt > pm->ps->speed * pm->ps->crouchSpeedScale)
-		{
-			wishspeedAlt = pm->ps->speed * pm->ps->crouchSpeedScale;
 		}
 	}
 
@@ -1849,11 +1840,6 @@ static void PM_WalkMove(void)
 		{
 			wishspeed = pm->ps->speed * waterScale;
 		}
-
-		if (wishspeedAlt > pm->ps->speed * waterScale)
-		{
-			wishspeedAlt = pm->ps->speed * waterScale;
-		}
 	}
 
 	// when a player gets hit, they temporarily lose
@@ -1868,10 +1854,7 @@ static void PM_WalkMove(void)
 	}
 
 	// ETJump: store values in pmext
-	pm->pmext->wishspeed = wishspeed;
-	pm->pmext->wishspeedAlt = wishspeedAlt;
 	pm->pmext->accel = accelerate;
-	VectorCopy(wishvel, pm->pmext->wishvel);
 	VectorCopy(pm->ps->velocity, pm->pmext->velocity);
 
 	PM_Accelerate(wishdir, wishspeed, accelerate);

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -567,12 +567,12 @@ typedef struct
 	float frametime;
 	qboolean ladder;
 
-	vec3_t velocity;		// we need to store this before PM_Accelerate scales it back
-							// to preserve the true effect friction has on ground speed
-	float wishspeed;
-	float wishspeedAlt;		// wishspeed without upmove component
+	vec3_t velocity;        // we need to store this before PM_Accelerate scales it back
+	                        // to preserve the true effect friction has on ground speed
+
+	float scale;
+	float scaleAlt;         // cmdScale without upmove component
 	float accel;
-	vec3_t wishvel;
 } pmoveExt_t;   // data used both in client and server - store it here
                 // instead of playerstate to prevent different engine versions of playerstate between XP and MP
 


### PR DESCRIPTION
`PM_WalkMove` projects wishvel along the groundplane normal, which resulted in inaccurate drawing of CGaz and snaphud when sliding on slopes. For this reason, we can't rely on wishspeed that is stored from Pmove and need to replicate it over at cgame. Both CGaz and snaphud are now drawn as if you're always on a flat ground plane, which is how it's always been (technically this is incorrect, but so is projecting along non-flat groundplane via `PM_ClipVelocity`).

closes #678 
refs #666 