### PR TITLE
Broadcast new timerun records with a banner print

### DIFF
--- a/src/game/etj_timerun.cpp
+++ b/src/game/etj_timerun.cpp
@@ -291,11 +291,11 @@ std::string diffToString(int selfTime, int otherTime) {
 
   const char *diffSign;
   if (diff > 0) {
-    diffSign = "^\\+";
+    diffSign = "^2-";
   } else if (diff < 0) {
-    diffSign = "^j-";
+    diffSign = "^1+";
   } else {
-    diffSign = "^z+";
+    diffSign = "^7+";
   }
 
   return ETJump::stringFormat("%s%02i:%02i.%03i", diffSign, diffComponents.min,
@@ -737,20 +737,34 @@ void Timerun::sortRecords() {
 }
 
 void Timerun::checkRecord(Player *player, int clientNum) {
-  time_t t;
-  time(&t);
+  int currentBestTime = 0;
 
-  int millis = player->completionTime;
-  int seconds = millis / 1000;
-  millis = millis - seconds * 1000;
-  int minutes = seconds / 60;
-  seconds = seconds - minutes * 60;
+  // sort and grab the #1 records for each run before storing completion time
+  // otherwise we might have our current run time as currentBestTime
+  sortRecords();
+  for (const auto &records : _recordsByName) {
+    if (ETJump::sanitize(player->currentRunName, true) ==
+        ETJump::sanitize(records.first, true)) {
+      currentBestTime = records.second[0]->time;
+    }
+  }
 
   auto previousRecord = findPreviousRecord(player);
   if (previousRecord) {
     updatePreviousRecord(previousRecord, player, clientNum);
   } else {
     addNewRecord(player, clientNum);
+  }
+
+  // currentBestTime will be 0 for completely new records since records
+  // are only registered on the first completion of any run, so the loop
+  // above will not register anything for a run with no records
+  if (player->completionTime < currentBestTime) {
+    std::string cleanRunName = ETJump::sanitize(player->currentRunName, false);
+    Printer::BroadCastBannerMessage(ETJump::stringFormat(
+        "^7%s ^7broke the server record on ^3%s\n^7with ^3%s ^z(%s^z) ^7!!!\n",
+        player->name, cleanRunName, millisToString(player->completionTime),
+        diffToString(player->completionTime, currentBestTime)));
   }
 }
 


### PR DESCRIPTION
Print a banner when someone breaks a server record on a run. Does not print for first records on a run, nor on tied runs.

This also changes the diff column in `ranks` display, the previous logic was to print times faster than you in red (your time is slower than them -> red print) to opposite, so that times faster than you are in green (their time is faster than you -> green print).

![image](https://user-images.githubusercontent.com/14221121/212360065-fe11c7b9-4b6d-491c-8bf5-0f1aae939d74.png)
