### PR TITLE
Support com_maxfps 1000 on clientInfo

### DIFF
--- a/src/cgame/cg_scoreboard.cpp
+++ b/src/cgame/cg_scoreboard.cpp
@@ -87,7 +87,7 @@ void CG_AltScoreboardDrawClientScore(float x, float y, score_t *score,
                        MINICHAR_HEIGHT, 12);
     }
   } else {
-    CG_DrawMiniString(tempX, y, va("%3i", ci->maxFPS), fade);
+    CG_DrawMiniString(tempX, y, va("%i", ci->maxFPS), fade);
     tempX += ALT_SCOREBOARD_FPS_WIDTH;
 
     CG_DrawMiniString(tempX, y, va("%4i", score->ping), fade);
@@ -306,7 +306,7 @@ void CG_ThirdScoreboardDrawClientScore(float x, float y, score_t *score,
                        MINICHAR_HEIGHT, 12);
     }
   } else {
-    CG_DrawMiniString(tempX, y, va("%3i", ci->maxFPS), fade);
+    CG_DrawMiniString(tempX, y, va("%i", ci->maxFPS), fade);
     tempX += ALT_SCOREBOARD_FPS_WIDTH;
 
     CG_DrawMiniString(tempX, y, va("%4i", score->ping), fade);

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -1787,7 +1787,9 @@ bool UpdateClientConfigString(gentity_t &gent) {
          gent.client->sess.playerWeapon, gent.client->sess.latchPlayerWeapon,
          gent.client->sess.latchPlayerWeapon2, gent.client->sess.muted ? 1 : 0,
          gent.client->pers.pmoveFixed ? 1 : 0,
-         gent.client->pers.maxFPS < 999 && gent.client->pers.maxFPS > 0
+         // while engine caps at 1000 fps, 2.60b doesn't actually cap com_maxfps
+         // value, but let's not display such silliness
+         gent.client->pers.maxFPS <= 1000 && gent.client->pers.maxFPS > 0
              ? gent.client->pers.maxFPS
              : 0,
          gent.client->pers.cgaz > 0 ? gent.client->pers.cgaz : 0,


### PR DESCRIPTION
Support engine cap 1000fps when storing `com_maxfps` value in `clientInfo` for scoreboard display. 2.60b doesn't actually cap `com_maxfps` value, so this might be inaccurate if client sets it over 1000 for some reason.

Fixes #843 