### PR TITLE
Fix toClock hours calculation

### DIFF
--- a/src/cgame/etj_autodemo_recorder.cpp
+++ b/src/cgame/etj_autodemo_recorder.cpp
@@ -202,7 +202,7 @@ std::string ETJump::AutoDemoRecorder::createTimeString()
 
 std::string ETJump::AutoDemoRecorder::formatRunTime(int millis)
 {
-	Clock clock = toClock(millis);
+	Clock clock = toClock(millis, false);
 	return stringFormat("%02d.%02d.%03d", clock.min, clock.sec, clock.ms);
 }
 

--- a/src/game/etj_time_utilities.cpp
+++ b/src/game/etj_time_utilities.cpp
@@ -40,9 +40,15 @@ ETJump::Clock ETJump::getCurrentClock()
 	return{ tstruct.tm_hour, tstruct.tm_min, tstruct.tm_sec, (int)ms.count() };
 }
 
-ETJump::Clock ETJump::toClock(long long timestamp)
+ETJump::Clock ETJump::toClock(long long timestamp, bool useHours)
 {
-	auto hours = timestamp / 6000;
+	auto hours = timestamp / 3600000;
+
+	if (useHours)
+	{
+		timestamp -= hours * 3600000;
+	}
+
 	auto minutes = timestamp / 60000;
 	timestamp -= minutes * 60000;
 	auto seconds = timestamp / 1000;

--- a/src/game/etj_time_utilities.h
+++ b/src/game/etj_time_utilities.h
@@ -57,7 +57,7 @@ namespace ETJump
 
 	long long getCurrentTimestamp();
 	Clock getCurrentClock();
-	Clock toClock(long long timestamp);
+	Clock toClock(long long timestamp, bool useHours);
 	Date getCurrentDate();
 	Time getCurrentTime();
 }

--- a/src/game/etj_timerun.cpp
+++ b/src/game/etj_timerun.cpp
@@ -285,7 +285,7 @@ std::string diffToString(int selfTime, int otherTime)
 {
 	auto diff = otherTime - selfTime;
 	auto ams = std::abs(diff);
-	auto diffComponents = ETJump::toClock(ams);
+	auto diffComponents = ETJump::toClock(ams, false);
 
 	const char* diffSign;
 	if (diff > 0)


### PR DESCRIPTION
Now correctly returns 1 hour every 60 minutes. Optionally can be ignored so that minutes won't roll over from `59 -> 00`.

Fixes #790 