### PR TITLE
Skip strafe quality/upmove meter updates on invalid ps

### DIFF
--- a/src/cgame/etj_strafe_quality_drawable.cpp
+++ b/src/cgame/etj_strafe_quality_drawable.cpp
@@ -184,6 +184,13 @@ void StrafeQuality::render() const {
 }
 
 bool StrafeQuality::canSkipUpdate(usercmd_t cmd, int frameTime) {
+  // do not try to update if we don't have a valid playerState yet
+  // this is usually the case for few frames at the start of a map
+  // especially on high client frame rates
+  if (!pm->ps) {
+    return true;
+  }
+
   // only count this frame if it's relevant to pmove
   // this makes sure that if clients FPS > 125
   // we only count frames at pmove_msec intervals
@@ -197,18 +204,17 @@ bool StrafeQuality::canSkipUpdate(usercmd_t cmd, int frameTime) {
   }
 
   // don't update if not in air or on ice
-  if (cg.snap->ps.groundEntityNum != ENTITYNUM_NONE &&
+  if (pm->ps->groundEntityNum != ENTITYNUM_NONE &&
       !(pm->pmext->groundTrace.surfaceFlags & SURF_SLICK)) {
     return true;
   }
 
-  if (cg.snap->ps.pm_type == PM_NOCLIP || cg.snap->ps.pm_type == PM_DEAD) {
+  if (pm->ps->pm_type == PM_NOCLIP || pm->ps->pm_type == PM_DEAD) {
     return true;
   }
 
-  if (BG_PlayerMounted(cg.snap->ps.eFlags) ||
-      cg.snap->ps.weapon == WP_MOBILE_MG42_SET ||
-      cg.snap->ps.weapon == WP_MORTAR_SET) {
+  if (BG_PlayerMounted(pm->ps->eFlags) ||
+      pm->ps->weapon == WP_MOBILE_MG42_SET || pm->ps->weapon == WP_MORTAR_SET) {
     return true;
   }
 

--- a/src/cgame/etj_upmove_meter_drawable.cpp
+++ b/src/cgame/etj_upmove_meter_drawable.cpp
@@ -285,13 +285,19 @@ void UpmoveMeter::render() const {
 }
 
 bool UpmoveMeter::canSkipUpdate() const {
-  if (cg.snap->ps.pm_type == PM_NOCLIP || cg.snap->ps.pm_type == PM_DEAD) {
+  // do not try to update if we don't have a valid playerState yet
+  // this is usually the case for few frames at the start of a map
+  // especially on high client frame rates
+  if (!pm->ps) {
     return true;
   }
 
-  if (BG_PlayerMounted(cg.snap->ps.eFlags) ||
-      cg.snap->ps.weapon == WP_MOBILE_MG42_SET ||
-      cg.snap->ps.weapon == WP_MORTAR_SET) {
+  if (pm->ps->pm_type == PM_NOCLIP || pm->ps->pm_type == PM_DEAD) {
+    return true;
+  }
+
+  if (BG_PlayerMounted(pm->ps->eFlags) ||
+      pm->ps->weapon == WP_MOBILE_MG42_SET || pm->ps->weapon == WP_MORTAR_SET) {
     return true;
   }
 


### PR DESCRIPTION
Reverts #835 

Instead of using `cg.snap->ps` for update checking (which causes some inaccuracy in strafe quality `groundEntityNum` check), early out if we don't have a valid playerState to not try to read garbage data, which will crash the client.