### PR TITLE
Fix speclock bypass

### DIFF
--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2688,6 +2688,11 @@ void ClientDisconnect(int clientNum)
 		{
 			Cmd_FollowCycle_f(flag, 1);
 		}
+		// invalidate our specinvites
+		if (COM_BitCheck(flag->client->sess.specInvitedClients, clientNum))
+		{
+			COM_BitClear(flag->client->sess.specInvitedClients, clientNum);
+		}
 	}
 
 	if (g_landminetimeout.integer)


### PR DESCRIPTION
Upon disconnect, invalidate any invites we have gotten to spectate other clients, to prevent other clients getting assigned the same clientnum later in the session to bypass speclock.

Fixes #553 