### PR TITLE
Fix multiline tooltip spacing issues

### DIFF
--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -29,6 +29,8 @@ extern itemDef_t *g_editItem;
 
 uiInfo_t uiInfo;
 
+static const int glyphxSkipMax = 14;	// the biggest xSkip value used in glyph mapping
+
 static const char *MonthAbbrev[] =
 {
 	"Jan", "Feb", "Mar",
@@ -454,7 +456,6 @@ int Multiline_Text_Width(const char *text, float scale, int limit)
 	int         count, len;
 	float       out = 0;
 	float       width, widest = 0;
-	glyphInfo_t *glyph;
 	const char  *s    = text;
 	fontInfo_t  *font = &uiInfo.uiDC.Assets.fonts[uiInfo.activeFont];
 
@@ -486,8 +487,10 @@ int Multiline_Text_Width(const char *text, float scale, int limit)
 				}
 				else
 				{
-					glyph = &font->glyphs[(unsigned char)*s];
-					out  += glyph->xSkip;
+					// this will ensure a bit more flexible x spacing in tooltips
+					// since xSkip varies per glyph, but the positioning of glyphs
+					// isn't all that precise, sometimes resulting in badly spaced tooltips
+					out  += glyphxSkipMax;
 				}
 				s++;
 				count++;


### PR DESCRIPTION
Multiline tooltip line height was only taking into account the highest glyph in the tooltip. This caused issues with glyphs such as `_` which are 1. not tall enough to impact the line height and 2. drawn from a Y coordinate with negative value. Since line height was counted as `0 + max`, this completely ignored the space needs for glyphs that started from negative Y coordinate, which caused problems especially with our settings menu tooltips that have the cvar name on the second line, as that always contains an underscore.

For width, using `glyph->xSkip` is problematic because it varies per glyph, but the actual glyph spacing isn't all that precise, sometimes resulting in less space reserved for a glyph than is actually required. Using a fixed (max) glyph width value results in more "relaxed" tooltip width calculation, with a more consistent padding towards the right edge.

Fixes #632 