### PR TITLE
Limit most/leastplayed output to 100 maps

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -35,6 +35,7 @@
 #include "etj_tokens.h"
 #include "etj_string_utilities.h"
 #include "etj_printer.h"
+#include "etj_numeric_utilities.h"
 
 typedef std::function<bool(gentity_t *ent, Arguments argv)> Command;
 typedef std::pair<std::function<bool(gentity_t *ent, Arguments argv)>, char>
@@ -922,7 +923,7 @@ bool LeastPlayed(gentity_t *ent, Arguments argv) {
   auto mapsToList = 10;
   if (argv->size() == 2) {
     try {
-      mapsToList = std::stoi((*argv)[1]);
+      mapsToList = std::stoi(argv->at(1), nullptr, 10);
     } catch (const std::invalid_argument &) {
       ChatPrintTo(ent, ETJump::stringFormat("^3Error: ^7%s^7 is not a number",
                                             argv->at(1)));
@@ -933,6 +934,7 @@ bool LeastPlayed(gentity_t *ent, Arguments argv) {
   }
 
   auto leastPlayed = game.mapStatistics->getLeastPlayed();
+  mapsToList = Numeric::clamp(mapsToList, 0, 100);
 
   auto listedMaps = 0;
   std::string buffer = "^zLeast played maps are:\n"
@@ -1178,17 +1180,18 @@ bool MostPlayed(gentity_t *ent, Arguments argv) {
   auto mapsToList = 10;
   if (argv->size() == 2) {
     try {
-      mapsToList = std::stoi((*argv)[1]);
+      mapsToList = std::stoi(argv->at(1), nullptr, 10);
     } catch (const std::invalid_argument &) {
       ChatPrintTo(ent, ETJump::stringFormat("^3Error: ^7%s^7 is not a number",
                                             argv->at(1)));
       return false;
     } catch (const std::out_of_range &) {
-      mapsToList = 1000;
+      mapsToList = 10;
     }
   }
 
   auto mostPlayed = game.mapStatistics->getMostPlayed();
+  mapsToList = Numeric::clamp(mapsToList, 0, 100);
 
   auto listedMaps = 0;
   std::string buffer = "^zMost played maps are:\n"

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -35,7 +35,6 @@
 #include "etj_tokens.h"
 #include "etj_string_utilities.h"
 #include "etj_printer.h"
-#include "etj_numeric_utilities.h"
 
 typedef std::function<bool(gentity_t *ent, Arguments argv)> Command;
 typedef std::pair<std::function<bool(gentity_t *ent, Arguments argv)>, char>
@@ -931,11 +930,18 @@ bool LeastPlayed(gentity_t *ent, Arguments argv) {
     } catch (const std::out_of_range &) {
       mapsToList = 10;
     }
+
+    if (mapsToList <= 0) {
+      ChatPrintTo(ent, "^3leastplayed: ^7second argument must be over 0");
+      return false;
+    }
+
+    if (mapsToList > 100) {
+      mapsToList = 100;
+    }
   }
 
   auto leastPlayed = game.mapStatistics->getLeastPlayed();
-  mapsToList = Numeric::clamp(mapsToList, 0, 100);
-
   auto listedMaps = 0;
   std::string buffer = "^zLeast played maps are:\n"
                        "^gMap                    Played                        "
@@ -1014,8 +1020,7 @@ bool ListMaps(gentity_t *ent, Arguments argv) {
     }
 
     if (perRow <= 0) {
-      ChatPrintTo(ent, "^3listmaps: ^7second argument "
-                       "must be over 0");
+      ChatPrintTo(ent, "^3listmaps: ^7second argument must be over 0");
       return false;
     }
 
@@ -1188,11 +1193,18 @@ bool MostPlayed(gentity_t *ent, Arguments argv) {
     } catch (const std::out_of_range &) {
       mapsToList = 10;
     }
+
+    if (mapsToList <= 0) {
+      ChatPrintTo(ent, "^3mostplayed: ^7second argument must be over 0");
+      return false;
+    }
+
+    if (mapsToList > 100) {
+      mapsToList = 100;
+    }
   }
 
   auto mostPlayed = game.mapStatistics->getMostPlayed();
-  mapsToList = Numeric::clamp(mapsToList, 0, 100);
-
   auto listedMaps = 0;
   std::string buffer = "^zMost played maps are:\n"
                        "^gMap                    Played                        "


### PR DESCRIPTION
Avoids `Msg overflowed` error in engine when requesting huge (500+) amount of maps with a big database.

Fixes #860 