### PR TITLE
Re-utilize cg_drawRoundTimer to display elapsed time from map start

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -622,6 +622,39 @@ static float CG_DrawSpeed(float y)
 	return y + 12 + 4;
 }
 
+/*
+=================
+CG_DrawTimer
+=================
+*/
+
+static float CG_DrawTimer(float y)
+{
+	char   *s;
+	int    w;
+	int    msec;
+	vec4_t color           = { 0.625f, 0.625f, 0.6f, 1.0f };
+	vec4_t timerBackground = { 0.16f, 0.2f, 0.17f, 0.8f };
+	vec4_t timerBorder     = { 0.5f, 0.5f, 0.5f, 0.5f };
+
+	msec = cg.time - cgs.levelStartTime;
+
+	auto seconds = (msec / 1000) % 60 ;
+	auto minutes = ((msec / (1000 * 60)) % 60);
+	auto hours   = ((msec / (1000 * 60 * 60)) % 24);
+
+	s = hours > 0 ? va("%02d:%02d:%02d", hours, minutes, seconds) : va("%02d:%02d", minutes, seconds);
+
+	w = CG_Text_Width_Ext(s, 0.19f, 0, &cgs.media.limboFont1);
+
+	CG_FillRect(UPPERRIGHT_X - w - 2, y, w + 5, 12 + 2, timerBackground);
+	CG_DrawRect_FixedBorder(UPPERRIGHT_X - w - 2, y, w + 5, 12 + 2, 1, timerBorder);
+
+	CG_Text_Paint_Ext(UPPERRIGHT_X - w, y + 11, 0.19f, 0.19f, color, s, 0, 0, 0, &cgs.media.limboFont1);
+
+	return y + 12 + 4;
+}
+
 float CG_DrawTime(float y)
 {
 	char    displayTime[12];
@@ -780,9 +813,10 @@ static void CG_DrawUpperRight(void)
 		return;
 	}
 
-	/*if ( cg_drawRoundTimer.integer ) {
+	if (cg_drawRoundTimer.integer)
+	{
 	    y = CG_DrawTimer( y );
-	}*/
+	}
 
 	if (etj_drawClock.integer)
 	{

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -640,8 +640,8 @@ static float CG_DrawTimer(float y)
 	msec = cg.time - cgs.levelStartTime;
 
 	auto seconds = (msec / 1000) % 60 ;
-	auto minutes = ((msec / (1000 * 60)) % 60);
-	auto hours   = ((msec / (1000 * 60 * 60)) % 24);
+	auto minutes = (msec / (1000 * 60)) % 60;
+	auto hours   = (msec / (1000 * 60 * 60)) % 24;
 
 	s = hours > 0 ? va("%02d:%02d:%02d", hours, minutes, seconds) : va("%02d:%02d", minutes, seconds);
 

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -9,6 +9,7 @@
 #include "etj_utilities.h"
 #include "../game/etj_numeric_utilities.h"
 #include "../game/etj_string_utilities.h"
+#include "../game/etj_time_utilities.h"
 
 #define STATUSBARHEIGHT 452
 char *BindingFromName(const char *cvar);
@@ -638,12 +639,9 @@ static float CG_DrawTimer(float y)
 	vec4_t timerBorder     = { 0.5f, 0.5f, 0.5f, 0.5f };
 
 	msec = cg.time - cgs.levelStartTime;
+	auto time = ETJump::toClock(msec, true);
 
-	auto seconds = (msec / 1000) % 60 ;
-	auto minutes = (msec / (1000 * 60)) % 60;
-	auto hours   = (msec / (1000 * 60 * 60)) % 24;
-
-	s = hours > 0 ? va("%02d:%02d:%02d", hours, minutes, seconds) : va("%02d:%02d", minutes, seconds);
+	s = time.hours > 0 ? va("%02d:%02d:%02d", time.hours, time.min, time.sec) : va("%02d:%02d", time.min, time.sec);
 
 	w = CG_Text_Width_Ext(s, 0.19f, 0, &cgs.media.limboFont1);
 

--- a/src/cgame/etj_autodemo_recorder.cpp
+++ b/src/cgame/etj_autodemo_recorder.cpp
@@ -202,7 +202,7 @@ std::string ETJump::AutoDemoRecorder::createTimeString()
 
 std::string ETJump::AutoDemoRecorder::formatRunTime(int millis)
 {
-	Clock clock = toClock(millis);
+	Clock clock = toClock(millis, false);
 	return stringFormat("%02d.%02d.%03d", clock.min, clock.sec, clock.ms);
 }
 

--- a/src/game/etj_time_utilities.cpp
+++ b/src/game/etj_time_utilities.cpp
@@ -40,9 +40,15 @@ ETJump::Clock ETJump::getCurrentClock()
 	return{ tstruct.tm_hour, tstruct.tm_min, tstruct.tm_sec, (int)ms.count() };
 }
 
-ETJump::Clock ETJump::toClock(long long timestamp)
+ETJump::Clock ETJump::toClock(long long timestamp, bool useHours)
 {
-	auto hours = timestamp / 6000;
+	auto hours = timestamp / 3600000;
+
+	if (useHours)
+	{
+		timestamp -= hours * 3600000;
+	}
+
 	auto minutes = timestamp / 60000;
 	timestamp -= minutes * 60000;
 	auto seconds = timestamp / 1000;

--- a/src/game/etj_time_utilities.h
+++ b/src/game/etj_time_utilities.h
@@ -57,7 +57,7 @@ namespace ETJump
 
 	long long getCurrentTimestamp();
 	Clock getCurrentClock();
-	Clock toClock(long long timestamp);
+	Clock toClock(long long timestamp, bool useHours);
 	Date getCurrentDate();
 	Time getCurrentTime();
 }

--- a/src/game/etj_timerun.cpp
+++ b/src/game/etj_timerun.cpp
@@ -285,7 +285,7 @@ std::string diffToString(int selfTime, int otherTime)
 {
 	auto diff = otherTime - selfTime;
 	auto ams = std::abs(diff);
-	auto diffComponents = ETJump::toClock(ams);
+	auto diffComponents = ETJump::toClock(ams, false);
 
 	const char* diffSign;
 	if (diff > 0)


### PR DESCRIPTION
`cg_drawRoundTimer` now displays a timer indication how long the current map has been played for. Displays `MM:SS` up until an hour is played, after which the display swaps into `HH:MM:SS`

Closes #747 