### PR TITLE
Fix prediction errors with crashland

### DIFF
--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -2048,6 +2048,8 @@ static void PM_CheckFallDamage(const float delta)
 	}
 	else if (delta > 67)
 	{
+		pm->ps->pm_time = 1000;
+		pm->ps->pm_flags |= PMF_TIME_KNOCKBACK;
 		PM_AddEventExt(EV_FALL_DMG_50, PM_FootstepForSurface());
 	}
 	else if (delta > 58)
@@ -2055,6 +2057,8 @@ static void PM_CheckFallDamage(const float delta)
 		// this is a pain grunt, so don't play it if dead
 		if (pm->ps->stats[STAT_HEALTH] > 0)
 		{
+			pm->ps->pm_time = 250;
+			pm->ps->pm_flags |= PMF_TIME_KNOCKBACK;
 			PM_AddEventExt(EV_FALL_DMG_25, PM_FootstepForSurface());
 		}
 	}
@@ -2063,6 +2067,8 @@ static void PM_CheckFallDamage(const float delta)
 		// this is a pain grunt, so don't play it if dead
 		if (pm->ps->stats[STAT_HEALTH] > 0)
 		{
+			pm->ps->pm_time = 1000;
+			pm->ps->pm_flags |= PMF_TIME_KNOCKBACK;
 			PM_AddEventExt(EV_FALL_DMG_15, PM_FootstepForSurface());
 		}
 	}
@@ -2071,6 +2077,8 @@ static void PM_CheckFallDamage(const float delta)
 		// this is a pain grunt, so don't play it if dead
 		if (pm->ps->stats[STAT_HEALTH] > 0)
 		{
+			pm->ps->pm_time = 1000;
+			pm->ps->pm_flags |= PMF_TIME_KNOCKBACK;
 			PM_AddEventExt(EV_FALL_DMG_10, PM_FootstepForSurface());
 		}
 	}
@@ -2438,7 +2446,10 @@ static void PM_GroundTrace(void)
 		{
 			// don't allow another jump for a little while
 			pm->ps->pm_flags |= PMF_TIME_LAND;
-			pm->ps->pm_time   = 250;
+			if (pm->ps->pm_time < 250)
+			{
+				pm->ps->pm_time   = 250;
+			}
 		}
 	}
 

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -786,53 +786,6 @@ void ClientEvents(gentity_t *ent, int oldEventSequence)
 			//case EV_FALL_DMG_75:
 
 			crashEvent = event; //Feen: Store for processing after event loop
-
-			// rain - VectorClear() used to be done here whenever falling
-			// damage occured, but I moved it to bg_pmove where it belongs.
-
-			//Feen: Moved outside of event loop - CrashLand Fix
-			/*
-
-			if ( ent->s.eType != ET_PLAYER ) {
-			    break;		// not in the player model
-			}
-			if ( event == EV_FALL_NDIE )
-			{
-			    damage = 9999;
-			}
-			else if (event == EV_FALL_DMG_50)
-			{
-			    damage = 50;
-			    ent->client->ps.pm_time = 1000;
-			    ent->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;
-			}
-			else if (event == EV_FALL_DMG_25)
-			{
-			    damage = 25;
-			    ent->client->ps.pm_time = 250;
-			    ent->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;
-			}
-			else if (event == EV_FALL_DMG_15)
-			{
-			    damage = 15;
-			    ent->client->ps.pm_time = 1000;
-			    ent->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;
-			}
-			else if (event == EV_FALL_DMG_10)
-			{
-			    damage = 10;
-			    ent->client->ps.pm_time = 1000;
-			    ent->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;
-			}
-			else
-			    damage = 5; // never used
-			VectorSet (dir, 0, 0, 1);
-			ent->pain_debounce_time = level.time + 200;	// no normal pain sound
-			G_Damage (ent, NULL, NULL, NULL, NULL, damage, 0, MOD_FALLING);
-			break;
-
-			*/
-
 			break;
 
 		case EV_FIRE_WEAPON_MG42:
@@ -885,23 +838,15 @@ void ClientEvents(gentity_t *ent, int oldEventSequence)
 
 	if (crashEvent > 0)
 	{
-
-
 		if (ent->s.eType != ET_PLAYER)
 		{
 			return;     // not in the player model
 		}
 
-
 		if (!portalEvent)
 		{
-
 			// rain - VectorClear() used to be done here whenever falling
 			// damage occured, but I moved it to bg_pmove where it belongs.
-
-			//un-fixed rain's fix...
-			VectorClear(ent->client->ps.velocity);
-
 
 			if (crashEvent == EV_FALL_NDIE)
 			{
@@ -910,26 +855,18 @@ void ClientEvents(gentity_t *ent, int oldEventSequence)
 			else if (crashEvent == EV_FALL_DMG_50)
 			{
 				damage                    = 50;
-				ent->client->ps.pm_time   = 1000;
-				ent->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;
 			}
 			else if (crashEvent == EV_FALL_DMG_25)
 			{
 				damage                    = 25;
-				ent->client->ps.pm_time   = 250;
-				ent->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;
 			}
 			else if (crashEvent == EV_FALL_DMG_15)
 			{
 				damage                    = 15;
-				ent->client->ps.pm_time   = 1000;
-				ent->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;
 			}
 			else if (crashEvent == EV_FALL_DMG_10)
 			{
 				damage                    = 10;
-				ent->client->ps.pm_time   = 1000;
-				ent->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;
 			}
 			else
 			{
@@ -937,10 +874,7 @@ void ClientEvents(gentity_t *ent, int oldEventSequence)
 			}
 			ent->pain_debounce_time = level.time + 200; // no normal pain sound
 			G_Damage(ent, NULL, NULL, NULL, NULL, damage, 0, MOD_FALLING);
-
-
 		}
-
 	}//Feen: End CrashLand Fix
 
 


### PR DESCRIPTION
Set `pm_time` and `pm_flags` in `bg_pmove` like they are supposed to, to avoid prediction error where client doesn't know yet that it's going to `PMF_TIME_KNOCKBACK` state. Also stop unnecessarily setting `pm_time` to 250 every single time we hit the ground. Also removed Feens un-fix of calling `VectorClear` on crashland in `g_active` because as the comment said, it will cause prediction errors.