### PR TITLE
Add func_missilepad

### DIFF
--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(qagame MODULE
 	"etj_main.cpp"
 	"etj_main_ext.cpp"
 	"etj_map_statistics.cpp"
+	"etj_missilepad.cpp"
 	"etj_motd.cpp"
 	"etj_printer.cpp"
 	"etj_progression_tracker.cpp"

--- a/src/game/etj_missilepad.cpp
+++ b/src/game/etj_missilepad.cpp
@@ -1,0 +1,68 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "g_local.h"
+#include "etj_missilepad.h"
+
+namespace ETJump {
+void Missilepad::touch(gentity_t *self, gentity_t *other) {
+  // could check for classnames "m7_grenade" and "gpg40_grenade" here
+  // but MOD is likely the simplest and marginally faster than string compare
+  // we CANNOT check for ent->s.weapon here
+  // because a client might be holding the weapon
+  if (!(other->methodOfDeath == MOD_GPG40 || other->methodOfDeath == MOD_M7)) {
+    return;
+  }
+
+  G_UseTargets(self, other);
+}
+
+void Missilepad::use(gentity_t *ent) {
+  if (ent->r.linked) {
+    trap_UnlinkEntity(ent);
+  } else {
+    trap_LinkEntity(ent);
+  }
+}
+
+void Missilepad::spawn(gentity_t *ent) {
+  trap_SetBrushModel(ent, ent->model);
+  InitMover(ent);
+  VectorCopy(ent->s.origin, ent->s.pos.trBase);
+  VectorCopy(ent->s.origin, ent->r.currentOrigin);
+  ent->use = [](gentity_t *ent, gentity_t *other, gentity_t *activator) {
+    Missilepad::use(ent);
+  };
+
+  if (ent->spawnflags & static_cast<int>(Spawnflags::StartInvis)) {
+    trap_UnlinkEntity(ent);
+  }
+
+  ent->touch = [](gentity_t *ent, gentity_t *activator, trace_t *trace) {
+    Missilepad::touch(ent, activator);
+  };
+}
+} // namespace ETJump
+
+void SP_func_missilepad(gentity_t *ent) { ETJump::Missilepad::spawn(ent); }

--- a/src/game/etj_missilepad.h
+++ b/src/game/etj_missilepad.h
@@ -1,0 +1,40 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+namespace ETJump {
+class Missilepad {
+  static void use(gentity_t *ent);
+  static void touch(gentity_t *self, gentity_t *other);
+
+  enum class Spawnflags {
+    None = 0,
+    StartInvis = 1,
+  };
+
+public:
+  static void spawn(gentity_t *ent);
+};
+} // namespace ETJump

--- a/src/game/g_missile.cpp
+++ b/src/game/g_missile.cpp
@@ -167,7 +167,7 @@ void G_MissileImpact(gentity_t *ent, trace_t *trace, int impactDamage) {
       }
 
       // its possible of the func_explosive not to die
-      // from this and it should reflect the missile or
+      // from this, and it should reflect the missile or
       // explode it not vanish into oblivion
       if (other->health <= 0) {
         return;
@@ -175,30 +175,26 @@ void G_MissileImpact(gentity_t *ent, trace_t *trace, int impactDamage) {
     }
   }
 
-  // check for bounce
-  if ((!other->takedamage || !ent->damage) &&
-      (ent->s.eFlags & (EF_BOUNCE | EF_BOUNCE_HALF))) {
-    G_BounceMissile(ent, trace);
-    // JPW NERVE -- spotter White Phosphorous rounds shouldn't
-    // bounce noise
-    if (!Q_stricmp(ent->classname, "WP")) {
+  // ignore bounces for rifle grenades hitting a func_missilepad
+  // and call the touch function instead
+  if ((ent->s.weapon == WP_GPG40 || ent->s.weapon == WP_M7) &&
+      !Q_stricmp(other->classname, "func_missilepad")) {
+    other->touch(other, ent, trace);
+  } else {
+    // check for bounce
+    if ((!other->takedamage || !ent->damage) &&
+        (ent->s.eFlags & (EF_BOUNCE | EF_BOUNCE_HALF))) {
+      G_BounceMissile(ent, trace);
+      // JPW NERVE -- spotter White Phosphorous rounds shouldn't
+      // bounce noise
+      if (!Q_stricmp(ent->classname, "WP")) {
+        return;
+      }
+      G_AddEvent(ent, EV_GRENADE_BOUNCE,
+                 BG_FootstepForSurface(trace->surfaceFlags));
       return;
     }
-    // jpw
-    /*		if (!Q_stricmp (ent->classname, "flamebarrel"))
-       { G_AddEvent( ent, EV_FLAMEBARREL_BOUNCE, 0 ); } else {*/
-    G_AddEvent(ent, EV_GRENADE_BOUNCE,
-               BG_FootstepForSurface(trace->surfaceFlags));
-    //		}
-    return;
   }
-
-  // Gordon: unused?
-  /*	if (other->takedamage && ent->s.density == 1)
-      {
-          G_ExplodeMissilePoisonGas (ent);
-          return;
-      }*/
 
   // impact damage
   if (other->takedamage || other->dmgparent) {
@@ -206,7 +202,7 @@ void G_MissileImpact(gentity_t *ent, trace_t *trace, int impactDamage) {
       AccuracyHit(other, &g_entities[ent->r.ownerNum]);
       BG_EvaluateTrajectoryDelta(&ent->s.pos, level.time, velocity, qfalse,
                                  ent->s.effect2Time);
-      if (!VectorLengthSquared(velocity)) {
+      if (VectorLengthSquared(velocity) == 0) {
         velocity[2] = 1; // stepped on a grenade
       }
       G_Damage(other->dmgparent ? other->dmgparent : other, ent,
@@ -227,10 +223,6 @@ void G_MissileImpact(gentity_t *ent, trace_t *trace, int impactDamage) {
     event = EV_MISSILE_HIT;
     param = DirToByte(trace->plane.normal);
     otherentnum = other->s.number;
-    //		G_AddEvent( ent, EV_MISSILE_HIT, DirToByte(
-    // trace->plane.normal
-    //)
-    //); 		ent->s.otherEntityNum = other->s.number;
   } else {
     // Ridah, try projecting it in the direction it came from,
     // for better decals
@@ -241,32 +233,10 @@ void G_MissileImpact(gentity_t *ent, trace_t *trace, int impactDamage) {
 
     event = EV_MISSILE_MISS;
     param = DirToByte(dir);
-    //		G_AddEvent( ent, EV_MISSILE_MISS, DirToByte( dir )
-    //);
   }
-
-  //	ent->freeAfterEvent = qtrue;
-
-  // change over to a normal entity right at the point of impact
-  //	etype = ent->s.eType;
-  //	ent->s.eType = ET_GENERAL;
-
-  //	SnapVectorTowards( trace->endpos, ent->s.pos.trBase );	// save
-  // net
-  // bandwidth
-  /*	{
-          gentity_t* tent;
-
-          tent = G_TempEntity( trace->endpos, EV_RAILTRAIL );
-          VectorMA(trace->endpos, 16, trace->plane.normal,
-     tent->s.origin2); tent->s.dmgFlags = 0;
-      }*/
-
-  //	G_SetOrigin( ent, trace->endpos );
 
   temp = G_TempEntity(trace->endpos, event);
   temp->s.otherEntityNum = otherentnum;
-  //	temp->r.svFlags |= SVF_BROADCAST;
   temp->s.eventParm = param;
   temp->s.weapon = ent->s.weapon;
   temp->s.clientNum = ent->r.ownerNum;
@@ -278,11 +248,10 @@ void G_MissileImpact(gentity_t *ent, trace_t *trace, int impactDamage) {
 
   // splash damage (doesn't apply to person directly hit)
   if (ent->splashDamage) {
-    G_RadiusDamage(trace->endpos, ent, ent->parent, ent->splashDamage,
-                   ent->splashRadius, other, ent->splashMethodOfDeath);
+    G_RadiusDamage(
+        trace->endpos, ent, ent->parent, static_cast<float>(ent->splashDamage),
+        static_cast<float>(ent->splashRadius), other, ent->splashMethodOfDeath);
   }
-
-  //	trap_LinkEntity( ent );
 
   G_FreeEntity(ent);
 }
@@ -1150,10 +1119,9 @@ void G_RunFlamechunk(gentity_t *ent) {
   gentity_t *ignoreent = NULL;
 
   // TAT 11/12/2002
-  //		vel was only being set if (level.time - ent->timestamp >
-  // 50 		However, below, it was being used when we hit something and
-  // it
-  // was 		uninitialized
+  // vel was only being set if (level.time - ent->timestamp > 50)
+  // However, below, it was being used when we hit something,
+  // and it was uninitialized
   VectorCopy(ent->s.pos.trDelta, vel);
 
   // Adust the current speed of the chunk

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -476,6 +476,8 @@ void SP_target_tjldisplay(gentity_t *self);
 
 void SP_target_init(gentity_t *self);
 
+void SP_func_missilepad(gentity_t *ent);
+
 spawn_t spawns[] = {
     // info entities don't do anything at all, but provide positional
     // information for things controlled by other processes
@@ -720,6 +722,7 @@ spawn_t spawns[] = {
     {"target_displaytjl", SP_target_tjldisplay},
     {"target_cleartjl", SP_target_tjlclear},
     {"target_init", SP_target_init},
+    {"func_missilepad", SP_func_missilepad},
     {0, 0}};
 
 /*


### PR DESCRIPTION
`func_missilepad` entity that can be used to mimic the behavior of Q3 grenade launcher + `func_door/func_button`. Explodes a rifle grenade upon impact and fires any targeted entities.

Entity for NetRadiant
```xml
<group name="func_missilepad" color="0.5 0.5 0.5">
Explodes riflegrenades on impact.
-------- KEYS --------
<target key="target" name="Target">Targets to fire upon impact.</target>
-------- Q3MAP2 KEYS --------
<integer key="_cs" name="Cast shadows">Per-entity control of shadow casting, used to disable (0) or enable shadow casting to entities with corresponding "_rs" value. Defaults to 1 on world, 0 on entities.</integer>
<integer key="_rs" name="Receive shadows">Per-entity control of shadow receiving, used to disable (0) or enable shadow receiving from entities with corresponding "_cs" value. Defaults to 1 on everything.</integer>
<real key="_lightmapscale" name="Lightmap Scale" value="1.0">Scaling factor for lightmap size.</real>
<integer key="_samplesize" name="Samplesize">Default surface lightmap sample size.</integer>
<real key="_shadeangle" name="Shadeangle">Largest allowed angle between faces to be treated as same nonplanar surface.</real>
<string key="_clone" name="Clone">Name of the brush entity to copy brushes from (can be used to use the same brush model multiple times).</string>
<string key="_clonename" name="Clonename">Name referenced by "_clone".</string>
<texture key="_celshader" name="CelShader">CelShader to use, omit "textures/" prefix.</texture>
<boolean key="_patchMeta" name="Patch Meta">Generate meta surfaces from patches.</boolean>
<integer key="_patchQuality" name="Patch Quality">Quality multiplier for patches when "_patchMeta" is set. Note: integer values only.</integer>
<integer key="_patchSubdivide" name="Patch Subdivide">Absolute quality setting for patches when "_patchMeta" is set. Note: integer values only.</integer>
-------- SPAWNFLAGS --------
<flag key="START_INVIS" name="Start invisible" bit="0">Start the entity as non-existent, if targeted, it will toggle existence when triggered.</flag>
-------- NOTES --------
Only activates for direct impact, splash damage is ignored.
Toggling existence does NOT fire targets, only impacts from rifle grenades.
</group>
```
Gtk
```
/*QUAKED func_missilepad (0 .5 .5) ? START_INVIS 
Explodes riflegrenades on impact.
-------- KEYS --------
"target" targets to fire upon impact
-------- Q3MAP2 KEYS --------
"_lightmapscale" Scaling factor for lightmap size.
"_cs" Per-entity control of shadow casting, used to disable (0) or enable shadow casting to entities with corresponding "_rs" value. Defaults to 1 on world, 0 on entities.
"_rs" Per-entity control of shadow receiving, used to disable (0) or enable shadow receiving from entities with corresponding "_cs" value. Defaults to 1 on everything.
"_celshader" CelShader to use, omit "textures/" prefix.
"_clone" Name of the brush entity to copy brushes from (can be used to use the same brush model multiple times).
"_clonename" Name referenced by "_clone".
-------- SPAWNFLAGS --------
START_INVIS will start the entity as non-existant, if targeted, it will toggle existance when triggered
-------- NOTES --------
Only activates for direct impact, splash damage is ignored.
Toggling existence does NOT fire targets, only impacts from rifle grenades.
*/
```