### PR TITLE
Use playerEventsHandler for more reliable drawable resets

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -2503,11 +2503,6 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       trap_S_StartSound(NULL, es->number, CHAN_VOICE,
                         CG_CustomSound(es->number, va("*death%i.wav",
                                                       event - EV_DEATH1 + 1)));
-      if (clientNum == cg.predictedPlayerState.clientNum) {
-        trap_SendConsoleCommand("resetJumpSpeeds\n");
-        trap_SendConsoleCommand("resetStrafeQuality\n");
-        trap_SendConsoleCommand("resetUpmoveMeter\n");
-      }
       break;
 
     case EV_OBITUARY:
@@ -2535,11 +2530,6 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       trap_S_StartSound(es->pos.trBase, -1, CHAN_AUTO, cgs.media.gibSound);
       ByteToDir(es->eventParm, dir);
       CG_GibPlayer(cent, cent->lerpOrigin, dir);
-      if (clientNum == cg.predictedPlayerState.clientNum) {
-        trap_SendConsoleCommand("resetJumpSpeeds\n");
-        trap_SendConsoleCommand("resetStrafeQuality\n");
-        trap_SendConsoleCommand("resetUpmoveMeter\n");
-      }
       break;
 
     case EV_STOPLOOPINGSOUND:

--- a/src/cgame/etj_jump_speeds.cpp
+++ b/src/cgame/etj_jump_speeds.cpp
@@ -25,6 +25,7 @@
 #include "etj_jump_speeds.h"
 #include "etj_utilities.h"
 #include "etj_client_commands_handler.h"
+#include "etj_player_events_handler.h"
 
 namespace ETJump {
 JumpSpeeds::JumpSpeeds(EntityEventsHandler *entityEventsHandler)
@@ -37,6 +38,9 @@ JumpSpeeds::JumpSpeeds(EntityEventsHandler *entityEventsHandler)
       [&](const std::vector<std::string> &args) { queueJumpSpeedsReset(); });
   entityEventsHandler->subscribe(EV_JUMP,
                                  [&](centity_t *cent) { updateJumpSpeeds(); });
+  playerEventsHandler->subscribe(
+      "respawn",
+      [&](const std::vector<std::string> &args) { queueJumpSpeedsReset(); });
 }
 
 JumpSpeeds::~JumpSpeeds() {

--- a/src/cgame/etj_strafe_quality_drawable.cpp
+++ b/src/cgame/etj_strafe_quality_drawable.cpp
@@ -29,6 +29,7 @@
 #include "etj_snaphud.h"
 #include "etj_cgaz.h"
 #include "etj_pmove_utils.h"
+#include "etj_player_events_handler.h"
 
 namespace ETJump {
 StrafeQuality::StrafeQuality() {
@@ -44,6 +45,9 @@ void StrafeQuality::startListeners() {
 
   consoleCommandsHandler->subscribe(
       "resetStrafeQuality",
+      [&](const std::vector<std::string> &args) { resetStrafeQuality(); });
+  playerEventsHandler->subscribe(
+      "respawn",
       [&](const std::vector<std::string> &args) { resetStrafeQuality(); });
 }
 

--- a/src/cgame/etj_upmove_meter_drawable.cpp
+++ b/src/cgame/etj_upmove_meter_drawable.cpp
@@ -27,6 +27,7 @@
 #include "etj_client_commands_handler.h"
 #include "etj_utilities.h"
 #include "etj_pmove_utils.h"
+#include "etj_player_events_handler.h"
 
 namespace ETJump {
 UpmoveMeter::UpmoveMeter() {
@@ -70,6 +71,10 @@ void UpmoveMeter::startListeners() {
 
   consoleCommandsHandler->subscribe(
       "resetUpmoveMeter",
+      [&](const std::vector<std::string> &args) { resetUpmoveMeter(); });
+
+  playerEventsHandler->subscribe(
+      "respawn",
       [&](const std::vector<std::string> &args) { resetUpmoveMeter(); });
 }
 


### PR DESCRIPTION
Use more reliable `playerEventsHandler respawn` to make sure we reset jump speeds, strafe quality and upmove meter upon death, as `EV_DEATHx` and `EV_GIB` events are often dropped.