### PR TITLE
Fix player collision with pmove_fixed 1

### DIFF
--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1175,6 +1175,8 @@ void ClientThink_real(gentity_t *ent) {
   pm.noWeapClips = qfalse;
 
   VectorCopy(client->ps.origin, client->oldOrigin);
+  VectorCopy(ent->r.mins, pm.mins);
+  VectorCopy(ent->r.maxs, pm.maxs);
 
   // NERVE - SMF
   pm.gametype = g_gametype.integer;


### PR DESCRIPTION
Player mins/maxs were not set correctly sometimes in `ClientThink_real`, because they are supposed to be setup by Pmove. But since we don't run Pmove every frame with `pmove_fixed 1`, and because Pmove struct is cleared before we actually call it, sometimes players would get their mins/maxs set to 0 after they are copied back to `ent` from `pm`, after Pmove is called.

To account for this, always copy `pm.mins/maxs` to `ent->r.mins/maxs` before we wipe Pmove struct, so we just use old mins/maxs in cases where Pmove isn't actually run.

Big thanks to ryzyk_krzysiek for helping me figure this out.

Fixes #571 