### PR TITLE
Disable CGaz/snaphud in noclip, fix MAX_SNAPHUD_ZONES_Q1 correctness

### DIFF
--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -400,7 +400,7 @@ namespace ETJump
 			return true;
 		}
 
-		if (ps->persistant[PERS_TEAM] == TEAM_SPECTATOR)
+		if (ps->persistant[PERS_TEAM] == TEAM_SPECTATOR || ps->pm_type == PM_NOCLIP)
 		{
 			return true;
 		}

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -55,7 +55,7 @@ namespace ETJump
 	{
 		snap.maxAccel = (unsigned char)(snap.a + 0.5f);
 		unsigned char xnyAccel = (unsigned char)(snap.a / sqrtf(2.0f) + 0.5f); // xAccel and yAccel at 45deg
-		                                                                      // ^       ^  ^
+		                                                                       // ^       ^  ^
 
 		// find the last shortangle in each snapzone which is smaller than 45deg (= 8192) using
 		//  /asin -> increasing angles
@@ -193,13 +193,13 @@ namespace ETJump
 		snap.zones[2 * snap.maxAccel] = snap.zones[0] + 16384;
 	}
 
-	void Snaphud::UpdateMaxSnapZones(void)
+	void Snaphud::UpdateMaxSnapZones(float wishspeed)
 	{
 		// calculate max number of snapzones in 1 quadrant
 		// this needs to be dynamically calculated because
 		// ps->speed can be modified by target_scale_velocity
 		// on default settings, the number of zones is 57
-		const int MAX_SNAPHUD_ZONES_Q1 = round(ps->speed * ps->sprintSpeedScale / (1000.0f / pmove_msec.integer) * pm_accelerate) * 2 + 1;
+		const int MAX_SNAPHUD_ZONES_Q1 = round(wishspeed / (1000.0f / pmove_msec.integer) * pm_accelerate) * 2 + 1;
 
 		snap.zones.resize(MAX_SNAPHUD_ZONES_Q1);
 		snap.xAccel.resize(MAX_SNAPHUD_ZONES_Q1);
@@ -240,7 +240,7 @@ namespace ETJump
 		if (a != snap.a)
 		{
 			snap.a = a;
-			UpdateMaxSnapZones();
+			UpdateMaxSnapZones(wishspeed);
 			UpdateSnapState();
 		}
 	}
@@ -321,12 +321,13 @@ namespace ETJump
 		float opt = CGaz::getOptAngle(ps, pm);
 
 		// update snapzones even if snaphud is not drawn
-		const float scale = PmoveUtils::PM_SprintScale(&ps);
-		const float speed = cg.snap->ps.speed * scale * pm->pmext->frametime;
+		vec3_t wishvel;
+		const float wishspeed = PmoveUtils::PM_GetWishspeed(wishvel, pm->pmext->scale, cmd, pm->pmext->forward, pm->pmext->right, pm->pmext->up, ps, pm);
+		const float speed = wishspeed * pm->pmext->frametime;
 		if (speed != s.snap.a)
 		{
 			s.snap.a = speed;
-			s.UpdateMaxSnapZones();
+			s.UpdateMaxSnapZones(wishspeed);
 			s.UpdateSnapState();
 		}
 
@@ -407,7 +408,7 @@ namespace ETJump
 			return true;
 		}
 
-		if (ps->persistant[PERS_TEAM] == TEAM_SPECTATOR)
+		if (ps->persistant[PERS_TEAM] == TEAM_SPECTATOR || ps->pm_type == PM_NOCLIP)
 		{
 			return true;
 		}

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -39,7 +39,7 @@ namespace ETJump
 	private:
 		bool canSkipDraw() const;
 		void InitSnaphud(vec3_t wishvel, int8_t uCmdScale, usercmd_t cmd);
-		void UpdateMaxSnapZones(void);
+		void UpdateMaxSnapZones(float wishspeed);
 		void UpdateSnapState(void);
 
 		enum class SnapTrueness

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -1647,7 +1647,7 @@ static void PM_AirMove(void)
 	wishspeed  = VectorNormalize(wishdir);
 	wishspeed *= scale;
 
-	// ETJump: store wishspeed and accel in pmext
+	// ETJump: store values in pmext
 	pm->pmext->scale = scale;
 	pm->pmext->scaleAlt = scaleAlt;
 	pm->pmext->accel = pm_airaccelerate;
@@ -1773,10 +1773,6 @@ static void PM_WalkMove(void)
 	scale    = PM_CmdScale(&cmd);
 	scaleAlt = PM_CmdScaleAlt(&cmd);
 
-	// ETJump: store values in pmext
-	pm->pmext->scale = scale;
-	pm->pmext->scaleAlt = scaleAlt;
-
 // Ridah, moved this down, so we use the actual movement direction
 	// set the movementDir so clients can rotate the legs for strafing
 //	PM_SetMovementDir();
@@ -1854,6 +1850,8 @@ static void PM_WalkMove(void)
 	}
 
 	// ETJump: store values in pmext
+	pm->pmext->scale = scale;
+	pm->pmext->scaleAlt = scaleAlt;
 	pm->pmext->accel = accelerate;
 	VectorCopy(pm->ps->velocity, pm->pmext->velocity);
 


### PR DESCRIPTION
* Don't draw CGaz/snaphud while noclipping
* Fix `MAX_SNAPHUD_ZONES_Q1` being unnecessarily big when strafing on ground with non-default cmdScale