### PR TITLE
Add softnoclip

### DIFF
--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -400,6 +400,12 @@ namespace ETJump
 			return true;
 		}
 
+		// a bit weird but this will match players who are softnoclipping
+		if (!(ps->persistant[PERS_TEAM] == TEAM_SPECTATOR) && ps->pm_type == PM_SPECTATOR)
+		{
+			return true;
+		}
+
 		if (ps->persistant[PERS_TEAM] == TEAM_SPECTATOR || ps->pm_type == PM_NOCLIP)
 		{
 			return true;

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -420,6 +420,12 @@ namespace ETJump
 			return true;
 		}
 
+		// a bit weird but this will match players who are softnoclipping
+		if (!(ps->persistant[PERS_TEAM] == TEAM_SPECTATOR) && ps->pm_type == PM_SPECTATOR)
+		{
+			return true;
+		}
+
 		if (ps->persistant[PERS_TEAM] == TEAM_SPECTATOR || ps->pm_type == PM_NOCLIP)
 		{
 			return true;

--- a/src/cgame/etj_strafe_quality_drawable.cpp
+++ b/src/cgame/etj_strafe_quality_drawable.cpp
@@ -211,6 +211,12 @@ namespace ETJump
 			return true;
 		}
 
+		// a bit weird but this will match players who are softnoclipping
+		if (!(_team == TEAM_SPECTATOR) && pm->ps->pm_type == PM_SPECTATOR)
+		{
+			return true;
+		}
+
 		// don't update if not in air or on ice
 		if (pm->ps->groundEntityNum != ENTITYNUM_NONE && !(pm->pmext->groundTrace.surfaceFlags & SURF_SLICK))
 		{

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -6808,7 +6808,8 @@ void PmoveSingle(pmove_t *pmove)
 	}
 
 
-	if (!(pm->ps->pm_flags & PMF_RESPAWNED) && (pm->ps->pm_type != PM_INTERMISSION) && (pm->ps->pm_type != PM_NOCLIP))
+	if (!(pm->ps->pm_flags & PMF_RESPAWNED) && (pm->ps->pm_type != PM_INTERMISSION)
+		&& !(pm->ps->pm_type == PM_NOCLIP || pm->ps->pm_type == PM_SPECTATOR))
 	{
 		// check for ammo
 		if (PM_WeaponAmmoAvailable(pm->ps->weapon))

--- a/src/game/etj_save_system.cpp
+++ b/src/game/etj_save_system.cpp
@@ -143,6 +143,12 @@ void ETJump::SaveSystem::save(gentity_t *ent)
 		return;
 	}
 
+	if (client->softNoclip)
+	{
+		CPTo(ent, "^7You can not ^3save^7 while softnoclipping.");
+		return;
+	}
+
 	if (client->sess.timerunActive && client->sess.runSpawnflags & TIMERUN_DISABLE_SAVE)
 	{
 		CPTo(ent, "^3Save ^7is disabled for this timerun.");

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -534,7 +534,7 @@ void SpectatorThink(gentity_t *ent, usercmd_t *ucmd)
 
 		// Rafael - Activate
 		// Ridah, made it a latched event (occurs on keydown only)
-		if (client->latched_buttons & BUTTON_ACTIVATE)
+		if (client->latched_buttons & BUTTON_ACTIVATE && !client->softNoclip)
 		{
 			Cmd_Activate_f(ent);
 		}
@@ -542,7 +542,10 @@ void SpectatorThink(gentity_t *ent, usercmd_t *ucmd)
 		// save results of pmove
 		VectorCopy(client->ps.origin, ent->s.origin);
 
-		G_TouchTriggers(ent);
+		if (!client->softNoclip)
+		{
+			G_TouchTriggers(ent);
+		}
 		trap_UnlinkEntity(ent);
 	}
 
@@ -2151,7 +2154,10 @@ void ClientEndFrame(gentity_t *ent)
 	// zinx - #280 - run touch functions here too, so movers don't have to wait
 	// until the next ClientThink, which will be too late for some map
 	// scripts (railgun)
-	G_TouchTriggers(ent);
+	if (!ent->client->softNoclip)
+	{
+		G_TouchTriggers(ent);
+	}
 
 	// run entity scripting
 	G_Script_ScriptRun(ent);

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -89,7 +89,7 @@ void P_WorldEffects(gentity_t *ent)
 {
 	int waterlevel;
 
-	if (ent->client->noclip)
+	if (ent->client->noclip || ent->client->softNoclip)
 	{
 		ent->client->airOutTime = level.time + HOLDBREATHTIME;  // don't need air
 		return;

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -493,11 +493,13 @@ void SpectatorThink(gentity_t *ent, usercmd_t *ucmd)
 			client->pmext.noclipScale = client->pers.noclipScale;
 		}
 
-		if (client->ps.sprintExertTime)
+		if (client->ps.sprintExertTime && !client->softNoclip)
 		{
 			client->ps.speed *= 3;  // (SA) allow sprint in free-cam mode
-
-
+		}
+		if (client->softNoclip)
+		{
+			client->ps.speed *= client->pmext.noclipScale;
 		}
 		// OSP - dead players are frozen too, in a timeout
 		if ((client->ps.pm_flags & PMF_LIMBO) && level.match_pause != PAUSE_NONE)
@@ -560,7 +562,7 @@ void SpectatorThink(gentity_t *ent, usercmd_t *ucmd)
 	client->latched_wbuttons = client->wbuttons & ~client->oldwbuttons;
 
 	// attack button cycles through spectators
-	if ((client->buttons & BUTTON_ATTACK) && !(client->oldbuttons & BUTTON_ATTACK))
+	if (((client->buttons & BUTTON_ATTACK) && !(client->oldbuttons & BUTTON_ATTACK)) && !ent->client->softNoclip)
 	{
 		Cmd_FollowCycle_f(ent, 1);
 	}
@@ -1191,7 +1193,7 @@ void ClientThink_real(gentity_t *ent)
 
 	// spectators don't do much
 	// DHM - Nerve :: In limbo use SpectatorThink
-	if (client->sess.sessionTeam == TEAM_SPECTATOR || client->ps.pm_flags & PMF_LIMBO)
+	if (client->sess.sessionTeam == TEAM_SPECTATOR || client->ps.pm_flags & PMF_LIMBO || client->softNoclip)
 	{
 		/*if ( client->sess.spectatorState == SPECTATOR_SCOREBOARD ) {
 		    return;

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -1359,7 +1359,6 @@ namespace ETJump
 	void softNoclip(gentity_t* ent)
 	{
 		auto* name = ConcatArgs(1);
-		auto clientNum = ClientNum(ent);
 		auto oldSpecState = ent->client->sess.spectatorState;
 
 		if (!Q_stricmp(name, "on") || atoi(name) || !ent->client->softNoclip)

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -1410,7 +1410,7 @@ void Cmd_Noclip_f(gentity_t *ent)
 			// only print if we are not already softnoclipping
 			if (!ent->client->softNoclip)
 			{
-				Printer::SendChatMessage(clientNum, "^3noclip^7 unavailable - enabling ^3softnoclip^7\n");
+				Printer::SendConsoleMessage(clientNum, "^3noclip^7 unavailable - enabling ^3softnoclip^7\n");
 			}
 			ETJump::softNoclip(ent);
 		}

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -5254,7 +5254,6 @@ static command_t noIntermissionCommands[] =
 	{ "tracker_print", qtrue, ETJump::printTracker },
 	{ "tracker_set", qtrue, ETJump::setTracker },
 	{ "clearsaves", qtrue, ETJump::clearSaves },
-	{ "softnoclip", qfalse, ETJump::softNoclip },
 };
 
 qboolean ClientIsFlooding(gentity_t *ent)

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -149,7 +149,7 @@ void Cmd_Score_f(gentity_t *ent)
 CheatsOk
 ==================
 */
-qboolean    CheatsOk(gentity_t *ent)
+qboolean CheatsOk(gentity_t *ent)
 {
 	if (!g_cheats.integer)
 	{
@@ -1059,7 +1059,7 @@ namespace ETJump
 			if (ent->client->pers.noclipCount == 0 &&
 				!ent->client->noclip)
 			{
-				if (!g_noclip.integer && !CheatsOk(ent))
+				if (!g_noclip.integer)
 				{
 					return{ false, "^7You can no longer use ^3%s^7.\n" };
 				}

--- a/src/game/g_combat.cpp
+++ b/src/game/g_combat.cpp
@@ -760,6 +760,9 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int 
 
 	CalculateRanks();
 
+	// if we're softnoclipping, we can still die, so reset the state
+	self->client->softNoclip = false;
+
 	if (self->client->sess.timerunActive)
 	{
 		limbo(self, qfalse);

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1113,6 +1113,11 @@ struct gclient_s
 	qboolean alreadyActivatedSetHealth;
 
 	etj_votingInfo_t votingInfo;
+
+	bool softNoclip;
+	vec3_t softNoclipStartPos;
+	int softNoclipStance;
+	vec3_t softNoclipVAngles;
 };
 
 typedef struct

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -2057,7 +2057,7 @@ void target_startTimer_use(gentity_t *self, gentity_t *other, gentity_t *activat
 	// We don't need any of these checks if we are debugging
 	if (g_debugTimeruns.integer <= 0)
 	{
-		if (activator->client->noclip || activator->flags == FL_GODMODE)
+		if (activator->client->noclip || activator->client->softNoclip || activator->flags == FL_GODMODE)
 		{
 			Printer::SendCenterMessage(clientNum, "^3WARNING: ^7Timerun was not started. Invalid playerstate!");
 			return;


### PR DESCRIPTION
An extension to `noclip` command - whenever `noclip` is not available, clients will (barring other restrictions such as during timeruns) enter `softnoclip` state. In this state, they act as sepctators: they have normal collision with the world, ~can activate triggers and such~. When toggling `noclip` off, players are returned to their original location, similar to if they had saved before starting and loaded back. `etj_noclipScale` will affect movement speed during this state. This state cannot be triggered on its own, it is automatically entered whenever client tries to use noclip while it's unavailable.

closes #620 