### PR TITLE
Fix strafe quality issues

### DIFF
--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -193,6 +193,20 @@ namespace ETJump
 		snap.zones[2 * snap.maxAccel] = snap.zones[0] + 16384;
 	}
 
+	void Snaphud::UpdateMaxSnapZones(void)
+	{
+		// calculate max number of snapzones in 1 quadrant
+		// this needs to be dynamically calculated because
+		// ps->speed can be modified by target_scale_velocity
+		// on default settings, the number of zones is 57
+		const int MAX_SNAPHUD_ZONES_Q1 = round(ps->speed * ps->sprintSpeedScale / (1000.0f / pmove_msec.integer) * pm_accelerate) * 2 + 1;
+
+		snap.zones.resize(MAX_SNAPHUD_ZONES_Q1);
+		snap.xAccel.resize(MAX_SNAPHUD_ZONES_Q1);
+		snap.yAccel.resize(MAX_SNAPHUD_ZONES_Q1);
+		snap.absAccel.resize(MAX_SNAPHUD_ZONES_Q1);
+	}
+
 	void Snaphud::beforeRender()
 	{
 		const int8_t uCmdScale = ps->stats[STAT_USERCMD_BUTTONS] & (BUTTON_WALKING << 8) ? CMDSCALE_WALK : CMDSCALE_DEFAULT;
@@ -226,17 +240,7 @@ namespace ETJump
 		if (a != snap.a)
 		{
 			snap.a = a;
-			// calculate max number of snapzones in 1 quadrant
-			// this needs to be dynamically calculated here because
-			// ps->speed can be modified by target_scale_velocity
-			// on default settings, the number of zones is 57
-			const int MAX_SNAPHUD_ZONES_Q1 = round(ps->speed * ps->sprintSpeedScale / ( 1000.0f / pmove_msec.integer) * pm_accelerate) * 2 + 1;
-
-			snap.zones.resize(MAX_SNAPHUD_ZONES_Q1);
-			snap.xAccel.resize(MAX_SNAPHUD_ZONES_Q1);
-			snap.yAccel.resize(MAX_SNAPHUD_ZONES_Q1);
-			snap.absAccel.resize(MAX_SNAPHUD_ZONES_Q1);
-
+			UpdateMaxSnapZones();
 			UpdateSnapState();
 		}
 	}
@@ -295,40 +299,10 @@ namespace ETJump
 		}
 	}
 
-	// TODO: this should be removed
-	constexpr int SNAPHUD_MAXZONES{ 128 };
-	float         snapSpeed;
-	float         snapZones[SNAPHUD_MAXZONES];
-	int           snapCount;
-
-	static int QDECL sortSnapZones(const void *a, const void *b)
-	{
-		return *(float *)a - *(float *)b;
-	}
-
-	static void UpdateSnapHUDSettings(float speed)
-	{
-		float step;
-
-		snapSpeed = speed;
-		speed    /= 125;
-		snapCount = 0;
-
-		for (step = floor(speed + 0.5) - 0.5; step > 0 && snapCount < SNAPHUD_MAXZONES - 2; step--)
-		{
-			snapZones[snapCount] = RAD2DEG(acos(step / speed));
-			snapCount++;
-			snapZones[snapCount] = RAD2DEG(asin(step / speed));
-			snapCount++;
-		}
-
-		qsort(snapZones, snapCount, sizeof(snapZones[0]), sortSnapZones);
-		snapZones[snapCount] = snapZones[0] + 90;
-	}
-
-	// TODO: this should be refactored to use the new snaphud code
 	bool Snaphud::inMainAccelZone(const playerState_t& ps, pmove_t* pm)
 	{
+		static Snaphud s;
+
 		// get player yaw
 		float yaw = ps.viewangles[YAW];
 
@@ -346,12 +320,14 @@ namespace ETJump
 		// get opt angle
 		float opt = CGaz::getOptAngle(ps, pm);
 
-		// update snapzones even if snaphud not drawn
+		// update snapzones even if snaphud is not drawn
 		const float scale = PmoveUtils::PM_SprintScale(&ps);
-		const float speed = cg.snap->ps.speed * scale;
-		if (speed != snapSpeed)
+		const float speed = cg.snap->ps.speed * scale * pm->pmext->frametime;
+		if (speed != s.snap.a)
 		{
-			UpdateSnapHUDSettings(speed);
+			s.snap.a = speed;
+			s.UpdateMaxSnapZones();
+			s.UpdateSnapState();
 		}
 
 		// necessary 45 degrees shift to match snapzones
@@ -365,10 +341,21 @@ namespace ETJump
 		yaw = std::fmod(AngleNormalize360(yaw), 90);
 		opt = std::fmod(AngleNormalize360(opt), 90);
 
+		// get number of snapzones
+		auto snapCount = 0;
+		for (auto j = 0; j < s.snap.zones.size(); j++)
+		{
+			if (s.snap.zones[j] == 0)
+			{
+				break;
+			}
+			snapCount = j;
+		}
+
 		// get snapzone index which corresponds to the *next* snapzone
-		int i = 0;
 		// linear search is good enough here as snapCount is always relatively small
-		while (i < snapCount && opt >= snapZones[i])
+		int i = 0;
+		while (i < snapCount && opt >= SHORT2DEG(s.snap.zones[i]))
 		{
 			++i;
 		}
@@ -380,7 +367,7 @@ namespace ETJump
 		}
 
 		// get the snapzone
-		const float& snap = snapZones[i];
+		const float& snap = SHORT2DEG(s.snap.zones[i]);
 		// snap now contains the yaw value corresponding to the start of the next snapzone,
 		// or equivalently the end of the current snapzone
 

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -343,7 +343,7 @@ namespace ETJump
 
 		// get number of snapzones
 		auto snapCount = 0;
-		for (auto j = 0; j < s.snap.zones.size(); j++)
+		for (unsigned short j = 0; j < s.snap.zones.size(); j++)
 		{
 			if (s.snap.zones[j] == 0)
 			{

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -39,6 +39,7 @@ namespace ETJump
 	private:
 		bool canSkipDraw() const;
 		void InitSnaphud(vec3_t wishvel, int8_t uCmdScale, usercmd_t cmd);
+		void UpdateMaxSnapZones(void);
 		void UpdateSnapState(void);
 
 		enum class SnapTrueness

--- a/src/cgame/etj_strafe_quality_drawable.cpp
+++ b/src/cgame/etj_strafe_quality_drawable.cpp
@@ -93,7 +93,7 @@ namespace ETJump
 		// to last update time, using commandTime for clients for 100% accuracy
 		// and cg.time for spectators/demos as an approximation
 		// note: this will be wrong for clients running < 125FPS... oh well
-		const uint32_t frameTime = (pm->ps->pm_flags & PMF_FOLLOW || cg.demoPlayback)
+		const auto frameTime = (pm->ps->pm_flags & PMF_FOLLOW || cg.demoPlayback)
 			? cg.time
 			: pm->ps->commandTime;
 

--- a/src/cgame/etj_strafe_quality_drawable.cpp
+++ b/src/cgame/etj_strafe_quality_drawable.cpp
@@ -67,7 +67,7 @@ namespace ETJump
 	void StrafeQuality::beforeRender()
 	{
 		// get player state
-		const playerState_t& ps = *getValidPlayerState();
+		const playerState_t& ps = cg.predictedPlayerState;
 
 		// get usercmd
 		// cmdScale is only checked here to be 0 or !0
@@ -88,20 +88,22 @@ namespace ETJump
 			resetStrafeQuality();
 		}
 
-		// don't count frames if not strafing
-		if (cmd.forwardmove == 0 && cmd.rightmove == 0)
-		{
-			return;
-		}
+		// check if current frame should count towards strafe quality
+		// we check for framerate dependency here by comparing current time
+		// to last update time, using commandTime for clients for 100% accuracy
+		// and cg.time for spectators/demos as an approximation
+		// note: this will be wrong for clients running < 125FPS... oh well
+		const uint32_t frameTime = (pm->ps->pm_flags & PMF_FOLLOW || cg.demoPlayback)
+			? cg.time
+			: pm->ps->commandTime;
 
-		// don't count frames if not in air and not on ice
-		if (ps.groundEntityNum != ENTITYNUM_NONE &&
-				!(pm->pmext->groundTrace.surfaceFlags & SURF_SLICK))
+		if (canSkipUpdate(cmd, frameTime))
 		{
 			return;
 		}
 
 		// count this frame towards strafe quality
+		_lastUpdateTime = frameTime;
 		++_totalFrames;
 
 		// check whether user input is good
@@ -152,8 +154,7 @@ namespace ETJump
 	void StrafeQuality::render() const
 	{
 		// check whether to skip render
-		if (!etj_drawStrafeQuality.integer || cg.showScores ||
-				cg.scoreFadeTime + FADE_TIME > cg.time || _team == TEAM_SPECTATOR)
+		if (canSkipDraw())
 		{
 			return;
 		}
@@ -192,5 +193,61 @@ namespace ETJump
 		// draw quality on screen
 		CG_Text_Paint_Ext(x, y, size, size, _color, str, 0, 0, textStyle,
 			&cgs.media.limboFont1);
+	}
+
+	bool StrafeQuality::canSkipUpdate(usercmd_t cmd, uint32_t frameTime)
+	{
+		// only count this frame if it's relevant to pmove
+		// this makes sure that if clients FPS > 125
+		// we only count frames at pmove_msec intervals
+		if (_lastUpdateTime + pm->pmove_msec > frameTime)
+		{
+			return true;
+		}
+
+		// not strafing
+		if (cmd.forwardmove == 0 && cmd.rightmove == 0)
+		{
+			return true;
+		}
+
+		// don't update if not in air or on ice
+		if (pm->ps->groundEntityNum != ENTITYNUM_NONE && !(pm->pmext->groundTrace.surfaceFlags & SURF_SLICK))
+		{
+			return true;
+		}
+
+		if (pm->ps->pm_type == PM_NOCLIP)
+		{
+			return true;
+		}
+
+		// no updates underwater or on ladders
+		if (pm->pmext->waterlevel > 1 || pm->pmext->ladder)
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	bool StrafeQuality::canSkipDraw() const
+	{
+		if (!etj_drawStrafeQuality.integer)
+		{
+			return true;
+		}
+
+		if (_team == TEAM_SPECTATOR)
+		{
+			return true;
+		}
+
+		if (cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time)
+		{
+			return true;
+		}
+
+		return false;
 	}
 } // namespace ETJump

--- a/src/cgame/etj_strafe_quality_drawable.cpp
+++ b/src/cgame/etj_strafe_quality_drawable.cpp
@@ -195,7 +195,7 @@ namespace ETJump
 			&cgs.media.limboFont1);
 	}
 
-	bool StrafeQuality::canSkipUpdate(usercmd_t cmd, uint32_t frameTime)
+	bool StrafeQuality::canSkipUpdate(usercmd_t cmd, int frameTime)
 	{
 		// only count this frame if it's relevant to pmove
 		// this makes sure that if clients FPS > 125

--- a/src/cgame/etj_strafe_quality_drawable.h
+++ b/src/cgame/etj_strafe_quality_drawable.h
@@ -31,6 +31,7 @@ namespace ETJump {
 		double _totalFrames{ 0 };
 		double _goodFrames{ 0 };
 		double _strafeQuality{ 0 };
+		int _lastUpdateTime{ 0 };
 
 		float _oldSpeed{ 0 };
 		int _team{ 0 };
@@ -45,6 +46,8 @@ namespace ETJump {
 		void startListeners();
 		void parseColor();
 		void resetStrafeQuality();
+		bool canSkipDraw() const;
+		bool canSkipUpdate(usercmd_t cmd, uint32_t frameTime);
 
 		pmove_t* pm;
 

--- a/src/cgame/etj_strafe_quality_drawable.h
+++ b/src/cgame/etj_strafe_quality_drawable.h
@@ -47,7 +47,7 @@ namespace ETJump {
 		void parseColor();
 		void resetStrafeQuality();
 		bool canSkipDraw() const;
-		bool canSkipUpdate(usercmd_t cmd, uint32_t frameTime);
+		bool canSkipUpdate(usercmd_t cmd, int frameTime);
 
 		pmove_t* pm;
 

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -521,6 +521,7 @@ extern vec4_t g_color_table[32];
 #define RAD2DEG(a) (((a) * 180.0f) / M_PI)
 #define RAD2SHORT(a) ((a) * (32768.f / (float)M_PI))
 #define SHORT2RAD(a) ((a) * ((float)M_PI / 32768.f))
+#define SHORT2DEG(a) (((a) / 32768.f) * 180.0f)
 
 struct cplane_s;
 


### PR DESCRIPTION
* fixed framerate dependency - updates now always happen at 8ms intervals
  * if client it running < 125FPS, the score will be wrong (as was the case earlier too) since we calculate things in cgame
* improved consistency between client/spectator/demo score - still not 1:1 match, but it's as close as we can get with interpolation (spectator/demo score is usually ~3% higher)
* removed old snaphud code and integrated `inMainAccelZone` function to new snaphud code

closes #646, closes #647 