### PR TITLE
Disable obsolete stripping of symbols on macOS

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -16,9 +16,9 @@ function(create_compiler_opts target)
 	set(GCC_LINK_FLAGS
 		$<IF:$<PLATFORM_ID:Darwin>,-Wl$<COMMA>-undefined$<COMMA>error,-Wl$<COMMA>--no-undefined>
 		$<$<CONFIG:Release>:
-			-flto              # link time optimizations
-			-O3                # max optimization
-			-s>)               # strip symbols
+			-flto                                # link time optimizations
+			-O3                                  # max optimization
+			$<IF:$<STREQUAL:${APPLE},1>,,-s>>)   # strip symbols
 
 	set(GCC_CXX_FLAGS
 		-pipe


### PR DESCRIPTION
Closes #684