### PR TITLE
Remove `g_saveMsg`, add `etj_saveMsg`

### DIFF
--- a/assets/ui/etjump_settings_1.menu
+++ b/assets/ui/etjump_settings_1.menu
@@ -4,7 +4,7 @@
 #define WINDOW_WIDTH 608
 #define WINDOW_HEIGHT 448
 #define SUBW_GENERAL_Y 32
-#define SUBW_PLAYERS_Y 272
+#define SUBW_PLAYERS_Y 286
 #define SUBW_CHAT_Y 32
 #define SUBW_CONSOLE_Y 212
 #define SUBW_SOUNDS_Y 284
@@ -25,7 +25,7 @@ menuDef {
 
     WINDOW("SETTINGS", 94)
 
-    SUBWINDOW(8, 32, 292, 232, "GENERAL")
+    SUBWINDOW(8, 32, 292, 244, "GENERAL")
         YESNO				(16, SUBW_GENERAL_Y + 20, 276, 8, "pmove_fixed:", 0.2, 8, "pmove_fixed", "Enable fixed 125 FPS player movement\npmove_fixed")
         MULTI				(16, SUBW_GENERAL_Y + 32, 276, 8, "Max FPS:", 0.2, 8, "com_maxfps", cvarFloatList { "43" 43 "76" 76 "125" 125 "250" 250 "333" 333 }, "Sets the FPS limit\ncom_maxfps")
         MULTI				(16, SUBW_GENERAL_Y + 44, 276, 8, "Memory limit:", 0.2, 8, "com_hunkmegs", cvarFloatList { "56MB" 56 "64MB" 64 "128MB" 128 "256MB" 256 "512MB" 512 }, "How much memory ET can use (restart required)\ncom_hunkmegs")
@@ -44,8 +44,9 @@ menuDef {
         YESNO				(16, SUBW_GENERAL_Y + 188, 276, 8, "Item pickup text:", 0.2, 8, "etj_itemPickupText", "Notify on item pickups\netj_itemPickupText")
         YESNO				(16, SUBW_GENERAL_Y + 200, 276, 8, "Draw tokens:", 0.2, 8, "etj_drawTokens", "Draw collectible tokens\netj_drawTokens")
         YESNO				(16, SUBW_GENERAL_Y + 212, 276, 8, "Log banners:", 0.2, 8, "etj_logBanner", "Log banners in console\netj_logBanner")
+        EDITFIELD           (16, SUBW_GENERAL_Y + 224, 276, 10, "Save message:", 0.2, 8, "etj_saveMsg", 128, 32, "Message to print when saving position\netj_saveMsg")
 
-    SUBWINDOW(8, 272, 292, 112, "PLAYERS")
+    SUBWINDOW(8, 286, 292, 112, "PLAYERS")
         YESNO				(16, SUBW_PLAYERS_Y + 20, 276, 8, "Hide players:", 0.2, 8, "etj_hide", "Hides other players when they are too close\netj_hide")
         CVARINTLABEL		(16, SUBW_PLAYERS_Y + 32, 276, 8, "etj_hideDistance", 0.2, ITEM_ALIGN_RIGHT, 276, 8)
         SLIDER				(16, SUBW_PLAYERS_Y + 32, 276, 8, "Hide distance:", 0.2, 8, etj_hideDistance 128 0 1000 10, "Distance at which other players are hidden\netj_hideDistance")

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2662,6 +2662,7 @@ extern vmCvar_t etj_strafeQualitySize;
 extern vmCvar_t etj_strafeQualityStyle;
 
 extern vmCvar_t etj_projection;
+extern vmCvar_t etj_saveMsg;
 
 //
 // cg_main.c

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -611,6 +611,7 @@ vmCvar_t etj_strafeQualitySize;
 vmCvar_t etj_strafeQualityStyle;
 
 vmCvar_t etj_projection;
+vmCvar_t etj_saveMsg;
 
 typedef struct
 {
@@ -1042,6 +1043,7 @@ cvarTable_t cvarTable[] =
 	{ &etj_strafeQualityStyle, "etj_strafeQualityStyle", "0", CVAR_ARCHIVE },
 
 	{ &etj_projection, "etj_projection", "0", CVAR_ARCHIVE },
+	{ &etj_saveMsg, "etj_saveMsg", "^7Saved", CVAR_ARCHIVE },
 };
 
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -3104,6 +3104,22 @@ static void CG_ServerCommand(void)
 		return;
 	}
 
+	if (!Q_stricmp(cmd, "savePrint"))
+	{
+		if (trap_Argc() > 1)
+		{
+			auto pos = atoi(CG_Argv(1));
+			std::string saveMsg = etj_saveMsg.string;
+			saveMsg += ' ' + std::to_string(pos);
+			CPri(saveMsg.c_str());
+		}
+		else
+		{
+			CPri(etj_saveMsg.string);
+		}
+		return;
+	}
+
 	if (found) return;
 
 	CG_Printf("Unknown client game command: %s\n", cmd);

--- a/src/game/etj_save_system.cpp
+++ b/src/game/etj_save_system.cpp
@@ -222,16 +222,7 @@ void ETJump::SaveSystem::save(gentity_t *ent)
 
 	storePosition(client, pos);
 
-	sendClientCommands(ent);
-
-	if (position == 0)
-	{
-		CP(va("cp \"%s\n\"", g_savemsg.string));
-	}
-	else
-	{
-		CP(va("cp \"%s ^7%d\n\"", g_savemsg.string, position));
-	}
+	sendClientCommands(ent, position);
 }
 
 // Loads position
@@ -345,7 +336,7 @@ void ETJump::SaveSystem::forceSave(gentity_t *location, gentity_t *ent)
 		? Crouch
 		: client->ps.eFlags & EF_PRONE ? Prone : Stand;
 
-	trap_SendServerCommand(ent - g_entities, g_savemsg.string);
+	trap_SendServerCommand(ent - g_entities, "savePrint");
 }
 
 // Loads backup position
@@ -884,11 +875,12 @@ void ETJump::SaveSystem::storePosition(gclient_s* client, SavePosition *pos)
 	}
 }
 
-void ETJump::SaveSystem::sendClientCommands(gentity_t* ent)
+void ETJump::SaveSystem::sendClientCommands(gentity_t* ent, int position)
 {
 	auto client = ClientNum(ent);
 	trap_SendServerCommand(client, "resetStrafeQuality\n");
 	trap_SendServerCommand(client, "resetJumpSpeeds\n");
+	trap_SendServerCommand(client, position == 0 ? "savePrint\n" : va("savePrint %d\n", position));
 }
 
 

--- a/src/game/etj_save_system.h
+++ b/src/game/etj_save_system.h
@@ -163,7 +163,7 @@ namespace ETJump
 		SavePosition* getValidTeamUnloadPos(gentity_t* ent, team_t team);
 
 		// Commands that are sent to client when they succesfully save position
-		void sendClientCommands(gentity_t* ent);
+		void sendClientCommands(gentity_t* ent, int position);
 
 		// All clients' save related data
 		Client _clients[MAX_CLIENTS];

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1995,7 +1995,6 @@ extern vmCvar_t g_nofatigue;
 extern vmCvar_t g_blockCheatCvars;
 extern vmCvar_t g_weapons;
 extern vmCvar_t g_noclip;
-extern vmCvar_t g_savemsg;
 extern vmCvar_t g_nameChangeLimit;
 extern vmCvar_t g_nameChangeInterval;
 

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -216,7 +216,6 @@ vmCvar_t g_nofatigue;
 vmCvar_t g_blockCheatCvars;
 vmCvar_t g_weapons;
 vmCvar_t g_noclip;
-vmCvar_t g_savemsg;
 vmCvar_t g_mapScriptDir;
 vmCvar_t g_blockedMaps;
 vmCvar_t g_nameChangeLimit;
@@ -491,7 +490,6 @@ cvarTable_t gameCvarTable[] =
 	{ &g_blockCheatCvars,           "g_blockCheatCvars",           "0",                                                      CVAR_ARCHIVE },
 	{ &g_weapons,                   "g_weapons",                   "1",                                                      CVAR_ARCHIVE },
 	{ &g_noclip,                    "g_noclip",                    "0",                                                      CVAR_ARCHIVE },
-	{ &g_savemsg,                   "g_savemsg",                   "^7Saved",                                                CVAR_ARCHIVE },
 	{ &g_nameChangeLimit,           "g_nameChangeLimit",           "5",                                                      CVAR_ARCHIVE },
 	{ &g_nameChangeInterval,        "g_nameChangeInterval",        "60",                                                     CVAR_ARCHIVE },
 	{ &g_mapScriptDir,              "g_mapScriptDir",              "scripts",                                                CVAR_ARCHIVE },

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1823,7 +1823,6 @@ void target_save_use(gentity_t *self, gentity_t *other, gentity_t *activator)
 	}
 
 	ETJump::saveSystem->forceSave(self, activator);
-	trap_SendServerCommand(activator - g_entities, g_savemsg.string);
 }
 
 void SP_target_save(gentity_t *self)


### PR DESCRIPTION
Removed server side `g_saveMsg` cvar in favor of client side `etj_saveMsg` cvar, to allow clients to specify their own save message.

closes #362