### PR TITLE
Fix incorrect memset size causing memset to only clear small portion

### DIFF
--- a/src/game/bg_animation.cpp
+++ b/src/game/bg_animation.cpp
@@ -821,7 +821,7 @@ static void BG_ParseCommands(char **input, animScriptItem_t *scriptItem, animMod
 				BG_AnimParseError("BG_ParseCommands: exceeded maximum number of animations (%i)", MAX_ANIMSCRIPT_ANIMCOMMANDS);
 			}
 			command = &scriptItem->commands[scriptItem->numCommands++];
-			memset(command, 0, sizeof(animScriptCommand_t));
+			memset(command, 0, sizeof(*command));
 		}
 
 		command->bodyPart[partIndex] = BG_IndexForString(token, animBodyPartsStr, qtrue);

--- a/src/game/g_character.cpp
+++ b/src/game/g_character.cpp
@@ -86,8 +86,7 @@ static qboolean G_CheckForExistingAnimModelInfo(const char *animationGroup, cons
 	{
 		*animModelInfo = firstFree;
 		// clear the structure out ready for use
-		// FIXME: doesn't actually clear the entire structure, just the sizeof int ptr
-		memset(*animModelInfo, 0, sizeof(animModelInfo_t));
+		memset(*animModelInfo, 0, sizeof(animModelInfo));
 	}
 
 	// qfalse signifies that we need to parse the information from the script files


### PR DESCRIPTION
ET vanilla code bug which was only memsetting the size of int pointer length aka 4 or 8 rather than struct size.