### PR TITLE
Notify player when starting a timerun when cheats are enabled

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -785,6 +785,7 @@ typedef struct {
 
   qboolean timerunActive;
   qboolean receivedTimerunStates;
+  bool timerunCheatsNotified;
 
   // new implementation of progression
 #define MAX_PROGRESSION_TRACKERS 50

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1748,10 +1748,6 @@ void target_startTimer_use(gentity_t *self, gentity_t *other,
   auto clientNum = ClientNum(activator);
   float speed = VectorLength(activator->client->ps.velocity);
 
-  if (!activator) {
-    return;
-  }
-
   if (!activator->client) {
     return;
   }
@@ -1771,24 +1767,25 @@ void target_startTimer_use(gentity_t *self, gentity_t *other,
   // We don't need any of these checks if we are debugging
   if (g_debugTimeruns.integer <= 0) {
     if (activator->client->noclip || activator->flags == FL_GODMODE) {
-      Printer::SendCenterMessage(clientNum, "^3WARNING: ^7Timerun was not "
-                                            "started. Invalid playerstate!");
+      Printer::SendCenterMessage(
+          clientNum,
+          "^3WARNING: ^7Timerun was not started. Invalid playerstate!");
       return;
     }
 
     if (speed > self->velocityUpperLimit) {
-      std::string speedMsg =
-          ETJump::stringFormat("^3WARNING: ^7Timerun was not started. Too "
-                               "high "
+      Printer::SendCenterMessage(
+          clientNum,
+          ETJump::stringFormat("^3WARNING: ^7Timerun was not started. Too high "
                                "starting speed (%.2f > %.2f)\n",
-                               speed, self->velocityUpperLimit);
-      Printer::SendCenterMessage(clientNum, speedMsg);
+                               speed, self->velocityUpperLimit));
       return;
     }
 
     if (activator->client->ps.viewangles[ROLL] != 0) {
-      Printer::SendCenterMessage(clientNum, "^3WARNING: ^7Timerun was not "
-                                            "started. Z-rotation detected!");
+      Printer::SendCenterMessage(
+          clientNum,
+          "^3WARNING: ^7Timerun was not started. Z-rotation detected!");
       return;
     }
   }
@@ -1799,11 +1796,18 @@ void target_startTimer_use(gentity_t *self, gentity_t *other,
   if (activator->client->sess.runSpawnflags == 0 ||
       activator->client->sess.runSpawnflags & TIMERUN_RESET_ON_PMOVE_NULL) {
     if (activator->client->pers.pmoveFixed == qfalse) {
-      Printer::SendCenterMessage(clientNum,
-                                 "^3WARNING: ^7Timerun was not started. "
-                                 "pmove_fixed is set to 0!");
+      Printer::SendCenterMessage(
+          clientNum,
+          "^3WARNING: ^7Timerun was not started. pmove_fixed is set to 0!");
       return;
     }
+  }
+
+  if (!activator->client->sess.timerunCheatsNotified && g_cheats.integer) {
+    Printer::SendPopupMessage(clientNum,
+                              "^3WARNING: ^7Cheats are enabled! Timerun "
+                              "records will not be saved!\n");
+    activator->client->sess.timerunCheatsNotified = true;
   }
 
   StartTimer(level.timerunNames[self->runIndex], activator);


### PR DESCRIPTION
If cheats are enabled, notify players about records not being saved on the first timerun start of the map.