### PR TITLE
Fix prediction error with save

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -1702,6 +1702,7 @@ void CG_InitConsoleCommands(void)
 	trap_AddCommand("nocall");
 	trap_AddCommand("resetmaxspeed");
 	trap_AddCommand("resetStrafeQuality");
+	trap_AddCommand("resetJumpSpeeds");
 	trap_AddCommand("class");
 	trap_AddCommand("startTimer");
 	trap_AddCommand("stopTimer");

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -5704,7 +5704,6 @@ static void CG_Draw2D(void)
 		{
 			CG_DrawLagometer();
 			CG_DrawFollow();
-			ETJump::DrawJumpSpeeds();
 			CG_DrawOB();
 			CG_DrawSlick();
 			CG_DrawJumpDelay();

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -1965,7 +1965,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		trap_S_StartSound(NULL, es->number, CHAN_VOICE, CG_CustomSound(es->number, "*jump1.wav"));
 		if (clientNum == cg.predictedPlayerState.clientNum)
 		{
-			ETJump::UpdateJumpSpeeds();
+			ETJump::entityEventsHandler->check(EV_JUMP, cent);
 		}
 		break;
 	case EV_TAUNT:
@@ -2618,7 +2618,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		                  CG_CustomSound(es->number, va("*death%i.wav", event - EV_DEATH1 + 1)));
 		if (clientNum == cg.predictedPlayerState.clientNum)
 		{
-			ETJump::QueueJumpSpeedsReset();
+			trap_SendConsoleCommand("resetJumpSpeeds\n");
 			trap_SendConsoleCommand("resetStrafeQuality\n");
 		}
 		break;
@@ -2648,7 +2648,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		CG_GibPlayer(cent, cent->lerpOrigin, dir);
 		if (clientNum == cg.predictedPlayerState.clientNum)
 		{
-			ETJump::QueueJumpSpeedsReset();
+			trap_SendConsoleCommand("resetJumpSpeeds\n");
 			trap_SendConsoleCommand("resetStrafeQuality\n");
 		}
 		break;
@@ -3037,16 +3037,8 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		DEBUGNAME("EV_LOAD_TELEPORT");
 		ETJump::entityEventsHandler->check(EV_LOAD_TELEPORT, cent);
 		ETJump::playerEventsHandler->check("load", {});
-		ETJump::QueueJumpSpeedsReset();
+		trap_SendConsoleCommand("resetJumpSpeeds\n");
 		trap_SendConsoleCommand("resetStrafeQuality\n");
-		break;
-	case EV_SAVE:
-		DEBUGNAME("EV_SAVE");
-		if (clientNum == cg.predictedPlayerState.clientNum)
-		{
-			ETJump::QueueJumpSpeedsReset();
-			trap_SendConsoleCommand("resetStrafeQuality\n");
-		}
 		break;
 	default:
 		DEBUGNAME("UNKNOWN");

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4025,10 +4025,6 @@ namespace ETJump
 	int checkExtraTrace(int value);
 	void onPlayerRespawn(qboolean revived);
 	void runFrameEnd();
-	void DrawJumpSpeeds();
-	void UpdateJumpSpeeds();
-	void QueueJumpSpeedsReset();
-	void ResetJumpSpeeds();
 	playerState_t *getValidPlayerState();
 
 	enum extraTraceOptions {

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -24,6 +24,7 @@
 #include "etj_utilities.h"
 #include "etj_speed_drawable.h"
 #include "etj_strafe_quality_drawable.h"
+#include "etj_jump_speeds.h"
 #include "etj_quick_follow_drawable.h"
 #include "etj_awaited_command_handler.h"
 #include "etj_event_loop.h"
@@ -3796,9 +3797,6 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
     );
 	ETJump::eventLoop = std::make_shared<ETJump::EventLoop>();
 
-	// reset jump speed history
-	ETJump::ResetJumpSpeeds();
-
 	////////////////////////////////////////////////////////////////
 	// TODO: move these to own client commands handler
 	////////////////////////////////////////////////////////////////
@@ -3817,6 +3815,7 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
 	ETJump::renderables.push_back(std::unique_ptr<ETJump::IRenderable>(new ETJump::DisplayMaxSpeed(ETJump::entityEventsHandler.get())));
 	ETJump::renderables.push_back(std::unique_ptr<ETJump::IRenderable>(new ETJump::DisplaySpeed()));
 	ETJump::renderables.push_back(std::unique_ptr<ETJump::IRenderable>(new ETJump::StrafeQuality()));
+	ETJump::renderables.push_back(std::unique_ptr<ETJump::IRenderable>(new ETJump::JumpSpeeds(ETJump::entityEventsHandler.get())));
 	ETJump::renderables.push_back(std::unique_ptr<ETJump::IRenderable>(new ETJump::QuickFollowDrawer()));
 	ETJump::renderables.push_back(std::unique_ptr<ETJump::IRenderable>(new ETJump::CGaz()));
 	ETJump::renderables.push_back(std::unique_ptr<ETJump::IRenderable>(new ETJump::Snaphud()));
@@ -3889,8 +3888,6 @@ void CG_Shutdown(void)
 		ETJump::consoleCommandsHandler->unsubcribe("minimize");
 		////////////////////////////////////////////////////////////////
 
-		ETJump::consoleCommandsHandler = nullptr;
-		ETJump::serverCommandsHandler = nullptr;
 		ETJump::operatingSystem = nullptr;
 		ETJump::authentication = nullptr;
 		ETJump::renderables.clear();
@@ -3902,6 +3899,8 @@ void CG_Shutdown(void)
 		ETJump::consoleAlphaHandler = nullptr;
 		ETJump::eventLoop->shutdown();
 		ETJump::eventLoop = nullptr;
+		ETJump::consoleCommandsHandler = nullptr;
+		ETJump::serverCommandsHandler = nullptr;
 		ETJump::playerEventsHandler = nullptr;
 		ETJump::entityEventsHandler = nullptr;
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -3098,6 +3098,12 @@ static void CG_ServerCommand(void)
 		return;
 	}
 
+	// shut up console when we send this over from save
+	if (!Q_stricmp(cmd, "resetStrafeQuality"))
+	{
+		return;
+	}
+
 	if (found) return;
 
 	CG_Printf("Unknown client game command: %s\n", cmd);

--- a/src/cgame/etj_jump_speeds.cpp
+++ b/src/cgame/etj_jump_speeds.cpp
@@ -49,12 +49,11 @@ namespace ETJump
 	{
 		consoleCommandsHandler->unsubcribe("resetJumpSpeeds");
 		serverCommandsHandler->unsubcribe("resetJumpSpeeds");
-		entityEventsHandler->unsubcribe(EV_JUMP);
+		_entityEventsHandler->unsubcribe(EV_JUMP);
 	}
 
 	void JumpSpeeds::render() const
 	{
-		playerState_t* ps = getValidPlayerState();
 		float x1 = 6 + etj_jumpSpeedsX.value;
 		float x2 = 6 + 30 + etj_jumpSpeedsX.value;
 		float y1 = 240 + etj_jumpSpeedsY.value;

--- a/src/cgame/etj_jump_speeds.cpp
+++ b/src/cgame/etj_jump_speeds.cpp
@@ -24,10 +24,35 @@
 
 #include "etj_jump_speeds.h"
 #include "etj_utilities.h"
+#include "etj_client_commands_handler.h"
 
 namespace ETJump
 {
-	void DrawJumpSpeeds()
+	JumpSpeeds::JumpSpeeds(EntityEventsHandler* entityEventsHandler) :
+		_entityEventsHandler{ entityEventsHandler }
+	{
+		serverCommandsHandler->subscribe("resetJumpSpeeds", [&](const std::vector<std::string>& args)
+		{
+			queueJumpSpeedsReset();
+		});
+		consoleCommandsHandler->subscribe("resetJumpSpeeds", [&](const std::vector<std::string>& args)
+			{
+				queueJumpSpeedsReset();
+			});
+		entityEventsHandler->subscribe(EV_JUMP, [&](centity_t* cent)
+		{
+			updateJumpSpeeds();
+		});
+	}
+
+	JumpSpeeds::~JumpSpeeds()
+	{
+		consoleCommandsHandler->unsubcribe("resetJumpSpeeds");
+		serverCommandsHandler->unsubcribe("resetJumpSpeeds");
+		entityEventsHandler->unsubcribe(EV_JUMP);
+	}
+
+	void JumpSpeeds::render() const
 	{
 		playerState_t* ps = getValidPlayerState();
 		float x1 = 6 + etj_jumpSpeedsX.value;
@@ -38,17 +63,7 @@ namespace ETJump
 		vec4_t color;
 		bool vertical = !etj_jumpSpeedsStyle.integer;
 
-		if (!etj_drawJumpSpeeds.integer)
-		{
-			return;
-		}
-
-		if (ps->persistant[PERS_TEAM] == TEAM_SPECTATOR)
-		{
-			return;
-		}
-
-		if (cg.zoomedBinoc || cg.zoomedScope)
+		if (canSkipDraw())
 		{
 			return;
 		}
@@ -67,7 +82,7 @@ namespace ETJump
 			auto jumpSpeed = std::to_string(jumpSpeedHistory.at(i));
 			if (etj_jumpSpeedsShowDiff.integer)
 			{
-				AdjustColors(i, &color);
+				adjustColors(i, overwriteHistory(i), &color);
 			}
 			if (vertical)
 			{
@@ -93,7 +108,7 @@ namespace ETJump
 		}
 	}
 
-	void UpdateJumpSpeeds()
+	void JumpSpeeds::updateJumpSpeeds()
 	{
 		// events are processed at playerstate transition before interpolation runs,
 		// so we can't rely on predictedPlayerState on demos because it still contains
@@ -105,12 +120,12 @@ namespace ETJump
 		// queue reset if last update was on different team
 		if (team != ps->persistant[PERS_TEAM])
 		{
-			QueueJumpSpeedsReset();
+			queueJumpSpeedsReset();
 		}
 		// if reset is queued, do that before we start storing new jump speeds
 		if (resetQueued)
 		{
-			ResetJumpSpeeds();
+			resetJumpSpeeds();
 			resetQueued = false;
 		}
 
@@ -124,20 +139,24 @@ namespace ETJump
 			jumpSpeedHistory.erase(jumpSpeedHistory.begin());
 			jumpSpeedDeleted = true;
 		}
+		else
+		{
+			jumpSpeedDeleted = false;
+		}
 	}
 
-	void QueueJumpSpeedsReset()
+	void JumpSpeeds::queueJumpSpeedsReset()
 	{
 		resetQueued = true;
 	}
 
-	void ResetJumpSpeeds()
+	void JumpSpeeds::resetJumpSpeeds()
 	{
 		jumpSpeedHistory.clear();
 		lastDeletedSpeed = 0;
 	}
 
-	void AdjustColors(int jumpNum, vec4_t* color)
+	void JumpSpeeds::adjustColors(int jumpNum, bool overwrite, vec4_t* color) const
 	{
 		// equal/first jump color comes from etj_jumpSpeedsColor
 		vec4_t fasterColor;
@@ -152,7 +171,7 @@ namespace ETJump
 		// and we start deleting jump speeds (11th jump)
 		if (jumpNum == 0)
 		{
-			if (jumpSpeedHistory.size() == MAX_JUMPS && jumpSpeedDeleted)
+			if (overwrite)
 			{
 				// faster than previous jump
 				if (currentJumpSpeed > lastDeletedSpeed)
@@ -164,11 +183,6 @@ namespace ETJump
 				{
 					Vector4Copy(slowerColor, *color);
 				}
-			}
-			// history not full
-			else
-			{
-				jumpSpeedDeleted = false;
 			}
 		}
 		else
@@ -185,5 +199,35 @@ namespace ETJump
 				Vector4Copy(slowerColor, *color);
 			}
 		}
+	}
+
+	bool JumpSpeeds::overwriteHistory(int jumpNum) const
+	{
+		if (jumpSpeedHistory.size() == MAX_JUMPS && jumpSpeedDeleted)
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	bool JumpSpeeds::canSkipDraw() const
+	{
+		if (!etj_drawJumpSpeeds.integer)
+		{
+			return true;
+		}
+
+		if (team == TEAM_SPECTATOR)
+		{
+			return true;
+		}
+
+		if (cg.zoomedBinoc || cg.zoomedScope)
+		{
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/cgame/etj_jump_speeds.h
+++ b/src/cgame/etj_jump_speeds.h
@@ -25,19 +25,34 @@
 #pragma once
 
 #include "cg_local.h"
+#include "etj_irenderable.h"
+#include "etj_entity_events_handler.h"
 
 namespace ETJump
 {
-	constexpr int MAX_JUMPS = 10;
-	std::vector<int> jumpSpeedHistory;		// last 10 jump speeds
-	bool jumpSpeedDeleted;
-	bool resetQueued;
-	int lastDeletedSpeed;					// last jump speed that was deleted from history
-	int team;
+	class JumpSpeeds : public IRenderable
+	{
+	public:
+		explicit JumpSpeeds(EntityEventsHandler* entityEventsHandler);
+		~JumpSpeeds();
 
-	void DrawJumpSpeeds();
-	void UpdateJumpSpeeds();
-	void QueueJumpSpeedsReset();
-	void ResetJumpSpeeds();
-	void AdjustColors(int jumpNum, vec4_t* color);
+		void render() const override;
+		void beforeRender() override {};
+
+	private:
+		EntityEventsHandler* _entityEventsHandler;
+		static const int MAX_JUMPS = 10;
+		std::vector<int> jumpSpeedHistory;		// last 10 jump speeds
+		bool jumpSpeedDeleted;
+		bool resetQueued;
+		int lastDeletedSpeed;					// last jump speed that was deleted from history
+		int team;
+
+		void updateJumpSpeeds();
+		void queueJumpSpeedsReset();
+		void resetJumpSpeeds();
+		void adjustColors(int jumpNum, bool overwrite, vec4_t* color) const;
+		bool overwriteHistory(int jumpNum) const;
+		bool canSkipDraw() const;
+	};
 }

--- a/src/game/etj_save_system.cpp
+++ b/src/game/etj_save_system.cpp
@@ -222,7 +222,7 @@ void ETJump::SaveSystem::save(gentity_t *ent)
 
 	storePosition(client, pos);
 
-	G_AddEvent(ent, EV_SAVE, 0);
+	sendClientCommands(ent);
 
 	if (position == 0)
 	{
@@ -882,6 +882,13 @@ void ETJump::SaveSystem::storePosition(gclient_s* client, SavePosition *pos)
 	{
 		pos->stance = Stand;
 	}
+}
+
+void ETJump::SaveSystem::sendClientCommands(gentity_t* ent)
+{
+	auto client = ClientNum(ent);
+	trap_SendServerCommand(client, "resetStrafeQuality\n");
+	trap_SendServerCommand(client, "resetJumpSpeeds\n");
 }
 
 

--- a/src/game/etj_save_system.h
+++ b/src/game/etj_save_system.h
@@ -162,6 +162,9 @@ namespace ETJump
 		
 		SavePosition* getValidTeamUnloadPos(gentity_t* ent, team_t team);
 
+		// Commands that are sent to client when they succesfully save position
+		void sendClientCommands(gentity_t* ent);
+
 		// All clients' save related data
 		Client _clients[MAX_CLIENTS];
 

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -5389,6 +5389,12 @@ void ClientCommand(int clientNum)
 		return;
 	}
 
+	// shut up console when we send this over from save
+	if (!Q_stricmp(cmd, "resetJumpSpeeds"))
+	{
+		return;
+	}
+
 	CP(va("print \"Unknown command %s^7.\n\"", cmd));
 }
 

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -5389,12 +5389,6 @@ void ClientCommand(int clientNum)
 		return;
 	}
 
-	// shut up console when we send this over from save
-	if (!Q_stricmp(cmd, "resetJumpSpeeds"))
-	{
-		return;
-	}
-
 	CP(va("print \"Unknown command %s^7.\n\"", cmd));
 }
 


### PR DESCRIPTION
Adding `G_AddEvent` to save was causing prediction errors due to adding an event to playerstate from game. Removed this and reworked jump speeds and strafequality to not rely on `EV_SAVE` event as it no longer exists, and used servercommands instead to sent resets on save to clients.

refs #608 #641 