### PR TITLE
Add etj_jumpSpeedsMinSpeed for slow jump speed "monitoring"

### DIFF
--- a/assets/ui/etjump_settings_5.menu
+++ b/assets/ui/etjump_settings_5.menu
@@ -14,7 +14,7 @@
 
 #define SUBW_JUMPSPEEDS_Y SUBW_SPECTATOR_Y + SUBW_SPECTATOR_HEIGHT + SUBW_SPACING_Y
 #define SUBW_JUMPSPEEDS_ITEM_Y SUBW_JUMPSPEEDS_Y + SUBW_HEADER_HEIGHT
-#define SUBW_JUMPSPEEDS_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 8)
+#define SUBW_JUMPSPEEDS_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 9)
 
 // Right side menus
 #define SUBW_STRAFEQUALITY_Y SUBW_Y
@@ -73,6 +73,8 @@ menuDef {
         YESNO               (SUBW_ITEM_LEFT_X, SUBW_JUMPSPEEDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 6), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Show difference:", 0.2, SUBW_ITEM_HEIGHT, "etj_jumpSpeedsShowDiff", "Colorize speed if it's faster/slower than previous\netj_jumpSpeedsShowDiff")
         MULTI               (SUBW_ITEM_LEFT_X, SUBW_JUMPSPEEDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 7), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Faster color:", 0.2, SUBW_ITEM_HEIGHT, "etj_jumpSpeedsFasterColor", cvarStrList { "White"; "white"; "Yellow"; "yellow"; "Red"; "red"; "Green"; "green"; "Blue"; "blue"; "Magenta"; "magenta"; "Cyan"; "cyan"; "Orange"; "orange"; "Light Blue"; "0xa0c0ff"; "Medium Blue"; "mdblue"; "Light Red"; "0xffc0a0"; "Medium Red"; "mdred"; "Light Green"; "0xa0ffc0"; "Medium Green"; "mdgreen"; "Dark Green"; "dkgreen"; "Medium Cyan"; "mdcyan"; "Medium Yellow"; "mdyellow"; "Medium Orange"; "mdorange"; "Light Grey"; "ltgrey"; "Medium Grey"; "mdgrey"; "Dark Grey"; "dkgrey"; "Black"; "black" }, "Sets color of faster jumps\netj_jumpSpeedsFasterColor")
         MULTI               (SUBW_ITEM_LEFT_X, SUBW_JUMPSPEEDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 8), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Slower color:", 0.2, SUBW_ITEM_HEIGHT, "etj_jumpSpeedsSlowerColor", cvarStrList { "White"; "white"; "Yellow"; "yellow"; "Red"; "red"; "Green"; "green"; "Blue"; "blue"; "Magenta"; "magenta"; "Cyan"; "cyan"; "Orange"; "orange"; "Light Blue"; "0xa0c0ff"; "Medium Blue"; "mdblue"; "Light Red"; "0xffc0a0"; "Medium Red"; "mdred"; "Light Green"; "0xa0ffc0"; "Medium Green"; "mdgreen"; "Dark Green"; "dkgreen"; "Medium Cyan"; "mdcyan"; "Medium Yellow"; "mdyellow"; "Medium Orange"; "mdorange"; "Light Grey"; "ltgrey"; "Medium Grey"; "mdgrey"; "Dark Grey"; "dkgrey"; "Black"; "black" }, "Sets color of slower jumps\netj_jumpSpeedsSlowerColor")
+        CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_JUMPSPEEDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 9), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_jumpSpeedsMinSpeed", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_JUMPSPEEDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 9), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Minimum speed:", 0.2, SUBW_ITEM_HEIGHT, etj_jumpSpeedsMinSpeed 0 0 500 1, "Color jumps below this value with the slower color value\netj_jumpSpeedsMinSpeed")
 
     SUBWINDOW(SUBW_RECT_RIGHT_X, SUBW_STRAFEQUALITY_Y, SUBW_WIDTH, SUBW_STRAFEQUALITY_HEIGHT, "STRAFE QUALITY")
         YESNO               (SUBW_ITEM_RIGHT_X, SUBW_STRAFEQUALITY_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Strafe quality:", 0.2, SUBW_ITEM_HEIGHT, "etj_drawStrafeQuality", "Draw strafe quality\netj_drawStrafeQuality")

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2639,6 +2639,7 @@ extern vmCvar_t etj_jumpSpeedsStyle;
 extern vmCvar_t etj_jumpSpeedsShowDiff;
 extern vmCvar_t etj_jumpSpeedsFasterColor;
 extern vmCvar_t etj_jumpSpeedsSlowerColor;
+extern vmCvar_t etj_jumpSpeedsMinSpeed;
 
 // Strafe quality
 extern vmCvar_t etj_drawStrafeQuality;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -564,6 +564,7 @@ vmCvar_t etj_jumpSpeedsStyle;
 vmCvar_t etj_jumpSpeedsShowDiff;
 vmCvar_t etj_jumpSpeedsFasterColor;
 vmCvar_t etj_jumpSpeedsSlowerColor;
+vmCvar_t etj_jumpSpeedsMinSpeed;
 
 // Strafe quality
 vmCvar_t etj_drawStrafeQuality;
@@ -1052,6 +1053,7 @@ cvarTable_t cvarTable[] = {
      CVAR_ARCHIVE},
     {&etj_jumpSpeedsSlowerColor, "etj_jumpSpeedsSlowerColor", "1.0 0.0 0.0 1.0",
      CVAR_ARCHIVE},
+    {&etj_jumpSpeedsMinSpeed, "etj_jumpSpeedsMinSpeed", "0", CVAR_ARCHIVE},
     // Strafe quality
     {&etj_drawStrafeQuality, "etj_drawStrafeQuality", "0", CVAR_ARCHIVE},
     {&etj_strafeQualityX, "etj_strafeQualityX", "0", CVAR_ARCHIVE},

--- a/src/cgame/etj_jump_speeds.cpp
+++ b/src/cgame/etj_jump_speeds.cpp
@@ -172,8 +172,13 @@ void JumpSpeeds::updateJumpSpeeds() {
     adjustColors();
   }
 
-  // parse the colors for drawing here, so we don't need to do it every
-  // frame
+  if (etj_jumpSpeedsMinSpeed.integer >
+      jumpSpeeds.at(jumpSpeeds.size() - 1).first) {
+    jumpSpeeds.at(jumpSpeeds.size() - 1).second =
+        etj_jumpSpeedsSlowerColor.string;
+  }
+
+  // parse the colors for drawing here, so we don't need to do it every frame
   colorStrToVec();
 }
 
@@ -185,8 +190,7 @@ void JumpSpeeds::adjustColors() {
   slowerColorStr = etj_jumpSpeedsSlowerColor.string;
 
   if (jumpSpeeds[jumpNum].first == jumpSpeeds[jumpNum - 1].first) {
-    return; // color is already set to default, no need to
-            // adjust
+    return; // color is already set to default, no need to adjust
   }
 
   jumpSpeeds[jumpNum].second =


### PR DESCRIPTION
Colors any jumps that are slower than the value the cvar is set to with `etj_jumpSpeedsSlowerColor`. Useful for "monitoring" CJ speeds for example, although it does work for all jumps, not just the first one. Works independently of `etj_jumpSpeedsShowDiff`.

Refs #746 