### PR TITLE
Fix savelimit worldspawn key not working

### DIFF
--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -3123,17 +3123,21 @@ static void CG_ServerCommand(void)
 
 	if (!Q_stricmp(cmd, "savePrint"))
 	{
-		if (trap_Argc() > 1)
+		int pos = atoi(CG_Argv(1));
+		std::string saveMsg = etj_saveMsg.string;
+
+		if (pos)
 		{
-			auto pos = atoi(CG_Argv(1));
-			std::string saveMsg = etj_saveMsg.string;
 			saveMsg += ' ' + std::to_string(pos);
-			CPri(saveMsg.c_str());
 		}
-		else
+		if (trap_Argc() == 3)
 		{
-			CPri(etj_saveMsg.string);
+			int remainingSaves = atoi(CG_Argv(2));
+			std::string remainingSavesStr = va("^7(^3%d ^7remaining)\n", remainingSaves);
+			saveMsg += '\n' + remainingSavesStr;
 		}
+
+		CPri(saveMsg.c_str());
 		return;
 	}
 

--- a/src/game/etj_save_system.h
+++ b/src/game/etj_save_system.h
@@ -101,6 +101,9 @@ namespace ETJump
 
 			// So called "map ident"
 			int progression;
+
+			// Global map savelimit
+			int saveLimit;
 		};
 
 		enum class SaveLoadRestrictions

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2065,6 +2065,7 @@ const char *ClientConnect(int clientNum, qboolean firstTime, qboolean isBot)
 	ent->client->sess.muted             = qfalse;
 	ent->client->pers.race.isRouteMaker = qfalse;
 	client->sess.portalTeam             = 0;
+	client->sess.saveLimit              = level.saveLimit;
 
 	// count current clients and rank for scoreboard
 	CalculateRanks();

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -743,6 +743,8 @@ typedef struct
 	qboolean specLocked;
 	int specInvitedClients[MAX_CLIENTS / (sizeof(int) * 8)];
 	// Fireteam save limit
+	int saveLimitFt;
+	// Global map savelimit
 	int saveLimit;
 	// Map ident
 	int clientMapProgression;
@@ -1380,7 +1382,7 @@ typedef struct
 	ipMute_t ipMutes[MAX_IP_MUTES];    // I don't think we need more than 16
 
 	qboolean ghostPlayers;
-	qboolean saveLimit;
+	int saveLimit;
 	int portalTeam;
 
 #define MAX_TIMERUNS 20

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -1305,12 +1305,13 @@ void SP_worldspawn(void)
 	G_SpawnString("savelimit", "0", &s);
 	if (atoi(s))
 	{
-		level.saveLimit = qtrue;
-		G_Printf("Save is limited.\n");
+		int limit = atoi(s);
+		level.saveLimit = limit;
+		G_Printf("Save is limited to %s.\n", ETJump::getPluralizedString(limit, "save").c_str());
 	}
 	else
 	{
-		level.saveLimit = qfalse;
+		level.saveLimit = 0;
 		G_Printf("Save is not limited.\n");
 	}
 


### PR DESCRIPTION
Fixes non-functioning `savelimit` worldspawn key, actually does something now and limits saves to set value. Persists for the entire duration of the map, so it's not possible to disconnect and reconnect to get around the limit. Fireteam save limit is disabled if level wide save limit is set. `devmap` disables the limit.