### PR TITLE
Fix timer drawing on demo when run stops

### DIFF
--- a/src/cgame/etj_timerun_view.cpp
+++ b/src/cgame/etj_timerun_view.cpp
@@ -85,8 +85,9 @@ void ETJump::TimerunView::draw() {
   }
 
   auto run = currentRun();
+  auto hasTimerun = ((cg.demoPlayback && (run->lastRunTimer || run->running)) ||
+                     cg.hasTimerun);
 
-  auto hasTimerun = (cg.demoPlayback && run->running) || cg.hasTimerun;
   if (etj_drawRunTimer.integer == 0 || !hasTimerun) {
     return;
   }


### PR DESCRIPTION
Fixes timerun timer disappearing on demo playback as soon as the timer is stopped. `cg.hasTimerun` isn't correctly set on demo playback, so without checking that `run->lastRunTimer` is non-zero, it would instantly stop drawing because stopping a timerun sets `run->running` to false.

Fixes #546 