### PR TITLE
Replace atoi with sanitized Q_atoi

### DIFF
--- a/src/cgame/cg_character.cpp
+++ b/src/cgame/cg_character.cpp
@@ -94,13 +94,13 @@ static qboolean CG_ParseHudHeadConfig(const char *filename, animation_t *hha) {
     if (!token) {
       break;
     }
-    hha[i].firstFrame = atoi(token);
+    hha[i].firstFrame = Q_atoi(token);
 
     token = COM_Parse(&text_p); // length
     if (!token) {
       break;
     }
-    hha[i].numFrames = atoi(token);
+    hha[i].numFrames = Q_atoi(token);
 
     token = COM_Parse(&text_p); // fps
     if (!token) {
@@ -118,7 +118,7 @@ static qboolean CG_ParseHudHeadConfig(const char *filename, animation_t *hha) {
     if (!token) {
       break;
     }
-    hha[i].loopFrames = atoi(token);
+    hha[i].loopFrames = Q_atoi(token);
 
     if (hha[i].loopFrames > hha[i].numFrames) {
       hha[i].loopFrames = hha[i].numFrames;

--- a/src/cgame/cg_commandmap.cpp
+++ b/src/cgame/cg_commandmap.cpp
@@ -133,7 +133,7 @@ void CG_ParseMapEntity(int *mapEntityCount, int *offset, team_t team) {
   char buffer[16];
 
   trap_Argv((*offset)++, buffer, 16);
-  mEnt->type = atoi(buffer);
+  mEnt->type = static_cast<char>(Q_atoi(buffer));
 
   switch (mEnt->type) {
     case ME_CONSTRUCT: // Gordon: these ones don't need much
@@ -146,36 +146,36 @@ void CG_ParseMapEntity(int *mapEntityCount, int *offset, team_t team) {
     case ME_TANK:
     case ME_TANK_DEAD:
       trap_Argv((*offset)++, buffer, 16);
-      mEnt->x = atoi(buffer) * 128;
+      mEnt->x = Q_atoi(buffer) * 128;
 
       trap_Argv((*offset)++, buffer, 16);
-      mEnt->y = atoi(buffer) * 128;
+      mEnt->y = Q_atoi(buffer) * 128;
 
       if (cgs.ccLayers) {
         trap_Argv((*offset)++, buffer, 16);
-        mEnt->z = atoi(buffer) * 128;
+        mEnt->z = Q_atoi(buffer) * 128;
       }
       break;
 
     default:
       trap_Argv((*offset)++, buffer, 16);
-      mEnt->x = atoi(buffer) * 128;
+      mEnt->x = Q_atoi(buffer) * 128;
 
       trap_Argv((*offset)++, buffer, 16);
-      mEnt->y = atoi(buffer) * 128;
+      mEnt->y = Q_atoi(buffer) * 128;
 
       if (cgs.ccLayers) {
         trap_Argv((*offset)++, buffer, 16);
-        mEnt->z = atoi(buffer) * 128;
+        mEnt->z = Q_atoi(buffer) * 128;
       }
 
       trap_Argv((*offset)++, buffer, 16);
-      mEnt->yaw = atoi(buffer);
+      mEnt->yaw = Q_atoi(buffer);
       break;
   }
 
   trap_Argv((*offset)++, buffer, 16);
-  mEnt->data = atoi(buffer);
+  mEnt->data = Q_atoi(buffer);
 
   mEnt->transformed[0] =
       (mEnt->x - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0] * CC_2D_W;
@@ -560,7 +560,7 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
       }
 
       /*		if((mEnt->yaw & 0xFF) & (1 <<
-         (atoi(CG_ConfigString(mEnt->team == TEAM_AXIS ?
+         (Q_atoi(CG_ConfigString(mEnt->team == TEAM_AXIS ?
          CS_MAIN_AXIS_OBJECTIVE :
          CS_MAIN_ALLIES_OBJECTIVE)) - 1))) {
          trap_R_SetColor( colorYellow );

--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -521,7 +521,7 @@ static void CG_MessageSend_f(void) {
   // get values
   trap_Cvar_VariableStringBuffer("cg_messageType", messageText,
                                  sizeof(messageText));
-  messageType = atoi(messageText);
+  messageType = Q_atoi(messageText);
   trap_Cvar_VariableStringBuffer("cg_messageText", messageText,
                                  sizeof(messageText));
 
@@ -555,12 +555,12 @@ static void CG_SetWeaponCrosshair_f(void) {
   char crosshair[64];
 
   trap_Argv(1, crosshair, 64);
-  cg.newCrosshairIndex = atoi(crosshair) + 1;
+  cg.newCrosshairIndex = Q_atoi(crosshair) + 1;
 }
 // -NERVE - SMF
 
 static void CG_SelectBuddy_f(void) {
-  int pos = atoi(CG_Argv(1));
+  int pos = Q_atoi(CG_Argv(1));
   int i;
   clientInfo_t *ci;
 
@@ -815,9 +815,9 @@ static void CG_DumpSpeaker_f(void) {
           Q_strncpyz( soundfile, soundfile, buffptr - soundfile + 1 );
 
           if( !Q_stricmp( soundfile, "wait" ) )
-              wait = atoi( valueptr );
+              wait = Q_atoi( valueptr );
           else if( !Q_stricmp( soundfile, "random" ) )
-              random = atoi( valueptr );
+              random = Q_atoi( valueptr );
       }
 
       // parse soundfile

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -3226,7 +3226,7 @@ static void CG_DrawWarmup(void) {
            cgs.currentRound + 1);
 
     cs = CG_ConfigString(CS_MULTI_INFO);
-    defender = atoi(Info_ValueForKey(cs, "defender"));
+    defender = Q_atoi(Info_ValueForKey(cs, "defender"));
 
     if (!defender) {
       if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_AXIS) {

--- a/src/cgame/cg_fireteamoverlay.cpp
+++ b/src/cgame/cg_fireteamoverlay.cpp
@@ -113,7 +113,7 @@ void CG_ParseFireteams() {
     //		CG_Printf("Fireteam: %s\n",
     // cg.fireTeams[i].name);
 
-    j = atoi(Info_ValueForKey(p, "id"));
+    j = Q_atoi(Info_ValueForKey(p, "id"));
     if (j == -1) {
       cg.fireTeams[i].inuse = qfalse;
       continue;
@@ -123,7 +123,7 @@ void CG_ParseFireteams() {
     }
 
     s = Info_ValueForKey(p, "l");
-    cg.fireTeams[i].leader = atoi(s);
+    cg.fireTeams[i].leader = Q_atoi(s);
 
     s = Info_ValueForKey(p, "c");
     Q_strncpyz(hexbuffer + 2, s, 9);

--- a/src/cgame/cg_limbopanel.cpp
+++ b/src/cgame/cg_limbopanel.cpp
@@ -1407,7 +1407,7 @@ int CG_LimboPanel_GetMaxObjectives(void) {
     return 0;
   }
 
-  return atoi(
+  return Q_atoi(
       Info_ValueForKey(CG_ConfigString(CS_MULTI_INFO), "numobjectives"));
 }
 
@@ -1464,13 +1464,13 @@ void CG_LimboPanel_RenderObjectiveText(panel_button_t *button) {
           // info = Info_ValueForKey(
           // cs, "axis_desc" );
           info = cg.objDescription_Axis[cgs.ccSelectedObjective];
-          status = atoi(
+          status = Q_atoi(
               Info_ValueForKey(cs, va("x%i", cgs.ccSelectedObjective + 1)));
         } else {
           // info = Info_ValueForKey(
           // cs, "allied_desc" );
           info = cg.objDescription_Allied[cgs.ccSelectedObjective];
-          status = atoi(
+          status = Q_atoi(
               Info_ValueForKey(cs, va("a%i", cgs.ccSelectedObjective + 1)));
         }
 

--- a/src/cgame/cg_loadpanel.cpp
+++ b/src/cgame/cg_loadpanel.cpp
@@ -307,13 +307,13 @@ void CG_DrawConnectScreen(qboolean interactive, qboolean forcerefresh) {
     }
 
     str = Info_ValueForKey(buffer, "sv_punkbuster");
-    if (str && *str && atoi(str)) {
+    if (str && *str && Q_atoi(str)) {
       x = SCREEN_OFFSET_X + 518;
       CG_DrawPic(x, y, 16, 16, bg_filter_pb);
     }
 
     str = Info_ValueForKey(buffer, "g_antilag");
-    if (str && *str && atoi(str)) {
+    if (str && *str && Q_atoi(str)) {
       x = SCREEN_OFFSET_X + 575;
       CG_DrawPic(x, y, 16, 16, bg_filter_al);
     }
@@ -401,7 +401,7 @@ void CG_LoadPanel_RenderMissionDescriptionText(panel_button_t *button) {
 
   // DC->getConfigString( CS_SERVERINFO, buffer, sizeof( buffer ) );
   // cs = Info_ValueForKey( buffer, "g_gametype" );
-  // gametype = atoi(cs);
+  // gametype = Q_atoi(cs);
 
   //	DC->fillRect( button->rect.x, button->rect.y, button->rect.w,
   // button->rect.h, colorRed );
@@ -512,7 +512,7 @@ void CG_LoadPanel_RenderCampaignPins(panel_button_t *button) {
 
   DC->getConfigString( CS_SERVERINFO, buffer, sizeof( buffer ) );
   s = Info_ValueForKey( buffer, "g_gametype" );
-  gametype = atoi(s);*/
+  gametype = Q_atoi(s);*/
 
   if (cgs.gametype == GT_WOLF_STOPWATCH || cgs.gametype == GT_WOLF_LMS ||
       cgs.gametype == GT_WOLF) {
@@ -535,8 +535,8 @@ void CG_LoadPanel_RenderCampaignPins(panel_button_t *button) {
     for (i = 0; i < cgs.campaignData.mapCount; i++) {
       float px, py;
 
-      cg.teamWonRounds[1] = atoi(CG_ConfigString(CS_ROUNDSCORES1));
-      cg.teamWonRounds[0] = atoi(CG_ConfigString(CS_ROUNDSCORES2));
+      cg.teamWonRounds[1] = Q_atoi(CG_ConfigString(CS_ROUNDSCORES1));
+      cg.teamWonRounds[0] = Q_atoi(CG_ConfigString(CS_ROUNDSCORES2));
 
       if (cg.teamWonRounds[1] & (1 << i)) {
         shader = bg_axispin;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1135,7 +1135,7 @@ void CG_RegisterCvars(void) {
 
   // see if we are also running the server on this machine
   trap_Cvar_VariableStringBuffer("sv_running", var, sizeof(var));
-  cgs.localServer = atoi(var) ? qtrue : qfalse;
+  cgs.localServer = Q_atoi(var) ? qtrue : qfalse;
 
   // Gordon: um, here, why?
   CG_setClientFlags();
@@ -1417,7 +1417,7 @@ int CG_findClientNum(char *s) {
 
   // numeric values are just slot numbers
   if (fIsNumber) {
-    id = atoi(s);
+    id = Q_atoi(s);
     if (id >= 0 && id < cgs.maxclients && cgs.clientinfo[id].infoValid) {
       return (id);
     }
@@ -1562,24 +1562,24 @@ void CG_SetupDlightstyles(void) {
     }
 
     token = COM_Parse(&str); // ent num
-    entnum = atoi(token);
+    entnum = Q_atoi(token);
     cent = &cg_entities[entnum];
 
     token = COM_Parse(&str); // stylestring
     Q_strncpyz(cent->dl_stylestring, token, strlen(token));
 
     token = COM_Parse(&str); // offset
-    cent->dl_frame = atoi(token);
+    cent->dl_frame = Q_atoi(token);
     cent->dl_oldframe = cent->dl_frame - 1;
     if (cent->dl_oldframe < 0) {
       cent->dl_oldframe = strlen(cent->dl_stylestring);
     }
 
     token = COM_Parse(&str); // sound id
-    cent->dl_sound = atoi(token);
+    cent->dl_sound = Q_atoi(token);
 
     token = COM_Parse(&str); // attenuation
-    cent->dl_atten = atoi(token);
+    cent->dl_atten = Q_atoi(token);
 
     for (j = 0; j < static_cast<int>(strlen(cent->dl_stylestring)); j++) {
 
@@ -3780,10 +3780,10 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum,
                 GAME_VERSION_DATED); // So server can check
 
   s = CG_ConfigString(CS_LEVEL_START_TIME);
-  cgs.levelStartTime = atoi(s);
+  cgs.levelStartTime = Q_atoi(s);
 
   s = CG_ConfigString(CS_INTERMISSION_START_TIME);
-  cgs.intermissionStartTime = atoi(s);
+  cgs.intermissionStartTime = Q_atoi(s);
 
   cg.lastScoreTime = 0;
 
@@ -3870,10 +3870,10 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum,
   trap_S_ClearLoopingSounds();
   trap_S_ClearSounds(qfalse);
 
-  cg.teamWonRounds[1] = atoi(CG_ConfigString(CS_ROUNDSCORES1));
-  cg.teamWonRounds[0] = atoi(CG_ConfigString(CS_ROUNDSCORES2));
+  cg.teamWonRounds[1] = Q_atoi(CG_ConfigString(CS_ROUNDSCORES1));
+  cg.teamWonRounds[0] = Q_atoi(CG_ConfigString(CS_ROUNDSCORES2));
 
-  cg.filtercams = atoi(CG_ConfigString(CS_FILTERCAMS)) ? qtrue : qfalse;
+  cg.filtercams = Q_atoi(CG_ConfigString(CS_FILTERCAMS)) ? qtrue : qfalse;
 
   CG_ParseFireteams();
 

--- a/src/cgame/cg_newDraw.cpp
+++ b/src/cgame/cg_newDraw.cpp
@@ -615,7 +615,7 @@ void CG_MouseEvent(int x, int y) {
         my += y;
 
         trap_Cvar_VariableStringBuffer("m_filter", buffer, sizeof(buffer));
-        m_filter = atoi(buffer);
+        m_filter = Q_atoi(buffer);
 
         trap_Cvar_VariableStringBuffer("sensitivity", buffer, sizeof(buffer));
         sensitivity = Q_atof(buffer);

--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -1468,7 +1468,7 @@ int CG_NewParticleArea(int num) {
 
   // returns type 128 64 or 32
   token = COM_Parse(&str);
-  type = atoi(token);
+  type = Q_atoi(token);
 
   if (type == 1) {
     range = 128;
@@ -1499,13 +1499,13 @@ int CG_NewParticleArea(int num) {
   }
 
   token = COM_Parse(&str);
-  numparticles = atoi(token);
+  numparticles = Q_atoi(token);
 
   token = COM_Parse(&str);
-  turb = atoi(token);
+  turb = Q_atoi(token);
 
   token = COM_Parse(&str);
-  snum = atoi(token);
+  snum = Q_atoi(token);
 
   for (i = 0; i < numparticles; i++) {
     if (type >= 4) {

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -156,22 +156,22 @@ void CG_NewClientInfo(int clientNum) {
 
   // bot skill
   v = Info_ValueForKey(configstring, "skill");
-  newInfo.botSkill = atoi(v);
+  newInfo.botSkill = Q_atoi(v);
 
   // team
   v = Info_ValueForKey(configstring, "t");
-  newInfo.team = (team_t)atoi(v);
+  newInfo.team = (team_t)Q_atoi(v);
 
   // class
   v = Info_ValueForKey(configstring, "c");
-  newInfo.cls = atoi(v);
+  newInfo.cls = Q_atoi(v);
 
   // rank
   v = Info_ValueForKey(configstring, "r");
-  newInfo.rank = atoi(v);
+  newInfo.rank = Q_atoi(v);
 
   v = Info_ValueForKey(configstring, "f");
-  newInfo.fireteam = atoi(v);
+  newInfo.fireteam = Q_atoi(v);
 
   v = Info_ValueForKey(configstring, "m");
   if (*v) {
@@ -180,14 +180,14 @@ void CG_NewClientInfo(int clientNum) {
     buf[1] = '\0';
     for (i = 0; i < SK_NUM_SKILLS; i++) {
       buf[0] = *v;
-      newInfo.medals[i] = atoi(buf);
+      newInfo.medals[i] = Q_atoi(buf);
       v++;
     }
   }
 
   v = Info_ValueForKey(configstring, "ch");
   if (*v) {
-    newInfo.character = cgs.gameCharacters[atoi(v)];
+    newInfo.character = cgs.gameCharacters[Q_atoi(v)];
   }
 
   v = Info_ValueForKey(configstring, "s");
@@ -200,7 +200,7 @@ void CG_NewClientInfo(int clientNum) {
       skill[0] = v[i];
       skill[1] = '\0';
 
-      newInfo.skill[i] = atoi(skill);
+      newInfo.skill[i] = Q_atoi(skill);
     }
   }
 
@@ -210,42 +210,42 @@ void CG_NewClientInfo(int clientNum) {
 
   // disguiseRank
   v = Info_ValueForKey(configstring, "dr");
-  newInfo.disguiseRank = atoi(v);
+  newInfo.disguiseRank = Q_atoi(v);
 
   // Gordon: weapon and latchedweapon ( FIXME: make these more secure )
   v = Info_ValueForKey(configstring, "w");
-  newInfo.weapon = atoi(v);
+  newInfo.weapon = Q_atoi(v);
 
   v = Info_ValueForKey(configstring, "lw");
-  newInfo.latchedweapon = atoi(v);
+  newInfo.latchedweapon = Q_atoi(v);
 
   v = Info_ValueForKey(configstring, "sw");
-  newInfo.secondaryweapon = atoi(v);
+  newInfo.secondaryweapon = Q_atoi(v);
 
   // pmove_fixed
   v = Info_ValueForKey(configstring, "pm");
-  newInfo.pmoveFixed = atoi(v);
+  newInfo.pmoveFixed = Q_atoi(v);
   // com_maxfps
   v = Info_ValueForKey(configstring, "fps");
-  newInfo.maxFPS = atoi(v);
+  newInfo.maxFPS = Q_atoi(v);
 
   v = Info_ValueForKey(configstring, "cgaz");
-  newInfo.CGaz = atoi(v);
+  newInfo.CGaz = Q_atoi(v);
 
   v = Info_ValueForKey(configstring, "h");
-  newInfo.hideMe = atoi(v);
+  newInfo.hideMe = Q_atoi(v);
 
   v = Info_ValueForKey(configstring, "sl");
-  newInfo.specLocked = atoi(v) > 0 ? qtrue : qfalse;
+  newInfo.specLocked = Q_atoi(v) > 0 ? qtrue : qfalse;
 
   v = Info_ValueForKey(configstring, "tr");
-  newInfo.timerunActive = atoi(v) > 0 ? qtrue : qfalse;
+  newInfo.timerunActive = Q_atoi(v) > 0 ? qtrue : qfalse;
 
   v = Info_ValueForKey(configstring, "vs");
-  newInfo.snaphud = atoi(v);
+  newInfo.snaphud = Q_atoi(v);
 
   v = Info_ValueForKey(configstring, "i");
-  newInfo.clientIsInactive = atoi(v);
+  newInfo.clientIsInactive = Q_atoi(v);
 
   // Gordon: detect rank/skill changes client side
   if (clientNum == cg.clientNum) {

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -29,26 +29,26 @@ static void CG_ParseScore(team_t team) {
   if (team == TEAM_AXIS) {
     cg.numScores = 0;
 
-    cg.teamScores[0] = atoi(CG_Argv(1));
-    cg.teamScores[1] = atoi(CG_Argv(2));
+    cg.teamScores[0] = Q_atoi(CG_Argv(1));
+    cg.teamScores[1] = Q_atoi(CG_Argv(2));
 
     offset = 4;
   } else {
     offset = 2;
   }
 
-  numScores = atoi(CG_Argv(offset - 1));
+  numScores = Q_atoi(CG_Argv(offset - 1));
 
   for (j = 0; j < numScores; j++) {
     i = cg.numScores;
 
-    cg.scores[i].client = atoi(CG_Argv(offset + 0 + (j * 7)));
-    cg.scores[i].score = atoi(CG_Argv(offset + 1 + (j * 7)));
-    cg.scores[i].ping = atoi(CG_Argv(offset + 2 + (j * 7)));
-    cg.scores[i].time = atoi(CG_Argv(offset + 3 + (j * 7)));
-    powerups = atoi(CG_Argv(offset + 4 + (j * 7)));
-    cg.scores[i].playerClass = atoi(CG_Argv(offset + 5 + (j * 7)));
-    cg.scores[i].followedClient = atoi(CG_Argv(offset + 6 + (j * 7)));
+    cg.scores[i].client = Q_atoi(CG_Argv(offset + 0 + (j * 7)));
+    cg.scores[i].score = Q_atoi(CG_Argv(offset + 1 + (j * 7)));
+    cg.scores[i].ping = Q_atoi(CG_Argv(offset + 2 + (j * 7)));
+    cg.scores[i].time = Q_atoi(CG_Argv(offset + 3 + (j * 7)));
+    powerups = Q_atoi(CG_Argv(offset + 4 + (j * 7)));
+    cg.scores[i].playerClass = Q_atoi(CG_Argv(offset + 5 + (j * 7)));
+    cg.scores[i].followedClient = Q_atoi(CG_Argv(offset + 6 + (j * 7)));
 
     if (cg.scores[i].client < 0 || cg.scores[i].client >= MAX_CLIENTS) {
       cg.scores[i].client = 0;
@@ -75,15 +75,15 @@ static void CG_ParseTeamInfo(void) {
   int client;
   int numSortedTeamPlayers;
 
-  numSortedTeamPlayers = atoi(CG_Argv(1));
+  numSortedTeamPlayers = Q_atoi(CG_Argv(1));
 
   for (i = 0; i < numSortedTeamPlayers; i++) {
-    client = atoi(CG_Argv(i * NUMARGS + 2));
+    client = Q_atoi(CG_Argv(i * NUMARGS + 2));
 
-    cgs.clientinfo[client].location[0] = atoi(CG_Argv(i * NUMARGS + 3));
-    cgs.clientinfo[client].location[1] = atoi(CG_Argv(i * NUMARGS + 4));
-    cgs.clientinfo[client].health = atoi(CG_Argv(i * NUMARGS + 5));
-    cgs.clientinfo[client].powerups = atoi(CG_Argv(i * NUMARGS + 6));
+    cgs.clientinfo[client].location[0] = Q_atoi(CG_Argv(i * NUMARGS + 3));
+    cgs.clientinfo[client].location[1] = Q_atoi(CG_Argv(i * NUMARGS + 4));
+    cgs.clientinfo[client].health = Q_atoi(CG_Argv(i * NUMARGS + 5));
+    cgs.clientinfo[client].powerups = Q_atoi(CG_Argv(i * NUMARGS + 6));
   }
 }
 
@@ -101,8 +101,9 @@ void CG_ParseServerinfo(void) {
 
   info = CG_ConfigString(CS_SERVERINFO);
   cg_gameType.integer = cgs.gametype =
-      (gametype_t)atoi(Info_ValueForKey(info, "g_gametype"));
-  cg_antilag.integer = cgs.antilag = atoi(Info_ValueForKey(info, "g_antilag"));
+      (gametype_t)Q_atoi(Info_ValueForKey(info, "g_gametype"));
+  cg_antilag.integer = cgs.antilag =
+      Q_atoi(Info_ValueForKey(info, "g_antilag"));
   if (!cgs.localServer) {
     trap_Cvar_Set("g_gametype", va("%i", cgs.gametype));
     trap_Cvar_Set("g_antilag", va("%i", cgs.antilag));
@@ -110,7 +111,7 @@ void CG_ParseServerinfo(void) {
     trap_Cvar_Update(&cg_gameType);
   }
   cgs.timelimit = Q_atof(Info_ValueForKey(info, "timelimit"));
-  cgs.maxclients = atoi(Info_ValueForKey(info, "sv_maxclients"));
+  cgs.maxclients = Q_atoi(Info_ValueForKey(info, "sv_maxclients"));
   mapname = Info_ValueForKey(info, "mapname");
   Q_strncpyz(cgs.rawmapname, mapname, sizeof(cgs.rawmapname));
   Com_sprintf(cgs.mapname, sizeof(cgs.mapname), "maps/%s.bsp", mapname);
@@ -119,18 +120,17 @@ void CG_ParseServerinfo(void) {
   // don't want to break anything that might be improperly set for wolf
   // SP, so I'm just parsing MP relevant stuff here
   trap_Cvar_Set("g_redlimbotime", Info_ValueForKey(info, "g_redlimbotime"));
-  cg_redlimbotime.integer = atoi(Info_ValueForKey(info, "g_redlimbotime"));
+  cg_redlimbotime.integer = Q_atoi(Info_ValueForKey(info, "g_redlimbotime"));
   trap_Cvar_Set("g_bluelimbotime", Info_ValueForKey(info, "g_bluelimbotime"));
-  cg_bluelimbotime.integer = atoi(Info_ValueForKey(info, "g_bluelimbotime"));
+  cg_bluelimbotime.integer = Q_atoi(Info_ValueForKey(info, "g_bluelimbotime"));
 
-  cg_ghostPlayers.integer = atoi(Info_ValueForKey(info, "g_ghostPlayers"));
+  cg_ghostPlayers.integer = Q_atoi(Info_ValueForKey(info, "g_ghostPlayers"));
 
-  etj_spectatorVote.integer = atoi(Info_ValueForKey(info, "g_spectatorVote"));
+  etj_spectatorVote.integer = Q_atoi(Info_ValueForKey(info, "g_spectatorVote"));
 
-  cgs.minclients =
-      atoi(Info_ValueForKey(info,
-                            "g_minGameClients")); // NERVE - SMF -- OSP:
-                                                  // overloaded for ready counts
+  cgs.minclients = Q_atoi(Info_ValueForKey(
+      info, "g_minGameClients")); // NERVE - SMF -- OSP:
+                                  // overloaded for ready counts
 
   // TTimo - make this available for ingame_callvote
   trap_Cvar_Set("cg_ui_voteFlags", Info_ValueForKey(info, "voteFlags"));
@@ -139,20 +139,20 @@ void CG_ParseServerinfo(void) {
 void CG_ParseSysteminfo(void) {
   const char *info = CG_ConfigString(CS_SYSTEMINFO);
 
-  cgs.shared = atoi(Info_ValueForKey(info, "shared"));
+  cgs.shared = Q_atoi(Info_ValueForKey(info, "shared"));
 
-  cgs.pmove_msec = atoi(Info_ValueForKey(info, "pmove_msec"));
+  cgs.pmove_msec = Q_atoi(Info_ValueForKey(info, "pmove_msec"));
   if (cgs.pmove_msec < 8) {
     cgs.pmove_msec = 8;
   } else if (cgs.pmove_msec > 33) {
     cgs.pmove_msec = 33;
   }
 
-  cgs.cheats = atoi(Info_ValueForKey(info, "sv_cheats"));
+  cgs.cheats = Q_atoi(Info_ValueForKey(info, "sv_cheats"));
 
 #ifdef ALLOW_GSYNC
   cgs.synchronousClients =
-      (atoi(Info_ValueForKey(info, "g_synchronousClients"))) ? qtrue : qfalse;
+      (Q_atoi(Info_ValueForKey(info, "g_synchronousClients"))) ? qtrue : qfalse;
 #endif
 }
 
@@ -167,7 +167,7 @@ static void CG_ParseWarmup(void) {
 
   info = CG_ConfigString(CS_WARMUP);
 
-  warmup = atoi(info);
+  warmup = Q_atoi(info);
 
   if (warmup == 0 && cg.warmup) {
 
@@ -226,27 +226,27 @@ void CG_ParseOIDInfo(int num) {
 
   cs = Info_ValueForKey(info, "s");
   if (cs && *cs) {
-    cgs.oidInfo[index].spawnflags = atoi(cs);
+    cgs.oidInfo[index].spawnflags = Q_atoi(cs);
   }
 
   cs = Info_ValueForKey(info, "cia");
   if (cs && *cs) {
-    cgs.oidInfo[index].customimageallies = cgs.gameShaders[atoi(cs)];
+    cgs.oidInfo[index].customimageallies = cgs.gameShaders[Q_atoi(cs)];
   }
 
   cs = Info_ValueForKey(info, "cix");
   if (cs && *cs) {
-    cgs.oidInfo[index].customimageaxis = cgs.gameShaders[atoi(cs)];
+    cgs.oidInfo[index].customimageaxis = cgs.gameShaders[Q_atoi(cs)];
   }
 
   cs = Info_ValueForKey(info, "o");
   if (cs && *cs) {
-    cgs.oidInfo[index].objflags = atoi(cs);
+    cgs.oidInfo[index].objflags = Q_atoi(cs);
   }
 
   cs = Info_ValueForKey(info, "e");
   if (cs && *cs) {
-    cgs.oidInfo[index].entityNum = atoi(cs);
+    cgs.oidInfo[index].entityNum = Q_atoi(cs);
   }
 
   cs = Info_ValueForKey(info, "n");
@@ -256,17 +256,17 @@ void CG_ParseOIDInfo(int num) {
 
   cs = Info_ValueForKey(info, "x");
   if (cs && *cs) {
-    cgs.oidInfo[index].origin[0] = atoi(cs);
+    cgs.oidInfo[index].origin[0] = Q_atof(cs);
   }
 
   cs = Info_ValueForKey(info, "y");
   if (cs && *cs) {
-    cgs.oidInfo[index].origin[1] = atoi(cs);
+    cgs.oidInfo[index].origin[1] = Q_atof(cs);
   }
 
   cs = Info_ValueForKey(info, "z");
   if (cs && *cs) {
-    cgs.oidInfo[index].origin[2] = atoi(cs);
+    cgs.oidInfo[index].origin[2] = Q_atof(cs);
   }
 }
 
@@ -291,11 +291,12 @@ void CG_ParseWolfinfo(void) {
 
   info = CG_ConfigString(CS_WOLFINFO);
 
-  cgs.currentRound = atoi(Info_ValueForKey(info, "g_currentRound"));
+  cgs.currentRound = Q_atoi(Info_ValueForKey(info, "g_currentRound"));
   cgs.nextTimeLimit = Q_atof(Info_ValueForKey(info, "g_nextTimeLimit"));
-  cgs.gamestate = (gamestate_t)atoi(Info_ValueForKey(info, "gamestate"));
+  cgs.gamestate = (gamestate_t)Q_atoi(Info_ValueForKey(info, "gamestate"));
   cgs.currentCampaign = Info_ValueForKey(info, "g_currentCampaign");
-  cgs.currentCampaignMap = atoi(Info_ValueForKey(info, "g_currentCampaignMap"));
+  cgs.currentCampaignMap =
+      Q_atoi(Info_ValueForKey(info, "g_currentCampaignMap"));
 
   // OSP - Announce game in progress if we are really playing
   if (old_gs != GS_PLAYING && cgs.gamestate == GS_PLAYING) {
@@ -336,7 +337,7 @@ void CG_ParseSpawns(void) {
   // first index is for autopicking
   Q_strncpyz(cg.spawnPoints[0], CG_TranslateString("Auto Pick"), MAX_SPAWNDESC);
 
-  cg.spawnCount = atoi(s) + 1;
+  cg.spawnCount = Q_atoi(s) + 1;
 
   for (i = 1; i < cg.spawnCount; i++) {
     info = CG_ConfigString(CS_MULTI_SPAWNTARGETS + i - 1);
@@ -373,7 +374,7 @@ void CG_ParseSpawns(void) {
 
     s = Info_ValueForKey(info, "t");
 
-    newteam = atoi(s);
+    newteam = Q_atoi(s);
     if (cg.spawnTeams[i] != newteam) {
       cg.spawnTeams_old[i] = cg.spawnTeams[i];
       cg.spawnTeams_changeTime[i] = cg.time;
@@ -381,7 +382,7 @@ void CG_ParseSpawns(void) {
     }
 
     s = Info_ValueForKey(info, "c");
-    cg.spawnPlayerCounts[i] = atoi(s);
+    cg.spawnPlayerCounts[i] = Q_atoi(s);
   }
 }
 
@@ -400,9 +401,9 @@ static void CG_ParseScreenFade(void) {
   cgs.fadeAlpha = Q_atof(token);
 
   token = COM_Parse(&info);
-  cgs.fadeStartTime = atoi(token);
+  cgs.fadeStartTime = Q_atoi(token);
   token = COM_Parse(&info);
-  cgs.fadeDuration = atoi(token);
+  cgs.fadeDuration = Q_atoi(token);
 
   if (cgs.fadeStartTime + cgs.fadeDuration < cg.time) {
     cgs.fadeAlphaCurrent = cgs.fadeAlpha;
@@ -440,7 +441,7 @@ static void CG_ParseFog(void) {
   token = COM_Parse(&info);
   b = Q_atof(token);
   token = COM_Parse(&info);
-  time = atoi(token);
+  time = Q_atoi(token);
 
   if (fa) // far of '0' from a target_fog means "return to map fog"
   {
@@ -461,9 +462,9 @@ static void CG_ParseGlobalFog(void) {
   info = CG_ConfigString(CS_GLOBALFOGVARS);
 
   token = COM_Parse(&info);
-  restore = atoi(token) ? qtrue : qfalse;
+  restore = Q_atoi(token) ? qtrue : qfalse;
   token = COM_Parse(&info);
-  duration = atoi(token);
+  duration = Q_atoi(token);
 
   if (restore) {
     trap_R_SetGlobalFog(qtrue, duration, 0.f, 0.f, 0.f, 0);
@@ -485,7 +486,7 @@ static void CG_ParseGlobalFog(void) {
 void CG_ParseServerVersionInfo(const char *pszVersionInfo) {
   // This will expand to a tokenized string, eventually but for
   // now we only need to worry about 1 number :)
-  cgs.game_versioninfo = atoi(pszVersionInfo);
+  cgs.game_versioninfo = Q_atoi(pszVersionInfo);
 }
 
 // Parse reinforcement offsets
@@ -497,9 +498,9 @@ void CG_ParseReinforcementTimes(const char *pszReinfSeedString) {
   if ((tmp = strchr(tmp, ' ')) == NULL) {                                      \
     return;                                                                    \
   }                                                                            \
-  x = atoi(++tmp) / y;
+  x = Q_atoi(++tmp) / y;
 
-  dwOffset[TEAM_ALLIES] = atoi(pszReinfSeedString) >> REINF_BLUEDELT;
+  dwOffset[TEAM_ALLIES] = Q_atoi(pszReinfSeedString) >> REINF_BLUEDELT;
   GETVAL(dwOffset[TEAM_AXIS], (1 << REINF_REDDELT));
   tmp2 = tmp;
 
@@ -523,9 +524,10 @@ Called on load to set the initial values from configure strings
 ================
 */
 void CG_SetConfigValues(void) {
-  cgs.levelStartTime = atoi(CG_ConfigString(CS_LEVEL_START_TIME));
-  cgs.intermissionStartTime = atoi(CG_ConfigString(CS_INTERMISSION_START_TIME));
-  cg.warmup = atoi(CG_ConfigString(CS_WARMUP));
+  cgs.levelStartTime = Q_atoi(CG_ConfigString(CS_LEVEL_START_TIME));
+  cgs.intermissionStartTime =
+      Q_atoi(CG_ConfigString(CS_INTERMISSION_START_TIME));
+  cg.warmup = Q_atoi(CG_ConfigString(CS_WARMUP));
 
   // rain - set all of this crap in cgs - it won't be set if it doesn't
   // change, otherwise.  consider:
@@ -534,16 +536,16 @@ void CG_SetConfigValues(void) {
   // you have nothing to use if another 'Match Reset' vote is called
   // (no update will be sent because the string will be the same.)
 
-  cgs.voteTime = atoi(CG_ConfigString(CS_VOTE_TIME));
-  cgs.voteYes = atoi(CG_ConfigString(CS_VOTE_YES));
-  cgs.voteNo = atoi(CG_ConfigString(CS_VOTE_NO));
+  cgs.voteTime = Q_atoi(CG_ConfigString(CS_VOTE_TIME));
+  cgs.voteYes = Q_atoi(CG_ConfigString(CS_VOTE_YES));
+  cgs.voteNo = Q_atoi(CG_ConfigString(CS_VOTE_NO));
   Q_strncpyz(cgs.voteString, CG_ConfigString(CS_VOTE_STRING),
              sizeof(cgs.voteString));
 
-  cg.teamFirstBlood = atoi(CG_ConfigString(CS_FIRSTBLOOD));
+  cg.teamFirstBlood = Q_atoi(CG_ConfigString(CS_FIRSTBLOOD));
   // rain - yes, the order is this way on purpose. not my fault!
-  cg.teamWonRounds[1] = atoi(CG_ConfigString(CS_ROUNDSCORES1));
-  cg.teamWonRounds[0] = atoi(CG_ConfigString(CS_ROUNDSCORES2));
+  cg.teamWonRounds[1] = Q_atoi(CG_ConfigString(CS_ROUNDSCORES1));
+  cg.teamWonRounds[0] = Q_atoi(CG_ConfigString(CS_ROUNDSCORES2));
 
   // OSP
   CG_ParseServerVersionInfo(CG_ConfigString(CS_VERSIONINFO));
@@ -583,8 +585,8 @@ void CG_ShaderStateChanged(void) {
         strncpy(timeOffset, t, o - t);
         timeOffset[o - t] = 0;
         o++;
-        trap_R_RemapShader(cgs.gameShaderNames[atoi(originalShader)],
-                           cgs.gameShaderNames[atoi(newShader)], timeOffset);
+        trap_R_RemapShader(cgs.gameShaderNames[Q_atoi(originalShader)],
+                           cgs.gameShaderNames[Q_atoi(newShader)], timeOffset);
       }
     } else {
       break;
@@ -602,16 +604,16 @@ void CG_ChargeTimesChanged(void) {
 
   info = CG_ConfigString(CS_CHARGETIMES);
 
-  cg.soldierChargeTime[0] = atoi(Info_ValueForKey(info, "axs_sld"));
-  cg.soldierChargeTime[1] = atoi(Info_ValueForKey(info, "ald_sld"));
-  cg.medicChargeTime[0] = atoi(Info_ValueForKey(info, "axs_mdc"));
-  cg.medicChargeTime[1] = atoi(Info_ValueForKey(info, "ald_mdc"));
-  cg.engineerChargeTime[0] = atoi(Info_ValueForKey(info, "axs_eng"));
-  cg.engineerChargeTime[1] = atoi(Info_ValueForKey(info, "ald_eng"));
-  cg.ltChargeTime[0] = atoi(Info_ValueForKey(info, "axs_lnt"));
-  cg.ltChargeTime[1] = atoi(Info_ValueForKey(info, "ald_lnt"));
-  cg.covertopsChargeTime[0] = atoi(Info_ValueForKey(info, "axs_cvo"));
-  cg.covertopsChargeTime[1] = atoi(Info_ValueForKey(info, "ald_cvo"));
+  cg.soldierChargeTime[0] = Q_atoi(Info_ValueForKey(info, "axs_sld"));
+  cg.soldierChargeTime[1] = Q_atoi(Info_ValueForKey(info, "ald_sld"));
+  cg.medicChargeTime[0] = Q_atoi(Info_ValueForKey(info, "axs_mdc"));
+  cg.medicChargeTime[1] = Q_atoi(Info_ValueForKey(info, "ald_mdc"));
+  cg.engineerChargeTime[0] = Q_atoi(Info_ValueForKey(info, "axs_eng"));
+  cg.engineerChargeTime[1] = Q_atoi(Info_ValueForKey(info, "ald_eng"));
+  cg.ltChargeTime[0] = Q_atoi(Info_ValueForKey(info, "axs_lnt"));
+  cg.ltChargeTime[1] = Q_atoi(Info_ValueForKey(info, "ald_lnt"));
+  cg.covertopsChargeTime[0] = Q_atoi(Info_ValueForKey(info, "axs_cvo"));
+  cg.covertopsChargeTime[1] = Q_atoi(Info_ValueForKey(info, "ald_cvo"));
 }
 
 /*
@@ -624,7 +626,7 @@ static void CG_ConfigStringModified(void) {
   const char *str;
   int num;
 
-  num = atoi(CG_Argv(1));
+  num = Q_atoi(CG_Argv(1));
 
   // get the gamestate from the client system, which will have the
   // new configstring already integrated
@@ -648,11 +650,11 @@ static void CG_ConfigStringModified(void) {
   {
     CG_ParseWolfinfo();
   } else if (num == CS_FIRSTBLOOD) {
-    cg.teamFirstBlood = atoi(str);
+    cg.teamFirstBlood = Q_atoi(str);
   } else if (num == CS_ROUNDSCORES1) {
-    cg.teamWonRounds[1] = atoi(str);
+    cg.teamWonRounds[1] = Q_atoi(str);
   } else if (num == CS_ROUNDSCORES2) {
-    cg.teamWonRounds[0] = atoi(str);
+    cg.teamWonRounds[0] = Q_atoi(str);
   } else if (num >= CS_MULTI_SPAWNTARGETS &&
              num < CS_MULTI_SPAWNTARGETS + MAX_MULTI_SPAWNTARGETS) {
     CG_ParseSpawns();
@@ -663,22 +665,22 @@ static void CG_ConfigStringModified(void) {
     CG_ParseReinforcementTimes(
         str); // OSP - set reinforcement times for each team
   } else if (num == CS_LEVEL_START_TIME) {
-    cgs.levelStartTime = atoi(str);
+    cgs.levelStartTime = Q_atoi(str);
   } else if (num == CS_INTERMISSION_START_TIME) {
-    cgs.intermissionStartTime = atoi(str);
+    cgs.intermissionStartTime = Q_atoi(str);
   } else if (num == CS_VOTE_TIME) {
-    cgs.voteTime = atoi(str);
+    cgs.voteTime = Q_atoi(str);
     cgs.voteModified = qtrue;
   } else if (num == CS_VOTE_YES) {
-    cgs.voteYes = atoi(str);
+    cgs.voteYes = Q_atoi(str);
     cgs.voteModified = qtrue;
   } else if (num == CS_VOTE_NO) {
-    cgs.voteNo = atoi(str);
+    cgs.voteNo = Q_atoi(str);
     cgs.voteModified = qtrue;
   } else if (num == CS_VOTE_STRING) {
     Q_strncpyz(cgs.voteString, str, sizeof(cgs.voteString));
   } else if (num == CS_INTERMISSION) {
-    cg.intermissionStarted = atoi(str) ? qtrue : qfalse;
+    cg.intermissionStarted = Q_atoi(str) ? qtrue : qfalse;
   } else if (num == CS_SCREENFADE) {
     CG_ParseScreenFade();
   } else if (num == CS_FOGVARS) {
@@ -736,7 +738,7 @@ static void CG_ConfigStringModified(void) {
   } else if (num >= CS_TAGCONNECTS && num < CS_TAGCONNECTS + MAX_TAGCONNECTS) {
     CG_ParseTagConnect(num);
   } else if (num == CS_FILTERCAMS) {
-    cg.filtercams = atoi(str) ? qtrue : qfalse;
+    cg.filtercams = Q_atoi(str) ? qtrue : qfalse;
   } else if (num >= CS_OID_DATA && num < CS_OID_DATA + MAX_OID_TRIGGERS) {
     CG_ParseOIDInfo(num);
   }
@@ -1017,7 +1019,7 @@ static void CG_MapRestart(void) {
   cg.v_noFireTime = 0;
   cg.v_fireTime = 0;
 
-  cg.filtercams = atoi(CG_ConfigString(CS_FILTERCAMS)) ? qtrue : qfalse;
+  cg.filtercams = Q_atoi(CG_ConfigString(CS_FILTERCAMS)) ? qtrue : qfalse;
 
   CG_ChargeTimesChanged();
 
@@ -1563,22 +1565,22 @@ void CG_VoiceChat(int mode) {
 
   memset(&vsay, 0, sizeof(vsay));
 
-  voiceOnly = atoi(CG_Argv(1)) ? qtrue : qfalse;
-  clientNum = atoi(CG_Argv(2));
-  color = atoi(CG_Argv(3));
+  voiceOnly = Q_atoi(CG_Argv(1)) ? qtrue : qfalse;
+  clientNum = Q_atoi(CG_Argv(2));
+  color = Q_atoi(CG_Argv(3));
 
   if (mode != SAY_ALL) {
     // NERVE - SMF - added origin
-    origin[0] = atoi(CG_Argv(5));
-    origin[1] = atoi(CG_Argv(6));
-    origin[2] = atoi(CG_Argv(7));
+    origin[0] = Q_atof(CG_Argv(5));
+    origin[1] = Q_atof(CG_Argv(6));
+    origin[2] = Q_atof(CG_Argv(7));
 
     variant = 8;
     rand = 9;
     custom = 10;
   }
 
-  vsay.variant = atoi(CG_Argv(variant));
+  vsay.variant = Q_atoi(CG_Argv(variant));
   trap_Argv(4, vsay.id, sizeof(vsay.id));
   vsay.random = Q_atof(CG_Argv(rand));
   trap_Argv(custom, vsay.custom, sizeof(vsay.custom));
@@ -1702,18 +1704,18 @@ void CG_wstatsParse_cmd(void) {
 
 void CG_topshotsParse_cmd(qboolean doBest) {
   int iArg = 1;
-  int iWeap = atoi(CG_Argv(iArg++));
+  int iWeap = Q_atoi(CG_Argv(iArg++));
   topshotStats_t *ts = &cgs.topshots;
 
   ts->cWeapons = 0;
 
   while (iWeap) {
-    int cnum = atoi(CG_Argv(iArg++));
-    int hits = atoi(CG_Argv(iArg++));
-    int atts = atoi(CG_Argv(iArg++));
-    int kills = atoi(CG_Argv(iArg++));
+    int cnum = Q_atoi(CG_Argv(iArg++));
+    int hits = Q_atoi(CG_Argv(iArg++));
+    int atts = Q_atoi(CG_Argv(iArg++));
+    int kills = Q_atoi(CG_Argv(iArg++));
     // rain - unused
-    // int deaths = atoi(CG_Argv(iArg++));
+    // int deaths = Q_atoi(CG_Argv(iArg++));
     float acc = (atts > 0) ? (float)(hits * 100) / (float)atts : 0.0f;
     char name[32];
 
@@ -1730,27 +1732,27 @@ void CG_topshotsParse_cmd(qboolean doBest) {
                  sizeof(ts->strWS[0]));
     }
 
-    iWeap = atoi(CG_Argv(iArg++));
+    iWeap = Q_atoi(CG_Argv(iArg++));
   }
 }
 
 void CG_ParseWeaponStats(void) {
-  cgs.ccWeaponShots = atoi(CG_Argv(1));
-  cgs.ccWeaponHits = atoi(CG_Argv(2));
+  cgs.ccWeaponShots = Q_atoi(CG_Argv(1));
+  cgs.ccWeaponHits = Q_atoi(CG_Argv(2));
 }
 
 void CG_ParsePortalPos(void) {
   int i;
 
-  cgs.ccCurrentCamObjective = atoi(CG_Argv(1));
-  cgs.ccPortalEnt = atoi(CG_Argv(8));
+  cgs.ccCurrentCamObjective = Q_atoi(CG_Argv(1));
+  cgs.ccPortalEnt = Q_atoi(CG_Argv(8));
 
   for (i = 0; i < 3; i++) {
-    cgs.ccPortalPos[i] = atoi(CG_Argv(i + 2));
+    cgs.ccPortalPos[i] = Q_atof(CG_Argv(i + 2));
   }
 
   for (i = 0; i < 3; i++) {
-    cgs.ccPortalAngles[i] = atoi(CG_Argv(i + 5));
+    cgs.ccPortalAngles[i] = Q_atof(CG_Argv(i + 5));
   }
 }
 
@@ -1759,9 +1761,9 @@ void CG_parseWeaponStatsGS_cmd(void) {
   clientInfo_t *ci;
   gameStats_t *gs = &cgs.gamestats;
   int i, iArg = 1;
-  int nClientID = atoi(CG_Argv(iArg++));
-  int nRounds = atoi(CG_Argv(iArg++));
-  int weaponMask = atoi(CG_Argv(iArg++));
+  int nClientID = Q_atoi(CG_Argv(iArg++));
+  int nRounds = Q_atoi(CG_Argv(iArg++));
+  int weaponMask = Q_atoi(CG_Argv(iArg++));
   int skillMask, xp = 0;
 
   gs->cWeapons = 0;
@@ -1782,11 +1784,11 @@ void CG_parseWeaponStatsGS_cmd(void) {
 
     for (i = WS_KNIFE; i < WS_MAX; i++) {
       if (weaponMask & (1 << i)) {
-        int nHits = atoi(CG_Argv(iArg++));
-        int nShots = atoi(CG_Argv(iArg++));
-        int nKills = atoi(CG_Argv(iArg++));
-        int nDeaths = atoi(CG_Argv(iArg++));
-        int nHeadshots = atoi(CG_Argv(iArg++));
+        int nHits = Q_atoi(CG_Argv(iArg++));
+        int nShots = Q_atoi(CG_Argv(iArg++));
+        int nKills = Q_atoi(CG_Argv(iArg++));
+        int nDeaths = Q_atoi(CG_Argv(iArg++));
+        int nHeadshots = Q_atoi(CG_Argv(iArg++));
 
         Q_strncpyz(strName, va("%-12s  ", aWeaponInfo[i].pszName),
                    sizeof(strName));
@@ -1813,9 +1815,9 @@ void CG_parseWeaponStatsGS_cmd(void) {
     }
 
     if (gs->fHasStats) {
-      int dmg_given = atoi(CG_Argv(iArg++));
-      int dmg_rcvd = atoi(CG_Argv(iArg++));
-      int team_dmg = atoi(CG_Argv(iArg++));
+      int dmg_given = Q_atoi(CG_Argv(iArg++));
+      int dmg_rcvd = Q_atoi(CG_Argv(iArg++));
+      int team_dmg = Q_atoi(CG_Argv(iArg++));
 
       Q_strncpyz(gs->strExtra[0],
                  va("Damage Given: %-6d  Team Damage: %d", dmg_given, team_dmg),
@@ -1826,10 +1828,10 @@ void CG_parseWeaponStatsGS_cmd(void) {
   }
 
   // Derive XP from individual skill XP
-  skillMask = atoi(CG_Argv(iArg++));
+  skillMask = Q_atoi(CG_Argv(iArg++));
   for (i = SK_BATTLE_SENSE; i < SK_NUM_SKILLS; i++) {
     if (skillMask & (1 << i)) {
-      ci->skillpoints[i] = atoi(CG_Argv(iArg++));
+      ci->skillpoints[i] = Q_atoi(CG_Argv(iArg++));
       xp += ci->skillpoints[i];
     }
   }
@@ -1878,9 +1880,9 @@ void CG_parseWeaponStats_cmd(void(txt_dump)(const char *)) {
   char strName[MAX_STRING_CHARS];
   int atts, deaths, dmg_given, dmg_rcvd, hits, kills, team_dmg, headshots;
   unsigned int i, iArg = 1;
-  unsigned int nClient = atoi(CG_Argv(iArg++));
-  unsigned int nRounds = atoi(CG_Argv(iArg++));
-  unsigned int dwWeaponMask = atoi(CG_Argv(iArg++));
+  unsigned int nClient = Q_atoi(CG_Argv(static_cast<int>(iArg++)));
+  unsigned int nRounds = Q_atoi(CG_Argv(static_cast<int>(iArg++)));
+  unsigned int dwWeaponMask = Q_atoi(CG_Argv(static_cast<int>(iArg++)));
   unsigned int dwSkillPointMask, xp = 0;
 
   ci = &cgs.clientinfo[nClient];
@@ -1905,11 +1907,11 @@ void CG_parseWeaponStats_cmd(void(txt_dump)(const char *)) {
   } else {
     for (i = WS_KNIFE; i < WS_MAX; i++) {
       if (dwWeaponMask & (1 << i)) {
-        hits = atoi(CG_Argv(iArg++));
-        atts = atoi(CG_Argv(iArg++));
-        kills = atoi(CG_Argv(iArg++));
-        deaths = atoi(CG_Argv(iArg++));
-        headshots = atoi(CG_Argv(iArg++));
+        hits = Q_atoi(CG_Argv(static_cast<int>(iArg++)));
+        atts = Q_atoi(CG_Argv(static_cast<int>(iArg++)));
+        kills = Q_atoi(CG_Argv(static_cast<int>(iArg++)));
+        deaths = Q_atoi(CG_Argv(static_cast<int>(iArg++)));
+        headshots = Q_atoi(CG_Argv(static_cast<int>(iArg++)));
 
         Q_strncpyz(strName, va("^3%-9s: ", aWeaponInfo[i].pszName),
                    sizeof(strName));
@@ -1939,9 +1941,9 @@ void CG_parseWeaponStats_cmd(void(txt_dump)(const char *)) {
     }
 
     if (fHasStats) {
-      dmg_given = atoi(CG_Argv(iArg++));
-      dmg_rcvd = atoi(CG_Argv(iArg++));
-      team_dmg = atoi(CG_Argv(iArg++));
+      dmg_given = Q_atoi(CG_Argv(static_cast<int>(iArg++)));
+      dmg_rcvd = Q_atoi(CG_Argv(static_cast<int>(iArg++)));
+      team_dmg = Q_atoi(CG_Argv(static_cast<int>(iArg++)));
 
       if (!fFull) {
         txt_dump("\n\n");
@@ -1959,10 +1961,10 @@ void CG_parseWeaponStats_cmd(void(txt_dump)(const char *)) {
   }
 
   // Derive XP from individual skill XP
-  dwSkillPointMask = atoi(CG_Argv(iArg++));
+  dwSkillPointMask = Q_atoi(CG_Argv(static_cast<int>(iArg++)));
   for (i = SK_BATTLE_SENSE; i < SK_NUM_SKILLS; i++) {
     if (dwSkillPointMask & (1 << i)) {
-      ci->skillpoints[i] = atoi(CG_Argv(iArg++));
+      ci->skillpoints[i] = Q_atoi(CG_Argv(static_cast<int>(iArg++)));
       xp += ci->skillpoints[i];
     }
   }
@@ -2018,7 +2020,7 @@ void CG_parseBestShotsStats_cmd(qboolean doTop, void(txt_dump)(const char *)) {
   int iArg = 1;
   qboolean fFull = (txt_dump != CG_printWindow) ? qtrue : qfalse;
 
-  int iWeap = atoi(CG_Argv(iArg++));
+  int iWeap = Q_atoi(CG_Argv(iArg++));
   if (!iWeap) {
     txt_dump(va("^3No qualifying %sshot info available.\n",
                 ((doTop) ? "top" : "bottom")));
@@ -2038,11 +2040,11 @@ void CG_parseBestShotsStats_cmd(qboolean doTop, void(txt_dump)(const char *)) {
   }
 
   while (iWeap) {
-    int cnum = atoi(CG_Argv(iArg++));
-    int hits = atoi(CG_Argv(iArg++));
-    int atts = atoi(CG_Argv(iArg++));
-    int kills = atoi(CG_Argv(iArg++));
-    int deaths = atoi(CG_Argv(iArg++));
+    int cnum = Q_atoi(CG_Argv(iArg++));
+    int hits = Q_atoi(CG_Argv(iArg++));
+    int atts = Q_atoi(CG_Argv(iArg++));
+    int kills = Q_atoi(CG_Argv(iArg++));
+    int deaths = Q_atoi(CG_Argv(iArg++));
     float acc = (atts > 0) ? (float)(hits * 100) / (float)atts : 0.0;
     char name[32];
 
@@ -2058,15 +2060,15 @@ void CG_parseBestShotsStats_cmd(qboolean doTop, void(txt_dump)(const char *)) {
                   deaths, name));
     }
 
-    iWeap = atoi(CG_Argv(iArg++));
+    iWeap = Q_atoi(CG_Argv(iArg++));
   }
 }
 
 void CG_parseTopShotsStats_cmd(qboolean doTop, void(txt_dump)(const char *)) {
   int i, iArg = 1;
-  int cClients = atoi(CG_Argv(iArg++));
-  int iWeap = atoi(CG_Argv(iArg++));
-  int wBestAcc = atoi(CG_Argv(iArg++));
+  int cClients = Q_atoi(CG_Argv(iArg++));
+  int iWeap = Q_atoi(CG_Argv(iArg++));
+  int wBestAcc = Q_atoi(CG_Argv(iArg++));
 
   txt_dump(va("Weapon accuracies for: ^3%s\n",
               (iWeap >= WS_KNIFE && iWeap < WS_MAX) ? aWeaponInfo[iWeap].pszName
@@ -2081,11 +2083,11 @@ void CG_parseTopShotsStats_cmd(qboolean doTop, void(txt_dump)(const char *)) {
   }
 
   for (i = 0; i < cClients; i++) {
-    int cnum = atoi(CG_Argv(iArg++));
-    int hits = atoi(CG_Argv(iArg++));
-    int atts = atoi(CG_Argv(iArg++));
-    int kills = atoi(CG_Argv(iArg++));
-    int deaths = atoi(CG_Argv(iArg++));
+    int cnum = Q_atoi(CG_Argv(iArg++));
+    int hits = Q_atoi(CG_Argv(iArg++));
+    int atts = Q_atoi(CG_Argv(iArg++));
+    int kills = Q_atoi(CG_Argv(iArg++));
+    int deaths = Q_atoi(CG_Argv(iArg++));
     float acc = (atts > 0) ? (float)(hits * 100) / (float)atts : 0.0;
     const char *color = (((doTop) ? acc : ((float)wBestAcc) + 0.999) >=
                          ((doTop) ? wBestAcc : acc))
@@ -2283,29 +2285,29 @@ static void CG_ServerCommand(void) {
         continue;
       }
 
-      cgs.playerStats.weaponStats[i].kills = atoi(CG_Argv(start++));
-      cgs.playerStats.weaponStats[i].killedby = atoi(CG_Argv(start++));
-      cgs.playerStats.weaponStats[i].teamkills = atoi(CG_Argv(start++));
+      cgs.playerStats.weaponStats[i].kills = Q_atoi(CG_Argv(start++));
+      cgs.playerStats.weaponStats[i].killedby = Q_atoi(CG_Argv(start++));
+      cgs.playerStats.weaponStats[i].teamkills = Q_atoi(CG_Argv(start++));
     }
 
-    cgs.playerStats.suicides = atoi(CG_Argv(start++));
+    cgs.playerStats.suicides = Q_atoi(CG_Argv(start++));
 
     for (i = 0; i < HR_NUM_HITREGIONS; i++) {
-      cgs.playerStats.hitRegions[i] = atoi(CG_Argv(start++));
+      cgs.playerStats.hitRegions[i] = Q_atoi(CG_Argv(start++));
     }
 
-    cgs.numOIDtriggers = atoi(CG_Argv(start++));
+    cgs.numOIDtriggers = Q_atoi(CG_Argv(start++));
 
     for (i = 0; i < cgs.numOIDtriggers; i++) {
-      cgs.playerStats.objectiveStats[i] = atoi(CG_Argv(start++));
-      cgs.teamobjectiveStats[i] = atoi(CG_Argv(start++));
+      cgs.playerStats.objectiveStats[i] = Q_atoi(CG_Argv(start++));
+      cgs.teamobjectiveStats[i] = Q_atoi(CG_Argv(start++));
     }
 
     return;
   }
 
   if (!Q_stricmp(cmd, "hasTimerun")) {
-    cg.hasTimerun = atoi(CG_Argv(1)) ? qtrue : qfalse;
+    cg.hasTimerun = Q_atoi(CG_Argv(1)) ? qtrue : qfalse;
     return;
   }
 
@@ -2343,12 +2345,12 @@ static void CG_ServerCommand(void) {
 
       // OSP - for client logging
       if (cg_printObjectiveInfo.integer > 0 &&
-          (args == 4 || atoi(CG_Argv(2)) > 1)) {
+          (args == 4 || Q_atoi(CG_Argv(2)) > 1)) {
         CG_Printf("[cgnotify]*** ^3INFO: ^5%s\n",
                   CG_LocalizeServerCommand(CG_Argv(1)));
       }
       CG_PriorityCenterPrint(s, SCREEN_HEIGHT - (SCREEN_HEIGHT * 0.20),
-                             SMALLCHAR_WIDTH, atoi(CG_Argv(2)));
+                             SMALLCHAR_WIDTH, Q_atoi(CG_Argv(2)));
     } else {
       CG_CenterPrint(CG_LocalizeServerCommand(CG_Argv(1)),
                      SCREEN_HEIGHT - (SCREEN_HEIGHT * 0.20),
@@ -2377,10 +2379,10 @@ static void CG_ServerCommand(void) {
     int allied_number, axis_number;
 
     trap_Argv(1, buffer, 16);
-    axis_number = atoi(buffer);
+    axis_number = Q_atoi(buffer);
 
     trap_Argv(2, buffer, 16);
-    allied_number = atoi(buffer);
+    allied_number = Q_atoi(buffer);
 
     CG_ParseMapEntityInfo(axis_number, allied_number);
 
@@ -2395,7 +2397,7 @@ static void CG_ServerCommand(void) {
       return;
     }
 
-    if (atoi(CG_Argv(3))) {
+    if (Q_atoi(CG_Argv(3))) {
       s = CG_LocalizeServerCommand(CG_Argv(1));
     } else {
       s = CG_Argv(1);
@@ -2409,8 +2411,8 @@ static void CG_ServerCommand(void) {
 
     CG_RemoveChatEscapeChar(text);
     CG_FixLinesEndingWithCaret(text, MAX_SAY_TEXT);
-    s = CG_AddChatModifications(text, atoi(CG_Argv(2)));
-    CG_AddToTeamChat(s, atoi(CG_Argv(2)));
+    s = CG_AddChatModifications(text, Q_atoi(CG_Argv(2)));
+    CG_AddToTeamChat(s, Q_atoi(CG_Argv(2)));
     CG_Printf("%s\n", s);
 
     return;
@@ -2421,7 +2423,7 @@ static void CG_ServerCommand(void) {
 
     const char *s;
 
-    if (atoi(CG_Argv(3))) {
+    if (Q_atoi(CG_Argv(3))) {
       s = CG_LocalizeServerCommand(CG_Argv(1));
     } else {
       s = CG_Argv(1);
@@ -2433,11 +2435,11 @@ static void CG_ServerCommand(void) {
     }
     CG_RemoveChatEscapeChar(text);
 
-    s = CG_AddChatModifications(text, atoi(CG_Argv(2)));
+    s = CG_AddChatModifications(text, Q_atoi(CG_Argv(2)));
     Q_strncpyz(text, s, MAX_SAY_TEXT);
 
     CG_FixLinesEndingWithCaret(text, MAX_SAY_TEXT);
-    CG_AddToTeamChat(text, atoi(CG_Argv(2)));
+    CG_AddToTeamChat(text, Q_atoi(CG_Argv(2)));
     CG_Printf("%s\n", text); // JPW NERVE
 
     return;
@@ -2466,7 +2468,7 @@ static void CG_ServerCommand(void) {
   // DHM - Nerve :: Allow client to lodge a complaing
   if (!Q_stricmp(cmd, "complaint") && cgs.gamestate == GS_PLAYING) {
     cgs.complaintEndTime = cg.time + 20000;
-    cgs.complaintClient = atoi(CG_Argv(1));
+    cgs.complaintClient = Q_atoi(CG_Argv(1));
 
     if (cgs.complaintClient < 0) {
       cgs.complaintEndTime = cg.time + 10000;
@@ -2544,12 +2546,12 @@ static void CG_ServerCommand(void) {
   }
 
   if (!Q_stricmp(cmd, "startCam")) {
-    CG_StartCamera(CG_Argv(1), atoi(CG_Argv(2)) ? qtrue : qfalse);
+    CG_StartCamera(CG_Argv(1), Q_atoi(CG_Argv(2)) ? qtrue : qfalse);
     return;
   }
 
   if (!Q_stricmp(cmd, "SetInitialCamera")) {
-    CG_SetInitialCamera(CG_Argv(1), atoi(CG_Argv(2)) ? qtrue : qfalse);
+    CG_SetInitialCamera(CG_Argv(1), Q_atoi(CG_Argv(2)) ? qtrue : qfalse);
     return;
   }
 
@@ -2559,7 +2561,7 @@ static void CG_ServerCommand(void) {
   }
 
   if (!Q_stricmp(cmd, "setspawnpt")) {
-    cg.selectedSpawnPoint = atoi(CG_Argv(1)) + 1;
+    cg.selectedSpawnPoint = Q_atoi(CG_Argv(1)) + 1;
     return;
   }
 
@@ -2582,7 +2584,7 @@ static void CG_ServerCommand(void) {
 
   if (!Q_stricmp(cmd, "application")) {
     cgs.applicationEndTime = cg.time + 20000;
-    cgs.applicationClient = atoi(CG_Argv(1));
+    cgs.applicationClient = Q_atoi(CG_Argv(1));
 
     if (cgs.applicationClient < 0) {
       cgs.applicationEndTime = cg.time + 10000;
@@ -2593,7 +2595,7 @@ static void CG_ServerCommand(void) {
 
   if (!Q_stricmp(cmd, "invitation")) {
     cgs.invitationEndTime = cg.time + 20000;
-    cgs.invitationClient = atoi(CG_Argv(1));
+    cgs.invitationClient = Q_atoi(CG_Argv(1));
 
     if (cgs.invitationClient < 0) {
       cgs.invitationEndTime = cg.time + 10000;
@@ -2604,8 +2606,8 @@ static void CG_ServerCommand(void) {
 
   if (!Q_stricmp(cmd, "proposition")) {
     cgs.propositionEndTime = cg.time + 20000;
-    cgs.propositionClient = atoi(CG_Argv(1));
-    cgs.propositionClient2 = atoi(CG_Argv(2));
+    cgs.propositionClient = Q_atoi(CG_Argv(1));
+    cgs.propositionClient2 = Q_atoi(CG_Argv(2));
 
     if (cgs.propositionClient < 0) {
       cgs.propositionEndTime = cg.time + 10000;
@@ -2616,7 +2618,7 @@ static void CG_ServerCommand(void) {
 
   if (!Q_stricmp(cmd, "aft")) {
     cgs.autoFireteamEndTime = cg.time + 20000;
-    cgs.autoFireteamNum = atoi(CG_Argv(1));
+    cgs.autoFireteamNum = Q_atoi(CG_Argv(1));
 
     if (cgs.autoFireteamNum < -1) {
       cgs.autoFireteamEndTime = cg.time + 10000;
@@ -2626,7 +2628,7 @@ static void CG_ServerCommand(void) {
 
   if (!Q_stricmp(cmd, "aftc")) {
     cgs.autoFireteamCreateEndTime = cg.time;
-    cgs.autoFireteamCreateNum = atoi(CG_Argv(1));
+    cgs.autoFireteamCreateNum = Q_atoi(CG_Argv(1));
 
     if (cgs.autoFireteamCreateNum < -1) {
       cgs.autoFireteamCreateEndTime = cg.time + 10000;
@@ -2636,7 +2638,7 @@ static void CG_ServerCommand(void) {
 
   if (!Q_stricmp(cmd, "aftj")) {
     cgs.autoFireteamJoinEndTime = cg.time + 20000;
-    cgs.autoFireteamJoinNum = atoi(CG_Argv(1));
+    cgs.autoFireteamJoinNum = Q_atoi(CG_Argv(1));
 
     if (cgs.autoFireteamJoinNum < -1) {
       cgs.autoFireteamJoinEndTime = cg.time + 10000;
@@ -2663,7 +2665,7 @@ static void CG_ServerCommand(void) {
 
     Q_strncpyz(text, CG_Argv(2), MAX_SAY_TEXT);
     if (strlen(text)) {
-      fadeTime = atoi(text);
+      fadeTime = Q_atoi(text);
     }
 
     trap_S_StartBackgroundTrack(CG_Argv(1), CG_Argv(1), fadeTime);
@@ -2677,7 +2679,7 @@ static void CG_ServerCommand(void) {
 
     Q_strncpyz(text, CG_Argv(2), MAX_SAY_TEXT);
     if (strlen(text)) {
-      fadeTime = atoi(text);
+      fadeTime = Q_atoi(text);
     }
 
     trap_S_StartBackgroundTrack(CG_Argv(1), "onetimeonly", fadeTime);
@@ -2690,7 +2692,7 @@ static void CG_ServerCommand(void) {
 
     Q_strncpyz(text, CG_Argv(1), MAX_SAY_TEXT);
     if (strlen(text)) {
-      fadeTime = atoi(text);
+      fadeTime = Q_atoi(text);
     }
 
     trap_S_FadeBackgroundTrack(0.0f, fadeTime, 0);
@@ -2699,13 +2701,13 @@ static void CG_ServerCommand(void) {
     return;
   }
   if (!Q_stricmp(cmd, "mu_fade")) {
-    trap_S_FadeBackgroundTrack(Q_atof(CG_Argv(1)), atoi(CG_Argv(2)), 0);
+    trap_S_FadeBackgroundTrack(Q_atof(CG_Argv(1)), Q_atoi(CG_Argv(2)), 0);
     return;
   }
 
   if (!Q_stricmp(cmd, "snd_fade")) {
-    trap_S_FadeAllSound(Q_atof(CG_Argv(1)), atoi(CG_Argv(2)),
-                        atoi(CG_Argv(3)) ? qtrue : qfalse);
+    trap_S_FadeAllSound(Q_atof(CG_Argv(1)), Q_atoi(CG_Argv(2)),
+                        Q_atoi(CG_Argv(3)) ? qtrue : qfalse);
     return;
   }
 
@@ -2713,7 +2715,7 @@ static void CG_ServerCommand(void) {
     char info[MAX_INFO_STRING];
     trap_Argv(1, info, sizeof(info));
 
-    cg.botMenuIcons = atoi(info);
+    cg.botMenuIcons = Q_atoi(info);
 
     return;
   }
@@ -2810,14 +2812,14 @@ static void CG_ServerCommand(void) {
   }
 
   if (!Q_stricmp(cmd, "savePrint")) {
-    int pos = atoi(CG_Argv(1));
+    int pos = Q_atoi(CG_Argv(1));
     std::string saveMsg = etj_saveMsg.string;
 
     if (pos) {
       saveMsg += ' ' + std::to_string(pos);
     }
     if (trap_Argc() == 3) {
-      int remainingSaves = atoi(CG_Argv(2));
+      int remainingSaves = Q_atoi(CG_Argv(2));
       std::string remainingSavesStr =
           va("^7(^3%d ^7remaining)\n", remainingSaves);
       saveMsg += '\n' + remainingSavesStr;

--- a/src/cgame/cg_snapshot.cpp
+++ b/src/cgame/cg_snapshot.cpp
@@ -156,7 +156,7 @@ void CG_SetInitialSnapshot(snapshot_t *snap) {
   cg_fxflags = 0;
 
   trap_Cvar_VariableStringBuffer("r_oldMode", buff, sizeof(buff));
-  if (atoi(buff)) {
+  if (Q_atoi(buff)) {
     // Arnout: confirmation screen
     trap_UI_Popup(UIMENU_INGAME);
   } else if (cg.demoPlayback) {

--- a/src/cgame/cg_spawn.cpp
+++ b/src/cgame/cg_spawn.cpp
@@ -41,7 +41,7 @@ qboolean CG_SpawnInt(const char *key, const char *defaultString, int *out) {
   qboolean present;
 
   present = CG_SpawnString(key, defaultString, &s);
-  *out = atoi(s);
+  *out = Q_atoi(s);
   return present;
 }
 
@@ -350,11 +350,11 @@ void SP_worldspawn(void) {
   CG_ParseSpawns();
 
   CG_SpawnString("cclayers", "0", &s);
-  cgs.ccLayers = atoi(s);
+  cgs.ccLayers = Q_atoi(s);
 
   for (i = 0; i < cgs.ccLayers; i++) {
     CG_SpawnString(va("cclayerceil%i", i), "0", &s);
-    cgs.ccLayerCeils[i] = atoi(s);
+    cgs.ccLayerCeils[i] = Q_atoi(s);
   }
 
   cg.mapcoordsScale[0] = 1 / (cg.mapcoordsMaxs[0] - cg.mapcoordsMins[0]);

--- a/src/cgame/cg_syscalls.cpp
+++ b/src/cgame/cg_syscalls.cpp
@@ -499,7 +499,7 @@ void trap_GetCurrentSnapshotNumber(int *snapshotNumber, int *serverTime) {
     int fakeLag;
 
     trap_Cvar_VariableStringBuffer("g_fakelag", s, sizeof(s));
-    fakeLag = atoi(s);
+    fakeLag = Q_atoi(s);
     if (fakeLag < 0) {
       fakeLag = 0;
     }
@@ -532,7 +532,7 @@ qboolean trap_GetSnapshot(int snapshotNumber, snapshot_t *snapshot) {
     }
 
     trap_Cvar_VariableStringBuffer("g_fakelag", s, sizeof(s));
-    fakeLag = atoi(s);
+    fakeLag = Q_atoi(s);
     if (fakeLag < 0) {
       fakeLag = 0;
     }

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -1516,7 +1516,7 @@ void CG_ParseSkyBox(void) {
 
   token = CG_MustParse(&cstr,
                        "CG_ParseSkyBox: error parsing skybox configstring\n");
-  cg.skyboxViewFov = atoi(token);
+  cg.skyboxViewFov = Q_atof(token);
 
   if (!cg.skyboxViewFov) {
     cg.skyboxViewFov = 90;
@@ -1526,7 +1526,7 @@ void CG_ParseSkyBox(void) {
   // after that
   token = CG_MustParse(&cstr, "CG_ParseSkyBox: error parsing skybox "
                               "configstring.  No fog state\n");
-  if (atoi(token)) // this camera has fog
+  if (Q_atoi(token)) // this camera has fog
   {
     token = CG_MustParse(&cstr, "CG_DrawSkyBoxPortal: error parsing "
                                 "skybox configstring.  No fog[0]\n");
@@ -1541,10 +1541,10 @@ void CG_ParseSkyBox(void) {
     fogColor[2] = Q_atof(token);
 
     token = COM_ParseExt(&cstr, qfalse);
-    fogStart = atoi(token);
+    fogStart = Q_atoi(token);
 
     token = COM_ParseExt(&cstr, qfalse);
-    fogEnd = atoi(token);
+    fogEnd = Q_atoi(token);
 
     trap_R_SetFog(FOG_PORTALVIEW, fogStart, fogEnd, fogColor[0], fogColor[1],
                   fogColor[2], 1.1f);
@@ -1580,14 +1580,14 @@ void CG_ParseTagConnect(int tagNum) {
 
   token = CG_MustParse(&pString, "Invalid TAGCONNECT configstring\n");
 
-  entNum = atoi(token);
+  entNum = Q_atoi(token);
   if (entNum < 0 || entNum >= MAX_GENTITIES) {
     CG_Error("Invalid TAGCONNECT entitynum\n");
   }
 
   token = CG_MustParse(&pString, "Invalid TAGCONNECT configstring\n");
 
-  cg_entities[entNum].tagParent = atoi(token);
+  cg_entities[entNum].tagParent = Q_atoi(token);
   if (cg_entities[entNum].tagParent < 0 ||
       cg_entities[entNum].tagParent >= MAX_GENTITIES) {
     CG_Error("Invalid TAGCONNECT tagparent\n");

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -1001,13 +1001,13 @@ static qboolean CG_ParseWeaponConfig(const char *filename, weaponInfo_t *wi) {
     if (!token) {
       break;
     }
-    wi->weapAnimations[i].firstFrame = atoi(token);
+    wi->weapAnimations[i].firstFrame = Q_atoi(token);
 
     token = COM_Parse(&text_p); // length
     if (!token) {
       break;
     }
-    wi->weapAnimations[i].numFrames = atoi(token);
+    wi->weapAnimations[i].numFrames = Q_atoi(token);
 
     token = COM_Parse(&text_p); // fps
     if (!token) {
@@ -1025,7 +1025,7 @@ static qboolean CG_ParseWeaponConfig(const char *filename, weaponInfo_t *wi) {
     if (!token) {
       break;
     }
-    wi->weapAnimations[i].loopFrames = atoi(token);
+    wi->weapAnimations[i].loopFrames = Q_atoi(token);
     if (wi->weapAnimations[i].loopFrames > wi->weapAnimations[i].numFrames) {
       wi->weapAnimations[i].loopFrames = wi->weapAnimations[i].numFrames;
     } else if (wi->weapAnimations[i].loopFrames < 0) {
@@ -1041,13 +1041,13 @@ static qboolean CG_ParseWeaponConfig(const char *filename, weaponInfo_t *wi) {
       if (!token) {
         break;
       }
-      wi->weapAnimations[i].moveSpeed = atoi(token);
+      wi->weapAnimations[i].moveSpeed = Q_atoi(token);
 
       token = COM_Parse(&text_p); // animated weapon
       if (!token) {
         break;
       }
-      if (atoi(token)) {
+      if (Q_atoi(token)) {
         wi->weapAnimations[i].moveSpeed |=
             (1 << W_MAX_PARTS); // set the bit one
                                 // higher than can
@@ -1063,7 +1063,7 @@ static qboolean CG_ParseWeaponConfig(const char *filename, weaponInfo_t *wi) {
         break;
       }
       wi->weapAnimations[i].moveSpeed |=
-          ((atoi(token)) << 8); // use 2nd byte for draw bits
+          ((Q_atoi(token)) << 8); // use 2nd byte for draw bits
     }
   }
 
@@ -4563,7 +4563,7 @@ void CG_WeaponBank_f(void) {
     return;
   }
 
-  bank = atoi(CG_Argv(1));
+  bank = Q_atoi(CG_Argv(1));
 
   if (bank <= 0 || bank > MAX_WEAP_BANKS_MP) {
     return;
@@ -4660,7 +4660,7 @@ void CG_Weapon_f(void) {
     return;
   }
 
-  num = atoi(CG_Argv(1));
+  num = Q_atoi(CG_Argv(1));
 
   // JPW NERVE
   // weapon bind should execute weaponbank instead -- for splitting out

--- a/src/cgame/etj_autodemo_recorder.cpp
+++ b/src/cgame/etj_autodemo_recorder.cpp
@@ -76,7 +76,7 @@ ETJump::AutoDemoRecorder::AutoDemoRecorder() {
 
   playerEventsHandler->subscribe("respawn",
                                  [&](const std::vector<std::string> &args) {
-                                   auto revive = atoi(args[0].c_str());
+                                   auto revive = Q_atoi(args[0].c_str());
                                    if (revive)
                                      return;
                                    if (etj_autoDemo.integer > 0)
@@ -190,7 +190,7 @@ ETJump::AutoDemoRecorder::createTimerunDemoPath(const std::string &runName,
       FileSystem::Path::sanitizeFolder(etj_ad_targetPath.string),
       FileSystem::Path::sanitize(cgs.clientinfo[cg.clientNum].cleanname),
       cgs.rawmapname, FileSystem::Path::sanitize(runName),
-      formatRunTime(atoi(runTime.c_str())), createTimeString());
+      formatRunTime(Q_atoi(runTime.c_str())), createTimeString());
 }
 
 std::string

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -326,9 +326,9 @@ qboolean CG_ServerCommandExt(const char *cmd) {
 
   // timerun_start runStartTime{integer} runName{string}
   if (command == "timerun_start") {
-    auto startTime = atoi(CG_Argv(1));
+    auto startTime = Q_atoi(CG_Argv(1));
     std::string runName = CG_Argv(2);
-    auto previousRecord = atoi(CG_Argv(3));
+    auto previousRecord = Q_atoi(CG_Argv(3));
     ETJump::timerun->startTimerun(runName, startTime, previousRecord);
     ETJump::execCmdOnRunStart();
     // run name, completion time, previous record
@@ -343,10 +343,10 @@ qboolean CG_ServerCommandExt(const char *cmd) {
       return qtrue;
     }
 
-    auto clientNum = atoi(CG_Argv(1));
-    auto runStartTime = atoi(CG_Argv(2));
+    auto clientNum = Q_atoi(CG_Argv(1));
+    auto runStartTime = Q_atoi(CG_Argv(2));
     std::string runName = CG_Argv(3);
-    auto previousRecord = atoi(CG_Argv(4));
+    auto previousRecord = Q_atoi(CG_Argv(4));
 
     ETJump::timerun->startSpectatorTimerun(clientNum, runName, runStartTime,
                                            previousRecord);
@@ -360,7 +360,7 @@ qboolean CG_ServerCommandExt(const char *cmd) {
   }
   // timerun_stop completionTime{integer}
   if (command == "timerun_stop") {
-    auto completionTime = atoi(CG_Argv(1));
+    auto completionTime = Q_atoi(CG_Argv(1));
 
     ETJump::timerun->stopTimerun(completionTime);
     ETJump::execCmdOnRunEnd();
@@ -376,8 +376,8 @@ qboolean CG_ServerCommandExt(const char *cmd) {
       return qtrue;
     }
 
-    auto clientNum = atoi(CG_Argv(1));
-    auto completionTime = atoi(CG_Argv(2));
+    auto clientNum = Q_atoi(CG_Argv(1));
+    auto completionTime = Q_atoi(CG_Argv(2));
     std::string runName = CG_Argv(3);
 
     ETJump::timerun->stopSpectatorTimerun(clientNum, completionTime, runName);
@@ -385,9 +385,9 @@ qboolean CG_ServerCommandExt(const char *cmd) {
     return qtrue;
   }
   if (command == "record") {
-    auto clientNum = atoi(CG_Argv(1));
+    auto clientNum = Q_atoi(CG_Argv(1));
     std::string runName = CG_Argv(2);
-    auto completionTime = atoi(CG_Argv(3));
+    auto completionTime = Q_atoi(CG_Argv(3));
 
     ETJump::timerun->record(clientNum, runName, completionTime);
 
@@ -400,9 +400,9 @@ qboolean CG_ServerCommandExt(const char *cmd) {
     return qtrue;
   }
   if (command == "completion") {
-    auto clientNum = atoi(CG_Argv(1));
+    auto clientNum = Q_atoi(CG_Argv(1));
     std::string runName = CG_Argv(2);
-    auto completionTime = atoi(CG_Argv(3));
+    auto completionTime = Q_atoi(CG_Argv(3));
 
     ETJump::timerun->completion(clientNum, runName, completionTime);
 
@@ -656,7 +656,7 @@ qboolean CG_displaybyname() {
 qboolean CG_displaybynumber() {
   const auto argc = trap_Argc();
   if (argc > 1) {
-    const auto number = atoi(CG_Argv(1));
+    const auto number = Q_atoi(CG_Argv(1));
     const auto total = ETJump::trickjumpLines->countRoute();
     if (number > -1 && number < total) {
       ETJump::trickjumpLines->setCurrentRouteToRender(number);

--- a/src/cgame/etj_timerun_view.cpp
+++ b/src/cgame/etj_timerun_view.cpp
@@ -45,16 +45,16 @@ ETJump::TimerunView::TimerunView() : Drawable() {
 ETJump::TimerunView::~TimerunView() {}
 
 void ETJump::TimerunView::start() {
-  auto clientNum = atoi(CG_Argv(2));
-  _playersTimerunInformation[clientNum].startTime = atoi(CG_Argv(3));
+  auto clientNum = Q_atoi(CG_Argv(2));
+  _playersTimerunInformation[clientNum].startTime = Q_atoi(CG_Argv(3));
   _playersTimerunInformation[clientNum].runName = CG_Argv(4);
-  _playersTimerunInformation[clientNum].previousRecord = atoi(CG_Argv(5));
+  _playersTimerunInformation[clientNum].previousRecord = Q_atoi(CG_Argv(5));
   _playersTimerunInformation[clientNum].running = true;
 }
 
 void ETJump::TimerunView::stop() {
-  auto clientNum = atoi(CG_Argv(2));
-  _playersTimerunInformation[clientNum].completionTime = atoi(CG_Argv(3));
+  auto clientNum = Q_atoi(CG_Argv(2));
+  _playersTimerunInformation[clientNum].completionTime = Q_atoi(CG_Argv(3));
   _playersTimerunInformation[clientNum].running = false;
   _playersTimerunInformation[clientNum].lastRunTimer = cg.time;
 }
@@ -70,7 +70,7 @@ void ETJump::TimerunView::interrupt(
 }
 
 void ETJump::TimerunView::interrupt() {
-  auto clientNum = atoi(CG_Argv(2));
+  auto clientNum = Q_atoi(CG_Argv(2));
   interrupt(_playersTimerunInformation[clientNum]);
 }
 

--- a/src/cgame/etj_trickjump_lines.cpp
+++ b/src/cgame/etj_trickjump_lines.cpp
@@ -709,7 +709,7 @@ void TrickjumpLines::loadRoutes(const char *loadname) {
       Json::Value colorValue = root[i]["color"];
       for (int j = 0; j < static_cast<int>(colorValue.size()); ++j) {
         loadRoute.color[j] =
-            (unsigned char)std::atoi(colorValue[j].asString().c_str());
+            (unsigned char)Q_atoi(colorValue[j].asString().c_str());
       }
 
       // Loop on each trail in a route (tjl)

--- a/src/game/bg_animation.cpp
+++ b/src/game/bg_animation.cpp
@@ -796,7 +796,7 @@ static void BG_ParseCommands(const char **input, animScriptItem_t *scriptItem,
                               "duration "
                               "value");
           }
-          command->animDuration[partIndex] = atoi(token);
+          command->animDuration[partIndex] = Q_atoi(token);
         } else // unget the token
         {
           COM_RestoreParseSession(input);

--- a/src/game/etj_levels.cpp
+++ b/src/game/etj_levels.cpp
@@ -272,7 +272,7 @@ int ReadInt(const char **configFile) {
     G_LogPrintf("readconfig: missing = before \"%s\" on line %d.", token,
                 COM_GetCurrentParseLine());
   }
-  return atoi(token);
+  return Q_atoi(token);
 }
 
 std::string ReadString(const char **configFile) {

--- a/src/game/g_antilag.cpp
+++ b/src/game/g_antilag.cpp
@@ -125,8 +125,8 @@ void G_ResetMarkers(gentity_t *ent) {
 
   trap_Cvar_VariableStringBuffer("sv_fps", buffer, sizeof(buffer) - 1);
 
-  period = atoi(buffer);
-  if (!period) {
+  period = Q_atof(buffer);
+  if (period == 0.0f) {
     period = 50;
   } else {
     period = 1000.f / period;

--- a/src/game/g_character.cpp
+++ b/src/game/g_character.cpp
@@ -169,7 +169,7 @@ void G_UpdateCharacter(gclient_t *client) {
   trap_GetUserinfo(client->ps.clientNum, infostring, sizeof(infostring));
   s = Info_ValueForKey(infostring, "ch");
   if (*s) {
-    characterIndex = atoi(s);
+    characterIndex = Q_atoi(s);
     if (characterIndex < 0 || characterIndex >= MAX_CHARACTERS) {
       goto set_default_character;
     }

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -288,7 +288,7 @@ int ClientNumberFromString(gentity_t *to, char *s) {
 
   // numeric values are just slot numbers
   if (fIsNumber) {
-    idnum = atoi(s);
+    idnum = Q_atoi(s);
     if (idnum < 0 || idnum >= level.maxclients) {
       CPx(to - g_entities, va("print \"Bad client slot: [lof]%i\n\"", idnum));
       return -1;
@@ -345,7 +345,7 @@ int ClientNumbersFromString(const char *s, int *plist) {
     }
   }
   if (is_slot) {
-    i = atoi(s);
+    i = Q_atoi(s);
     if (i >= 0 && i < level.maxclients) {
       p = &level.clients[i];
       if (p->pers.connected == CON_CONNECTED ||
@@ -551,7 +551,7 @@ void Cmd_Give_f(gentity_t *ent) {
   if (*amt) {
     hasAmount = qtrue;
   }
-  amount = atoi(amt);
+  amount = Q_atoi(amt);
   //----(SA)	end
 
   name = ConcatArgs(1);
@@ -763,7 +763,7 @@ void Cmd_God_f(gentity_t *ent) {
       msg = "godmode all OFF\n";
     }
   } else {
-    if (!Q_stricmp(name, "on") || atoi(name)) {
+    if (!Q_stricmp(name, "on") || Q_atoi(name)) {
       ent->flags |= FL_GODMODE;
     } else if (!Q_stricmp(name, "off") || !Q_stricmp(name, "0")) {
       ent->flags &= ~FL_GODMODE;
@@ -799,7 +799,7 @@ void Cmd_Nofatigue_f(gentity_t *ent) {
     return;
   }
 
-  if (!Q_stricmp(name, "on") || atoi(name)) {
+  if (!Q_stricmp(name, "on") || Q_atoi(name)) {
     ent->flags |= FL_NOFATIGUE;
   } else if (!Q_stricmp(name, "off") || !Q_stricmp(name, "0")) {
     ent->flags &= ~FL_NOFATIGUE;
@@ -1010,7 +1010,7 @@ void printTracker(gentity_t *ent) {
 
     for (i = 1; i < numArgs; i++) {
       trap_Argv(i, buffer, sizeof buffer);
-      int idx = atoi(buffer);
+      int idx = Q_atoi(buffer);
 
       if (checkTrackerIndex(clientNum, idx, buffer, false)) {
         printTrackerMsg = stringFormat("Index: ^3%i ^7value: ^2%i\n", idx,
@@ -1046,7 +1046,7 @@ void setTracker(gentity_t *ent) {
   }
 
   trap_Argv(1, bufferIndex, sizeof bufferIndex);
-  int idx = atoi(bufferIndex);
+  int idx = Q_atoi(bufferIndex);
 
   if (!Q_stricmp("all", bufferIndex)) {
     if (trap_Argc() == 2) {
@@ -1056,7 +1056,7 @@ void setTracker(gentity_t *ent) {
     }
 
     trap_Argv(2, bufferValue, sizeof bufferValue);
-    value = atoi(bufferValue);
+    value = Q_atoi(bufferValue);
 
     if (checkTrackerValue(clientNum, bufferValue)) {
       for (i = 0; i < MAX_PROGRESSION_TRACKERS; i++) {
@@ -1098,7 +1098,7 @@ void setTracker(gentity_t *ent) {
       }
 
       if (checkTrackerValue(clientNum, bufferValue)) {
-        value = atoi(bufferValue);
+        value = Q_atoi(bufferValue);
         ent->client->sess.progression[idx - 1] = value;
         setTrackerMsg = stringFormat("^7Tracker set - index: ^3%i "
                                      "^7value: ^2%i\n",
@@ -1135,7 +1135,7 @@ void Cmd_Noclip_f(gentity_t *ent) {
     return;
   }
 
-  if (!Q_stricmp(name, "on") || atoi(name)) {
+  if (!Q_stricmp(name, "on") || Q_atoi(name)) {
     ent->client->noclip = qtrue;
   } else if (!Q_stricmp(name, "off") || !Q_stricmp(name, "0")) {
     ent->client->noclip = qfalse;
@@ -1668,10 +1668,10 @@ void Cmd_Team_f(gentity_t *ent) {
   trap_Argv(3, weap, sizeof(weap));
   trap_Argv(4, weap2, sizeof(weap2));
 
-  w = static_cast<weapon_t>(atoi(weap));
-  w2 = static_cast<weapon_t>(atoi(weap2));
+  w = static_cast<weapon_t>(Q_atoi(weap));
+  w2 = static_cast<weapon_t>(Q_atoi(weap2));
 
-  ent->client->sess.latchPlayerType = atoi(ptype);
+  ent->client->sess.latchPlayerType = Q_atoi(ptype);
   if (ent->client->sess.latchPlayerType < PC_SOLDIER ||
       ent->client->sess.latchPlayerType > PC_COVERTOPS) {
     ent->client->sess.latchPlayerType = PC_SOLDIER;
@@ -1746,7 +1746,7 @@ void Cmd_TeamBot_f(gentity_t *foo) {
   gentity_t *ent;
 
   trap_Argv(1, entNumStr, sizeof(entNumStr));
-  entNum = atoi(entNumStr);
+  entNum = Q_atoi(entNumStr);
 
   ent = g_entities + entNum;
 
@@ -1754,11 +1754,11 @@ void Cmd_TeamBot_f(gentity_t *foo) {
   trap_Argv(4, weap, sizeof(weap));
   trap_Argv(5, fireteam, sizeof(fireteam));
 
-  ent->client->sess.latchPlayerType = atoi(ptype);
-  ent->client->sess.latchPlayerWeapon = atoi(weap);
+  ent->client->sess.latchPlayerType = Q_atoi(ptype);
+  ent->client->sess.latchPlayerWeapon = Q_atoi(weap);
   ent->client->sess.latchPlayerWeapon2 = 0;
-  ent->client->sess.playerType = atoi(ptype);
-  ent->client->sess.playerWeapon = atoi(weap);
+  ent->client->sess.playerType = Q_atoi(ptype);
+  ent->client->sess.playerWeapon = Q_atoi(weap);
 
   // remove any weapon info from the userinfo, so SetWolfSpawnWeapons()
   // doesn't reset the weapon as that
@@ -2256,10 +2256,10 @@ void G_Voice(gentity_t *ent, gentity_t *target, int mode, vsayCmd_t *vsay,
 
     trap_Argv(1, buffer, 32);
 
-    cls = atoi(buffer);
+    cls = Q_atoi(buffer);
 
     trap_Argv(2, buffer, 32);
-    cnt = atoi(buffer);
+    cnt = Q_atoi(buffer);
     if (cnt > MAX_CLIENTS) {
       cnt = MAX_CLIENTS;
     }
@@ -2267,7 +2267,7 @@ void G_Voice(gentity_t *ent, gentity_t *target, int mode, vsayCmd_t *vsay,
     for (i = 0; i < cnt; i++) {
       trap_Argv(3 + i, buffer, 32);
 
-      num = atoi(buffer);
+      num = Q_atoi(buffer);
       if (num < 0) {
         continue;
       }
@@ -2335,7 +2335,7 @@ static void Cmd_Voice_f(gentity_t *ent, int mode, qboolean arg0,
     if (Q_isnumeric(variant[0])) {
       id = 2;
       cust = 3;
-      vsay.variant = atoi(variant);
+      vsay.variant = Q_atoi(variant);
     }
 
     trap_Argv(id, vsay.id, sizeof(vsay.id));
@@ -2346,7 +2346,7 @@ static void Cmd_Voice_f(gentity_t *ent, int mode, qboolean arg0,
     int index;
 
     trap_Argv(2, buffer, sizeof(buffer));
-    index = atoi(buffer);
+    index = Q_atoi(buffer);
     if (index < 0) {
       index = 0;
     }
@@ -2360,7 +2360,7 @@ static void Cmd_Voice_f(gentity_t *ent, int mode, qboolean arg0,
     if (Q_isnumeric(variant[0])) {
       id = 4 + index;
       cust = 5 + index;
-      vsay.variant = atoi(variant);
+      vsay.variant = Q_atoi(variant);
     } else {
       id = 3;
       cust = 4;
@@ -2397,7 +2397,7 @@ static void Cmd_VoiceTell_f(gentity_t *ent, qboolean voiceonly)
 	}
 
 	trap_Argv(1, arg, sizeof(arg));
-	targetNum = atoi(arg);
+	targetNum = Q_atoi(arg);
 	if (targetNum < 0 || targetNum >= level.maxclients)
 	{
 		return;
@@ -3665,11 +3665,11 @@ void Cmd_ClientMonsterSlickAngle (gentity_t *clent) {
     }
 
     trap_Argv( 1, s, sizeof( s ) );
-    entnum = atoi(s);
+    entnum = Q_atoi(s);
     ent = &g_entities[entnum];
 
     trap_Argv( 2, s, sizeof( s ) );
-    angle = atoi(s);
+    angle = Q_atoi(s);
 
     // sanity check (also protect from cheaters)
     if (g_gametype.integer != GT_SINGLE_PLAYER && entnum != clent->s.number) {
@@ -3694,8 +3694,8 @@ void G_UpdateSpawnCounts(void) {
   for (i = 0; i < level.numspawntargets; i++) {
     trap_GetConfigstring(CS_MULTI_SPAWNTARGETS + i, cs, sizeof(cs));
 
-    current = atoi(Info_ValueForKey(cs, "c"));
-    team = atoi(Info_ValueForKey(cs, "t")) & ~256;
+    current = Q_atoi(Info_ValueForKey(cs, "c"));
+    team = Q_atoi(Info_ValueForKey(cs, "t")) & ~256;
 
     count = 0;
     for (j = 0; j < level.numConnectedClients; j++) {
@@ -3770,7 +3770,7 @@ void Cmd_SetSpawnPoint_f(gentity_t *ent) {
   }
 
   trap_Argv(1, arg, sizeof(arg));
-  val = atoi(arg);
+  val = Q_atoi(arg);
 
   if (ent->client) {
     SetPlayerSpawn(ent, val, qtrue);
@@ -3892,7 +3892,7 @@ waypoints as spectator.\n\"" ); return;
 
     VectorCopy( trace.endpos, loc );
 
-    G_SetWayPoint( ent, atoi(arg), loc );
+    G_SetWayPoint( ent, Q_atoi(arg), loc );
 }*/
 
 /*
@@ -3922,7 +3922,7 @@ void Cmd_WeaponStat_f(gentity_t *ent) {
     return;
   }
   trap_Argv(1, buffer, 16);
-  stat = static_cast<extWeaponStats_t>(atoi(buffer));
+  stat = static_cast<extWeaponStats_t>(Q_atoi(buffer));
   if (stat >= 0 && stat < WS_MAX) {
     trap_SendServerCommand(ent - g_entities,
                            va("rws %i %i",
@@ -3941,7 +3941,7 @@ void Cmd_IntermissionWeaponStats_f(gentity_t *ent) {
 
   trap_Argv(1, buffer, sizeof(buffer));
 
-  clientNum = atoi(buffer);
+  clientNum = Q_atoi(buffer);
   if (clientNum < 0 || clientNum > MAX_CLIENTS) {
     return;
   }
@@ -4058,7 +4058,7 @@ void Cmd_SelectedObjective_f(gentity_t *ent) {
     return;
   }
   trap_Argv(1, buffer, 16);
-  val = atoi(buffer) + 1;
+  val = Q_atoi(buffer) + 1;
 
   for (i = 0; i < level.numLimboCams; i++) {
     if (!level.limboCams[i].spawn && level.limboCams[i].info == val) {

--- a/src/game/g_cmds_ext.cpp
+++ b/src/game/g_cmds_ext.cpp
@@ -250,9 +250,9 @@ void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
     } else {
       trap_GetUserinfo(idnum, userinfo, sizeof(userinfo));
       s = Info_ValueForKey(userinfo, "rate");
-      user_rate = (max_rate > 0 && atoi(s) > max_rate) ? max_rate : atoi(s);
+      user_rate = (max_rate > 0 && Q_atoi(s) > max_rate) ? max_rate : Q_atoi(s);
       s = Info_ValueForKey(userinfo, "snaps");
-      user_snaps = atoi(s);
+      user_snaps = Q_atoi(s);
 
       strcpy(rate, va("%5d%6d%9d%7d", cl->pers.clientTimeNudge, user_rate,
                       cl->pers.clientMaxPackets, user_snaps));
@@ -665,7 +665,7 @@ void G_weaponRankings_cmd(gentity_t *ent, unsigned int dwCommand,
 
   // Find the weapon
   trap_Argv(1, z, sizeof(z));
-  if ((iWeap = atoi(z)) == 0 || iWeap < WS_KNIFE || iWeap >= WS_MAX) {
+  if ((iWeap = Q_atoi(z)) == 0 || iWeap < WS_KNIFE || iWeap >= WS_MAX) {
     for (iWeap = WS_SYRINGE; iWeap >= WS_KNIFE; iWeap--) {
       if (!Q_stricmp(z, aWeaponInfo[iWeap].pszCode)) {
         break;

--- a/src/game/g_fireteams.cpp
+++ b/src/game/g_fireteams.cpp
@@ -611,7 +611,7 @@ int G_FireteamNumberForString(const char *name, team_t team) {
   }
 
   if (fireteam <= 0) {
-    fireteam = atoi(name);
+    fireteam = Q_atoi(name);
   }
 
   return fireteam;
@@ -773,7 +773,7 @@ void G_SetFireTeamRules(int clientNum) {
       return;
     }
 
-    int limit = Numeric::clamp(atoi(val), -1, 100);
+    int limit = Numeric::clamp(Q_atoi(val), -1, 100);
     ft->saveLimit = limit;
 
     trap_SendServerCommand(
@@ -843,7 +843,7 @@ void Cmd_FireTeam_MP_f(gentity_t *ent) {
     }
 
     if (clientnum <= 0) {
-      clientnum = atoi(namebuffer);
+      clientnum = Q_atoi(namebuffer);
 
       if ((clientnum <= 0 || clientnum > MAX_CLIENTS) ||
           !g_entities[clientnum - 1].inuse ||
@@ -879,7 +879,7 @@ void Cmd_FireTeam_MP_f(gentity_t *ent) {
     }
 
     if (clientnum <= 0) {
-      clientnum = atoi(namebuffer);
+      clientnum = Q_atoi(namebuffer);
 
       if ((clientnum <= 0 || clientnum > MAX_CLIENTS) ||
           !g_entities[clientnum - 1].inuse ||
@@ -915,7 +915,7 @@ void Cmd_FireTeam_MP_f(gentity_t *ent) {
     }
 
     if (clientnum <= 0) {
-      clientnum = atoi(namebuffer);
+      clientnum = Q_atoi(namebuffer);
 
       if ((clientnum <= 0 || clientnum > MAX_CLIENTS) ||
           !g_entities[clientnum - 1].inuse ||
@@ -951,7 +951,7 @@ void Cmd_FireTeam_MP_f(gentity_t *ent) {
     }
 
     if (clientnum <= 0) {
-      clientnum = atoi(namebuffer);
+      clientnum = Q_atoi(namebuffer);
 
       if ((clientnum <= 0 || clientnum > MAX_CLIENTS) ||
           !g_entities[clientnum - 1].inuse ||

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -2529,7 +2529,7 @@ void FindIntermissionPoint(void) {
 
   trap_GetConfigstring(CS_MULTI_MAPWINNER, cs, sizeof(cs));
   buf = Info_ValueForKey(cs, "winner");
-  winner = atoi(buf);
+  winner = Q_atoi(buf);
 
   // Change from scripting value for winner (0==AXIS, 1==ALLIES) to
   // spawnflag value
@@ -2873,7 +2873,7 @@ qboolean ScoreIsTied(void) {
   trap_GetConfigstring(CS_MULTI_MAPWINNER, cs, sizeof(cs));
 
   buf = Info_ValueForKey(cs, "winner");
-  a = atoi(buf);
+  a = Q_atoi(buf);
 
   return a == -1 ? qtrue : qfalse;
 }
@@ -3269,14 +3269,14 @@ static void G_CheckLoadGame(void) {
 
   // trap_Cvar_Set( "g_reloading", "1" );	// moved down
 
-  if (strlen(loading) > 0 && atoi(loading) != 0) {
+  if (strlen(loading) > 0 && Q_atoi(loading) != 0) {
     trap_Cvar_Set("g_reloading", "1");
 
     // screen should be black if we are at this stage
     trap_SetConfigstring(CS_SCREENFADE, va("1 %i 1", level.time - 10));
 
-    //		if (!reloading && atoi(loading) == 2) {
-    if (!(g_reloading.integer) && atoi(loading) == 2) {
+    //		if (!reloading && Q_atoi(loading) == 2) {
+    if (!(g_reloading.integer) && Q_atoi(loading) == 2) {
       // (SA) hmm, this seems redundant when it sets it
       // above...
       //			reloading = qtrue;

--- a/src/game/g_match.cpp
+++ b/src/game/g_match.cpp
@@ -425,7 +425,7 @@ void G_deleteStats(int nClient) {
 void G_parseStats(char *pszStatsInfo) {
   gclient_t *cl;
   const char *tmp = pszStatsInfo;
-  unsigned int i, dwWeaponMask, dwClientID = atoi(pszStatsInfo);
+  unsigned int i, dwWeaponMask, dwClientID = Q_atoi(pszStatsInfo);
 
   if (dwClientID > MAX_CLIENTS) {
     return;
@@ -437,7 +437,7 @@ void G_parseStats(char *pszStatsInfo) {
   if ((tmp = strchr(tmp, ' ')) == NULL) {                                      \
     return;                                                                    \
   }                                                                            \
-  x = atoi(++tmp);
+  x = Q_atoi(++tmp);
 
   GETVAL(cl->sess.rounds);
   GETVAL(dwWeaponMask);

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -2581,7 +2581,7 @@ void SP_mg42(gentity_t *self) {
   self->nextthink = level.time + FRAMETIME;
 
   if (G_SpawnString("damage", "0", &damage)) {
-    self->damage = atoi(damage);
+    self->damage = Q_atoi(damage);
   }
 
   G_SpawnString("accuracy", "1.0", &accuracy);

--- a/src/game/g_mover.cpp
+++ b/src/game/g_mover.cpp
@@ -4116,7 +4116,7 @@ void InitExplosive(gentity_t *ent) {
 
   // pick it up if the level designer uses "damage" instead of "dmg"
   if (G_SpawnString("damage", "0", &damage)) {
-    ent->damage = atoi(damage);
+    ent->damage = Q_atoi(damage);
   }
 
   ent->s.eType = ET_EXPLOSIVE;
@@ -4640,7 +4640,7 @@ void func_constructible_use(gentity_t *self, gentity_t *other,
   self->s.modelindex = 0;
 
   if (!self->count2) {
-    self->s.modelindex2 = atoi(self->model + 1);
+    self->s.modelindex2 = Q_atoi(self->model + 1);
   } else {
     self->s.modelindex2 = self->conbmodels[0];
   }
@@ -5102,16 +5102,15 @@ void func_constructiblespawn(gentity_t *ent) {
 
           bmodel = bmodel_ent->model + 1;
 
-          ent->conbmodels[ent->count2++] = atoi(bmodel);
+          ent->conbmodels[ent->count2++] = Q_atoi(bmodel);
         }
 
         target_ptr = ptr + 1;
       }
     }
 
-    ent->conbmodels[ent->count2++] =
-        atoi(ent->model + 1); // the brushmodel of the func_constructible is
-                              // the final stage
+    // the brushmodel of the func_constructible is the final stage
+    ent->conbmodels[ent->count2++] = Q_atoi(ent->model + 1);
 
     // parse the destruction stages
     if (ent->count2 && ent->desstages) {
@@ -5161,7 +5160,7 @@ void func_constructiblespawn(gentity_t *ent) {
 
             bmodel = bmodel_ent->model + 1;
 
-            ent->desbmodels[numDesStages++] = atoi(bmodel);
+            ent->desbmodels[numDesStages++] = Q_atoi(bmodel);
           }
 
           target_ptr = ptr + 1;
@@ -5207,7 +5206,7 @@ void func_constructiblespawn(gentity_t *ent) {
       // other contents?
       trap_LinkEntity(ent);
 
-      ent->s.modelindex2 = atoi(ent->model + 1);
+      ent->s.modelindex2 = Q_atoi(ent->model + 1);
     } else {
       // set initial contents
       trap_SetBrushModel(ent, va("*%i", ent->conbmodels[0]));
@@ -5421,7 +5420,7 @@ void SP_func_brushmodel(gentity_t *ent) {
   }
 
   if (ent->targetname && level.numBrushModels < 128) {
-    level.brushModelInfo[level.numBrushModels].model = atoi(ent->model + 1);
+    level.brushModelInfo[level.numBrushModels].model = Q_atoi(ent->model + 1);
     Q_strncpyz(level.brushModelInfo[level.numBrushModels].modelname,
                ent->targetname, 32);
     level.numBrushModels++;
@@ -5464,7 +5463,7 @@ void SP_func_debris(gentity_t *ent) {
 
   debris = G_AllocDebrisChunk();
 
-  debris->model = atoi(ent->model + 1);
+  debris->model = Q_atoi(ent->model + 1);
 
   Q_strncpyz(debris->target, ent->target, sizeof(debris->target));
   Q_strncpyz(debris->targetname, ent->targetname, sizeof(debris->targetname));

--- a/src/game/g_props.cpp
+++ b/src/game/g_props.cpp
@@ -3101,7 +3101,7 @@ void SP_props_decoration(gentity_t *ent) {
   char *startonframe;
 
   if (G_SpawnString("startonframe", "0", &startonframe)) {
-    ent->s.frame = atoi(startonframe);
+    ent->s.frame = Q_atoi(startonframe);
   }
 
   if (ent->model2) {
@@ -3113,7 +3113,7 @@ void SP_props_decoration(gentity_t *ent) {
   }
 
   if ((ent->spawnflags & 32) && G_SpawnString("loop", "100", &loop)) {
-    ent->props_frame_state = atoi(loop);
+    ent->props_frame_state = Q_atoi(loop);
   }
 
   // if the "color" or "light" keys are set, setup constantLight

--- a/src/game/g_script.cpp
+++ b/src/game/g_script.cpp
@@ -293,11 +293,11 @@ qboolean G_Script_EventMatch_IntInRange(g_script_event_t *event,
   // get the cast name
   pString = eventParm;
   token = COM_ParseExt(&pString, qfalse);
-  int1 = atoi(token);
+  int1 = Q_atoi(token);
   token = COM_ParseExt(&pString, qfalse);
-  int2 = atoi(token);
+  int2 = Q_atoi(token);
 
-  eInt = atoi(event->params);
+  eInt = Q_atoi(event->params);
 
   if (eventParm && eInt > int1 && eInt <= int2) {
     return qtrue;

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -121,7 +121,7 @@ qboolean G_ScriptAction_SetAutoSpawn(gentity_t *ent, char *params) {
   if (!token[0]) {
     G_Error("G_Scripting: setautospawn must have a target team\n");
   }
-  team = static_cast<team_t>(atoi(token));
+  team = static_cast<team_t>(Q_atoi(token));
   pTeamAutoSpawn =
       team == 0 ? &(level.axisAutoSpawn) : &(level.alliesAutoSpawn);
 
@@ -224,7 +224,7 @@ qboolean G_ScriptAction_DamagePlayer(gentity_t *ent, char *params) {
   if (!token[0]) {
     G_Error("G_Scripting: damageplayer must have damage points\n");
   }
-  auto damaged = atoi(token);
+  auto damaged = Q_atoi(token);
   G_Damage(activator, nullptr, nullptr, nullptr, nullptr, damaged,
            DAMAGE_NO_PROTECTION, MOD_TELEFRAG);
   return qtrue;
@@ -363,7 +363,7 @@ qboolean G_ScriptAction_FollowPath(gentity_t *ent, char *params) {
               "direction\n");
     }
 
-    backward = atoi(token);
+    backward = Q_atoi(token);
 
     token = COM_ParseExt(&pString, qfalse);
     if (!token[0]) {
@@ -401,7 +401,7 @@ qboolean G_ScriptAction_FollowPath(gentity_t *ent, char *params) {
                     "value\n");
           }
 
-          length = atoi(token);
+          length = Q_atof(token);
         }
       }
     }
@@ -480,7 +480,7 @@ qboolean G_ScriptAction_AttatchToTrain(gentity_t *ent, char *params) {
     G_Error("G_Scripting: attatchtotrain must have a length\n");
   }
 
-  ent->s.angles2[0] = atoi(token);
+  ent->s.angles2[0] = Q_atof(token);
 
   ent->s.eFlags |= EF_PATH_LINK;
 
@@ -514,7 +514,7 @@ qboolean G_ScriptAction_StartAnimation(gentity_t *ent, char *params) {
             "frame\n");
   }
 
-  ent->s.legsAnim = atoi(token);
+  ent->s.legsAnim = Q_atoi(token);
 
   token = COM_ParseExt(&pString, qfalse);
   if (!token[0]) {
@@ -522,14 +522,14 @@ qboolean G_ScriptAction_StartAnimation(gentity_t *ent, char *params) {
             "count\n");
   }
 
-  ent->s.torsoAnim = atoi(token);
+  ent->s.torsoAnim = Q_atoi(token);
 
   token = COM_ParseExt(&pString, qfalse);
   if (!token[0]) {
     G_Error("G_Scripting: startanimation must have an fps count\n");
   }
 
-  ent->s.weapon = 1000.f / atoi(token);
+  ent->s.weapon = static_cast<int>(1000.f / Q_atof(token));
 
   while (token[0]) {
     token = COM_ParseExt(&pString, qfalse);
@@ -586,7 +586,7 @@ qboolean G_ScriptAction_SetSpeed(gentity_t *ent, char *params) {
       G_Error("G_Scripting: syntax: setspeed <x> <y> "
               "<z> [gravity|lowgravity]\n");
     }
-    speed[i] = atoi(token);
+    speed[i] = Q_atof(token);
   }
   token = COM_Parse(&pString);
   while (token && *token) {
@@ -634,7 +634,7 @@ qboolean G_ScriptAction_SetRotation(gentity_t *ent, char *params) {
               "<pitchspeed> <yawspeed> "
               "<rollspeed>\n");
     }
-    angles[i] = atoi(token);
+    angles[i] = Q_atof(token);
   }
 
   VectorCopy(angles, ent->s.apos.trDelta);
@@ -733,7 +733,7 @@ qboolean G_ScriptAction_FollowSpline(gentity_t *ent, char *params) {
                 "buffer index\n");
       }
 
-      bufferIndex = atoi(token);
+      bufferIndex = Q_atoi(token);
       if (bufferIndex < 0 || bufferIndex >= G_MAX_SCRIPT_ACCUM_BUFFERS) {
         G_Error("G_Scripting: accum buffer is "
                 "outside range (0 - %i)\n",
@@ -750,7 +750,7 @@ qboolean G_ScriptAction_FollowSpline(gentity_t *ent, char *params) {
                 "buffer index\n");
       }
 
-      bufferIndex = atoi(token);
+      bufferIndex = Q_atoi(token);
       if (bufferIndex < 0 || bufferIndex >= G_MAX_SCRIPT_ACCUM_BUFFERS) {
         G_Error("G_Scripting: accum buffer is "
                 "outside range (0 - %i)\n",
@@ -759,7 +759,7 @@ qboolean G_ScriptAction_FollowSpline(gentity_t *ent, char *params) {
 
       backward = level.globalAccumBuffer[bufferIndex] != 0 ? qtrue : qfalse;
     } else {
-      backward = atoi(token);
+      backward = Q_atoi(token);
     }
 
     token = COM_ParseExt(&pString, qfalse);
@@ -798,7 +798,7 @@ qboolean G_ScriptAction_FollowSpline(gentity_t *ent, char *params) {
                     "value\n");
           }
 
-          length = atoi(token);
+          length = Q_atof(token);
         }
 
         if (!Q_stricmp(token, "roll")) {
@@ -810,7 +810,7 @@ qboolean G_ScriptAction_FollowSpline(gentity_t *ent, char *params) {
                     "angle\n");
           }
 
-          roll[0] = atoi(token);
+          roll[0] = Q_atof(token);
 
           token = COM_ParseExt(&pString, qfalse);
           if (!token[0]) {
@@ -820,7 +820,7 @@ qboolean G_ScriptAction_FollowSpline(gentity_t *ent, char *params) {
                     "angle\n");
           }
 
-          roll[1] = atoi(token);
+          roll[1] = Q_atof(token);
         }
 
         if (!Q_stricmp(token, "dampin")) {
@@ -945,7 +945,7 @@ qboolean G_ScriptAction_SetChargeTimeFactor(gentity_t *ent, char *params) {
     G_Error("G_Scripting: setchargetimefactor must have a team\n");
   }
 
-  team = static_cast<team_t>(atoi(token));
+  team = static_cast<team_t>(Q_atoi(token));
 
   token = COM_ParseExt(&pString, qfalse);
   if (!token[0]) {
@@ -1054,7 +1054,7 @@ qboolean G_ScriptAction_AllowTankExit(gentity_t *ent, char *params) {
             "value\n");
   }
 
-  if (!Q_stricmp(token, "yes") || !Q_stricmp(token, "on") || atoi(token)) {
+  if (!Q_stricmp(token, "yes") || !Q_stricmp(token, "on") || Q_atoi(token)) {
     level.disableTankExit = qfalse;
   } else {
     level.disableTankExit = qtrue;
@@ -1073,7 +1073,7 @@ qboolean G_ScriptAction_AllowTankEnter(gentity_t *ent, char *params) {
             "value\n");
   }
 
-  if (!Q_stricmp(token, "yes") || !Q_stricmp(token, "on") || atoi(token)) {
+  if (!Q_stricmp(token, "yes") || !Q_stricmp(token, "on") || Q_atoi(token)) {
     level.disableTankEnter = qfalse;
   } else {
     level.disableTankEnter = qtrue;
@@ -1109,7 +1109,7 @@ qboolean G_ScriptAction_SetTankAmmo(gentity_t *ent, char *params) {
     G_Error("G_Scripting: settankammo must have an amount\n");
   }
 
-  tank->s.effect1Time = atoi(token);
+  tank->s.effect1Time = Q_atoi(token);
 
   return qtrue;
 }
@@ -1141,12 +1141,12 @@ qboolean G_ScriptAction_AddTankAmmo(gentity_t *ent, char *params) {
     G_Error("G_Scripting: addtankammo must have an amount\n");
   }
 
-  tank->s.effect1Time += atoi(token);
+  tank->s.effect1Time += Q_atoi(token);
 
   token = COM_ParseExt(&pString, qfalse);
   if (*token) {
-    if (tank->s.effect1Time > atoi(token)) {
-      tank->s.effect1Time = atoi(token);
+    if (tank->s.effect1Time > Q_atoi(token)) {
+      tank->s.effect1Time = Q_atoi(token);
     }
   }
 
@@ -1214,7 +1214,7 @@ qboolean G_ScriptAction_SetGlobalFog(gentity_t *ent, char *params) {
             "value\n");
   }
 
-  restore = atoi(token) ? qtrue : qfalse;
+  restore = Q_atoi(token) ? qtrue : qfalse;
 
   token = COM_ParseExt(&pString, qfalse);
   if (!token[0]) {
@@ -1222,7 +1222,7 @@ qboolean G_ScriptAction_SetGlobalFog(gentity_t *ent, char *params) {
             "value\n");
   }
 
-  duration = atoi(token);
+  duration = Q_atoi(token);
 
   if (restore) {
     trap_SetConfigstring(CS_GLOBALFOGVARS, va("1 %i 0 0 0 0", duration));
@@ -1522,14 +1522,14 @@ qboolean G_ScriptAction_Wait(gentity_t *ent, char *params) {
       G_Error("G_Scripting: wait random must have a "
               "min duration\n");
     }
-    min = atoi(token);
+    min = Q_atoi(token);
 
     token = COM_ParseExt(&pString, qfalse);
     if (!*token) {
       G_Error("G_Scripting: wait random must have a "
               "max duration\n");
     }
-    max = atoi(token);
+    max = Q_atoi(token);
 
     if (ent->scriptStatus.scriptStackChangeTime + min > level.time) {
       return qfalse;
@@ -1542,7 +1542,7 @@ qboolean G_ScriptAction_Wait(gentity_t *ent, char *params) {
     return !(rand() % (int)((max - min) * 0.02f)) ? qtrue : qfalse;
   }
 
-  duration = atoi(token);
+  duration = Q_atoi(token);
   return (ent->scriptStatus.scriptStackChangeTime + duration < level.time)
              ? qtrue
              : qfalse;
@@ -1699,7 +1699,7 @@ qboolean G_ScriptAction_PlaySound(gentity_t *ent, char *params) {
       looping = qtrue;
     } else if (!Q_stricmp(token, "volume")) {
       token = COM_ParseExt(&pString, qfalse);
-      volume = atoi(token);
+      volume = Q_atoi(token);
       if (!volume) {
         volume = 255;
       }
@@ -1760,7 +1760,7 @@ qboolean G_ScriptAction_FadeAllSounds(gentity_t *ent, char *params) {
 
   token = COM_ParseExt(&pString, qfalse);
 
-  time = atoi(token);
+  time = Q_atoi(token);
   if (!time) {
     G_Error("G_Scripting: FadeAllSounds found '%s' when "
             "expecting 'time'\n",
@@ -1795,7 +1795,7 @@ qboolean G_ScriptAction_MusicStart(gentity_t *ent, char *params) {
 
   token = COM_ParseExt(&pString, qfalse);
   if (token[0]) {
-    fadeupTime = atoi(token);
+    fadeupTime = Q_atoi(token);
   }
 
   trap_SendServerCommand(-1, va("mu_start %s %d", cvarName, fadeupTime));
@@ -1839,7 +1839,7 @@ qboolean G_ScriptAction_MusicStop(gentity_t *ent, char *params) {
   pString = params;
   token = COM_ParseExt(&pString, qfalse);
   if (token[0]) {
-    fadeoutTime = atoi(token);
+    fadeoutTime = Q_atoi(token);
   }
 
   trap_SendServerCommand(-1, va("mu_stop %i\n", fadeoutTime));
@@ -1895,7 +1895,7 @@ qboolean G_ScriptAction_MusicFade(gentity_t *ent, char *params) {
     G_Error("G_Scripting: syntax: mu_fade <target volume "
             "0.0-1.0> <fadeout time>");
   }
-  fadeoutTime = atoi(token);
+  fadeoutTime = Q_atoi(token);
 
   trap_SendServerCommand(-1, va("mu_fade %f %i\n", targetVol, fadeoutTime));
 
@@ -1942,8 +1942,8 @@ qboolean G_ScriptAction_PlayAnim(gentity_t *ent, char *params) {
     }
   }
 
-  startframe = atoi(tokens[0]);
-  endframe = atoi(tokens[1]);
+  startframe = Q_atoi(tokens[0]);
+  endframe = Q_atoi(tokens[1]);
 
   // check for optional parameters
   token = COM_ParseExt(&pString, qfalse);
@@ -1972,7 +1972,7 @@ qboolean G_ScriptAction_PlayAnim(gentity_t *ent, char *params) {
                                     // since we are going forever!
         forever = qtrue;
       } else {
-        endtime = ent->scriptStatus.scriptStackChangeTime + atoi(token);
+        endtime = ent->scriptStatus.scriptStackChangeTime + Q_atoi(token);
       }
 
       token = COM_ParseExt(&pString, qfalse);
@@ -1985,7 +1985,7 @@ qboolean G_ScriptAction_PlayAnim(gentity_t *ent, char *params) {
                 "parameter without an actual "
                 "rate specified");
       }
-      rate = atoi(token);
+      rate = Q_atoi(token);
     }
 
     if (!looping) {
@@ -2226,7 +2226,7 @@ qboolean G_ScriptAction_Accum(gentity_t *ent, char *params) {
     G_Error("G_Scripting: accum without a buffer index\n");
   }
 
-  bufferIndex = atoi(token);
+  bufferIndex = Q_atoi(token);
   if (bufferIndex >= G_MAX_SCRIPT_ACCUM_BUFFERS) {
     G_Error("G_Scripting: accum buffer is outside range (0 - %i)\n",
             G_MAX_SCRIPT_ACCUM_BUFFERS);
@@ -2244,12 +2244,12 @@ qboolean G_ScriptAction_Accum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    ent->scriptAccumBuffer[bufferIndex] += atoi(token);
+    ent->scriptAccumBuffer[bufferIndex] += Q_atoi(token);
   } else if (!Q_stricmp(lastToken, "abort_if_less_than")) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (ent->scriptAccumBuffer[bufferIndex] < atoi(token)) {
+    if (ent->scriptAccumBuffer[bufferIndex] < Q_atoi(token)) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -2258,7 +2258,7 @@ qboolean G_ScriptAction_Accum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (ent->scriptAccumBuffer[bufferIndex] > atoi(token)) {
+    if (ent->scriptAccumBuffer[bufferIndex] > Q_atoi(token)) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -2268,7 +2268,7 @@ qboolean G_ScriptAction_Accum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (ent->scriptAccumBuffer[bufferIndex] != atoi(token)) {
+    if (ent->scriptAccumBuffer[bufferIndex] != Q_atoi(token)) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -2277,7 +2277,7 @@ qboolean G_ScriptAction_Accum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (ent->scriptAccumBuffer[bufferIndex] == atoi(token)) {
+    if (ent->scriptAccumBuffer[bufferIndex] == Q_atoi(token)) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -2286,17 +2286,17 @@ qboolean G_ScriptAction_Accum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    ent->scriptAccumBuffer[bufferIndex] |= (1 << atoi(token));
+    ent->scriptAccumBuffer[bufferIndex] |= (1 << Q_atoi(token));
   } else if (!Q_stricmp(lastToken, "bitreset")) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    ent->scriptAccumBuffer[bufferIndex] &= ~(1 << atoi(token));
+    ent->scriptAccumBuffer[bufferIndex] &= ~(1 << Q_atoi(token));
   } else if (!Q_stricmp(lastToken, "abort_if_bitset")) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (ent->scriptAccumBuffer[bufferIndex] & (1 << atoi(token))) {
+    if (ent->scriptAccumBuffer[bufferIndex] & (1 << Q_atoi(token))) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -2305,7 +2305,7 @@ qboolean G_ScriptAction_Accum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (!(ent->scriptAccumBuffer[bufferIndex] & (1 << atoi(token)))) {
+    if (!(ent->scriptAccumBuffer[bufferIndex] & (1 << Q_atoi(token)))) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -2314,17 +2314,17 @@ qboolean G_ScriptAction_Accum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    ent->scriptAccumBuffer[bufferIndex] = atoi(token);
+    ent->scriptAccumBuffer[bufferIndex] = Q_atoi(token);
   } else if (!Q_stricmp(lastToken, "random")) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    ent->scriptAccumBuffer[bufferIndex] = rand() % atoi(token);
+    ent->scriptAccumBuffer[bufferIndex] = rand() % Q_atoi(token);
   } else if (!Q_stricmp(lastToken, "trigger_if_equal")) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (ent->scriptAccumBuffer[bufferIndex] == atoi(token)) {
+    if (ent->scriptAccumBuffer[bufferIndex] == Q_atoi(token)) {
       gentity_t *trent;
       int oldId;
       //			qboolean loop = qfalse;
@@ -2377,7 +2377,7 @@ qboolean G_ScriptAction_Accum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (ent->scriptAccumBuffer[bufferIndex] == atoi(token)) {
+    if (ent->scriptAccumBuffer[bufferIndex] == Q_atoi(token)) {
       return qfalse;
     }
   } else if (!Q_stricmp(lastToken, "set_to_dynamitecount")) {
@@ -2428,7 +2428,7 @@ qboolean G_ScriptAction_GlobalAccum(gentity_t *ent, char *params) {
     G_Error("G_Scripting: accum without a buffer index\n");
   }
 
-  bufferIndex = atoi(token);
+  bufferIndex = Q_atoi(token);
   if (bufferIndex >= G_MAX_SCRIPT_ACCUM_BUFFERS) {
     G_Error("G_Scripting: accum buffer is outside range (0 - %i)\n",
             G_MAX_SCRIPT_ACCUM_BUFFERS);
@@ -2446,12 +2446,12 @@ qboolean G_ScriptAction_GlobalAccum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    level.globalAccumBuffer[bufferIndex] += atoi(token);
+    level.globalAccumBuffer[bufferIndex] += Q_atoi(token);
   } else if (!Q_stricmp(lastToken, "abort_if_less_than")) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (level.globalAccumBuffer[bufferIndex] < atoi(token)) {
+    if (level.globalAccumBuffer[bufferIndex] < Q_atoi(token)) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -2460,7 +2460,7 @@ qboolean G_ScriptAction_GlobalAccum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (level.globalAccumBuffer[bufferIndex] > atoi(token)) {
+    if (level.globalAccumBuffer[bufferIndex] > Q_atoi(token)) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -2470,7 +2470,7 @@ qboolean G_ScriptAction_GlobalAccum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (level.globalAccumBuffer[bufferIndex] != atoi(token)) {
+    if (level.globalAccumBuffer[bufferIndex] != Q_atoi(token)) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -2479,7 +2479,7 @@ qboolean G_ScriptAction_GlobalAccum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (level.globalAccumBuffer[bufferIndex] == atoi(token)) {
+    if (level.globalAccumBuffer[bufferIndex] == Q_atoi(token)) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -2488,17 +2488,17 @@ qboolean G_ScriptAction_GlobalAccum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    level.globalAccumBuffer[bufferIndex] |= (1 << atoi(token));
+    level.globalAccumBuffer[bufferIndex] |= (1 << Q_atoi(token));
   } else if (!Q_stricmp(lastToken, "bitreset")) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    level.globalAccumBuffer[bufferIndex] &= ~(1 << atoi(token));
+    level.globalAccumBuffer[bufferIndex] &= ~(1 << Q_atoi(token));
   } else if (!Q_stricmp(lastToken, "abort_if_bitset")) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (level.globalAccumBuffer[bufferIndex] & (1 << atoi(token))) {
+    if (level.globalAccumBuffer[bufferIndex] & (1 << Q_atoi(token))) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -2507,7 +2507,7 @@ qboolean G_ScriptAction_GlobalAccum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (!(level.globalAccumBuffer[bufferIndex] & (1 << atoi(token)))) {
+    if (!(level.globalAccumBuffer[bufferIndex] & (1 << Q_atoi(token)))) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -2516,17 +2516,17 @@ qboolean G_ScriptAction_GlobalAccum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    level.globalAccumBuffer[bufferIndex] = atoi(token);
+    level.globalAccumBuffer[bufferIndex] = Q_atoi(token);
   } else if (!Q_stricmp(lastToken, "random")) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    level.globalAccumBuffer[bufferIndex] = rand() % atoi(token);
+    level.globalAccumBuffer[bufferIndex] = rand() % Q_atoi(token);
   } else if (!Q_stricmp(lastToken, "trigger_if_equal")) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (level.globalAccumBuffer[bufferIndex] == atoi(token)) {
+    if (level.globalAccumBuffer[bufferIndex] == Q_atoi(token)) {
       gentity_t *trent;
       int oldId;
       //			qboolean loop = qfalse;
@@ -2579,7 +2579,7 @@ qboolean G_ScriptAction_GlobalAccum(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("Scripting: accum %s requires a parameter\n", lastToken);
     }
-    if (level.globalAccumBuffer[bufferIndex] == atoi(token)) {
+    if (level.globalAccumBuffer[bufferIndex] == Q_atoi(token)) {
       return qfalse;
     }
   } else {
@@ -2617,7 +2617,7 @@ qboolean G_ScriptAction_Print(gentity_t *ent, char *params) {
   token = COM_ParseExt(&pString, qfalse);
   if (token && token[0] == '/') {
     // Get the integer version of the print debug level
-    printLevel = atoi(&(token[1]));
+    printLevel = Q_atoi(&(token[1]));
 
     // Just print what's left
     printThis = pString;
@@ -2663,7 +2663,7 @@ qboolean G_ScriptAction_FaceAngles(gentity_t *ent, char *params) {
                 "<pitch> <yaw> <roll> "
                 "<duration/GOTOTIME>\n");
       }
-      angles[i] = atoi(token);
+      angles[i] = Q_atof(token);
     }
 
     token = COM_Parse(&pString);
@@ -2675,7 +2675,7 @@ qboolean G_ScriptAction_FaceAngles(gentity_t *ent, char *params) {
     if (!Q_stricmp(token, "gototime")) {
       duration = ent->s.pos.trDuration;
     } else {
-      duration = atoi(token);
+      duration = Q_atoi(token);
     }
 
     token = COM_Parse(&pString);
@@ -2958,7 +2958,7 @@ qboolean G_ScriptAction_NumberofObjectives(gentity_t *ent, char *params) {
             "parameter required\n");
   }
 
-  num = atoi(token);
+  num = Q_atoi(token);
   if (num < 1 || num > MAX_OBJECTIVES) {
     G_Error("G_ScriptAction_NumberofObjectives: Invalid number "
             "of objectives\n");
@@ -2994,7 +2994,7 @@ qboolean G_ScriptAction_SetMainObjective(gentity_t *ent, char *params) {
      );
       }
 
-      num = atoi( token );
+      num = Q_atoi( token );
       if ( num < 1 || num > MAX_OBJECTIVES ) {
           G_Error( "G_ScriptAction_ObjectiveImage: Invalid objective
      number\n"
@@ -3008,7 +3008,7 @@ qboolean G_ScriptAction_SetMainObjective(gentity_t *ent, char *params) {
      required\n" );
       }
 
-      cs_obj = !atoi(token) ? CS_MAIN_AXIS_OBJECTIVE :
+      cs_obj = !Q_atoi(token) ? CS_MAIN_AXIS_OBJECTIVE :
      CS_MAIN_ALLIES_OBJECTIVE; trap_GetConfigstring( cs_obj, cs,
      sizeof(cs) );
 
@@ -3040,7 +3040,7 @@ qboolean G_ScriptAction_ObjectiveStatus(gentity_t *ent, char *params) {
             "required\n");
   }
 
-  num = atoi(token);
+  num = Q_atoi(token);
   if (num < 1 || num > MAX_OBJECTIVES) {
     G_Error("G_ScriptAction_ObjectiveImage: Invalid objective "
             "number\n");
@@ -3051,7 +3051,7 @@ qboolean G_ScriptAction_ObjectiveStatus(gentity_t *ent, char *params) {
     G_Error("G_ScriptAction_ObjectiveImage: team parameter "
             "required\n");
   }
-  parm = atoi(token) == 0 ? "x" : "a";
+  parm = Q_atoi(token) == 0 ? "x" : "a";
 
   token = COM_Parse(&pString);
   if (!token[0]) {
@@ -3059,7 +3059,7 @@ qboolean G_ScriptAction_ObjectiveStatus(gentity_t *ent, char *params) {
             "required\n");
   }
 
-  if (atoi(token) != 0 && atoi(token) != 1 && atoi(token) != 2) {
+  if (Q_atoi(token) != 0 && Q_atoi(token) != 1 && Q_atoi(token) != 2) {
     G_Error("G_ScriptAction_ObjectiveImage: status parameter "
             "must be 0 "
             "(default), 1 (complete) or 2 (failed)\n");
@@ -3088,7 +3088,7 @@ qboolean G_ScriptAction_SetDebugLevel(gentity_t *ent, char *params) {
   token = COM_ParseExt(&pString, qfalse);
   if (token && token[0]) {
     // Get the integer version of the debug level
-    debugLevel = atoi(token);
+    debugLevel = Q_atoi(token);
 
     // Set the debug level
     trap_Cvar_Set("g_scriptDebugLevel", va("%i", debugLevel));
@@ -3112,7 +3112,7 @@ qboolean G_ScriptAction_VoiceAnnounce(gentity_t *ent, char *params) {
             "required\n");
   }
 
-  num = atoi(token);
+  num = Q_atoi(token);
   if (num != 0 && num != 1) {
     G_Error("G_ScriptAction_VoiceAnnounce: Invalid team number\n");
   }
@@ -3160,7 +3160,7 @@ qboolean G_ScriptAction_SetWinner(gentity_t *ent, char *params) {
             "required\n");
   }
 
-  num = atoi(token);
+  num = Q_atoi(token);
   if (num < -1 || num > 1) {
     G_Error("G_ScriptAction_SetWinner: Invalid team number\n");
   }
@@ -3205,7 +3205,7 @@ qboolean G_ScriptAction_SetDefendingTeam(gentity_t *ent, char *params) {
             "required\n");
   }
 
-  num = atoi(token);
+  num = Q_atoi(token);
   if (num < 0 || num > 1) {
     G_Error("G_ScriptAction_SetDefendingTeam: Invalid team "
             "number\n");
@@ -3243,7 +3243,7 @@ qboolean G_ScriptAction_AddTeamVoiceAnnounce(gentity_t *ent, char *params) {
             "parameter required\n");
   }
 
-  if (atoi(token)) {
+  if (Q_atoi(token)) {
     team = 1;
   } else {
     team = 0;
@@ -3286,7 +3286,7 @@ qboolean G_ScriptAction_RemoveTeamVoiceAnnounce(gentity_t *ent, char *params) {
             "parameter required\n");
   }
 
-  if (atoi(token)) {
+  if (Q_atoi(token)) {
     team = 1;
   } else {
     team = 0;
@@ -3333,7 +3333,7 @@ qboolean G_ScriptAction_TeamVoiceAnnounce(gentity_t *ent, char *params) {
             "required\n");
   }
 
-  if (atoi(token)) {
+  if (Q_atoi(token)) {
     team = TEAM_ALLIES;
   } else {
     team = TEAM_AXIS;
@@ -3375,7 +3375,7 @@ qboolean G_ScriptAction_Announce_Icon(gentity_t *ent, char *params) {
     G_Error("G_ScriptAction_Announce_Icon: icon index "
             "parameter required\n");
   }
-  iconnumber = atoi(token);
+  iconnumber = Q_atoi(token);
   if (iconnumber < 0 || iconnumber >= PM_NUM_TYPES) {
     G_Error("G_ScriptAction_Announce_Icon: icon index "
             "parameter out of range %i\n",
@@ -3486,7 +3486,7 @@ qboolean G_ScriptAction_SetDamagable(gentity_t *ent, char *params) {
             "state\n");
   }
 
-  canDamage = atoi(state) == 1 ? qtrue : qfalse;
+  canDamage = Q_atoi(state) == 1 ? qtrue : qfalse;
 
   // look for entities
   target = &g_entities[MAX_CLIENTS - 1];
@@ -3597,7 +3597,7 @@ qboolean G_ScriptAction_StartCam(gentity_t *ent, char *params) {
 
   // issue a start camera command to the client
   trap_SendServerCommand(ent - g_entities,
-                         va("startCam %s %d", camfile, (int)atoi(token)));
+                         va("startCam %s %d", camfile, (int)Q_atoi(token)));
 
   return qtrue;
 }
@@ -3635,7 +3635,7 @@ qboolean G_ScriptAction_SetInitialCamera(gentity_t *ent, char *params) {
 
   // issue a start camera command to the client
   trap_SendServerCommand(ent - g_entities, va("SetInitialCamera %s %d", camfile,
-                                              (int)atoi(token)));
+                                              (int)Q_atoi(token)));
 
   return qtrue;
 }
@@ -3724,14 +3724,14 @@ qboolean G_ScriptAction_SetHQStatus(gentity_t *ent, char *params) {
     G_Error("G_Scripting: sethqstatus must have a team\n");
   }
 
-  team = static_cast<team_t>(atoi(token));
+  team = static_cast<team_t>(Q_atoi(token));
 
   token = COM_ParseExt(&pString, qfalse);
   if (!token[0]) {
     G_Error("G_Scripting: sethqstatus must have a status\n");
   }
 
-  exists = atoi(token) ? qtrue : qfalse;
+  exists = Q_atoi(token) ? qtrue : qfalse;
 
   // just in case
   if (!level.gameManager) {
@@ -3776,7 +3776,7 @@ qboolean G_ScriptAction_PrintAccum(gentity_t *ent, char *params) {
             "<accumNumber>\n");
   }
 
-  bufferIndex = atoi(token);
+  bufferIndex = Q_atoi(token);
   if ((bufferIndex < 0) || (bufferIndex >= MAX_SCRIPT_ACCUM_BUFFERS)) {
     G_Error("G_ScriptAction_PrintAccum: buffer is outside "
             "range (0 - %i)",
@@ -3818,7 +3818,7 @@ qboolean G_ScriptAction_PrintGlobalAccum(gentity_t *ent, char *params) {
             "<globalAccumNumber>\n");
   }
 
-  bufferIndex = atoi(token);
+  bufferIndex = Q_atoi(token);
   if ((bufferIndex < 0) || (bufferIndex >= MAX_SCRIPT_ACCUM_BUFFERS)) {
     G_Error("PrintGlobalAccum: buffer is outside range (0 - %i)",
             MAX_SCRIPT_ACCUM_BUFFERS);
@@ -3874,7 +3874,7 @@ qboolean G_ScriptAction_ConstructibleClass(gentity_t *ent, char *params) {
             "class value\n");
   }
 
-  value = atoi(token);
+  value = Q_atoi(token);
 
   if (value <= 0 || value > NUM_CONSTRUCTIBLE_CLASSES) {
     G_Error("G_Scripting: \"constructible_class\" has a bad "
@@ -3944,7 +3944,7 @@ qboolean G_ScriptAction_ConstructibleConstructXPBonus(gentity_t *ent,
             "xppoints value\n");
   }
 
-  value = atoi(token);
+  value = Q_atoi(token);
 
   if (value < 0) {
     G_Error("G_Scripting: \"constructible_constructxpbonus\" "
@@ -3977,7 +3977,7 @@ qboolean G_ScriptAction_ConstructibleDestructXPBonus(gentity_t *ent,
             "xppoints value\n");
   }
 
-  value = atoi(token);
+  value = Q_atoi(token);
 
   if (value < 0) {
     G_Error("G_Scripting: \"constructible_destructxpbonus\" "
@@ -4008,7 +4008,7 @@ qboolean G_ScriptAction_ConstructibleHealth(gentity_t *ent, char *params) {
             "health value\n");
   }
 
-  value = atoi(token);
+  value = Q_atoi(token);
 
   if (value <= 0) {
     G_Error("G_Scripting: \"constructible_health\" has a bad "
@@ -4041,7 +4041,7 @@ qboolean G_ScriptAction_ConstructibleWeaponclass(gentity_t *ent, char *params) {
             "class value\n");
   }
 
-  value = atoi(token);
+  value = Q_atoi(token);
 
   if (value < 1 || value > 3) {
     G_Error("G_Scripting: \"constructible_weaponclass\" has a "
@@ -4073,7 +4073,7 @@ qboolean G_ScriptAction_ConstructibleDuration(gentity_t *ent, char *params) {
             "a duration value\n");
   }
 
-  value = atoi(token);
+  value = Q_atoi(token);
 
   if (value < 0) {
     G_Error("G_Scripting: \"constructible_duration\" has a bad "
@@ -4126,7 +4126,7 @@ qboolean G_ScriptAction_Cvar(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("G_Scripting: cvar %s requires a parameter\n", lastToken);
     }
-    if (cvarValue < atoi(token)) {
+    if (cvarValue < Q_atoi(token)) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -4135,7 +4135,7 @@ qboolean G_ScriptAction_Cvar(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("G_Scripting: cvar %s requires a parameter\n", lastToken);
     }
-    if (cvarValue > atoi(token)) {
+    if (cvarValue > Q_atoi(token)) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -4145,7 +4145,7 @@ qboolean G_ScriptAction_Cvar(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("G_Scripting: cvar %s requires a parameter\n", lastToken);
     }
-    if (cvarValue != atoi(token)) {
+    if (cvarValue != Q_atoi(token)) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -4155,7 +4155,7 @@ qboolean G_ScriptAction_Cvar(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("G_Scripting: cvar %s requires a parameter\n", lastToken);
     }
-    if (cvarValue == atoi(token)) {
+    if (cvarValue == Q_atoi(token)) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -4164,17 +4164,17 @@ qboolean G_ScriptAction_Cvar(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("G_Scripting: cvar %s requires a parameter\n", lastToken);
     }
-    cvarValue |= (1 << atoi(token));
+    cvarValue |= (1 << Q_atoi(token));
   } else if (!Q_stricmp(lastToken, "bitreset")) {
     if (!token[0]) {
       G_Error("G_Scripting: cvar %s requires a parameter\n", lastToken);
     }
-    cvarValue &= ~(1 << atoi(token));
+    cvarValue &= ~(1 << Q_atoi(token));
   } else if (!Q_stricmp(lastToken, "abort_if_bitset")) {
     if (!token[0]) {
       G_Error("G_Scripting: cvar %s requires a parameter\n", lastToken);
     }
-    if (cvarValue & (1 << atoi(token))) {
+    if (cvarValue & (1 << Q_atoi(token))) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -4183,7 +4183,7 @@ qboolean G_ScriptAction_Cvar(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("G_Scripting: cvar %s requires a parameter\n", lastToken);
     }
-    if (!(cvarValue & (1 << atoi(token)))) {
+    if (!(cvarValue & (1 << Q_atoi(token)))) {
       // abort the current script
       ent->scriptStatus.scriptStackHead =
           ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
@@ -4192,18 +4192,18 @@ qboolean G_ScriptAction_Cvar(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("G_Scripting: cvar %s requires a parameter\n", lastToken);
     }
-    trap_Cvar_Set(cvarName, va("%i", atoi(token)));
+    trap_Cvar_Set(cvarName, va("%i", Q_atoi(token)));
   } else if (!Q_stricmp(lastToken, "random")) {
     if (!token[0]) {
       G_Error("G_Scripting: cvar %s requires a parameter\n", lastToken);
     }
-    cvarValue = rand() % atoi(token);
+    cvarValue = rand() % Q_atoi(token);
     trap_Cvar_Set(cvarName, va("%i", cvarValue));
   } else if (!Q_stricmp(lastToken, "trigger_if_equal")) {
     if (!token[0]) {
       G_Error("G_Scripting: cvar %s requires a parameter\n", lastToken);
     }
-    if (cvarValue == atoi(token)) {
+    if (cvarValue == Q_atoi(token)) {
       gentity_t *trent;
       int oldId;
       //			qboolean loop = qfalse;
@@ -4257,7 +4257,7 @@ qboolean G_ScriptAction_Cvar(gentity_t *ent, char *params) {
     if (!token[0]) {
       G_Error("G_Scripting: cvar %s requires a parameter\n", lastToken);
     }
-    if (cvarValue == atoi(token)) {
+    if (cvarValue == Q_atoi(token)) {
       return qfalse;
     }
   } else {

--- a/src/game/g_session.cpp
+++ b/src/game/g_session.cpp
@@ -313,7 +313,7 @@ void G_InitWorldSession(void) {
   int i, j;
 
   trap_Cvar_VariableStringBuffer("session", s, sizeof(s));
-  gt = atoi(s);
+  gt = Q_atoi(s);
 
   // if the gametype changed since the last session, don't use any
   // client sessions
@@ -329,7 +329,7 @@ void G_InitWorldSession(void) {
   if ((tmp = strchr(tmp, ' ')) == NULL) {                                      \
     return;                                                                    \
   }                                                                            \
-  x = atoi(++tmp);
+  x = Q_atoi(++tmp);
 
     // Get team lock stuff
     GETVAL(gt);
@@ -367,7 +367,7 @@ void G_InitWorldSession(void) {
             }*/
 
     p = Info_ValueForKey(s, "id");
-    j = atoi(p);
+    j = Q_atoi(p);
     if (!*p || j == -1) {
       level.fireTeams[i].inuse = qfalse;
     } else {
@@ -376,7 +376,7 @@ void G_InitWorldSession(void) {
     level.fireTeams[i].ident = j + 1;
 
     p = Info_ValueForKey(s, "p");
-    level.fireTeams[i].priv = !atoi(p) ? qfalse : qtrue;
+    level.fireTeams[i].priv = !Q_atoi(p) ? qfalse : qtrue;
 
     p = Info_ValueForKey(s, "i");
 
@@ -391,7 +391,7 @@ void G_InitWorldSession(void) {
         }
         Q_strncpyz(str, c, l - c + 1);
         str[l - c] = '\0';
-        level.fireTeams[i].joinOrder[j++] = atoi(str);
+        level.fireTeams[i].joinOrder[j++] = static_cast<char>(Q_atoi(str));
         c = l + 1;
       }
     }

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -51,7 +51,7 @@ qboolean G_SpawnIntExt(const char *key, const char *defaultString, int *out,
   qboolean present;
 
   present = G_SpawnStringExt(key, defaultString, &s, file, line);
-  *out = atoi(s);
+  *out = Q_atoi(s);
   return present;
 }
 
@@ -842,7 +842,7 @@ void G_ParseField(const char *key, const char *value, gentity_t *ent) {
           ((float *)(b + f->ofs))[2] = vec[2];
           break;
         case F_INT:
-          *(int *)(b + f->ofs) = atoi(value);
+          *(int *)(b + f->ofs) = Q_atoi(value);
           break;
         case F_FLOAT:
           *(float *)(b + f->ofs) = Q_atof(value);
@@ -1125,15 +1125,15 @@ void SP_worldspawn(void) {
   trap_SetConfigstring(CS_MESSAGE, s); // map specific message
 
   G_SpawnString("cclayers", "0", &s);
-  if (atoi(s)) {
+  if (Q_atoi(s)) {
     level.ccLayers = qtrue;
   }
 
   G_Printf("ETJump: checking worldspawn key values:\n");
 
   G_SpawnString("noexplosives", "0", &s);
-  if (atoi(s)) {
-    int noExplosives = atoi(s);
+  if (Q_atoi(s)) {
+    int noExplosives = Q_atoi(s);
     if (noExplosives > 2) {
       noExplosives = 2;
     } else if (noExplosives < 0) {
@@ -1145,7 +1145,7 @@ void SP_worldspawn(void) {
   G_Printf("Explosives are %s.\n", level.noExplosives ? "disabled" : "enabled");
 
   G_SpawnString("nonoclip", "0", &s);
-  if (atoi(s)) {
+  if (Q_atoi(s)) {
     level.noNoclip = qtrue;
   } else {
     level.noNoclip = qfalse;
@@ -1153,7 +1153,7 @@ void SP_worldspawn(void) {
   G_Printf("Noclip is %s.\n", level.noNoclip ? "disabled" : "enabled");
 
   G_SpawnString("nogod", "0", &s);
-  if (atoi(s)) {
+  if (Q_atoi(s)) {
     level.noGod = qtrue;
   } else {
     level.noGod = qfalse;
@@ -1161,7 +1161,7 @@ void SP_worldspawn(void) {
   G_Printf("God mode is %s.\n", level.noGod ? "disabled" : "enabled");
 
   G_SpawnString("nogoto", "0", &s);
-  if (atoi(s)) {
+  if (Q_atoi(s)) {
     level.noGoto = qtrue;
   } else {
     level.noGoto = qfalse;
@@ -1171,7 +1171,7 @@ void SP_worldspawn(void) {
   // Feen: PGM - Enable/Disable frivolous use
   //			  of portal gun....
   G_SpawnString("portalgun_spawn", "1", &s);
-  if (atoi(s)) {
+  if (Q_atoi(s)) {
     level.portalEnabled = qtrue;
     G_Printf("Players spawn with portal gun by default.\n");
   } else {
@@ -1180,7 +1180,7 @@ void SP_worldspawn(void) {
   }
 
   G_SpawnString("portalsurfaces", "1", &s);
-  if (atoi(s)) {
+  if (Q_atoi(s)) {
     level.portalSurfaces = qtrue;
   } else {
     level.portalSurfaces = qfalse;
@@ -1189,7 +1189,7 @@ void SP_worldspawn(void) {
            level.portalSurfaces ? "enabled" : "disabled");
 
   G_SpawnString("noghost", "0", &s);
-  if (atoi(s)) {
+  if (Q_atoi(s)) {
     char buf[32] = "\0";
     int currentValue = g_ghostPlayers.integer;
     currentValue |= 2;
@@ -1212,8 +1212,8 @@ void SP_worldspawn(void) {
   }
 
   G_SpawnString("limitedsaves", "0", &s);
-  if (atoi(s)) {
-    int limit = atoi(s);
+  if (Q_atoi(s)) {
+    int limit = Q_atoi(s);
     level.limitedSaves = limit;
     G_Printf("Save is limited to %s.\n",
              ETJump::getPluralizedString(limit, "save").c_str());
@@ -1223,7 +1223,7 @@ void SP_worldspawn(void) {
   }
 
   G_SpawnString("portalteam", "0", &s);
-  val = atoi(s);
+  val = Q_atoi(s);
   if (val) {
     if (val == 1) {
       level.portalTeam = 1;
@@ -1254,7 +1254,7 @@ void SP_worldspawn(void) {
   trap_SetConfigstring(CS_MOTD, g_motd.string); // message of the day
 
   G_SpawnString("spawnflags", "0", &s);
-  g_entities[ENTITYNUM_WORLD].spawnflags = atoi(s);
+  g_entities[ENTITYNUM_WORLD].spawnflags = Q_atoi(s);
   g_entities[ENTITYNUM_WORLD].r.worldflags =
       g_entities[ENTITYNUM_WORLD].spawnflags;
 

--- a/src/game/g_svcmds.cpp
+++ b/src/game/g_svcmds.cpp
@@ -105,7 +105,7 @@ qboolean StringToFilter(const char *s, ipFilter_t *f) {
       num[j++] = *s++;
     }
     num[j] = 0;
-    b[i] = atoi(num);
+    b[i] = Q_atoi(num);
     m[i] = 255;
 
     if (!*s) {
@@ -467,7 +467,7 @@ int refClientNumFromString(char *s) {
 
   // numeric values are just slot numbers
   if (fIsNumber) {
-    idnum = atoi(s);
+    idnum = Q_atoi(s);
     if (idnum < 0 || idnum >= level.maxclients) {
       G_Printf("Bad client slot: ^3%i\n", idnum);
       return -1;
@@ -515,7 +515,7 @@ gclient_t *ClientForString(const char *s) {
 
   // numeric values are just slot numbers
   if (s[0] >= '0' && s[0] <= '9') {
-    idnum = atoi(s);
+    idnum = Q_atoi(s);
     if (idnum < 0 || idnum >= level.maxclients) {
       Com_Printf("Bad client slot: %i\n", idnum);
       return NULL;
@@ -541,7 +541,7 @@ static qboolean G_Is_SV_Running(void) {
   char cvar[MAX_TOKEN_CHARS];
 
   trap_Cvar_VariableStringBuffer("sv_running", cvar, sizeof(cvar));
-  return (qboolean)atoi(cvar);
+  return (qboolean)Q_atoi(cvar);
 }
 
 /*
@@ -718,7 +718,7 @@ static void Svcmd_KickNum_f(void) {
 
   if (trap_Argc() == 3) {
     trap_Argv(2, sTimeout, sizeof(sTimeout));
-    timeout = atoi(sTimeout);
+    timeout = Q_atoi(sTimeout);
   } else {
     timeout = 300;
   }

--- a/src/game/g_syscalls.cpp
+++ b/src/game/g_syscalls.cpp
@@ -256,7 +256,7 @@ void trap_GetUsercmd(int clientNum, usercmd_t *cmd) {
     int fakeLag;
 
     trap_Cvar_VariableStringBuffer("g_fakelag", s, sizeof(s));
-    fakeLag = atoi(s);
+    fakeLag = Q_atoi(s);
     if (fakeLag < 0) {
       fakeLag = 0;
     }

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1337,13 +1337,13 @@ void SP_target_rumble(gentity_t *self) {
   }
 
   G_SpawnString("rampup", "0", &rampup);
-  self->start_size = atoi(rampup) * 1000;
+  self->start_size = Q_atoi(rampup) * 1000;
   if (!(self->start_size)) {
     self->start_size = 1000;
   }
 
   G_SpawnString("rampdown", "0", &rampdown);
-  self->end_size = atoi(rampdown) * 1000;
+  self->end_size = Q_atoi(rampdown) * 1000;
   if (!(self->end_size)) {
     self->end_size = 1000;
   }

--- a/src/game/g_trigger.cpp
+++ b/src/game/g_trigger.cpp
@@ -852,7 +852,7 @@ void SP_trigger_heal(gentity_t *self) {
   // healtotal specifies the maximum amount of health this trigger area
   // restores
   G_SpawnString("healtotal", "0", &spawnstr);
-  healvalue = atoi(spawnstr);
+  healvalue = Q_atoi(spawnstr);
   // Gordon: -9999 means infinite now
   self->health = healvalue;
   if (self->health <= 0) {
@@ -872,7 +872,7 @@ void SP_trigger_heal(gentity_t *self) {
 
   // healrate specifies the amount of healing per second
   G_SpawnString("healrate", "20", &spawnstr);
-  healvalue = atoi(spawnstr);
+  healvalue = Q_atoi(spawnstr);
   self->damage = healvalue; // store the rate of heal in damage
 }
 // END		xkan, 9/17/2002
@@ -1051,7 +1051,7 @@ void SP_trigger_ammo(gentity_t *self) {
   // ammototal specifies the maximum amount of ammo this trigger
   // contains
   G_SpawnString("ammototal", "0", &spawnstr);
-  ammovalue = atoi(spawnstr);
+  ammovalue = Q_atoi(spawnstr);
   // Gordon: -9999 means infinite now
   self->health = ammovalue;
   if (self->health <= 0) {
@@ -1071,7 +1071,7 @@ void SP_trigger_ammo(gentity_t *self) {
 
   // ammorate specifies the amount of ammo added per second
   G_SpawnString("ammorate", "1", &spawnstr);
-  ammovalue = atoi(spawnstr);
+  ammovalue = Q_atoi(spawnstr);
   // store the rate of ammo addition in damage
   self->damage = ammovalue;
 }

--- a/src/game/g_vote.cpp
+++ b/src/game/g_vote.cpp
@@ -218,7 +218,7 @@ int G_voteProcessOnOff(gentity_t *ent, char *arg, char *arg2, int curr_setting,
     return (G_INVALID);
   }
 
-  if ((atoi(arg2) && curr_setting) || (!atoi(arg2) && !curr_setting)) {
+  if ((Q_atoi(arg2) && curr_setting) || (!Q_atoi(arg2) && !curr_setting)) {
     G_cpmPrintf(ent, "^3%s^5 is already %s!", aVoteInfo[vote_type].pszVoteName,
                 ((curr_setting) ? ENABLED : DISABLED));
     return (G_INVALID);
@@ -226,7 +226,7 @@ int G_voteProcessOnOff(gentity_t *ent, char *arg, char *arg2, int curr_setting,
 
   Com_sprintf(level.voteInfo.vote_value, VOTE_MAXSTRING, "%s", arg2);
   Com_sprintf(arg2, VOTE_MAXSTRING, "%s",
-              (atoi(arg2)) ? ACTIVATED : DEACTIVATED);
+              (Q_atoi(arg2)) ? ACTIVATED : DEACTIVATED);
 
   return (G_OK);
 }
@@ -236,7 +236,7 @@ int G_voteProcessOnOff(gentity_t *ent, char *arg, char *arg2, int curr_setting,
 //
 void G_voteSetOnOff(const char *desc, const char *cvar) {
   AP(va("cpm \"^3%s is: ^5%s\n\"", desc,
-        (atoi(level.voteInfo.vote_value)) ? ENABLED : DISABLED));
+        (Q_atoi(level.voteInfo.vote_value)) ? ENABLED : DISABLED));
   // trap_SendConsoleCommand(EXEC_APPEND, va("%s %s\n", cvar,
   // level.voteInfo.vote_value));
   trap_Cvar_Set(cvar, level.voteInfo.vote_value);

--- a/src/game/q_math.cpp
+++ b/src/game/q_math.cpp
@@ -1293,11 +1293,6 @@ int Q_log2(int val) {
   return answer;
 }
 
-float Q_atof(const char *str) {
-  const float f = std::atof(str);
-  return (std::isfinite(f) ? f : 0);
-}
-
 /*
 =================
 PlaneTypeForNormal

--- a/src/game/q_shared.cpp
+++ b/src/game/q_shared.cpp
@@ -760,6 +760,15 @@ int Q_isforfilename(int c) {
   return (0);
 }
 
+float Q_atof(const char *str) {
+  const float f = std::strtof(str, nullptr);
+  return (std::isfinite(f) ? f : 0);
+}
+
+int Q_atoi(const char *str) {
+  return static_cast<int>(std::strtol(str, nullptr, 10));
+}
+
 /*
 =============
 Q_strncpyz

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -105,6 +105,7 @@
   #include <sys/stat.h> // rain
   #include <float.h>
   #include <cstdlib>
+  #include <string>
 
 #endif
 
@@ -664,6 +665,7 @@ void Vector4Scale(const vec4_t in, vec_t scale, vec4_t out);
 void VectorRotate(vec3_t in, vec3_t matrix[3], vec3_t out);
 int Q_log2(int val);
 float Q_atof(const char *str);
+int Q_atoi(const char *str);
 float Q_acos(float c);
 
 int Q_rand(int *seed);
@@ -950,7 +952,7 @@ typedef struct cvar_s {
   qboolean modified;     // set each time the cvar is changed
   int modificationCount; // incremented each time the cvar is changed
   float value;           // Q_atof( string )
-  int integer;           // atoi( string )
+  int integer;           // Q_atoi( string )
   struct cvar_s *next;
   struct cvar_s *hashNext;
 } cvar_t;

--- a/src/ui/ui_gameinfo.cpp
+++ b/src/ui/ui_gameinfo.cpp
@@ -267,20 +267,20 @@ void UI_LoadArenas(void) {
   // set timelimit
   /*		str = Info_ValueForKey( ui_arenaInfos[n], "Timelimit" );
           if ( *str )
-              uiInfo.mapList[uiInfo.mapCount].Timelimit = atoi( str );
+              uiInfo.mapList[uiInfo.mapCount].Timelimit = Q_atoi( str );
           else
               uiInfo.mapList[uiInfo.mapCount].Timelimit = 0;
 
           // set axis respawn time
           str = Info_ValueForKey( ui_arenaInfos[n], "AxisRespawnTime" );
           if ( *str )
-              uiInfo.mapList[uiInfo.mapCount].AxisRespawnTime = atoi(
+              uiInfo.mapList[uiInfo.mapCount].AxisRespawnTime = Q_atoi(
      str ); else uiInfo.mapList[uiInfo.mapCount].AxisRespawnTime = 0;
 
           // set allied respawn time
           str = Info_ValueForKey( ui_arenaInfos[n], "AlliedRespawnTime"
      ); if ( *str ) uiInfo.mapList[uiInfo.mapCount].AlliedRespawnTime =
-     atoi( str ); else uiInfo.mapList[uiInfo.mapCount].AlliedRespawnTime
+     Q_atoi( str ); else uiInfo.mapList[uiInfo.mapCount].AlliedRespawnTime
      = 0;
           // -NERVE - SMF
 

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -1371,7 +1371,7 @@ qboolean Load_Menu(int handle) {
 
 #ifdef LOCALIZATION_SUPPORT
     // NERVE - SMF - localization crap
-    cl_language = atoi(UI_Cvar_VariableString("cl_language"));
+    cl_language = Q_atoi(UI_Cvar_VariableString("cl_language"));
 
     if (cl_language) {
       const char *s = NULL; // TTimo: init
@@ -3081,10 +3081,10 @@ static void UI_BuildPlayerList() {
   trap_GetClientState(&cs);
   trap_GetConfigString(CS_PLAYERS + cs.clientNum, info, MAX_INFO_STRING);
   uiInfo.playerNumber = cs.clientNum;
-  uiInfo.teamLeader = atoi(Info_ValueForKey(info, "tl")) ? qtrue : qfalse;
-  team = atoi(Info_ValueForKey(info, "t"));
+  uiInfo.teamLeader = Q_atoi(Info_ValueForKey(info, "tl")) ? qtrue : qfalse;
+  team = Q_atoi(Info_ValueForKey(info, "t"));
   trap_GetConfigString(CS_SERVERINFO, info, sizeof(info));
-  count = atoi(Info_ValueForKey(info, "sv_maxclients"));
+  count = Q_atoi(Info_ValueForKey(info, "sv_maxclients"));
   uiInfo.playerCount = 0;
   uiInfo.myTeamCount = 0;
   playerTeamNumber = 0;
@@ -3098,14 +3098,14 @@ static void UI_BuildPlayerList() {
       //			Q_CleanStr( namebuf );
       Q_strncpyz(uiInfo.playerNames[uiInfo.playerCount], namebuf,
                  sizeof(uiInfo.playerNames[0]));
-      muted = atoi(Info_ValueForKey(info, "mu"));
+      muted = Q_atoi(Info_ValueForKey(info, "mu"));
       if (muted) {
         uiInfo.playerMuted[uiInfo.playerCount] = qtrue;
       } else {
         uiInfo.playerMuted[uiInfo.playerCount] = qfalse;
       }
       uiInfo.playerCount++;
-      team2 = atoi(Info_ValueForKey(info, "t"));
+      team2 = Q_atoi(Info_ValueForKey(info, "t"));
       if (team2 == team) {
         Q_strncpyz(namebuf, Info_ValueForKey(info, "n"), sizeof(namebuf));
         // fretn - dont expand colors twice, so:
@@ -5348,11 +5348,11 @@ void UI_RunMenuScript(const char **args) {
 
       trap_GetConfigString(CS_SERVERTOGGLES, info, sizeof(info));
       trap_Cvar_Set("ui_voteWarmupDamage",
-                    va("%d", ((atoi(info) & CV_SVS_WARMUPDMG) >> 2)));
+                    va("%d", ((Q_atoi(info) & CV_SVS_WARMUPDMG) >> 2)));
 
       trap_GetConfigString(CS_SERVERINFO, info, sizeof(info));
       trap_Cvar_Set("ui_voteTimelimit",
-                    va("%i", atoi(Info_ValueForKey(info, "timelimit"))));
+                    va("%i", Q_atoi(Info_ValueForKey(info, "timelimit"))));
 
       return;
     }
@@ -5573,7 +5573,7 @@ void UI_RunMenuScript(const char **args) {
       return;
     }
     if (Q_stricmp(name, "showSpecScores") == 0) {
-      if (atoi(UI_Cvar_VariableString("ui_isSpectator"))) {
+      if (Q_atoi(UI_Cvar_VariableString("ui_isSpectator"))) {
         trap_Cmd_ExecuteText(EXEC_APPEND, "+scores\n");
       }
       return;
@@ -6575,12 +6575,12 @@ static void UI_BuildServerDisplayList(int force) {
 
       trap_LAN_GetServerInfo(ui_netSource.integer, i, info, MAX_STRING_CHARS);
 
-      clients = atoi(Info_ValueForKey(info, "clients"));
+      clients = Q_atoi(Info_ValueForKey(info, "clients"));
       uiInfo.serverStatus.numPlayersOnServers += clients;
 
       trap_Cvar_Update(&ui_browserShowEmptyOrFull);
       if (ui_browserShowEmptyOrFull.integer) {
-        maxClients = atoi(Info_ValueForKey(info, "sv_maxclients"));
+        maxClients = Q_atoi(Info_ValueForKey(info, "sv_maxclients"));
 
         if (clients != maxClients &&
             ((!clients && ui_browserShowEmptyOrFull.integer == 2) ||
@@ -6600,7 +6600,7 @@ static void UI_BuildServerDisplayList(int force) {
 
       trap_Cvar_Update(&ui_browserShowPasswordProtected);
       if (ui_browserShowPasswordProtected.integer) {
-        password = atoi(Info_ValueForKey(info, "needpass"));
+        password = Q_atoi(Info_ValueForKey(info, "needpass"));
         if ((password && ui_browserShowPasswordProtected.integer == 2) ||
             (!password && ui_browserShowPasswordProtected.integer == 1)) {
           trap_LAN_MarkServerVisible(ui_netSource.integer, i, qfalse);
@@ -6610,7 +6610,7 @@ static void UI_BuildServerDisplayList(int force) {
 
       trap_Cvar_Update(&ui_browserShowFriendlyFire);
       if (ui_browserShowFriendlyFire.integer) {
-        friendlyFire = atoi(Info_ValueForKey(info, "friendlyFire"));
+        friendlyFire = Q_atoi(Info_ValueForKey(info, "friendlyFire"));
 
         if ((friendlyFire && ui_browserShowFriendlyFire.integer == 2) ||
             (!friendlyFire && ui_browserShowFriendlyFire.integer == 1)) {
@@ -6621,7 +6621,7 @@ static void UI_BuildServerDisplayList(int force) {
 
       trap_Cvar_Update(&ui_browserShowMaxlives);
       if (ui_browserShowMaxlives.integer) {
-        maxlives = atoi(Info_ValueForKey(info, "maxlives"));
+        maxlives = Q_atoi(Info_ValueForKey(info, "maxlives"));
         if ((maxlives && ui_browserShowMaxlives.integer == 2) ||
             (!maxlives && ui_browserShowMaxlives.integer == 1)) {
           trap_LAN_MarkServerVisible(ui_netSource.integer, i, qfalse);
@@ -6631,7 +6631,7 @@ static void UI_BuildServerDisplayList(int force) {
 
       trap_Cvar_Update(&ui_browserShowPunkBuster);
       if (ui_browserShowPunkBuster.integer) {
-        punkbuster = atoi(Info_ValueForKey(info, "punkbuster"));
+        punkbuster = Q_atoi(Info_ValueForKey(info, "punkbuster"));
 
         if ((punkbuster && ui_browserShowPunkBuster.integer == 2) ||
             (!punkbuster && ui_browserShowPunkBuster.integer == 1)) {
@@ -6642,7 +6642,7 @@ static void UI_BuildServerDisplayList(int force) {
 
       trap_Cvar_Update(&ui_browserShowAntilag);
       if (ui_browserShowAntilag.integer) {
-        antilag = atoi(Info_ValueForKey(info, "g_antilag"));
+        antilag = Q_atoi(Info_ValueForKey(info, "g_antilag"));
 
         if ((antilag && ui_browserShowAntilag.integer == 2) ||
             (!antilag && ui_browserShowAntilag.integer == 1)) {
@@ -6653,7 +6653,7 @@ static void UI_BuildServerDisplayList(int force) {
 
       trap_Cvar_Update(&ui_browserShowWeaponsRestricted);
       if (ui_browserShowWeaponsRestricted.integer) {
-        weaponrestricted = atoi(Info_ValueForKey(info, "weaprestrict"));
+        weaponrestricted = Q_atoi(Info_ValueForKey(info, "weaprestrict"));
 
         if ((weaponrestricted != 100 &&
              ui_browserShowWeaponsRestricted.integer == 2) ||
@@ -6666,7 +6666,7 @@ static void UI_BuildServerDisplayList(int force) {
 
       trap_Cvar_Update(&ui_browserShowTeamBalanced);
       if (ui_browserShowTeamBalanced.integer) {
-        balancedteams = atoi(Info_ValueForKey(info, "balancedteams"));
+        balancedteams = Q_atoi(Info_ValueForKey(info, "balancedteams"));
 
         if ((balancedteams && ui_browserShowTeamBalanced.integer == 2) ||
             (!balancedteams && ui_browserShowTeamBalanced.integer == 1)) {
@@ -6677,7 +6677,7 @@ static void UI_BuildServerDisplayList(int force) {
 
       trap_Cvar_Update(&ui_joinGameType);
       if (ui_joinGameType.integer != -1) {
-        game = atoi(Info_ValueForKey(info, "gametype"));
+        game = Q_atoi(Info_ValueForKey(info, "gametype"));
         if (game != ui_joinGameType.integer) {
           trap_LAN_MarkServerVisible(ui_netSource.integer, i, qfalse);
           continue;
@@ -7368,7 +7368,7 @@ const char *UI_FeederItemText(float feederID, int index, int column,
         lastColumn = column;
         lastTime = uiInfo.uiDC.realTime;
       }
-      ping = atoi(Info_ValueForKey(info, "ping"));
+      ping = Q_atoi(Info_ValueForKey(info, "ping"));
       if (ping == -1) {
         // if we ever see a ping that is out of
         // date, do a server refresh
@@ -7386,7 +7386,7 @@ const char *UI_FeederItemText(float feederID, int index, int column,
                           "[%"
                           "s]",
                           Info_ValueForKey(info, "hostname"),
-                          netnames[atoi(Info_ValueForKey(info, "nettype"))]);
+                          netnames[Q_atoi(Info_ValueForKey(info, "nettype"))]);
               return hostname;
             } else {
               return trimLeadingWiteSpace(Info_ValueForKey(info, "hostname"));
@@ -7400,7 +7400,7 @@ const char *UI_FeederItemText(float feederID, int index, int column,
                       Info_ValueForKey(info, "sv_maxclients"));
           return clientBuff;
         case SORT_GAME:
-          game = atoi(Info_ValueForKey(info, "gametype"));
+          game = Q_atoi(Info_ValueForKey(info, "gametype"));
           if (ping > /*=*/0 && game >= 0 && game < uiInfo.numGameTypes) {
             int i;
 
@@ -7422,7 +7422,7 @@ const char *UI_FeederItemText(float feederID, int index, int column,
             return "...";
           } else {
             /*antilag =
-            atoi(Info_ValueForKey(info,
+            Q_atoi(Info_ValueForKey(info,
             "g_antilag")); if
             (!antilag)
                 Com_sprintf(
@@ -7431,8 +7431,7 @@ const char *UI_FeederItemText(float feederID, int index, int column,
             "^3%3i", ping );
             else*/
 
-            serverload = atoi(Info_ValueForKey(info, "serverloa"
-                                                     "d"));
+            serverload = Q_atoi(Info_ValueForKey(info, "serverload"));
             if (serverload == -1) {
               Com_sprintf(pingstr, sizeof(pingstr),
                           " %"
@@ -7462,21 +7461,13 @@ const char *UI_FeederItemText(float feederID, int index, int column,
             return "";
           } else {
             *numhandles = 7;
-            needpass = atoi(Info_ValueForKey(info, "needpas"
-                                                   "s"));
-            friendlyfire = atoi(Info_ValueForKey(info, "friendlyFi"
-                                                       "re"));
-            maxlives = atoi(Info_ValueForKey(info, "maxlive"
-                                                   "s"));
-            punkbuster = atoi(Info_ValueForKey(info, "punkbuste"
-                                                     "r"));
-            weaponrestrictions = atoi(Info_ValueForKey(info, "weapre"
-                                                             "stric"
-                                                             "t"));
-            antilag = atoi(Info_ValueForKey(info, "g_"
-                                                  "antilag"));
-            balancedteams = atoi(Info_ValueForKey(info, "balancedte"
-                                                        "ams"));
+            needpass = Q_atoi(Info_ValueForKey(info, "needpass"));
+            friendlyfire = Q_atoi(Info_ValueForKey(info, "friendlyFire"));
+            maxlives = Q_atoi(Info_ValueForKey(info, "maxlives"));
+            punkbuster = Q_atoi(Info_ValueForKey(info, "punkbuster"));
+            weaponrestrictions = Q_atoi(Info_ValueForKey(info, "weaprestrict"));
+            antilag = Q_atoi(Info_ValueForKey(info, "g_antilag"));
+            balancedteams = Q_atoi(Info_ValueForKey(info, "balancedteams"));
 
             if (needpass) {
               handles[0] = uiInfo.passwordFilter;

--- a/src/ui/ui_players.cpp
+++ b/src/ui/ui_players.cpp
@@ -1081,7 +1081,7 @@ static qboolean AnimParseAnimConfig(playerInfo_t *animModelInfo,
       if (!token) {
         break;
       }
-      animModelInfo->version = atoi(token);
+      animModelInfo->version = Q_atoi(token);
       continue;
     } else if (!Q_stricmp(token, "skeletal")) {
       animModelInfo->isSkeletal = qtrue;
@@ -1139,7 +1139,7 @@ static qboolean AnimParseAnimConfig(playerInfo_t *animModelInfo,
       Q_strlwr(animations[i].name);
     }
 
-    animations[i].firstFrame = atoi(token);
+    animations[i].firstFrame = Q_atoi(token);
 
     if (!animModelInfo->isSkeletal) // skeletal models dont
                                     // require adjustment
@@ -1160,7 +1160,7 @@ static qboolean AnimParseAnimConfig(playerInfo_t *animModelInfo,
       // of file without
       // ENDANIMS" );
     }
-    animations[i].numFrames = atoi(token);
+    animations[i].numFrames = Q_atoi(token);
 
     token = COM_ParseExt(&text_p, qfalse);
     if (!token || !token[0]) {
@@ -1168,7 +1168,7 @@ static qboolean AnimParseAnimConfig(playerInfo_t *animModelInfo,
       // of file without
       // ENDANIMS: line %i" );
     }
-    animations[i].loopFrames = atoi(token);
+    animations[i].loopFrames = Q_atoi(token);
 
     token = COM_ParseExt(&text_p, qfalse);
     if (!token || !token[0]) {
@@ -1190,14 +1190,14 @@ static qboolean AnimParseAnimConfig(playerInfo_t *animModelInfo,
       // of file without
       // ENDANIMS" );
     }
-    animations[i].moveSpeed = atoi(token);
+    animations[i].moveSpeed = Q_atoi(token);
 
     // animation blending
     token = COM_ParseExt(&text_p, qfalse); // must be on same line
     if (!token) {
       animations[i].animBlend = 0;
     } else {
-      animations[i].animBlend = atoi(token);
+      animations[i].animBlend = Q_atoi(token);
     }
 
     // calculate the duration
@@ -1251,10 +1251,10 @@ static qboolean AnimParseAnimConfig(playerInfo_t *animModelInfo,
         }
 
         if (!i) {
-          skip = atoi(token);
+          skip = Q_atoi(token);
         }
 
-        headAnims[i].firstFrame = atoi(token);
+        headAnims[i].firstFrame = Q_atoi(token);
         // modify according to last frame of the
         // main animations, since the head is
         // totally seperate
@@ -1266,7 +1266,7 @@ static qboolean AnimParseAnimConfig(playerInfo_t *animModelInfo,
         if (!token || !token[0]) {
           break;
         }
-        headAnims[i].numFrames = atoi(token);
+        headAnims[i].numFrames = Q_atoi(token);
 
         // skip the movespeed
         token = COM_ParseExt(&text_p, qfalse);
@@ -1377,7 +1377,7 @@ static qboolean UI_ParseAnimationFile(const char *filename, playerInfo_t *pi) {
           if ( !token ) {
               break;
           }
-          animations[i].firstFrame = atoi( token );
+          animations[i].firstFrame = Q_atoi( token );
           // leg only frames are adjusted to not count the upper body
      only frames if ( i == LEGS_WALKCR ) { skip =
      animations[LEGS_WALKCR].firstFrame
@@ -1391,13 +1391,13 @@ static qboolean UI_ParseAnimationFile(const char *filename, playerInfo_t *pi) {
           if ( !token ) {
               break;
           }
-          animations[i].numFrames = atoi( token );
+          animations[i].numFrames = Q_atoi( token );
 
           token = COM_Parse( &text_p );
           if ( !token ) {
               break;
           }
-          animations[i].loopFrames = atoi( token );
+          animations[i].loopFrames = Q_atoi( token );
 
           token = COM_Parse( &text_p );
           if ( !token ) {

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -364,7 +364,7 @@ qboolean Int_Parse(const char **p, int *i) {
   token = COM_ParseExt(p, qfalse);
 
   if (token && token[0] != 0) {
-    *i = atoi(token);
+    *i = Q_atoi(token);
     return qtrue;
   } else {
     return qfalse;
@@ -1515,13 +1515,13 @@ void Script_ConditionalScript(itemDef_t *item, qboolean *bAbort,
              cvar, "voteflags", 9 ) ) {
               char
              info[MAX_INFO_STRING]; int
-             voteflags = atoi(cvar + 9);
+             voteflags = Q_atoi(cvar + 9);
 
               trap_Cvar_VariableStringBuffer(
              "cg_ui_voteFlags", info,
              sizeof(info) );
 
-              if( (atoi(info) &
+              if( (Q_atoi(info) &
              item->voteFlag) !=
              item->voteFlag ) {
                   Item_RunScript( item,
@@ -1531,7 +1531,7 @@ void Script_ConditionalScript(itemDef_t *item, qboolean *bAbort,
               }*/
 #ifndef CGAMEDLL
         } else if (!Q_stricmpn(cvar, "serversort_", 11)) {
-          int sorttype = atoi(cvar + 11);
+          int sorttype = Q_atoi(cvar + 11);
 
           if (sorttype != uiInfo.serverStatus.sortKey) {
             Item_RunScript(item, bAbort, script2);
@@ -1552,7 +1552,7 @@ void Script_ConditionalScript(itemDef_t *item, qboolean *bAbort,
           int r_mode = DC->getCVarValue("r_mode");
 
           DC->getCVarString("r_oldMode", r_oldModeStr, sizeof(r_oldModeStr));
-          r_oldMode = atoi(r_oldModeStr);
+          r_oldMode = Q_atoi(r_oldModeStr);
 
           if (*r_oldModeStr && r_oldMode != r_mode) {
             Item_RunScript(item, bAbort, script1);
@@ -1794,7 +1794,7 @@ void Script_AddListItem(itemDef_t *item, qboolean *bAbort, const char **args) {
       String_Parse(args, &name)) {
     t = Menu_FindItemByName((menuDef_t *)item->parent, itemname);
     if (t && t->special) {
-      DC->feederAddItem(t->special, name, atoi(val));
+      DC->feederAddItem(t->special, name, Q_atoi(val));
     }
   }
 }
@@ -1851,9 +1851,9 @@ qboolean Script_CheckProfile(char *profile_path) {
   trap_FS_Read(&f_data, sizeof(f_data) - 1, f);
 
   DC->getCVarString("com_pid", com_pid, sizeof(com_pid));
-  pid = atoi(com_pid);
+  pid = Q_atoi(com_pid);
 
-  f_pid = atoi(f_data);
+  f_pid = Q_atoi(f_data);
   if (f_pid != pid) {
     // pid doesn't match
     trap_FS_FCloseFile(f);
@@ -2122,16 +2122,16 @@ qboolean Item_SettingShow(itemDef_t *item, qboolean fVoteTest) {
 
   if (fVoteTest) {
     trap_Cvar_VariableStringBuffer("cg_ui_voteFlags", info, sizeof(info));
-    return ((atoi(info) & item->voteFlag) != item->voteFlag) ? qtrue : qfalse;
+    return ((Q_atoi(info) & item->voteFlag) != item->voteFlag) ? qtrue : qfalse;
   }
 
   DC->getConfigString(CS_SERVERTOGGLES, info, sizeof(info));
 
   if (item->settingFlags & SVS_ENABLED_SHOW) {
-    return (atoi(info) & item->settingTest) ? qtrue : qfalse;
+    return (Q_atoi(info) & item->settingTest) ? qtrue : qfalse;
   }
   if (item->settingFlags & SVS_DISABLED_SHOW) {
-    return (!(atoi(info) & item->settingTest)) ? qtrue : qfalse;
+    return (!(Q_atoi(info) & item->settingTest)) ? qtrue : qfalse;
   }
 
   return (qtrue);
@@ -8513,7 +8513,7 @@ void ETJump_DrawMapDetails() {
   trap_Cvar_LatchedVariableStringBuffer("ui_map_details", isUIopen_str,
                                         sizeof(isUIopen_str));
 
-  if (atoi(isUIopen_str) != 1) {
+  if (Q_atoi(isUIopen_str) != 1) {
     return;
   }
 


### PR DESCRIPTION
Sanitized `atoi` by using `std::strtol`. Also moves the previously implemented `Q_atof` from `q_math.cpp` to `q_shared.cpp`.

Some `atoi` calls were replaced with `Q_atof` instead since they expected float values to begin with, most notably some origin/angles variables in script actions, and some casts were added as well (e.g. int to char).