### PR TITLE
Fix gcc sanitizer runtime errors

### DIFF
--- a/src/cgame/cg_character.cpp
+++ b/src/cgame/cg_character.cpp
@@ -156,7 +156,7 @@ CG_CalcMoveSpeeds
 static void CG_CalcMoveSpeeds(bg_character_t *character)
 {
 	const char          *tags[2] = { "tag_footleft", "tag_footright" };
-	vec3_t        oldPos[2];
+	vec3_t        oldPos[2] = {0};
 	refEntity_t   refent;
 	animation_t   *anim;
 	int           i, j, k;

--- a/src/cgame/cg_character.cpp
+++ b/src/cgame/cg_character.cpp
@@ -156,7 +156,7 @@ CG_CalcMoveSpeeds
 static void CG_CalcMoveSpeeds(bg_character_t *character)
 {
 	const char          *tags[2] = { "tag_footleft", "tag_footright" };
-	vec3_t        oldPos[2] = {0};
+	vec3_t        oldPos[2] = {{0, 0}};
 	refEntity_t   refent;
 	animation_t   *anim;
 	int           i, j, k;

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -3193,7 +3193,7 @@ static qboolean CG_IsOverBounce(float vel, float initHeight,
                                 float finalHeight, float rintv,
                                 float psec, int gravity)
 {
-	float a, b, c;
+	float a, b, c, D;
 	float n1;
 	//float			n2;
 	float hn;
@@ -3202,8 +3202,22 @@ static qboolean CG_IsOverBounce(float vel, float initHeight,
 	a  = -psec * rintv / 2;
 	b  = psec * (vel - gravity * psec / 2 + rintv / 2);
 	c  = initHeight - finalHeight;
-	n1 = (-b - sqrt(b * b - 4 * a * c)) / (2 * a);
-	//n2 = (-b + sqrt(b * b - 4 * a * c)) / (2 * a);
+
+	if (a == 0)
+	{
+		// no quadratic equation
+		return qfalse;
+	}
+
+	D = b * b - 4 * a * c; // discriminant
+	if (D < 0)
+	{
+		// no real roots
+		return qfalse;
+	}
+
+	n1 = (-b - std::sqrt(D)) / (2 * a);
+	//n2 = (-b + sqrt(D)) / (2 * a);
 	//CG_Printf("n1=%f, n2=%f\n", n1, n2);
 
 	n  = floor(n1);

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -5141,11 +5141,7 @@ static void CG_DrawWeapRecharge(rectDef_t *rect)
 		chargeTime = cg.soldierChargeTime[cg.snap->ps.persistant[PERS_TEAM] - 1];
 	}
 
-	barFrac = (float)(cg.time - cg.snap->ps.classWeaponTime) / chargeTime;
-	if (barFrac > 1.0)
-	{
-		barFrac = 1.0;
-	}
+	barFrac = (chargeTime == 0 ? 1.0f : std::min(static_cast<float>(cg.time - cg.snap->ps.classWeaponTime) / chargeTime, 1.0f));
 
 	color[0] = 1.0f;
 	color[1] = color[2] = barFrac;

--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -336,8 +336,6 @@ static void CG_EntityEffects(centity_t *cent)
 	// DHM - Nerve :: If EF_SMOKING is set, emit smoke
 	else if (cent->currentState.eFlags & EF_SMOKING)
 	{
-		float rnd = random();
-
 		if (cent->lastTrailTime < cg.time)
 		{
 			cent->lastTrailTime = cg.time + 100;
@@ -353,8 +351,9 @@ static void CG_EntityEffects(centity_t *cent)
 //			dir[1] = crandom() * 10;
 //			dir[2] = 10 + rnd * 30;
 // jpw
+			const float rnd = std::min(0.3f + random(), 1.0f);
 			CG_SmokePuff(cent->lerpOrigin, dir, 15 + (random() * 10),
-			             0.3 + rnd, 0.3 + rnd, 0.3 + rnd, 0.4, 1500 + (rand() % 500),
+			             rnd, rnd, rnd, 0.4, 1500 + (rand() % 500),
 			             cg.time, cg.time + 500, 0, cgs.media.smokePuffShader);
 		}
 	}

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -1596,15 +1596,6 @@ void CG_MortarMiss(centity_t *cent, vec3_t origin)
 	}
 }
 
-// a convenience function for all footstep sound playing
-static void CG_StartFootStepSound(bg_playerclass_t *classInfo, entityState_t *es, sfxHandle_t sfx)
-{
-	if (cg_footsteps.integer)
-	{
-		trap_S_StartSound(NULL, es->number, CHAN_BODY, sfx);
-	}
-}
-
 /*
 ==============
 CG_EntityEvent
@@ -1626,10 +1617,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 	vec3_t           dir;
 	const char       *s;
 	int              clientNum;
-	clientInfo_t     *ci;
 	char             tempStr[MAX_QPATH];
-	bg_playerclass_t *classInfo;
-	bg_character_t   *character;
 
 // JPW NERVE copied here for mg42 SFX event
 	vec3_t porg, gorg, norm;                // player/gun origin
@@ -1661,9 +1649,6 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 	{
 		clientNum = 0;
 	}
-	ci        = &cgs.clientinfo[clientNum];
-	classInfo = CG_PlayerClassForClientinfo(ci, cent);
-	character = CG_CharacterForClientinfo(ci, cent);
 
 	switch (event)
 	{
@@ -1678,29 +1663,33 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		// fall through
 	case EV_FOOTSTEP:
 		DEBUGNAME("EV_FOOTSTEP");
-		if (es->eventParm != FOOTSTEP_TOTAL)
+		if (es->eventParm != FOOTSTEP_TOTAL && cg_footsteps.integer)
 		{
 			if (es->eventParm)
 			{
-				CG_StartFootStepSound(classInfo, es, cgs.media.footsteps[es->eventParm][footstepcnt]);
+				trap_S_StartSound(NULL, es->number, CHAN_BODY, cgs.media.footsteps[es->eventParm][footstepcnt]);
 			}
 			else
 			{
-				CG_StartFootStepSound(classInfo, es, cgs.media.footsteps[character->animModelInfo->footsteps][footstepcnt]);
+				bg_character_t *character = CG_CharacterForClientinfo(&cgs.clientinfo[clientNum], cent);
+				trap_S_StartSound(NULL, es->number, CHAN_BODY, cgs.media.footsteps[character->animModelInfo->footsteps][footstepcnt]);
 			}
 		}
 		break;
 	case EV_FOOTSPLASH:
 		DEBUGNAME("EV_FOOTSPLASH");
-		CG_StartFootStepSound(classInfo, es, cgs.media.footsteps[FOOTSTEP_SPLASH][splashfootstepcnt]);
+		if (cg_footsteps.integer)
+			trap_S_StartSound(NULL, es->number, CHAN_BODY, cgs.media.footsteps[FOOTSTEP_SPLASH][splashfootstepcnt]);
 		break;
 	case EV_FOOTWADE:
 		DEBUGNAME("EV_FOOTWADE");
-		CG_StartFootStepSound(classInfo, es, cgs.media.footsteps[FOOTSTEP_SPLASH][splashfootstepcnt]);
+		if (cg_footsteps.integer)
+			trap_S_StartSound(NULL, es->number, CHAN_BODY, cgs.media.footsteps[FOOTSTEP_SPLASH][splashfootstepcnt]);
 		break;
 	case EV_SWIM:
 		DEBUGNAME("EV_SWIM");
-		CG_StartFootStepSound(classInfo, es, cgs.media.footsteps[FOOTSTEP_SPLASH][footstepcnt]);
+		if (cg_footsteps.integer)
+			trap_S_StartSound(NULL, es->number, CHAN_BODY, cgs.media.footsteps[FOOTSTEP_SPLASH][footstepcnt]);
 		break;
 
 	case EV_FALL_SHORT:
@@ -1713,6 +1702,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 			}
 			else
 			{
+				bg_character_t *character = CG_CharacterForClientinfo(&cgs.clientinfo[clientNum], cent);
 				trap_S_StartSound(NULL, es->number, CHAN_AUTO, cgs.media.landSound[character->animModelInfo->footsteps]);
 			}
 		}
@@ -1744,6 +1734,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 				}
 				else
 				{
+					bg_character_t *character = CG_CharacterForClientinfo(&cgs.clientinfo[clientNum], cent);
 					trap_S_StartSound(NULL, es->number, CHAN_AUTO, cgs.media.landSound[character->animModelInfo->footsteps]);
 				}
 			}
@@ -1779,6 +1770,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 				}
 				else
 				{
+					bg_character_t *character = CG_CharacterForClientinfo(&cgs.clientinfo[clientNum], cent);
 					trap_S_StartSound(NULL, es->number, CHAN_AUTO, cgs.media.landSound[character->animModelInfo->footsteps]);
 				}
 			}
@@ -1814,6 +1806,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 				}
 				else
 				{
+					bg_character_t *character = CG_CharacterForClientinfo(&cgs.clientinfo[clientNum], cent);
 					trap_S_StartSound(NULL, es->number, CHAN_AUTO, cgs.media.landSound[character->animModelInfo->footsteps]);
 				}
 			}
@@ -1849,6 +1842,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 				}
 				else
 				{
+					bg_character_t *character = CG_CharacterForClientinfo(&cgs.clientinfo[clientNum], cent);
 					trap_S_StartSound(NULL, es->number, CHAN_AUTO, cgs.media.landSound[character->animModelInfo->footsteps]);
 				}
 			}
@@ -1887,6 +1881,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 				}
 				else
 				{
+					bg_character_t *character = CG_CharacterForClientinfo(&cgs.clientinfo[clientNum], cent);
 					trap_S_StartSound(NULL, es->number, CHAN_AUTO, cgs.media.landSound[character->animModelInfo->footsteps]);
 				}
 			}

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -2881,7 +2881,10 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 			break;
 		}
 
-		len = 1.0f - (len / (float)cent->currentState.onFireStart);
+		if (cent->currentState.onFireStart != 0)
+		{
+			len = 1.0f - len / cent->currentState.onFireStart;
+		}
 		len = std::min(1.f, len);
 
 		CG_StartShakeCamera(len, es);

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -2681,7 +2681,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		break;
 
 	case EV_FLAMETHROWER_EFFECT:
-		CG_FireFlameChunks(cent, cent->currentState.origin, cent->currentState.apos.trBase, 0.6, (qboolean)2);
+		CG_FireFlameChunks(cent, cent->currentState.origin, cent->currentState.apos.trBase, 0.6, qtrue);
 		break;
 
 	case EV_DUST:

--- a/src/cgame/cg_limbopanel.cpp
+++ b/src/cgame/cg_limbopanel.cpp
@@ -2368,7 +2368,7 @@ int CG_LimboPanel_RenderCounter_ValueForButton(panel_button_t *button)
 	return 0;
 }
 
-int CG_LimboPanel_RenderCounter_RollTimeForButton(panel_button_t *button)
+float CG_LimboPanel_RenderCounter_RollTimeForButton(panel_button_t *button)
 {
 	float diff;
 	switch (button->data[0])
@@ -2376,25 +2376,21 @@ int CG_LimboPanel_RenderCounter_RollTimeForButton(panel_button_t *button)
 	case 0:     // class counts
 	case 1:     // team counts
 		return 100.f;
-
 	case 4:     // skills
 		return 1000.f;
-
 	case 6:     // stats
 		diff = std::abs(button->data[3] - CG_LimboPanel_RenderCounter_ValueForButton(button));
 		if (diff < 5)
 		{
-			return 200.f / diff;
+			return (diff == 0 ? 1000.f : 200.f / diff);
 		}
-		else
-		{
-			return 50.f;
-		}
-
+		return 50.f;
 	case 5:     // clock
 	case 3:     // respawn time
 	case 2:     // xp
 		return 50.f;
+	default:
+		break;
 	}
 
 	return 1000.f;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3564,11 +3564,8 @@ void        CG_FreeCamera(int camNum);
 
 bg_playerclass_t *CG_PlayerClassForClientinfo(clientInfo_t *ci, centity_t *cent);
 
-void CG_FitTextToWidth(char *instr, int w, int size);
-void CG_FitTextToWidth2(char *instr, float scale, float w, int size);
 void CG_FitTextToWidth_Ext(char *instr, float scale, float w, int size, fontInfo_t *font);
 int CG_TrimLeftPixels(char *instr, float scale, float w, int size);
-void CG_FitTextToWidth_SingleLine(char *instr, float scale, float w, int size);
 
 void CG_LocateCampaign(void);
 void CG_LocateArena(void);

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -226,9 +226,9 @@ typedef struct
 	float backlerp;
 
 	float yawAngle;
-	qboolean yawing;
+	int yawing;                     // 0 = off, 1 = right, 2 = left
 	float pitchAngle;
-	qboolean pitching;
+	int pitching;                   // 0 = off, 1/2 presumably up/down, however 2 unused
 
 	int animationNumber;            // may include ANIM_TOGGLEBIT
 	int oldAnimationNumber;         // may include ANIM_TOGGLEBIT

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1071,12 +1071,12 @@ namespace ETJump
 	// General purpose etj_hideMe check for cgame events
 	bool hideMeCheck(int entityNum)
 	{
-		auto ci = &cgs.clientinfo[entityNum];
-		bool isHiddenPlayer = ci->hideMe && entityNum != cg.clientNum;
 		if (entityNum < MAX_CLIENTS)
 		{
-			if (isHiddenPlayer)
+			// entity is a player
+			if (cgs.clientinfo[entityNum].hideMe && entityNum != cg.clientNum)
 			{
+				// player is hidden and it is not ourselves
 				return true;
 			}
 		}

--- a/src/cgame/cg_newDraw.cpp
+++ b/src/cgame/cg_newDraw.cpp
@@ -85,6 +85,11 @@ void CG_FitTextToWidth_Ext(char *instr, float scale, float w, int size, fontInfo
 	char *s, *p, *c, *ls;
 	int  l;
 
+	if (*instr == '\0')
+	{
+		return;
+	}
+
 	Q_strncpyz(buffer, instr, 1024);
 	memset(instr, 0, size);
 

--- a/src/cgame/cg_newDraw.cpp
+++ b/src/cgame/cg_newDraw.cpp
@@ -3,53 +3,6 @@
 
 int CG_DrawField(int x, int y, int width, int value, int charWidth, int charHeight, qboolean dodrawpic, qboolean leftAlign);        // NERVE - SMF
 
-/*void CG_FitTextToWidth( char* instr, int w, int size) {
-    char buffer[1024];
-    char	*s, *p, *c, *ls;
-    int		l;
-
-    strcpy(buffer, instr);
-    memset(instr, 0, size);
-
-    c = s = instr;
-    p = buffer;
-    ls = NULL;
-    l = 0;
-    while(*p) {
-        *c = *p++;
-        l++;
-
-        if(*c == ' ') {
-            ls = c;
-        } // store last space, to try not to break mid word
-
-        c++;
-
-        if(*p == '\n') {
-            s = c+1;
-            l = 0;
-        } else if(l > w) {
-            if(ls) {
-                *ls = '\n';
-                l = strlen(ls+1);
-            } else {
-                *c = *(c-1);
-                *(c-1) = '\n';
-                s = c++;
-                l = 0;
-            }
-
-            ls = NULL;
-        }
-    }
-
-    if(c != buffer && (*(c-1) != '\n')) {
-        *c++ = '\n';
-    }
-
-    *c = '\0';
-}*/
-
 int CG_TrimLeftPixels(char *instr, float scale, float w, int size)
 {
 	char buffer[1024];
@@ -139,83 +92,6 @@ void CG_FitTextToWidth_Ext(char *instr, float scale, float w, int size, fontInfo
 	}
 
 	*c = '\0';
-}
-
-void CG_FitTextToWidth2(char *instr, float scale, float w, int size)
-{
-	char buffer[1024];
-	char *s, *p, *c, *ls;
-	int  l;
-
-	Q_strncpyz(buffer, instr, 1024);
-	memset(instr, 0, size);
-
-	c  = s = instr;
-	p  = buffer;
-	ls = NULL;
-	l  = 0;
-	while (*p)
-	{
-		*c = *p++;
-		l++;
-
-		if (*c == ' ')
-		{
-			ls = c;
-		} // store last space, to try not to break mid word
-
-		c++;
-
-		if (*p == '\n')
-		{
-			s = c + 1;
-			l = 0;
-		}
-		else if (CG_Text_Width(s, scale, 0) > w)
-		{
-			if (ls)
-			{
-				*ls = '\n';
-				s   = ls + 1;
-			}
-			else
-			{
-				*c       = *(c - 1);
-				*(c - 1) = '\n';
-				s        = c++;
-			}
-
-			ls = NULL;
-			l  = 0;
-		}
-	}
-
-	if (c != buffer && (*(c - 1) != '\n'))
-	{
-		*c++ = '\n';
-	}
-
-	*c = '\0';
-}
-
-void CG_FitTextToWidth_SingleLine(char *instr, float scale, float w, int size)
-{
-	char *s, *p;
-	char buffer[1024];
-
-	Q_strncpyz(buffer, instr, 1024);
-	memset(instr, 0, size);
-	p = instr;
-
-	for (s = buffer; *s; s++, p++)
-	{
-		*p = *s;
-		if (CG_Text_Width(instr, scale, 0) > w)
-		{
-			*p = '\0';
-			return;
-		}
-	}
 }
 
 /*

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -1045,7 +1045,7 @@ CG_SwingAngles
 ==================
 */
 static void CG_SwingAngles(float destination, float swingTolerance, float clampTolerance,
-                           float speed, float *angle, qboolean *swinging)
+                           float speed, float *angle, int *swinging)
 {
 	float swing;
 	float move;
@@ -1087,7 +1087,7 @@ static void CG_SwingAngles(float destination, float swingTolerance, float clampT
 		}
 		else
 		{
-			*swinging = (qboolean)SWING_LEFT;     // left
+			*swinging = SWING_LEFT;     // left
 		}
 		*angle = AngleMod(*angle + move);
 	}
@@ -1101,7 +1101,7 @@ static void CG_SwingAngles(float destination, float swingTolerance, float clampT
 		}
 		else
 		{
-			*swinging = (qboolean)SWING_RIGHT;    // right
+			*swinging = SWING_RIGHT;    // right
 		}
 		*angle = AngleMod(*angle + move);
 	}
@@ -2805,7 +2805,7 @@ CG_SwingAngles_Limbo
 ==================
 */
 static void CG_SwingAngles_Limbo(float destination, float swingTolerance, float clampTolerance,
-                                 float speed, float *angle, qboolean *swinging)
+                                 float speed, float *angle, int *swinging)
 {
 	float swing;
 	float move;

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -1371,8 +1371,6 @@ static void CG_BreathPuffs(centity_t *cent, refEntity_t *head)
 	int          contents;
 	vec3_t       mang, morg, maxis[3];
 
-	ci = &cgs.clientinfo[cent->currentState.number];
-
 	if (!cg_enableBreath.integer)
 	{
 		return;
@@ -1383,7 +1381,7 @@ static void CG_BreathPuffs(centity_t *cent, refEntity_t *head)
 		return;
 	}
 
-	if (!(cent->currentState.eFlags & EF_DEAD))
+	if (cent->currentState.eFlags & EF_DEAD)
 	{
 		return;
 	}
@@ -1399,6 +1397,8 @@ static void CG_BreathPuffs(centity_t *cent, refEntity_t *head)
 	{
 		return;
 	}
+
+	ci = &cgs.clientinfo[cent->currentState.number];
 	if (ci->breathPuffTime > cg.time)
 	{
 		return;

--- a/src/cgame/cg_playerstate.cpp
+++ b/src/cgame/cg_playerstate.cpp
@@ -32,7 +32,7 @@ void CG_CheckAmmo(void)
 
 	for (i = 0 ; i < WP_NUM_WEAPONS ; i++)
 	{
-		if (!(weapons[0] & (1 << i)))
+		if (!(static_cast<long>(weapons[0]) & (1L << i)))
 		{
 			continue;
 		}

--- a/src/cgame/cg_playerstate.cpp
+++ b/src/cgame/cg_playerstate.cpp
@@ -14,16 +14,12 @@ CG_CheckAmmo
 If the ammo has gone low enough to generate the warning, play a sound
 ==============
 */
-void CG_CheckAmmo(void)
+static void CG_CheckAmmo(const playerState_t *ps)
 {
 	int i;
 	int total;
-	int weapons[MAX_WEAPONS / (sizeof(int) * 8)];
 
-	// see about how many seconds of ammo we have remaining
-	memcpy(weapons, cg.snap->ps.weapons, sizeof(weapons));
-
-	if (!weapons[0] && !weapons[1])  // (SA) we start out with no weapons, so don't make a click on startup
+	if (!ps->weapons[0] && !ps->weapons[1])  // (SA) we start out with no weapons, so don't make a click on startup
 	{
 		return;
 	}
@@ -32,7 +28,7 @@ void CG_CheckAmmo(void)
 
 	for (i = 0 ; i < WP_NUM_WEAPONS ; i++)
 	{
-		if (!(static_cast<long>(weapons[0]) & (1L << i)))
+		if (!(COM_BitCheck(ps->weapons, i)))
 		{
 			continue;
 		}
@@ -63,10 +59,10 @@ void CG_CheckAmmo(void)
 		case WP_K43:
 		case WP_MORTAR_SET:
 		default:
-			total += cg.snap->ps.ammo[BG_FindAmmoForWeapon((weapon_t)i)] * 1000;
+			total += ps->ammo[BG_FindAmmoForWeapon(static_cast<weapon_t>(i))] * 1000;
 			break;
 //			default:
-//				total += cg.snap->ps.ammo[BG_FindAmmoForWeapon(i)] * 200;
+//				total += ps->ammo[BG_FindAmmoForWeapon(static_cast<weapon_t>(i))] * 200;
 //				break;
 		}
 
@@ -606,7 +602,7 @@ void CG_TransitionPlayerState(playerState_t *ps, playerState_t *ops)
 	}
 
 	// check for going low on ammo
-	CG_CheckAmmo();
+	CG_CheckAmmo(ps);
 
 	if (ps->eFlags & EF_PRONE_MOVING)
 	{

--- a/src/cgame/cg_snapshot.cpp
+++ b/src/cgame/cg_snapshot.cpp
@@ -536,7 +536,7 @@ static snapshot_t *CG_ReadNextSnapshot(void)
 					}
 					// shifting back all eTypes in demo, so it would match the current enum order
 					else if (es->eType > 9) {
-						es->eType = static_cast<entityType_t>(es->eType - 1);
+						--es->eType;
 					}
 				}
 			}

--- a/src/cgame/cg_trails.cpp
+++ b/src/cgame/cg_trails.cpp
@@ -727,11 +727,10 @@ void CG_AddTrailToScene(trailJunc_t *trail, int iteration, int numJuncs)
 		}
 		else
 		{
-			//s += sInc;
-			s += VectorDistance(j->pos, jNext->pos) / sInc;
-			if (s > 1.0)
+			s += (sInc == 0 ? 1.0f : VectorDistance(j->pos, jNext->pos) / sInc);
+			if (s > 1.0f)
 			{
-				s = 1.0;
+				s = 1.0f;
 			}
 		}
 

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -7029,6 +7029,7 @@ void CG_Bullet(vec3_t end, int sourceEntityNum, vec3_t normal, qboolean flesh, i
 	cent = &cg_entities[fleshEntityNum];
 
 	// Hideme check to prevent tracers & impact sounds
+	// FIXME: currently this works for players only
 	if (ETJump::hideMeCheck(sourceEntityNum))
 	{
 		return;

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -506,6 +506,12 @@ static void PM_Friction(void)
 	}
 
 	speed = VectorLength(vec);
+
+	if (speed == 0)
+	{
+		return;
+	}
+
 	// rain - #179 don't do this for PM_SPECTATOR/PM_NOCLIP, we always want them to stop
 	if (speed < 1 && pm->ps->pm_type != PM_SPECTATOR && pm->ps->pm_type != PM_NOCLIP)
 	{

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -2121,7 +2121,7 @@ static void PM_CrashLand(void)
 	float c = -dist;
 
 	float den = b * b - 4 * a * c;
-	if (den < 0)
+	if (a == 0 || den < 0)
 	{
 		return;
 	}

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -3920,6 +3920,14 @@ void PM_AdjustAimSpreadScale(void)
 	float increase, decrease;       // (SA) was losing lots of precision on slower weapons (scoped)
 	float viewchange, cmdTime, wpnScale;
 
+	cmdTime = (pm->cmd.serverTime - pm->oldcmd.serverTime) / 1000.0f;
+
+	if (cmdTime == 0)
+	{
+		// no time has passed for whatever reason
+		return;
+	}
+
 	// all weapons are very inaccurate in zoomed mode
 	if (pm->ps->eFlags & EF_ZOOMING)
 	{
@@ -3927,8 +3935,6 @@ void PM_AdjustAimSpreadScale(void)
 		pm->ps->aimSpreadScaleFloat = 255;
 		return;
 	}
-
-	cmdTime = (float)(pm->cmd.serverTime - pm->oldcmd.serverTime) / 1000.0;
 
 	wpnScale = 0.0f;
 	switch (pm->ps->weapon)

--- a/src/game/g_utils.cpp
+++ b/src/game/g_utils.cpp
@@ -789,7 +789,7 @@ gentity_t *G_TempEntity(vec3_t origin, int event)
 	vec3_t    snapped;
 
 	e          = G_Spawn();
-	e->s.eType = static_cast<entityType_t>(ET_EVENTS + event);
+	e->s.eType = ET_EVENTS + event;
 
 	e->classname      = "tempEntity";
 	e->eventTime      = level.time;
@@ -811,7 +811,7 @@ gentity_t *G_PopupMessage(popupMessageType_t type)
 	gentity_t *e;
 
 	e                 = G_Spawn();
-	e->s.eType        = static_cast<entityType_t>(ET_EVENTS + EV_POPUPMESSAGE);
+	e->s.eType        = ET_EVENTS + EV_POPUPMESSAGE;
 	e->classname      = "messageent";
 	e->eventTime      = level.time;
 	e->r.eventTime    = level.time;

--- a/src/game/q_math.cpp
+++ b/src/game/q_math.cpp
@@ -166,7 +166,7 @@ vec3_t bytedirs[NUMVERTEXNORMALS] =
 
 int     Q_rand(int *seed)
 {
-	*seed = (69069 * *seed + 1);
+	*seed = (69069L * *seed + 1);
 	return *seed;
 }
 

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -1520,8 +1520,8 @@ typedef enum
 
 typedef struct entityState_s
 {
-	int number;                     // entity index
-	entityType_t eType;             // entityType_t
+	int number;             // entity index
+	int eType;              // changed from entityType_t to int to allow ET_EVENTS + eventNum
 	int eFlags;
 
 	trajectory_t pos;       // for calculating position

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -536,9 +536,9 @@ typedef struct
 	float backlerp;
 
 	float yawAngle;
-	qboolean yawing;
+	int yawing;                     // 0 = off, 1 = right, 2 = left
 	float pitchAngle;
-	qboolean pitching;
+	int pitching;                   // 0 = off, 1/2 presumably up/down, however 2 unused
 
 	int animationNumber;            // may include ANIM_TOGGLEBIT
 	animation_t *animation;

--- a/src/ui/ui_players.cpp
+++ b/src/ui/ui_players.cpp
@@ -492,7 +492,7 @@ UI_SwingAngles
 ==================
 */
 static void UI_SwingAngles(float destination, float swingTolerance, float clampTolerance,
-                           float speed, float *angle, qboolean *swinging)
+                           float speed, float *angle, int *swinging)
 {
 	float swing;
 	float move;

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -9836,6 +9836,11 @@ void BG_FitTextToWidth_Ext(char *instr, float scale, float w, int size, fontInfo
 	char *s, *p, *c, *ls;
 	int  l;
 
+	if (*instr == '\0')
+	{
+		return;
+	}
+
 	Q_strncpyz(buffer, instr, 1024);
 	memset(instr, 0, size);
 

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -4691,7 +4691,7 @@ static float GetCharWidth(const char *symbol, float scale, fontInfo_t *font)
 
 	if (symbol)
 	{
-		glyph = &font->glyphs[static_cast<std::size_t>(*symbol)];
+		glyph = &font->glyphs[static_cast<unsigned char>(*symbol)];
 		out = glyph->xSkip;
 	}
 	return out * scale * font->glyphScale;

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -2577,22 +2577,14 @@ qboolean Item_SetFocus(itemDef_t *item, float x, float y)
 int Item_ListBox_MaxScroll(itemDef_t *item)
 {
 	listBoxDef_t *listPtr = (listBoxDef_t *)item->typeData;
-	int          count    = DC->feederCount(item->special);
-	int          max;
+	int max = DC->feederCount(item->special);
 
-	if (item->window.flags & WINDOW_HORIZONTAL)
+	if (max > 0)
 	{
-		max = count - (int)(item->window.rect.w / listPtr->elementWidth);
+		max -= static_cast<int>(item->window.flags & WINDOW_HORIZONTAL ? item->window.rect.w / listPtr->elementWidth : item->window.rect.h / listPtr->elementHeight);
 	}
-	else
-	{
-		max = count - (int)(item->window.rect.h / listPtr->elementHeight);
-	}
-	if (max < 0)
-	{
-		return 0;
-	}
-	return max;
+
+	return std::max(0, max);
 }
 
 int Item_ListBox_ThumbPosition(itemDef_t *item)


### PR DESCRIPTION
Fixes (common) modsided errors showing up at runtime with the following instrumentation flags:
`-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=pointer-compare -fsanitize=pointer-subtract -fsanitize=leak -fsanitize=undefined`