### PR TITLE
listmaps, findmap fixes, add newmaps command

### DIFF
--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2639,6 +2639,7 @@ static const struct Manual commandManuals[] = {
 		{ "userinfo",     "!userinfo [id]",                                                                                                                                                                 "Prints user info."                                                                  },
 		{ "ad_save",      "/ad_save [(optional) name]", "Saves currently ongoing autodemo temp file manually with given name." },
 		{ "clearsaves",   "/clearsaves", "Removes all your saved positions." },
+		{ "newmaps",      "!newmaps [(optional) count]", "Lists latest ^3[count] ^7maps added to server, sorted from oldest to newest." },
 };
 
 typedef struct

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -1133,7 +1133,7 @@ bool ListMaps(gentity_t *ent, Arguments argv)
 			perRow = 5;
 		}
 
-		if (perRow < 0)
+		if (perRow <= 0)
 		{
 			ChatPrintTo(ent, "^3listmaps: ^7second argument must be over 0");
 			return false;

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -838,6 +838,17 @@ bool FindMap(gentity_t *ent, Arguments argv)
 		{
 			perRow = 3;
 		}
+
+		if (perRow <= 0)
+		{
+			ChatPrintTo(ent, "^3findmap: ^7third argument must be over 0");
+			return false;
+		}
+
+		if (perRow > 5)
+		{
+			perRow = 5;
+		}
 	}
 
 	auto                     maps = game.mapStatistics->getMaps();

--- a/src/game/etj_utilities.cpp
+++ b/src/game/etj_utilities.cpp
@@ -174,30 +174,6 @@ static char *BuildOSPath(const char *file)
 }
 }
 
-void Utilities::toConsole(gentity_t *ent, std::string message)
-{
-	const auto               BYTES_PER_PACKET = 998;
-	std::vector<std::string> packets;
-	while (message.length() > BYTES_PER_PACKET)
-	{
-		packets.push_back(message.substr(0, BYTES_PER_PACKET));
-		message = message.substr(BYTES_PER_PACKET);
-	}
-	packets.push_back(message);
-
-	for (auto& packet : packets)
-	{
-		if (!ent)
-		{
-			G_Printf(packet.c_str());
-		}
-		else
-		{
-			trap_SendServerCommand(ClientNum(ent), ("print \"" + packet + "\"").c_str());
-		}
-	}
-}
-
 void Utilities::RemovePlayerWeapons(int clientNum)
 {
 	auto *cl = (g_entities + clientNum)->client;

--- a/src/game/etj_utilities.h
+++ b/src/game/etj_utilities.h
@@ -98,12 +98,6 @@ namespace Utilities {
 	 */
 	std::string timestampToString(int timestamp, const char *format = "%d/%m/%y %H:%M:%S", const char *start = "never");
 
-	/**
-	 * Prints a message to entity's console
-	 * if ent == nullptr, prints to server console
-	 */
-	void toConsole(gentity_t *ent, std::string message);
-
 	void RemovePlayerWeapons(int clientNum);
 }
 


### PR DESCRIPTION
* Changed default column number of `!listmaps` output from 3 to 5
* Capped max columns to 5 to avoid going over console line length limit which breaks formatting
* `!listmaps` and `!findmap` output is now alphabetically ordered
* Every other column of `!listmaps` and `!findmap` is now grey to improve readability
* `!findmap` now displays the number of matched maps, similar to `callvote map <partial name>`
* Added `!newmaps [N]` command to display latest N maps added to server
* Removed `Utilities::toConsole` function, identical to `Printer::SendConsoleMessage` except the latter handles command splitting properly (see fb9704d2c13d672a196556786f3b900a37bccac5)