### PR TITLE
Optimize CGaz and snaphud drawing

### DIFF
--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -177,7 +177,7 @@ Used by CGaz 2
 ==============
 */
 // Dzikie
-void DrawLine(float x1, float y1, float x2, float y2, vec4_t color)
+void DrawLine(float x1, float y1, float x2, float y2, const vec4_t color)
 {
 	float len, stepx, stepy;
 	float i;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2740,7 +2740,7 @@ void CG_AdjustFrom640(float *x, float *y, float *w, float *h);
 void CG_FillRect(float x, float y, float width, float height, const float *color);
 void CG_FillAngleYaw(float start, float end, float yaw, float y, float h, float fov, vec4_t const color);
 void PutPixel(float x, float y);
-void DrawLine(float x1, float y1, float x2, float y2, vec4_t color);
+void DrawLine(float x1, float y1, float x2, float y2, const vec4_t color);
 float AngleToScreenX(float angle, float fov);
 range_t AnglesToRange(float start, float end, float yaw, float fov);
 void CG_HorizontalPercentBar(float x, float y, float width, float height, float percent);

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -29,9 +29,56 @@
 #include "etj_utilities.h"
 #include "etj_pmove_utils.h"
 #include "../game/etj_numeric_utilities.h"
+#include "etj_cvar_update_handler.h"
 
 namespace ETJump
 {
+	CGaz::CGaz()
+	{
+		// CGaz 1
+		parseColorString(etj_CGaz1Color1.string, CGaz1Colors[0]);
+		parseColorString(etj_CGaz1Color2.string, CGaz1Colors[1]);
+		parseColorString(etj_CGaz1Color3.string, CGaz1Colors[2]);
+		parseColorString(etj_CGaz1Color4.string, CGaz1Colors[3]);
+
+		// CGaz 2
+		parseColorString(etj_CGaz2Color1.string, CGaz2Colors[0]);
+		parseColorString(etj_CGaz2Color2.string, CGaz2Colors[1]);
+
+		startListeners();
+	}
+
+	void CGaz::startListeners()
+	{
+		// CGaz 1
+		cvarUpdateHandler->subscribe(&etj_CGaz1Color1, [&](const vmCvar_t* cvar)
+			{
+				parseColorString(etj_CGaz1Color1.string, CGaz1Colors[0]);
+			});
+		cvarUpdateHandler->subscribe(&etj_CGaz1Color2, [&](const vmCvar_t* cvar)
+			{
+				parseColorString(etj_CGaz1Color2.string, CGaz1Colors[1]);
+			});
+		cvarUpdateHandler->subscribe(&etj_CGaz1Color3, [&](const vmCvar_t* cvar)
+			{
+				parseColorString(etj_CGaz1Color3.string, CGaz1Colors[2]);
+			});
+		cvarUpdateHandler->subscribe(&etj_CGaz1Color4, [&](const vmCvar_t* cvar)
+			{
+				parseColorString(etj_CGaz1Color4.string, CGaz1Colors[3]);
+			});
+
+		// CGaz 2
+		cvarUpdateHandler->subscribe(&etj_CGaz2Color1, [&](const vmCvar_t* cvar)
+			{
+				parseColorString(etj_CGaz2Color1.string, CGaz2Colors[0]);
+			});
+		cvarUpdateHandler->subscribe(&etj_CGaz2Color2, [&](const vmCvar_t* cvar)
+			{
+				parseColorString(etj_CGaz2Color2.string, CGaz2Colors[1]);
+			});
+	}
+
 	void CGaz::UpdateCGaz1(vec3_t wishvel, int8_t uCmdScale, usercmd_t cmd)
 	{
 		// set default key combination if no user input
@@ -194,26 +241,20 @@ namespace ETJump
 				fov = Numeric::clamp(etj_CGazFov.value, 1, 179);
 			}
 
-			vec4_t color;
-
 			// No accel zone
-			parseColorString(etj_CGaz1Color1.string, color);
-			CG_FillAngleYaw(-drawMin, +drawMin, yaw, y, h, fov, color);
+			CG_FillAngleYaw(-drawMin, +drawMin, yaw, y, h, fov, CGaz1Colors[0]);
 
 			// Min angle
-			parseColorString(etj_CGaz1Color2.string, color);
-			CG_FillAngleYaw(+drawMin, +drawOpt, yaw, y, h, fov, color);
-			CG_FillAngleYaw(-drawOpt, -drawMin, yaw, y, h, fov, color);
+			CG_FillAngleYaw(+drawMin, +drawOpt, yaw, y, h, fov, CGaz1Colors[1]);
+			CG_FillAngleYaw(-drawOpt, -drawMin, yaw, y, h, fov, CGaz1Colors[1]);
 
 			// Accel zone
-			parseColorString(etj_CGaz1Color3.string, color);
-			CG_FillAngleYaw(+drawOpt, +drawMaxCos, yaw, y, h, fov, color);
-			CG_FillAngleYaw(-drawMaxCos, -drawOpt, yaw, y, h, fov, color);
+			CG_FillAngleYaw(+drawOpt, +drawMaxCos, yaw, y, h, fov, CGaz1Colors[2]);
+			CG_FillAngleYaw(-drawMaxCos, -drawOpt, yaw, y, h, fov, CGaz1Colors[2]);
 
 			// Max angle
-			parseColorString(etj_CGaz1Color4.string, color);
-			CG_FillAngleYaw(+drawMaxCos, +drawMax, yaw, y, h, fov, color);
-			CG_FillAngleYaw(-drawMax, -drawMaxCos, yaw, y, h, fov, color);
+			CG_FillAngleYaw(+drawMaxCos, +drawMax, yaw, y, h, fov, CGaz1Colors[3]);
+			CG_FillAngleYaw(-drawMax, -drawMaxCos, yaw, y, h, fov, CGaz1Colors[3]);
 
 			return;
 		}
@@ -224,17 +265,13 @@ namespace ETJump
 			const usercmd_t cmd = pm->cmd;
 			int scx = SCREEN_CENTER_X - 1;
 			int scy = SCREEN_CENTER_Y - 1;
-			vec4_t color1, color2;
-
-			parseColorString(etj_CGaz2Color1.string, color1);
-			parseColorString(etj_CGaz2Color2.string, color2);
 
 			if (etj_stretchCgaz.integer)
 			{
 				ETJump_EnableWidthScale(false);
 				scx -= SCREEN_OFFSET_X;
 			}
-			DrawLine(scx, scy, scx + cmd.rightmove, scy - cmd.forwardmove, color2);
+			DrawLine(scx, scy, scx + cmd.rightmove, scy - cmd.forwardmove, CGaz2Colors[1]);
 
 			// When under wishspeed velocity, most accel happens when you move straight
 			// towards your current velocity, so skip drawing the "wings" on the sides
@@ -249,17 +286,17 @@ namespace ETJump
 
 			DrawLine(scx, scy,
 				scx + velSize * sin(drawVel),
-				scy - velSize * cos(drawVel), color1);
+				scy - velSize * cos(drawVel), CGaz2Colors[0]);
 
 			if (drawSides)
 			{
 				velSize /= 2;
 				DrawLine(scx, scy,
 					scx + velSize * sin(drawVel + drawOpt),
-					scy - velSize * cos(drawVel + drawOpt), color1);
+					scy - velSize * cos(drawVel + drawOpt), CGaz2Colors[0]);
 				DrawLine(scx, scy,
 					scx + velSize * sin(drawVel - drawOpt),
-					scy - velSize * cos(drawVel - drawOpt), color1);
+					scy - velSize * cos(drawVel - drawOpt), CGaz2Colors[0]);
 			}
 
 			if (etj_stretchCgaz.integer)

--- a/src/cgame/etj_cgaz.h
+++ b/src/cgame/etj_cgaz.h
@@ -35,6 +35,9 @@ namespace ETJump
 		static bool strafingForwards(const playerState_t& ps, pmove_t* pm);
 		static float getOptAngle(const playerState_t& ps, pmove_t* pm);
 
+		CGaz();
+		~CGaz() {};
+
 		void render() const override;
 		void beforeRender() override;
 
@@ -67,6 +70,8 @@ namespace ETJump
 		float drawMax;
 		float drawVel;
 		float yaw;
+		vec4_t CGaz1Colors[4];
+		vec4_t CGaz2Colors[2];
 
 		bool canSkipDraw() const;
 		void UpdateCGaz1(vec3_t wishvel, int8_t uCmdScale, usercmd_t cmd);
@@ -77,6 +82,7 @@ namespace ETJump
 		float UpdateDrawOpt(state_t const* state);
 		float UpdateDrawMaxCos(state_t const* state, float d_opt);
 		float UpdateDrawMax(state_t const* state, float d_max_cos);
+		void startListeners();
 
 		playerState_t* ps = &cg.predictedPlayerState;
 		pmove_t* pm;

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -36,11 +36,15 @@ namespace ETJump
 		void beforeRender() override;
 		static bool inMainAccelZone(const playerState_t& ps, pmove_t* pm);
 
+		Snaphud();
+		~Snaphud() {};
+
 	private:
 		bool canSkipDraw() const;
 		void InitSnaphud(vec3_t wishvel, int8_t uCmdScale, usercmd_t cmd);
 		void UpdateMaxSnapZones(float wishspeed, pmove_t* pm);
 		void UpdateSnapState(void);
+		void startListeners();
 
 		enum class SnapTrueness
 		{
@@ -63,6 +67,7 @@ namespace ETJump
 		snaphud_t snap;
 
 		int yaw;
+		vec4_t snaphudColors[4];
 
 		playerState_t* ps = &cg.predictedPlayerState;
 		pmove_t* pm;


### PR DESCRIPTION
Moved color parsing from draw functions to init, and added listeners for color changes. CPU time decreased on GCC from ~9% to < 1% for both, MSVC down from 2-3% to < 1%.

![image](https://user-images.githubusercontent.com/14221121/189979883-64fa6315-a4b8-4c3a-a114-9553ef007427.png)
![image](https://user-images.githubusercontent.com/14221121/189979902-8e899d3f-e216-4397-b918-bf03f5a5d2df.png)
