### PR TITLE
Hardcode chatbox lineheight to ensure proper spacing

### DIFF
--- a/assets/ui/ingame_messagemode.menu
+++ b/assets/ui/ingame_messagemode.menu
@@ -83,7 +83,7 @@ menuDef
 	itemDef {
 		name		"efleftbackSay:"
 		group		GROUP_NAME
-		rect		$evalfloat((SUBWINDOW_X+8)) $evalfloat(SUBWINDOW_Y+20) $evalfloat(SUBWINDOW_WIDTH-16) $evalfloat(20)
+		rect		$evalfloat((SUBWINDOW_X+8)) $evalfloat(SUBWINDOW_Y+20) $evalfloat(SUBWINDOW_WIDTH-16) $evalfloat(22)
 		style		WINDOW_STYLE_FILLED
 		backcolor	.5 .5 .5 .2
 		visible		1
@@ -95,7 +95,7 @@ menuDef
 	itemDef {
 		name			"inChatMessageText"
       	group			GROUP_NAME
-      	rect			$evalfloat(SUBWINDOW_X+10) $evalfloat(SUBWINDOW_Y+20) $evalfloat(SUBWINDOW_WIDTH-28) 20
+      	rect			$evalfloat(SUBWINDOW_X+10) $evalfloat(SUBWINDOW_Y+20) $evalfloat(SUBWINDOW_WIDTH-28) $evalfloat(22)
 		type			ITEM_TYPE_EDITFIELD
 		textfont		UI_FONT_COURBD_21
 		textstyle		ITEM_TEXTSTYLE_SHADOWED


### PR DESCRIPTION
Glyphs are not a reliable way to calculate height because their spacing is all over the place, sometimes the height is 0, sometimes it's fine but the glyph is offset negatively. Simply use a hardcoded lineheight of __11__ for now, maybe if we ever get to refactor chat this could be written better.

Before:
![image](https://user-images.githubusercontent.com/14221121/210187495-95aba57d-b725-4ff3-983f-e32883ba8432.png)

After:
![image](https://user-images.githubusercontent.com/14221121/210187509-82efa950-49c6-4735-9b2c-fb545a5d82b8.png)
