### PR TITLE
Fix shadow cvar desync on ETe/ETL

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1264,6 +1264,8 @@ typedef struct {
   bool requiresEntityTypeAdjustment; // ETJump 2.3.0 specific hack
 
   char deformText[MAX_RENDER_STRINGS][MAX_RENDER_STRING_LENGTH];
+
+  bool shadowCvarsSet;
 } cg_t;
 
 #define NUM_FUNNEL_SPRITES 21

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -137,11 +137,6 @@ void CG_ParseServerinfo(void) {
 }
 
 void CG_ParseSysteminfo(void) {
-  // force original cvars to match the shadow values
-  for (auto &cvarShadow : ETJump::cvarShadows) {
-    cvarShadow.get()->forceCvarSet();
-  }
-
   const char *info = CG_ConfigString(CS_SYSTEMINFO);
 
   cgs.shared = atoi(Info_ValueForKey(info, "shared"));

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -621,6 +621,16 @@ namespace ETJump {
 void runFrameEnd() {
   awaitedCommandHandler->runFrame();
   eventLoop->run();
+
+  // force original cvars to match the shadow values
+  // we need to delay this a bit from initial cgame load because ETe and ETL
+  // reset cheat cvars to original values after cgame VMCall is done
+  if (cg.clientFrame >= 10 && !cg.shadowCvarsSet) {
+    for (auto &cvarShadow : cvarShadows) {
+      cvarShadow->forceCvarSet();
+    }
+    cg.shadowCvarsSet = true;
+  }
 }
 
 playerState_t *getValidPlayerState() {


### PR DESCRIPTION
Delay cvar forcing a bit after cgame load to get around engine forcing cheat cvar values after cgvm call.

Fixes #397 