### PR TITLE
Add scoreboard helper func, prevent multiple scoreboard draw calls

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -1434,7 +1434,7 @@ static void CG_DrawWeapReticle(void)
         }*/
 
 		// hairs
-		if (!(cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time))
+		if (!ETJump::showingScores())
 		{
 			CG_FillRect(SCREEN_OFFSET_X + 84, 239, 150, 3, color);    // left
 			CG_FillRect(SCREEN_OFFSET_X + 234, 240, 173, 1, color);   // horiz center
@@ -1461,7 +1461,7 @@ static void CG_DrawWeapReticle(void)
 		}
 
 		// hairs
-		if (!(cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time))
+		if (!ETJump::showingScores())
 		{
 			CG_FillRect(SCREEN_OFFSET_X + 84, 239, 177, 2, color);    // left
 			CG_FillRect(SCREEN_OFFSET_X + 320, 242, 1, 58, color);    // center top
@@ -1837,7 +1837,7 @@ static void CG_DrawBinocReticle(void)
 		CG_FillRect(SCREEN_OFFSET_X + 640, 0, SCREEN_OFFSET_X, 480, color);
 	}
 
-	if (!CG_DrawScoreboard())
+	if (!ETJump::showingScores())
 	{
 		CG_FillRect(SCREEN_OFFSET_X + 146, 239, 348, 1, color);
 
@@ -1943,7 +1943,7 @@ static void CG_DrawCrosshair(void)
 	}
 
 	// any exceptions are handled, we can exit at this point if scoreboard is up
-	if (cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time)
+	if (ETJump::showingScores())
 	{
 		return;
 	}
@@ -2305,7 +2305,7 @@ static void CG_DrawCrosshairNames(void)
 		return;
 	}
 
-	if (cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time)
+	if (ETJump::showingScores())
 	{
 		return;
 	}
@@ -2401,7 +2401,7 @@ static void CG_DrawSpectator(void)
 {
 	const char *s;
 
-	if (cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time)
+	if (ETJump::showingScores())
 	{
 		return;
 	}
@@ -5438,7 +5438,7 @@ static void CG_Draw2D(void)
 
 	CG_DrawDemoRecording();
 
-	if (!CG_DrawScoreboard() && !cgs.demoCam.renderingFreeCam)
+	if (!ETJump::showingScores() && !cgs.demoCam.renderingFreeCam)
 	{
 		CG_DrawNewCompass();
 	}

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4036,6 +4036,7 @@ int checkExtraTrace(int value);
 void onPlayerRespawn(qboolean revived);
 void runFrameEnd();
 playerState_t *getValidPlayerState();
+bool showingScores();
 
 enum extraTraceOptions
 {

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -405,7 +405,7 @@ namespace ETJump
 			return true;
 		}
 
-		if (cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time)
+		if (showingScores())
 		{
 			return true;
 		}

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -166,6 +166,11 @@ namespace ETJump
 		keySetSystem->addKeyBindSet("keyset5");
 	}
 
+	bool showingScores()
+	{
+		return (cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time);
+	}
+
 	// shadow cvars mapping to real cvars, forces locked values change
 	std::vector<std::pair<vmCvar_t*, std::string>> cvars{
 		{ &etj_drawFoliage, "r_drawfoliage"},

--- a/src/cgame/etj_jump_speeds.cpp
+++ b/src/cgame/etj_jump_speeds.cpp
@@ -227,7 +227,7 @@ namespace ETJump
 			return true;
 		}
 
-		if (cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time)
+		if (showingScores())
 		{
 			return true;
 		}

--- a/src/cgame/etj_maxspeed.cpp
+++ b/src/cgame/etj_maxspeed.cpp
@@ -129,5 +129,5 @@ void ETJump::DisplayMaxSpeed::render() const
 
 bool ETJump::DisplayMaxSpeed::canSkipDraw() const
 {
-	return !etj_drawMaxSpeed.integer || cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time;
+	return !etj_drawMaxSpeed.integer || ETJump::showingScores();
 }

--- a/src/cgame/etj_quick_follow_drawable.cpp
+++ b/src/cgame/etj_quick_follow_drawable.cpp
@@ -57,7 +57,7 @@ bool ETJump::QuickFollowDrawer::canSkipDraw() const
 	{
 		return true;
 	}
-	if (cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time)
+	if (ETJump::showingScores())
 	{
 		return true;
 	}

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -425,7 +425,7 @@ namespace ETJump
 			return true;
 		}
 
-		if (cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time)
+		if (showingScores())
 		{
 			return true;
 		}

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -180,7 +180,7 @@ std::string ETJump::DisplaySpeed::getStatus() const
 
 bool ETJump::DisplaySpeed::canSkipDraw() const
 {
-	return !etj_drawSpeed2.integer || cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time;
+	return !etj_drawSpeed2.integer || ETJump::showingScores();
 }
 
 void ETJump::DisplaySpeed::popOldStoredSpeeds()

--- a/src/cgame/etj_strafe_quality_drawable.cpp
+++ b/src/cgame/etj_strafe_quality_drawable.cpp
@@ -248,7 +248,7 @@ namespace ETJump
 			return true;
 		}
 
-		if (cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time)
+		if (showingScores())
 		{
 			return true;
 		}

--- a/src/cgame/etj_timerun_view.cpp
+++ b/src/cgame/etj_timerun_view.cpp
@@ -284,5 +284,5 @@ bool ETJump::TimerunView::parseServerCommand()
 
 bool ETJump::TimerunView::canSkipDraw() const
 {
-	return cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time;
+	return ETJump::showingScores();
 }

--- a/src/cgame/etj_upper_right_drawable.cpp
+++ b/src/cgame/etj_upper_right_drawable.cpp
@@ -63,7 +63,7 @@ void ETJump::UpperRight::beforeRender()
 
 void ETJump::UpperRight::render() const
 {
-	if (!cg_drawFireteamOverlay.integer || cg_paused.integer || cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time)
+	if (cg_paused.integer || ETJump::showingScores())
 	{
 		return;
 	}


### PR DESCRIPTION
- Adds cgame helper function `ETJump::showingScores` to replace `cg.showScores || cg.scoreFadeTime + FADE_TIME > cg.time` checks.
- Fixes scoreboard drawing multiple times due to excess `CG_DrawScoreboard` calls
- Fixes upper right not drawing if `cg_drawFireteamOverlay 0`