### PR TITLE
Fix unnecessary drawing/updating of cgaz/snaphud/strafe quality

### DIFF
--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -415,6 +415,11 @@ namespace ETJump
 			return true;
 		}
 
+		if (BG_PlayerMounted(ps->eFlags) || ps->weapon == WP_MOBILE_MG42_SET || ps->weapon == WP_MORTAR_SET)
+		{
+			return true;
+		}
+
 		// water and ladder movement are not important
 		// since speed is capped anyway
 		if (pm->pmext->waterlevel > 1 || pm->pmext->ladder)

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -435,6 +435,11 @@ namespace ETJump
 			return true;
 		}
 
+		if (BG_PlayerMounted(ps->eFlags) || ps->weapon == WP_MOBILE_MG42_SET || ps->weapon == WP_MORTAR_SET)
+		{
+			return true;
+		}
+
 		// water and ladder movement are not important
 		// since speed is capped anyway
 		if (pm->pmext->waterlevel > 1 || pm->pmext->ladder)

--- a/src/cgame/etj_strafe_quality_drawable.cpp
+++ b/src/cgame/etj_strafe_quality_drawable.cpp
@@ -222,6 +222,11 @@ namespace ETJump
 			return true;
 		}
 
+		if (BG_PlayerMounted(pm->ps->eFlags) || pm->ps->weapon == WP_MOBILE_MG42_SET || pm->ps->weapon == WP_MORTAR_SET)
+		{
+			return true;
+		}
+
 		// no updates underwater or on ladders
 		if (pm->pmext->waterlevel > 1 || pm->pmext->ladder)
 		{


### PR DESCRIPTION
* Don't draw/update while mounted (mg42/tank)
* Don't draw/update while using a set weapon (deployed mg42/mortar)

refs #666 #641