### PR TITLE
Fix etj_speedColorUsesAccel ignoring etj_speedAlpha

### DIFF
--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -137,6 +137,8 @@ void ETJump::DisplaySpeed::render() const {
     frac = std::min(frac, 1.f);
 
     LerpColor(colorWhite, accelColor, color, frac);
+    // LerpColor adjusts alpha, make sure we still respect etj_speedAlpha
+    color[3] = etj_speedAlpha.value;
   }
 
   CG_Text_Paint_Ext(x - w, y, size, size, color, status.c_str(), 0, 0, style,


### PR DESCRIPTION
Allow alpha adjustment while using accel-based speed color.