### PR TITLE
Fix shared cvarflags

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -954,7 +954,7 @@ cvarTable_t cvarTable[] =
 	{ &etj_realFov,                  "etj_realFov",                 "0",                      CVAR_ARCHIVE             },
 	{ &etj_stretchCgaz,              "etj_stretchCgaz",             "1",                      CVAR_ARCHIVE             },
 	{ &etj_noActivateLean,           "etj_noActivateLean",          "0",                      CVAR_ARCHIVE             },
-	{ &shared, "shared", "0", CVAR_ROM },
+	{ &shared, "shared", "0", CVAR_SYSTEMINFO | CVAR_ROM },
 	{ &etj_drawObWatcher , "etj_drawObWatcher", "1", CVAR_ARCHIVE},
 	{ &etj_obWatcherX , "etj_obWatcherX", "100", CVAR_ARCHIVE},
 	{ &etj_obWatcherY , "etj_obWatcherY", "100", CVAR_ARCHIVE},

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -548,7 +548,7 @@ cvarTable_t gameCvarTable[] =
 
 	{ &g_customVoiceChat,           "g_customVoiceChat",           "1",                                                      CVAR_ARCHIVE },
 
-	{ &shared, "shared", "0", CVAR_SERVERINFO | CVAR_SYSTEMINFO | CVAR_ROM },
+	{ &shared, "shared", "0", CVAR_SYSTEMINFO | CVAR_ROM },
 	{ &vote_minVoteDuration, "vote_minVoteDuration", "5000", CVAR_ARCHIVE },
 	{ &g_moverScale, "g_moverScale", "1.0", 0 },
 	{ &g_debugTrackers, "g_debugTrackers", "0", CVAR_ARCHIVE | CVAR_LATCH },


### PR DESCRIPTION
`shared` was incorrectly set as `CVAR_ROM` only on client, and unnecessarily as `CVAR_SERVERINFO` on server. The client part caused issues with ETLegacy/ETe, where server was not allowed to set a cvar value on client, because it was not a `CVAR_SYSTEMINFO`..