### PR TITLE
Restore CVAR_SERVERINFO flag for spawntimes for now

### DIFF
--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -323,8 +323,10 @@ cvarTable_t gameCvarTable[] = {
      qfalse}, // Arnout: default to GT_WOLF_CAMPAIGN
 
     // JPW NERVE multiplayer stuffs
-    {&g_redlimbotime, "g_redlimbotime", "30000", CVAR_LATCH, 0, qfalse},
-    {&g_bluelimbotime, "g_bluelimbotime", "30000", CVAR_LATCH, 0, qfalse},
+    {&g_redlimbotime, "g_redlimbotime", "30000", CVAR_SERVERINFO | CVAR_LATCH,
+     0, qfalse},
+    {&g_bluelimbotime, "g_bluelimbotime", "30000", CVAR_SERVERINFO | CVAR_LATCH,
+     0, qfalse},
     {&g_medicChargeTime, "g_medicChargeTime", "1", CVAR_LATCH, 0, qfalse,
      qtrue},
     {&g_engineerChargeTime, "g_engineerChargeTime", "1", CVAR_LATCH, 0, qfalse,


### PR DESCRIPTION
This is required for now as spawntimes don't have their own CS, in reality we should nuke the whole spawntime code as it's useless, this info does not need to be communicated from servers to clients since we always have instant spawns anyway.