### PR TITLE
Clamp velocityScale, more max snapzones correctness

### DIFF
--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -361,7 +361,7 @@ namespace ETJump
 
 		// get snapzone index which corresponds to the *next* snapzone
 		// linear search is good enough here as snapCount is always relatively small
-		int i = 0;
+		unsigned int i = 0;
 		while (i < snapCount && opt >= SHORT2DEG(s.snap.zones[i]))
 		{
 			++i;

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -39,7 +39,7 @@ namespace ETJump
 	private:
 		bool canSkipDraw() const;
 		void InitSnaphud(vec3_t wishvel, int8_t uCmdScale, usercmd_t cmd);
-		void UpdateMaxSnapZones(float wishspeed);
+		void UpdateMaxSnapZones(float wishspeed, pmove_t* pm);
 		void UpdateSnapState(void);
 
 		enum class SnapTrueness

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -3,6 +3,7 @@
 #include "etj_save_system.h"
 #include "etj_printer.h"
 #include "etj_inactivity_timer.h"
+#include "etj_numeric_utilities.h"
 
 /*
 ===============
@@ -1252,7 +1253,7 @@ void ClientThink_real(gentity_t *ent)
 	{
 		if (ent->scaleTime > level.time)
 		{
-			client->ps.speed *= client->sess.velocityScale;
+			client->ps.speed *= Numeric::clamp(client->sess.velocityScale, 0.25f, 3.0f);
 		}
 		else
 		{


### PR DESCRIPTION
* Clamped `target_scale_velocity` base velocity scaling to __0.25__ - __3.0__
* Fixed unnecessarily big max snapzones when in air
* Clamped upper limit of max snapzones
* Renamed `MAX_SNAPHUD_ZONES_Q1` -> `maxSnaphudZonesQ1` as it's not a compile time constant