### PR TITLE
Move vector convenience functions to q_shared

### DIFF
--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -1834,20 +1834,6 @@ void CG_AddRefEntityWithPowerups(refEntity_t *ent, int powerups, int team,
   *ent = backupRefEnt;
 }
 
-char *vtosf(const vec3_t v) {
-  static int index;
-  static char str[8][64];
-  char *s;
-
-  // use an array so that multiple vtos won't collide
-  s = str[index];
-  index = (index + 1) & 7;
-
-  Com_sprintf(s, 64, "(%f %f %f)", v[0], v[1], v[2]);
-
-  return s;
-}
-
 /*
 ===============
 CG_AnimPlayerConditions

--- a/src/cgame/cg_spawn.cpp
+++ b/src/cgame/cg_spawn.cpp
@@ -64,28 +64,6 @@ qboolean CG_SpawnVector2D(const char *key, const char *defaultString,
   return present;
 }
 
-/*
-=============
-VectorToString
-
-This is just a convenience function
-for printing vectors
-=============
-*/
-char *vtos(const vec3_t v) {
-  static int index;
-  static char str[8][32];
-  char *s;
-
-  // use an array so that multiple vtos won't collide
-  s = str[index];
-  index = (index + 1) & 7;
-
-  Com_sprintf(s, 32, "(%i %i %i)", (int)v[0], (int)v[1], (int)v[2]);
-
-  return s;
-}
-
 void SP_path_corner_2(void) {
   char *targetname;
   vec3_t origin;

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1574,9 +1574,6 @@ void G_FreeEntity(gentity_t *e);
 
 void G_TouchTriggers(gentity_t *ent);
 
-float *tv(float x, float y, float z);
-char *vtos(const vec3_t v);
-
 void G_AddPredictableEvent(gentity_t *ent, int event, int eventParm);
 void G_AddEvent(gentity_t *ent, int event, int eventParm);
 void G_SetOrigin(gentity_t *ent, vec3_t origin);

--- a/src/game/g_utils.cpp
+++ b/src/game/g_utils.cpp
@@ -470,68 +470,6 @@ void G_UseTargetedEntities(gentity_t *ent, gentity_t *activator) {
 }
 
 /*
-=============
-TempVector
-
-This is just a convenience function
-for making temporary vectors for function calls
-=============
-*/
-/*
-float	*tv( float x, float y, float z ) {
-    static	int		index;
-    static	vec3_t	vecs[8];
-    float	*v;
-
-    // use an array so that multiple tempvectors won't collide
-    // for a while
-    v = vecs[index];
-    index = (index + 1)&7;
-
-    v[0] = x;
-    v[1] = y;
-    v[2] = z;
-
-    return v;
-}
-*/
-
-/*
-=============
-VectorToString
-
-This is just a convenience function
-for printing vectors
-=============
-*/
-char *vtos(const vec3_t v) {
-  static int index;
-  static char str[8][32];
-  char *s;
-
-  // use an array so that multiple vtos won't collide
-  s = str[index];
-  index = (index + 1) & 7;
-
-  Com_sprintf(s, 32, "(%i %i %i)", (int)v[0], (int)v[1], (int)v[2]);
-
-  return s;
-}
-char *vtosf(const vec3_t v) {
-  static int index;
-  static char str[8][64];
-  char *s;
-
-  // use an array so that multiple vtos won't collide
-  s = str[index];
-  index = (index + 1) & 7;
-
-  Com_sprintf(s, 64, "(%f %f %f)", v[0], v[1], v[2]);
-
-  return s;
-}
-
-/*
 ===============
 G_SetMovedir
 

--- a/src/game/q_shared.cpp
+++ b/src/game/q_shared.cpp
@@ -1048,6 +1048,41 @@ float *tv(float x, float y, float z) {
 }
 
 /*
+=============
+VectorToString
+
+This is just a convenience function
+for printing vectors
+=============
+*/
+char *vtos(const vec3_t v) {
+  static int index;
+  static char str[8][32];
+  char *s;
+
+  // use an array so that multiple vtos won't collide
+  s = str[index];
+  index = (index + 1) & 7;
+
+  Com_sprintf(s, 32, "(%i %i %i)", (int)v[0], (int)v[1], (int)v[2]);
+
+  return s;
+}
+char *vtosf(const vec3_t v) {
+  static int index;
+  static char str[8][64];
+  char *s;
+
+  // use an array so that multiple vtos won't collide
+  s = str[index];
+  index = (index + 1) & 7;
+
+  Com_sprintf(s, 64, "(%f %f %f)", v[0], v[1], v[2]);
+
+  return s;
+}
+
+/*
 =====================================================================
 
   INFO STRINGS

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -858,6 +858,8 @@ float BigFloat(float l);
 void Swap_Init(void);
 char *QDECL va(const char *format, ...);
 float *tv(float x, float y, float z);
+char *vtos(const vec3_t v);
+char *vtosf(const vec3_t v);
 
 //=============================================
 
@@ -1459,7 +1461,7 @@ typedef enum {
   TR_LINEAR_STOP_BACK, //----(SA)	added.  so reverse movement can
                        // be
                        // different than forward
-  TR_SINE, // value = base + sin( time / duration ) * delta
+  TR_SINE,             // value = base + sin( time / duration ) * delta
   TR_GRAVITY,
   // Ridah
   TR_GRAVITY_LOW,


### PR DESCRIPTION
`vtos` and `vtosf` are now in `q_shared.cpp` so they can easily be reused on all modules.