### PR TITLE
Fix potential div by 0 on cgaz when running over 125fps

### DIFF
--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -101,6 +101,12 @@ namespace ETJump
 
 	void CGaz::UpdateDraw(float wishspeed, float accel)
 	{
+		// this can happen when running > 125fps, set default wishspeed to avoid div by 0 later
+		if (wishspeed == 0)
+		{
+			wishspeed = ps->speed * ps->sprintSpeedScale;
+		}
+
 		state.gSquared = GetSlickGravity();
 		state.vSquared = VectorLengthSquared2(pm->pmext->previous_velocity);
 		state.vfSquared = VectorLengthSquared2(pm->pmext->velocity);


### PR DESCRIPTION
When running over 125fps, it's possible to get cgame frames where `ps->speed` is 0, but `usercmd` hasn't registered yet that we're not pressing any buttons, so it hasn't set a default wishspeed for drawing, and we get div by 0 later in CGaz code.