### PR TITLE
Add automatic versioning to credits UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.suo
 *.opendb
 *.VC.db
+assets/ui/git_version.h
 
 #################
 ## Eclipse

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,14 @@ create_compiler_opts(cxx_compiler_opts WARN 3 DEFINE
 )
 create_compiler_opts(cxx_compiler_opts_w0 WARN 0)
 
+# need to re-set these again for git_version.h since it can't read compiler opts
+# we still need to set compiler opts for the stuff in bg_public.h though
+set(GAME_NAME "${CMAKE_PROJECT_NAME}")
+set(GAME_URL "${CMAKE_PROJECT_HOMEPAGE_URL}")
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/git_version.h.in"
+		"${CMAKE_CURRENT_SOURCE_DIR}/assets/ui/git_version.h" @ONLY)
+
 add_subdirectory(deps/json)
 add_subdirectory(deps/sha-1)
 add_subdirectory(deps/sqlite)

--- a/assets/ui/etjump_credits.menu
+++ b/assets/ui/etjump_credits.menu
@@ -22,7 +22,8 @@ menuDef {
 
 	WINDOW( "CREDITS", 94 )
 
-	LABELWHITE(130, 35, WINDOW_WIDTH - 24, 18, "^7ETJump 2.5.1 Credits^7\n^7Developed by:\n^f_^7zero ^k>:3\n^1F^7eengur\n^zeT^>|^7setup^>.\n^0X^9I^7S\n^zeT^>|^7vallz^>.\n^7ryven\n^7^z999^7aciz\nsuburb\n\nSpecial thanks to:\n^wH^0e^wX^9|^wFate\nApple\n^99^z9^79^z|^0N^9o^zo^7d^zl^7e\n^7999Luvah\n^7999hazz\n^@W^!uTang^@H\n^5Ensiform\n^1ET^7: Legacy team\n\n^7We would also like to thank the entire Wolfenstein: Enemy Territory trickjump community for ideas, feedback and for being there. :)", .2, ITEM_ALIGN_CENTER, 0, 8 )
+	LABELWHITE(130, 35, WINDOW_WIDTH - 24, 18, "^7ETJump "GAME_VERSION, .25, ITEM_ALIGN_CENTER, 0, 8 )
+	LABELWHITE(130, 50, WINDOW_WIDTH - 24, 18, "\n^7Developed by:\n^f_^7zero ^k>:3\n^1F^7eengur\n^zeT^>|^7setup^>.\n^0X^9I^7S\n^zeT^>|^7vallz^>.\n^7ryven\n^7^z999^7aciz\nsuburb\n\nSpecial thanks to:\n^wH^0e^wX^9|^wFate\nApple\n^99^z9^79^z|^0N^9o^zo^7d^zl^7e\n^7999Luvah\n^7999hazz\n^@W^!uTang^@H\n^5Ensiform\n^1ET^7: Legacy team\n\n^7We would also like to thank the entire Wolfenstein: Enemy Territory trickjump community for ideas, feedback and for being there. :)", .2, ITEM_ALIGN_CENTER, 0, 8 )
 
 	BUTTON(6, 342, WINDOW_WIDTH - 12, 18, "BACK", .3, 14, close etjump_credits; open etjump)
 }

--- a/assets/ui/menumacros.h
+++ b/assets/ui/menumacros.h
@@ -1,3 +1,5 @@
+#include "ui/git_version.h"
+
 #define WINDOW_FUI( WINDOW_TEXT, GRADIENT_START_OFFSET )														\
 	itemDef {																									\
 		name		"window"																					\

--- a/cmake/git_version.h.in
+++ b/cmake/git_version.h.in
@@ -1,0 +1,11 @@
+// mod name
+#define GAME_NAME "@GAME_NAME@"
+
+// mod website
+#define GAME_URL "@GAME_URL@"
+
+// mod version, annotated with:
+// 1. most recent tag
+// 2. number of commits since last tag
+// 3. git hash of the latest commit
+#define GAME_VERSION "@GAME_VERSION@"

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -6059,7 +6059,7 @@ static void UI_BuildServerDisplayList(int force) {
       trap_Cvar_Update(&ui_browserShowETJump);
       if (ui_browserShowETJump.integer > 0) {
         bool isETJump =
-            Q_stricmpn(Info_ValueForKey(info, "game"), "etjump", 6) == 0;
+            Q_stricmpn(Info_ValueForKey(info, "game"), GAME_NAME, 6) == 0;
         if ((isETJump && ui_browserShowETJump.integer == 2) ||
             (!isETJump && ui_browserShowETJump.integer == 1)) {
           trap_LAN_MarkServerVisible(ui_netSource.integer, i, qfalse);


### PR DESCRIPTION
Implemented similarly to ET: Legacy, configure `git_version.h.in` with CMake that fills out `git_version.h` for assets, which gets included in `menumacros.h` for UI to be able to pull the current version string. Currently it fills out `GAME_NAME`, `GAME_URL` and `GAME_VERSION` macros, of which `GAME_URL` is used unused for now.

Fixes #851 