### PR TITLE
Fix crash with ETe and invalid playerstate

### DIFF
--- a/src/cgame/etj_strafe_quality_drawable.cpp
+++ b/src/cgame/etj_strafe_quality_drawable.cpp
@@ -193,17 +193,18 @@ bool StrafeQuality::canSkipUpdate(usercmd_t cmd, int frameTime) {
   }
 
   // don't update if not in air or on ice
-  if (pm->ps->groundEntityNum != ENTITYNUM_NONE &&
+  if (cg.snap->ps.groundEntityNum != ENTITYNUM_NONE &&
       !(pm->pmext->groundTrace.surfaceFlags & SURF_SLICK)) {
     return true;
   }
 
-  if (pm->ps->pm_type == PM_NOCLIP || pm->ps->pm_type == PM_DEAD) {
+  if (cg.snap->ps.pm_type == PM_NOCLIP || cg.snap->ps.pm_type == PM_DEAD) {
     return true;
   }
 
-  if (BG_PlayerMounted(pm->ps->eFlags) ||
-      pm->ps->weapon == WP_MOBILE_MG42_SET || pm->ps->weapon == WP_MORTAR_SET) {
+  if (BG_PlayerMounted(cg.snap->ps.eFlags) ||
+      cg.snap->ps.weapon == WP_MOBILE_MG42_SET ||
+      cg.snap->ps.weapon == WP_MORTAR_SET) {
     return true;
   }
 

--- a/src/cgame/etj_upmove_meter_drawable.cpp
+++ b/src/cgame/etj_upmove_meter_drawable.cpp
@@ -281,12 +281,13 @@ void UpmoveMeter::render() const {
 }
 
 bool UpmoveMeter::canSkipUpdate() const {
-  if (pm->ps->pm_type == PM_NOCLIP || pm->ps->pm_type == PM_DEAD) {
+  if (cg.snap->ps.pm_type == PM_NOCLIP || cg.snap->ps.pm_type == PM_DEAD) {
     return true;
   }
 
-  if (BG_PlayerMounted(pm->ps->eFlags) ||
-      pm->ps->weapon == WP_MOBILE_MG42_SET || pm->ps->weapon == WP_MORTAR_SET) {
+  if (BG_PlayerMounted(cg.snap->ps.eFlags) ||
+      cg.snap->ps.weapon == WP_MOBILE_MG42_SET ||
+      cg.snap->ps.weapon == WP_MORTAR_SET) {
     return true;
   }
 


### PR DESCRIPTION
Similar thing fixed once already in #685, not exactly sure why this needs to be done.