### PR TITLE
Link some missing weapon sound events to `etj_weaponVolume`

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -2097,29 +2097,29 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 
 		if (BG_PlayerMounted(es->eFlags))
 		{
-			trap_S_StartSoundVControl(NULL, es->number, CHAN_AUTO, cgs.media.hWeaponHeatSnd, 255);
+			trap_S_StartSoundVControl(NULL, es->number, CHAN_AUTO, cgs.media.hWeaponHeatSnd, 255 * etj_weaponVolume.value);
 		}
 		else if (es->eFlags & EF_MOUNTEDTANK)
 		{
 			if (cg_entities[cg_entities[cg_entities[es->number].tagParent].tankparent].currentState.density & 8)
 			{
-				trap_S_StartSoundVControl(NULL, es->number, CHAN_AUTO, cgs.media.hWeaponHeatSnd_2, 255);
+				trap_S_StartSoundVControl(NULL, es->number, CHAN_AUTO, cgs.media.hWeaponHeatSnd_2, 255 * etj_weaponVolume.value);
 			}
 			else
 			{
-				trap_S_StartSoundVControl(NULL, es->number, CHAN_AUTO, cgs.media.hWeaponHeatSnd, 255);
+				trap_S_StartSoundVControl(NULL, es->number, CHAN_AUTO, cgs.media.hWeaponHeatSnd, 255 * etj_weaponVolume.value);
 			}
 		}
 		else if (cg_weapons[es->weapon].overheatSound)
 		{
-			trap_S_StartSound(NULL, es->number, CHAN_AUTO, cg_weapons[es->weapon].overheatSound);
+			trap_S_StartSoundVControl(NULL, es->number, CHAN_AUTO, cg_weapons[es->weapon].overheatSound, DEFAULT_VOLUME * etj_weaponVolume.value);
 		}
 		break;
 
 // JPW NERVE
 	case EV_SPINUP:
 		DEBUGNAME("EV_SPINUP");
-		trap_S_StartSound(NULL, es->number, CHAN_AUTO, cg_weapons[es->weapon].spinupSound);
+		trap_S_StartSoundVControl(NULL, es->number, CHAN_AUTO, cg_weapons[es->weapon].spinupSound, DEFAULT_VOLUME * etj_weaponVolume.value);
 		break;
 // jpw
 	case EV_EMPTYCLIP:
@@ -2130,11 +2130,11 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		DEBUGNAME("EV_FILL_CLIP");
 		if (cgs.clientinfo[cg.clientNum].skill[SK_LIGHT_WEAPONS] >= 2 && BG_isLightWeaponSupportingFastReload(es->weapon) && cg_weapons[es->weapon].reloadFastSound)
 		{
-			trap_S_StartSound(NULL, es->number, CHAN_WEAPON, cg_weapons[es->weapon].reloadFastSound);
+			trap_S_StartSoundVControl(NULL, es->number, CHAN_WEAPON, cg_weapons[es->weapon].reloadFastSound, DEFAULT_VOLUME* etj_weaponVolume.value);
 		}
 		else if (cg_weapons[es->weapon].reloadSound)
 		{
-			trap_S_StartSound(NULL, es->number, CHAN_WEAPON, cg_weapons[es->weapon].reloadSound);   // JPW NERVE following sherman's SP fix, should allow killing reload sound when player dies
+			trap_S_StartSoundVControl(NULL, es->number, CHAN_WEAPON, cg_weapons[es->weapon].reloadSound, DEFAULT_VOLUME * etj_weaponVolume.value);  // JPW NERVE following sherman's SP fix, should allow killing reload sound when player dies
 		}
 		break;
 
@@ -2185,12 +2185,12 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		break;
 	case EV_CHANGE_WEAPON:
 		DEBUGNAME("EV_CHANGE_WEAPON");
-		trap_S_StartSound(NULL, es->number, CHAN_AUTO, cgs.media.selectSound);
+		trap_S_StartSoundVControl(NULL, es->number, CHAN_AUTO, cgs.media.selectSound, DEFAULT_VOLUME * etj_weaponVolume.value);
 		break;
 	case EV_CHANGE_WEAPON_2:
 		DEBUGNAME("EV_CHANGE_WEAPON");
 
-		trap_S_StartSound(NULL, es->number, CHAN_AUTO, cgs.media.selectSound);
+		trap_S_StartSoundVControl(NULL, es->number, CHAN_AUTO, cgs.media.selectSound, DEFAULT_VOLUME * etj_weaponVolume.value);
 
 		if (es->number == cg.snap->ps.clientNum)
 		{
@@ -2231,11 +2231,11 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 			VectorMA(cg.refdef_current->vieworg, 64, norm, gorg);
 			if (cg_entities[cg_entities[cg_entities[cent->currentState.number].tagParent].tankparent].currentState.density & 8)      // should we use a browning?
 			{
-				trap_S_StartSoundEx(gorg, cent->currentState.number, CHAN_WEAPON, cgs.media.hWeaponEchoSnd_2, SND_NOCUT);
+				trap_S_StartSoundExVControl(gorg, cent->currentState.number, CHAN_WEAPON, cgs.media.hWeaponEchoSnd_2, SND_NOCUT, DEFAULT_VOLUME * etj_weaponVolume.value);
 			}
 			else
 			{
-				trap_S_StartSoundEx(gorg, cent->currentState.number, CHAN_WEAPON, cgs.media.hWeaponEchoSnd, SND_NOCUT);
+				trap_S_StartSoundExVControl(gorg, cent->currentState.number, CHAN_WEAPON, cgs.media.hWeaponEchoSnd, SND_NOCUT, DEFAULT_VOLUME * etj_weaponVolume.value);
 			}
 		}
 		DEBUGNAME("EV_FIRE_WEAPON_MG42");

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3381,6 +3381,7 @@ int         trap_S_GetCurrentSoundTime(void);   // ydnar
 
 // a local sound is always played full volume
 void        trap_S_StartLocalSound(sfxHandle_t sfx, int channelNum);
+void        trap_S_StartLocalSoundVControl(sfxHandle_t sfx, int channelNum, int volume);
 void        trap_S_ClearLoopingSounds(void);
 void        trap_S_ClearSounds(qboolean killmusic);
 void        trap_S_AddLoopingSound(const vec3_t origin, const vec3_t velocity, sfxHandle_t sfx, int volume, int soundTime);

--- a/src/cgame/cg_newDraw.cpp
+++ b/src/cgame/cg_newDraw.cpp
@@ -314,7 +314,7 @@ void CG_DrawPlayerWeaponIcon(rectDef_t *rect, qboolean drawHighlighted, int alig
 		{
 			if (((cg.grenLastTime) % 1000) > ((cg.predictedPlayerState.grenadeTimeLeft) % 1000))
 			{
-				trap_S_StartLocalSound(cgs.media.grenadePulseSound4, CHAN_LOCAL_SOUND);
+				trap_S_StartLocalSoundVControl(cgs.media.grenadePulseSound4, CHAN_LOCAL_SOUND, DEFAULT_VOLUME * etj_weaponVolume.value);
 			}
 		}
 		else

--- a/src/cgame/cg_syscalls.cpp
+++ b/src/cgame/cg_syscalls.cpp
@@ -275,6 +275,11 @@ void    trap_S_StartLocalSound(sfxHandle_t sfx, int channelNum)
 	syscall(CG_S_STARTLOCALSOUND, sfx, channelNum, 127 /* Gordon: default volume always for the moment*/);
 }
 
+void    trap_S_StartLocalSoundVControl(sfxHandle_t sfx, int channelNum, int volume)
+{
+	syscall(CG_S_STARTLOCALSOUND, sfx, channelNum, volume);
+}
+
 void    trap_S_ClearLoopingSounds(void)
 {
 	syscall(CG_S_CLEARLOOPINGSOUNDS);

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -2658,7 +2658,7 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 		}
 		else if (weapon->readySound)
 		{
-			trap_S_AddLoopingSound(cent->lerpOrigin, vec3_origin, weapon->readySound, 255, 0);
+			trap_S_AddLoopingSound(cent->lerpOrigin, vec3_origin, weapon->readySound, 255 * etj_weaponVolume.value, 0);
 		}
 	}
 
@@ -3965,7 +3965,7 @@ void CG_PlaySwitchSound(int lastweap, int newweap)
 		return;
 	}
 
-	trap_S_StartSound(NULL, cg.snap->ps.clientNum, CHAN_WEAPON, switchsound);
+	trap_S_StartSoundVControl(NULL, cg.snap->ps.clientNum, CHAN_WEAPON, switchsound, DEFAULT_VOLUME * etj_weaponVolume.value);
 }
 
 /*
@@ -5594,11 +5594,11 @@ void CG_FireWeapon(centity_t *cent)
 	{
 		if (cg_entities[cg_entities[cg_entities[cent->currentState.number].tagParent].tankparent].currentState.density & 8)      // should we use a browning?
 		{
-			trap_S_StartSound(NULL, cent->currentState.number, CHAN_WEAPON, cgs.media.hWeaponSnd_2);
+			trap_S_StartSoundVControl(NULL, cent->currentState.number, CHAN_WEAPON, cgs.media.hWeaponSnd_2, DEFAULT_VOLUME * etj_weaponVolume.value);
 		}
 		else
 		{
-			trap_S_StartSound(NULL, cent->currentState.number, CHAN_WEAPON, cgs.media.hWeaponSnd);
+			trap_S_StartSoundVControl(NULL, cent->currentState.number, CHAN_WEAPON, cgs.media.hWeaponSnd, DEFAULT_VOLUME * etj_weaponVolume.value);
 		}
 		cent->muzzleFlashTime = cg.time;
 		return;
@@ -5613,7 +5613,7 @@ void CG_FireWeapon(centity_t *cent)
 		}
 		else
 		{
-			trap_S_StartSound(NULL, cent->currentState.number, CHAN_WEAPON, cgs.media.hWeaponSnd);
+			trap_S_StartSoundVControl(NULL, cent->currentState.number, CHAN_WEAPON, cgs.media.hWeaponSnd, DEFAULT_VOLUME * etj_weaponVolume.value);
 		}
 
 		if (cg_brassTime.integer > 0)


### PR DESCRIPTION
Fixed following weapon related sound events being unlinked from `etj_weaponVolume`

* reload sound
* weapon switch sound
* satchel detonator idle hum
* panzer/satchel detonator spin-up
* mounted MG42s and tanks
* overheating sounds
* dynamite spin-up (holding +attack before throwing it)

Grenade ticking sounds are still untied from this cvar, as they are useful to hear when doing grenade jumps.

refs #570 