### PR TITLE
Allow setting fixed speed value for CGaz 2 drawing

### DIFF
--- a/assets/ui/etjump_settings_2.menu
+++ b/assets/ui/etjump_settings_2.menu
@@ -19,7 +19,7 @@
 // Right side menus
 #define SUBW_CGAZ_Y SUBW_Y
 #define SUBW_CGAZ_ITEM_Y SUBW_CGAZ_Y + SUBW_HEADER_HEIGHT
-#define SUBW_CGAZ_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 12)
+#define SUBW_CGAZ_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 13)
 
 #define SUBW_POPUPS_Y SUBW_CGAZ_Y + SUBW_CGAZ_HEIGHT + SUBW_SPACING_Y
 #define SUBW_POPUPS_ITEM_Y SUBW_POPUPS_Y + SUBW_HEADER_HEIGHT
@@ -98,6 +98,8 @@ menuDef {
         YESNO               (SUBW_ITEM_RIGHT_X, SUBW_CGAZ_ITEM_Y + (SUBW_ITEM_SPACING_Y * 10), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Stretch CGaz:", 0.2, SUBW_ITEM_HEIGHT, "etj_stretchCgaz", "Stretch CGaz 2 when using widescreen resolution\netj_stretchCgaz")
         MULTI               (SUBW_ITEM_RIGHT_X, SUBW_CGAZ_ITEM_Y + (SUBW_ITEM_SPACING_Y * 11), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "CGaz trueness:", 0.2, SUBW_ITEM_HEIGHT, "etj_CGazTrueness", cvarFloatList { "Off" 0 "Upmove" 1 "Groundzones" 2 "Upmove + Groundzones" 3 }, "Sets trueness of CGaz\netj_CGazTrueness")
         YESNO               (SUBW_ITEM_RIGHT_X, SUBW_CGAZ_ITEM_Y + (SUBW_ITEM_SPACING_Y * 12), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "CGaz over Snaphud:", 0.2, SUBW_ITEM_HEIGHT, "etj_CGazOnTop", "Draw CGaz on top of snaphud (vid_restart required)\netj_CGazOnTop")
+        CVARINTLABEL        (SUBW_ITEM_RIGHT_X, SUBW_CGAZ_ITEM_Y + (SUBW_ITEM_SPACING_Y * 13), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_CGaz2FixedSpeed", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_CGAZ_ITEM_Y + (SUBW_ITEM_SPACING_Y * 13), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "CGaz fixed speed:", 0.2, SUBW_ITEM_HEIGHT, etj_CGaz2FixedSpeed 0 0 1200 50, "Fixed speed value to use for drawing CGaz 2 instead of real speed\netj_CGaz2FixedSpeed")
 
     SUBWINDOW(SUBW_RECT_RIGHT_X, SUBW_POPUPS_Y, SUBW_WIDTH, SUBW_POPUPS_HEIGHT, "POPUPS")
         MULTI               (SUBW_ITEM_RIGHT_X, SUBW_POPUPS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Draw popups:", 0.2, SUBW_ITEM_HEIGHT, "etj_HUD_popup", cvarFloatList { "No" 0 "Left" 1 "Right" 2 }, "Draw popups on HUD\netj_HUD_popup")

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2381,6 +2381,7 @@ extern vmCvar_t etj_CGaz1Color4;
 extern vmCvar_t etj_CGazFov;
 extern vmCvar_t etj_CGazTrueness;
 extern vmCvar_t etj_CGazOnTop;
+extern vmCvar_t etj_CGaz2FixedSpeed;
 
 extern vmCvar_t etj_drawOB;
 // Aciz: movable drawOB

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -306,6 +306,7 @@ vmCvar_t etj_CGaz1Color4;
 vmCvar_t etj_CGazFov;
 vmCvar_t etj_CGazTrueness;
 vmCvar_t etj_CGazOnTop;
+vmCvar_t etj_CGaz2FixedSpeed;
 
 vmCvar_t etj_drawOB;
 // Aciz: movable drawOB
@@ -811,6 +812,7 @@ cvarTable_t cvarTable[] = {
     {&etj_CGazFov, "etj_CGazFov", "0", CVAR_ARCHIVE},
     {&etj_CGazTrueness, "etj_CGazTrueness", "2", CVAR_ARCHIVE},
     {&etj_CGazOnTop, "etj_CGazOnTop", "0", CVAR_ARCHIVE | CVAR_LATCH},
+    {&etj_CGaz2FixedSpeed, "etj_CGaz2FixedSpeed", "0", CVAR_ARCHIVE},
 
     {&cl_yawspeed, "cl_yawspeed", "0", CVAR_ARCHIVE},
     {&cl_freelook, "cl_freelook", "1", CVAR_ARCHIVE},

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -262,7 +262,8 @@ void CGaz::render() const {
     // drawing the "wings" on the sides
     auto drawSides = state.vf > state.wishspeed;
 
-    auto velSize = state.vf;
+    auto velSize =
+        etj_CGaz2FixedSpeed.value > 0 ? etj_CGaz2FixedSpeed.value : state.vf;
     velSize /= 5;
     if (velSize > SCREEN_HEIGHT / 2) {
       velSize = SCREEN_HEIGHT / 2;


### PR DESCRIPTION
`etj_CGaz2FixedSpeed` can be used to set a fixed speed value to use for drawing CGaz 2, as opposed to being calculated based off current speed. Menu slider is capped at 1200 since that's the max it will scale to (cgaz code clamps the upper value to that).