### PR TITLE
Parse shared and other systeminfo keys directly

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -1312,7 +1312,7 @@ static void CG_DrawLagometer(void)
 
 	if (cg_nopredict.integer
 #ifdef ALLOW_GSYNC
-	    || cg_synchronousClients.integer
+	    || cgs.synchronousClients
 #endif // ALLOW_GSYNC
 	    )
 	{
@@ -3265,7 +3265,7 @@ static void CG_DrawOB(void)
 
 	playerState_t *ps = ETJump::getValidPlayerState();
 
-	psec    = pmove_msec.integer / 1000.0;
+	psec    = cgs.pmove_msec / 1000.0;
 	gravity = ps->gravity;
 	v0      = ps->velocity[2];
 	h0      = ps->origin[2] + ps->mins[2];
@@ -3437,7 +3437,7 @@ static void CG_DrawJumpDelay(void)
 
 	if (trace.surfaceFlags & SURF_NOJUMPDELAY)
 	{
-		if (shared.integer & BG_LEVEL_NO_JUMPDELAY)
+		if (cgs.shared & BG_LEVEL_NO_JUMPDELAY)
 		{
 			CG_DrawStringExt(x, y, "D", colorWhite, qfalse, qtrue, TINYCHAR_WIDTH, TINYCHAR_HEIGHT, 0);
 		}
@@ -3518,12 +3518,12 @@ static void CG_DrawSaveIndicator(void)
 	{
 		ETJump::drawSaveIcon(x, y);
 		// level no save AND not in the volume
-		if ((shared.integer & BG_LEVEL_NO_SAVE) && trace.fraction == 1.0)
+		if ((cgs.shared & BG_LEVEL_NO_SAVE) && trace.fraction == 1.0)
 		{
 			ETJump::drawForbidIcon(x, y);
 		}
 		// level save AND in the volume
-		else if (!(shared.integer & BG_LEVEL_NO_SAVE) && trace.fraction != 1.0)
+		else if (!(cgs.shared & BG_LEVEL_NO_SAVE) && trace.fraction != 1.0)
 		{
 			ETJump::drawForbidIcon(x, y);
 		}
@@ -3536,7 +3536,7 @@ static void CG_DrawSaveIndicator(void)
 		{
 			ETJump::drawSaveIcon(x, y);
 			// level no save
-			if (shared.integer & BG_LEVEL_NO_SAVE)
+			if (cgs.shared & BG_LEVEL_NO_SAVE)
 			{
 				ETJump::drawForbidIcon(x, y);
 			}
@@ -3550,7 +3550,7 @@ static void CG_DrawSaveIndicator(void)
 		{
 			ETJump::drawSaveIcon(x, y);
 			// level save
-			if (!(shared.integer & BG_LEVEL_NO_SAVE))
+			if (!(cgs.shared & BG_LEVEL_NO_SAVE))
 			{
 				ETJump::drawForbidIcon(x, y);
 			}
@@ -3588,12 +3588,12 @@ static void CG_DrawProneIndicator(void)
 	{
 		ETJump::drawProneIcon(x, y);
 		// level no prone AND not in the volume
-		if ((shared.integer & BG_LEVEL_NO_PRONE) && trace.fraction == 1.0)
+		if ((cgs.shared & BG_LEVEL_NO_PRONE) && trace.fraction == 1.0)
 		{
 			ETJump::drawForbidIcon(x, y);
 		}
 		// level prone AND in the volume
-		else if (!(shared.integer & BG_LEVEL_NO_PRONE) && trace.fraction != 1.0)
+		else if (!(cgs.shared & BG_LEVEL_NO_PRONE) && trace.fraction != 1.0)
 		{
 			ETJump::drawForbidIcon(x, y);
 		}
@@ -3606,7 +3606,7 @@ static void CG_DrawProneIndicator(void)
 		{
 			ETJump::drawProneIcon(x, y);
 			// level no prone
-			if (shared.integer & BG_LEVEL_NO_PRONE)
+			if (cgs.shared & BG_LEVEL_NO_PRONE)
 			{
 				ETJump::drawForbidIcon(x, y);
 			}
@@ -3620,7 +3620,7 @@ static void CG_DrawProneIndicator(void)
 		{
 			ETJump::drawProneIcon(x, y);
 			// level prone
-			if (!(shared.integer & BG_LEVEL_NO_PRONE))
+			if (!(cgs.shared & BG_LEVEL_NO_PRONE))
 			{
 				ETJump::drawForbidIcon(x, y);
 			}
@@ -3640,7 +3640,7 @@ static void CG_DrawPronePrint(void)
 
 	CG_TraceCapsule(&trace, ps->origin, ps->mins, ps->maxs, ps->origin, ps->clientNum, CONTENTS_NOPRONE);
 
-	if (shared.integer & BG_LEVEL_NO_PRONE)
+	if (cgs.shared & BG_LEVEL_NO_PRONE)
 	{
 		if (trace.fraction != 1.0f)
 		{

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -1926,7 +1926,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 			if (cg.demoPlayback || (cg.snap->ps.pm_flags & PMF_FOLLOW) ||
 			    cg_nopredict.integer
 #ifdef ALLOW_GSYNC
-			    || cg_synchronousClients.integer
+			    || cgs.synchronousClients
 #endif // ALLOW_GSYNC
 			    )
 			{

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1958,6 +1958,12 @@ typedef struct
 	gametype_t gametype;
 	int antilag;
 
+	int shared;
+	int pmove_msec;
+#ifdef ALLOW_GSYNC
+	qboolean synchronousClients;
+#endif
+
 	float timelimit;                        // NERVE - SMF - made this a float
 	int maxclients;
 	char mapname[MAX_QPATH];
@@ -2247,9 +2253,6 @@ extern vmCvar_t cg_thirdPersonAngle;
 extern vmCvar_t cg_thirdPerson;
 extern vmCvar_t cg_stereoSeparation;
 extern vmCvar_t cg_lagometer;
-#ifdef ALLOW_GSYNC
-extern vmCvar_t cg_synchronousClients;
-#endif // ALLOW_GSYNC
 extern vmCvar_t cg_teamChatTime;
 extern vmCvar_t cg_teamChatHeight;
 extern vmCvar_t cg_stats;
@@ -2268,7 +2271,6 @@ extern vmCvar_t cg_enableBreath;
 extern vmCvar_t cg_autoactivate;
 extern vmCvar_t cg_smoothClients;
 extern vmCvar_t pmove_fixed;
-extern vmCvar_t pmove_msec;
 
 extern vmCvar_t cg_cameraOrbit;
 extern vmCvar_t cg_cameraOrbitDelay;
@@ -3248,6 +3250,7 @@ void CG_FreecamGetPos_f(void);
 //
 void CG_ExecuteNewServerCommands(int latestSequence);
 void CG_ParseServerinfo(void);
+void CG_ParseSysteminfo( void );
 void CG_ParseWolfinfo(void);            // NERVE - SMF
 void CG_ParseSpawns(void);
 void CG_ParseServerVersionInfo(const char *pszVersionInfo);

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -196,9 +196,6 @@ vmCvar_t cg_thirdPersonRange;
 vmCvar_t cg_thirdPersonAngle;
 vmCvar_t cg_stereoSeparation;
 vmCvar_t cg_lagometer;
-#ifdef ALLOW_GSYNC
-vmCvar_t cg_synchronousClients;
-#endif // ALLOW_GSYNC
 vmCvar_t cg_teamChatTime;
 vmCvar_t cg_teamChatHeight;
 vmCvar_t cg_stats;
@@ -216,7 +213,6 @@ vmCvar_t cg_blinktime;      //----(SA)	added
 
 vmCvar_t cg_smoothClients;
 vmCvar_t pmove_fixed;
-vmCvar_t pmove_msec;
 
 // Rafael - particle switch
 vmCvar_t cg_wolfparticles;
@@ -713,7 +709,6 @@ cvarTable_t cvarTable[] =
 	{ &cg_timescale,                "timescale",                   "1",                      0                        },
 	{ &cg_cameraMode,               "com_cameraMode",              "0",                      CVAR_CHEAT               },
 	{ &pmove_fixed,                 "pmove_fixed",                 "1",                      0                        },
-	{ &pmove_msec,                  "pmove_msec",                  "8",                      CVAR_CHEAT               },
 	{ &cg_noTaunt,                  "cg_noTaunt",                  "0",                      CVAR_ARCHIVE             }, // NERVE - SMF
 	{ &cg_voiceSpriteTime,          "cg_voiceSpriteTime",          "6000",                   CVAR_ARCHIVE             }, // DHM - Nerve
 	{ &cg_smallFont,                "ui_smallFont",                "0.25",                   CVAR_ARCHIVE             },
@@ -3621,6 +3616,7 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
 	cg.warmupCount = -1;
 
 	CG_ParseServerinfo();
+	CG_ParseSysteminfo();
 	CG_ParseWolfinfo();             // NERVE - SMF
 
 	cgs.campaignInfoLoaded = qfalse;

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -971,7 +971,7 @@ void CG_PredictPlayerState(void)
 	// non-predicting local movement will grab the latest angles
 	if (cg_nopredict.integer
 #ifdef ALLOW_GSYNC
-	    || cg_synchronousClients.integer
+	    || cgs.synchronousClients
 #endif // ALLOW_GSYNC
 	    )
 	{
@@ -1127,20 +1127,11 @@ void CG_PredictPlayerState(void)
 	cg.physicsTime          = cg.snap->serverTime;
 //	}
 
-	if (pmove_msec.integer < 8)
-	{
-		trap_Cvar_Set("pmove_msec", "8");
-	}
-	else if (pmove_msec.integer > 33)
-	{
-		trap_Cvar_Set("pmove_msec", "33");
-	}
-
 	cg_pmove.pmove_fixed = pmove_fixed.integer;
-	cg_pmove.pmove_msec  = pmove_msec.integer;
+	cg_pmove.pmove_msec  = cgs.pmove_msec;
 
 	// Zero: shared values between server & client
-	cg_pmove.shared = shared.integer;
+	cg_pmove.shared = cgs.shared;
 
 	// run cmds
 	moved = qfalse;
@@ -1255,7 +1246,7 @@ void CG_PredictPlayerState(void)
 
 		if (cg_pmove.pmove_fixed)
 		{
-			cg_pmove.cmd.serverTime = ((cg_pmove.cmd.serverTime + pmove_msec.integer - 1) / pmove_msec.integer) * pmove_msec.integer;
+			cg_pmove.cmd.serverTime = ((cg_pmove.cmd.serverTime + cgs.pmove_msec - 1) / cgs.pmove_msec) * cgs.pmove_msec;
 		}
 
 		// ydnar: if server respawning, freeze the player

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -144,6 +144,29 @@ void CG_ParseServerinfo(void)
 	trap_Cvar_Set("cg_ui_voteFlags", Info_ValueForKey(info, "voteFlags"));
 }
 
+void CG_ParseSysteminfo( void ) {
+	// force original cvars to match the shadow values
+	for (auto &cvarShadow : ETJump::cvarShadows)
+	{
+		cvarShadow.get()->forceCvarSet();
+	}
+
+	const char *info = CG_ConfigString( CS_SYSTEMINFO );
+
+    cgs.shared = atoi(Info_ValueForKey(info, "shared"));
+
+	cgs.pmove_msec = atoi( Info_ValueForKey( info, "pmove_msec" ) );
+	if ( cgs.pmove_msec < 8 ) {
+		cgs.pmove_msec = 8;
+	} else if ( cgs.pmove_msec > 33 ) {
+		cgs.pmove_msec = 33;
+	}
+
+#ifdef ALLOW_GSYNC
+	cgs.synchronousClients = ( atoi( Info_ValueForKey( info, "g_synchronousClients" ) ) ) ? qtrue : qfalse;
+#endif
+}
+
 /*
 ==================
 CG_ParseWarmup
@@ -676,6 +699,10 @@ static void CG_ConfigStringModified(void)
 	{
 		CG_ParseServerinfo();
 	}
+	else if (num == CS_SYSTEMINFO)
+	{
+		CG_ParseSysteminfo();
+	}
 	else if (num == CS_WARMUP)
 	{
 		CG_ParseWarmup();
@@ -828,14 +855,6 @@ static void CG_ConfigStringModified(void)
 	else if (num >= CS_OID_DATA && num < CS_OID_DATA + MAX_OID_TRIGGERS)
 	{
 		CG_ParseOIDInfo(num);
-	}
-	else if (num == CS_SYSTEMINFO)
-	{
-		// force original cvars to match the shadow values
-		for (auto &cvarShadow : ETJump::cvarShadows)
-		{
-			cvarShadow.get()->forceCvarSet();
-		}
 	}
 }
 

--- a/src/cgame/cg_snapshot.cpp
+++ b/src/cgame/cg_snapshot.cpp
@@ -340,7 +340,7 @@ static void CG_TransitionSnapshot(void)
 		if (cg.demoPlayback || (cg.snap->ps.pm_flags & PMF_FOLLOW)
 		    || cg_nopredict.integer
 #ifdef ALLOW_GSYNC
-		    || cg_synchronousClients.integer
+		    || cgs.synchronousClients
 #endif // ALLOW_GSYNC
 		    )
 		{

--- a/src/cgame/etj_overbounce_watcher.cpp
+++ b/src/cgame/etj_overbounce_watcher.cpp
@@ -120,7 +120,7 @@ void ETJump::OverbounceWatcher::render() const
 		return;
 	}
 
-	float psec = pmove_msec.integer / 1000.f;
+	float psec = cgs.pmove_msec / 1000.f;
 	int gravity = ps->gravity;
 	float velocity = ps->velocity[2];
 	float currentHeight = ps->origin[2] + ps->mins[2];

--- a/src/cgame/etj_pmove_utils.cpp
+++ b/src/cgame/etj_pmove_utils.cpp
@@ -83,7 +83,7 @@ namespace ETJump
 		pmove.pointcontents = CG_PointContents;
 		pmove.skill = cgs.clientinfo[cg.snap->ps.clientNum].skill;
 		pmove.cmd = cmd;
-		pmove.pmove_msec = pmove_msec.integer;
+		pmove.pmove_msec = cgs.pmove_msec;
 		PmoveSingle(&pmove);
 		return &pmove;
 	}


### PR DESCRIPTION
Cleaner solution that avoids setting cvars on the client side which are intended to be copies of server settings for prediction.