### PR TITLE
Rename savelimit to limitedsaves

### DIFF
--- a/src/game/etj_save_system.cpp
+++ b/src/game/etj_save_system.cpp
@@ -152,7 +152,7 @@ void ETJump::SaveSystem::save(gentity_t *ent) {
       }
     }
 
-    if (level.saveLimit > 0) {
+    if (level.limitedSaves > 0) {
       if (client->sess.saveLimit == 0) {
         CPTo(ent, "^7You've used all your saves.");
         return;
@@ -778,7 +778,7 @@ void ETJump::SaveSystem::sendClientCommands(gentity_t *ent, int position) {
   int target;
   std::string saveMsg = va("savePrint %d\n", position);
 
-  if (!g_cheats.integer && level.saveLimit > 0) {
+  if (!g_cheats.integer && level.limitedSaves > 0) {
     saveMsg += va(" %d", ent->client->sess.saveLimit);
   }
 

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2147,7 +2147,7 @@ const char *ClientConnect(int clientNum, qboolean firstTime, qboolean isBot) {
   ent->client->sess.muted = qfalse;
   ent->client->pers.race.isRouteMaker = qfalse;
   client->sess.portalTeam = 0;
-  client->sess.saveLimit = level.saveLimit;
+  client->sess.saveLimit = level.limitedSaves;
 
   // count current clients and rank for scoreboard
   CalculateRanks();

--- a/src/game/g_fireteams.cpp
+++ b/src/game/g_fireteams.cpp
@@ -760,7 +760,7 @@ void G_SetFireTeamRules(int clientNum) {
   trap_Argv(2, arg1, sizeof(arg1));
 
   if (!Q_stricmp(arg1, "savelimit")) {
-    if (level.saveLimit > 0) {
+    if (level.limitedSaves > 0) {
       G_ClientPrintAndReturn(clientNum,
                              "fireteam: unable to set savelimit - save is "
                              "limited globally.");

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1233,7 +1233,7 @@ typedef struct {
   int follow1, follow2;           // clientNums for auto-follow spectators
 
   //	int			snd_fry;				// sound
-  //index for standing in lava
+  // index for standing in lava
 
   int warmupModificationCount; // for detecting if g_warmup is changed
 
@@ -1416,7 +1416,7 @@ typedef struct {
   ipMute_t ipMutes[MAX_IP_MUTES]; // I don't think we need more than 16
 
   qboolean ghostPlayers;
-  int saveLimit;
+  int limitedSaves;
   int portalTeam;
 
 #define MAX_TIMERUNS 20

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -1212,14 +1212,14 @@ void SP_worldspawn(void) {
     G_Printf("Ghosting is enabled.\n");
   }
 
-  G_SpawnString("savelimit", "0", &s);
+  G_SpawnString("limitedsaves", "0", &s);
   if (atoi(s)) {
     int limit = atoi(s);
-    level.saveLimit = limit;
+    level.limitedSaves = limit;
     G_Printf("Save is limited to %s.\n",
              ETJump::getPluralizedString(limit, "save").c_str());
   } else {
-    level.saveLimit = 0;
+    level.limitedSaves = 0;
     G_Printf("Save is not limited.\n");
   }
 


### PR DESCRIPTION
Rename `savelimit` worldspawn key to `limitedsaves` so we don't mess up old maps which might have set it when the key wasn't working prior to 2.5.0 (e.g. scafslab_v3)