### PR TITLE
Fix viewheight transitions not getting smoothed for specs

### DIFF
--- a/src/cgame/cg_playerstate.cpp
+++ b/src/cgame/cg_playerstate.cpp
@@ -505,6 +505,11 @@ void CG_TransitionPlayerState(playerState_t *ps, playerState_t *ops) {
     if (ps->clientNum == cg.clientNum) {
       ops->persistant[PERS_SPAWN_COUNT]--;
     }
+  } else {
+    // reset cg.thisFrameTeleport as spectators never run the code on
+    // CG_PredictPlayerState that would reset it,
+    // so the viewheight check at the end does not fail
+    cg.thisFrameTeleport = qfalse;
   }
 
   if (ps->eFlags & EF_FIRING) {


### PR DESCRIPTION
This is actually a vanilla bug, but doesn't manifest into anything because the check for `!cg.thisFrameTeleport` isn't present in the viewheight smoothing check, which caused viewheight transitions to happen when swapping teams.

Refs #916 