### PR TITLE
Add etj_footstepVolume to control footstep/landing related sound volume

### DIFF
--- a/assets/ui/etjump_settings_1.menu
+++ b/assets/ui/etjump_settings_1.menu
@@ -23,7 +23,7 @@
 
 #define SUBW_SOUNDS_Y SUBW_CONSOLE_Y + SUBW_CONSOLE_HEIGHT + SUBW_SPACING_Y
 #define SUBW_SOUNDS_ITEM_Y SUBW_SOUNDS_Y + SUBW_HEADER_HEIGHT
-#define SUBW_SOUNDS_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 2)
+#define SUBW_SOUNDS_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 3)
 
 #define SUBW_SCOREBOARD_Y SUBW_SOUNDS_Y + SUBW_SOUNDS_HEIGHT + SUBW_SPACING_Y
 #define SUBW_SCOREBOARD_ITEM_Y SUBW_SCOREBOARD_Y + SUBW_HEADER_HEIGHT
@@ -108,8 +108,10 @@ menuDef {
     SUBWINDOW(SUBW_RECT_RIGHT_X, SUBW_SOUNDS_Y, SUBW_WIDTH, SUBW_SOUNDS_HEIGHT, "SOUNDS")
         CVARFLOATLABEL      (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_weaponVolume", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
         SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Weapon sound volume:", 0.2, SUBW_ITEM_HEIGHT, etj_weaponVolume 1 0 5 0.1, "Scale weapon sound volume\netj_weaponVolume")
-        YESNO               (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Looped sounds:", 0.2, SUBW_ITEM_HEIGHT, "etj_loopedSounds", "Play looping sounds on map\netj_loopedSounds")
-        YESNO               (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Uphill step sounds:", 0.2, SUBW_ITEM_HEIGHT, "etj_uphillSteps", "Enable stepsounds on very low impact speeds\netj_uphillSteps")
+        CVARFLOATLABEL      (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_footstepVolume", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Footstep sound volume:", 0.2, SUBW_ITEM_HEIGHT, etj_footstepVolume 1 0 5 0.1, "Scale footstep and landing sound volume\netj_footstepVolume")
+        YESNO               (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Looped sounds:", 0.2, SUBW_ITEM_HEIGHT, "etj_loopedSounds", "Play looping sounds on map\netj_loopedSounds")
+        YESNO               (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Uphill step sounds:", 0.2, SUBW_ITEM_HEIGHT, "etj_uphillSteps", "Enable stepsounds on very low impact speeds\netj_uphillSteps")
 
     SUBWINDOW(SUBW_RECT_RIGHT_X, SUBW_SCOREBOARD_Y, SUBW_WIDTH, SUBW_SCOREBOARD_HEIGHT, "SCOREBOARD")
         MULTI               (SUBW_ITEM_RIGHT_X, SUBW_SCOREBOARD_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Custom scoreboard:", 0.2, SUBW_ITEM_HEIGHT, "etj_altScoreboard", cvarFloatList { "No" 0 "ETJump 1" 1 "ETJump 2" 2 "ETJump 3" 3 }, "Displays alternative scoreboard\netj_altScoreboard")

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -1545,51 +1545,61 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       DEBUGNAME("EV_FOOTSTEP");
       if (es->eventParm != FOOTSTEP_TOTAL && cg_footsteps.integer) {
         if (es->eventParm) {
-          trap_S_StartSound(nullptr, es->number, CHAN_BODY,
-                            cgs.media.footsteps[es->eventParm][footstepcnt]);
+          trap_S_StartSoundVControl(
+              nullptr, es->number, CHAN_BODY,
+              cgs.media.footsteps[es->eventParm][footstepcnt],
+              static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
         } else {
           bg_character_t *character =
               CG_CharacterForClientinfo(&cgs.clientinfo[clientNum], cent);
-          trap_S_StartSound(
+          trap_S_StartSoundVControl(
               nullptr, es->number, CHAN_BODY,
               cgs.media
-                  .footsteps[character->animModelInfo->footsteps][footstepcnt]);
+                  .footsteps[character->animModelInfo->footsteps][footstepcnt],
+              static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
         }
       }
       break;
     case EV_FOOTSPLASH:
       DEBUGNAME("EV_FOOTSPLASH");
       if (cg_footsteps.integer)
-        trap_S_StartSound(
+        trap_S_StartSoundVControl(
             nullptr, es->number, CHAN_BODY,
-            cgs.media.footsteps[FOOTSTEP_SPLASH][splashfootstepcnt]);
+            cgs.media.footsteps[FOOTSTEP_SPLASH][splashfootstepcnt],
+            static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
       break;
     case EV_FOOTWADE:
       DEBUGNAME("EV_FOOTWADE");
       if (cg_footsteps.integer)
-        trap_S_StartSound(
+        trap_S_StartSoundVControl(
             nullptr, es->number, CHAN_BODY,
-            cgs.media.footsteps[FOOTSTEP_SPLASH][splashfootstepcnt]);
+            cgs.media.footsteps[FOOTSTEP_SPLASH][splashfootstepcnt],
+            static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
       break;
     case EV_SWIM:
       DEBUGNAME("EV_SWIM");
       if (cg_footsteps.integer)
-        trap_S_StartSound(nullptr, es->number, CHAN_BODY,
-                          cgs.media.footsteps[FOOTSTEP_SPLASH][footstepcnt]);
+        trap_S_StartSoundVControl(
+            nullptr, es->number, CHAN_BODY,
+            cgs.media.footsteps[FOOTSTEP_SPLASH][footstepcnt],
+            static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
       break;
 
     case EV_FALL_SHORT:
       DEBUGNAME("EV_FALL_SHORT");
       if (es->eventParm != FOOTSTEP_TOTAL) {
         if (es->eventParm) {
-          trap_S_StartSound(nullptr, es->number, CHAN_AUTO,
-                            cgs.media.landSound[es->eventParm]);
+          trap_S_StartSoundVControl(
+              nullptr, es->number, CHAN_AUTO,
+              cgs.media.landSound[es->eventParm],
+              static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
         } else {
           bg_character_t *character =
               CG_CharacterForClientinfo(&cgs.clientinfo[clientNum], cent);
-          trap_S_StartSound(
+          trap_S_StartSoundVControl(
               nullptr, es->number, CHAN_AUTO,
-              cgs.media.landSound[character->animModelInfo->footsteps]);
+              cgs.media.landSound[character->animModelInfo->footsteps],
+              static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
         }
       }
       if (clientNum == cg.predictedPlayerState.clientNum) {
@@ -1605,17 +1615,22 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       if (!(cg.thisFrameTeleport || cg.nextFrameTeleport)) {
         if (es->eventParm != FOOTSTEP_TOTAL) {
           if (es->eventParm) {
-            trap_S_StartSound(nullptr, es->number, CHAN_AUTO,
-                              cgs.media.landSound[es->eventParm]);
+            trap_S_StartSoundVControl(
+                nullptr, es->number, CHAN_AUTO,
+                cgs.media.landSound[es->eventParm],
+                static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
           } else {
             bg_character_t *character =
                 CG_CharacterForClientinfo(&cgs.clientinfo[clientNum], cent);
-            trap_S_StartSound(
+            trap_S_StartSoundVControl(
                 nullptr, es->number, CHAN_AUTO,
-                cgs.media.landSound[character->animModelInfo->footsteps]);
+                cgs.media.landSound[character->animModelInfo->footsteps],
+                static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
           }
         }
-        trap_S_StartSound(nullptr, es->number, CHAN_AUTO, cgs.media.landHurt);
+        trap_S_StartSoundVControl(
+            nullptr, es->number, CHAN_AUTO, cgs.media.landHurt,
+            static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
         cent->pe.painTime = cg.time; // don't play a pain sound right after this
         if (clientNum == cg.predictedPlayerState.clientNum) {
           // smooth landing z changes
@@ -1631,17 +1646,22 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       if (!(cg.thisFrameTeleport || cg.nextFrameTeleport)) {
         if (es->eventParm != FOOTSTEP_TOTAL) {
           if (es->eventParm) {
-            trap_S_StartSound(nullptr, es->number, CHAN_AUTO,
-                              cgs.media.landSound[es->eventParm]);
+            trap_S_StartSoundVControl(
+                nullptr, es->number, CHAN_AUTO,
+                cgs.media.landSound[es->eventParm],
+                static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
           } else {
             bg_character_t *character =
                 CG_CharacterForClientinfo(&cgs.clientinfo[clientNum], cent);
-            trap_S_StartSound(
+            trap_S_StartSoundVControl(
                 nullptr, es->number, CHAN_AUTO,
-                cgs.media.landSound[character->animModelInfo->footsteps]);
+                cgs.media.landSound[character->animModelInfo->footsteps],
+                static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
           }
         }
-        trap_S_StartSound(nullptr, es->number, CHAN_AUTO, cgs.media.landHurt);
+        trap_S_StartSoundVControl(
+            nullptr, es->number, CHAN_AUTO, cgs.media.landHurt,
+            static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
         cent->pe.painTime = cg.time; // don't play a pain sound right after this
         if (clientNum == cg.predictedPlayerState.clientNum) {
           // smooth landing z changes
@@ -1657,17 +1677,22 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       if (!(cg.thisFrameTeleport || cg.nextFrameTeleport)) {
         if (es->eventParm != FOOTSTEP_TOTAL) {
           if (es->eventParm) {
-            trap_S_StartSound(nullptr, es->number, CHAN_AUTO,
-                              cgs.media.landSound[es->eventParm]);
+            trap_S_StartSoundVControl(
+                nullptr, es->number, CHAN_AUTO,
+                cgs.media.landSound[es->eventParm],
+                static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
           } else {
             bg_character_t *character =
                 CG_CharacterForClientinfo(&cgs.clientinfo[clientNum], cent);
-            trap_S_StartSound(
+            trap_S_StartSoundVControl(
                 nullptr, es->number, CHAN_AUTO,
-                cgs.media.landSound[character->animModelInfo->footsteps]);
+                cgs.media.landSound[character->animModelInfo->footsteps],
+                static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
           }
         }
-        trap_S_StartSound(nullptr, es->number, CHAN_AUTO, cgs.media.landHurt);
+        trap_S_StartSoundVControl(
+            nullptr, es->number, CHAN_AUTO, cgs.media.landHurt,
+            static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
         cent->pe.painTime = cg.time; // don't play a pain sound right after this
         if (clientNum == cg.predictedPlayerState.clientNum) {
           // smooth landing z changes
@@ -1683,17 +1708,22 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       if (!(cg.thisFrameTeleport || cg.nextFrameTeleport)) {
         if (es->eventParm != FOOTSTEP_TOTAL) {
           if (es->eventParm) {
-            trap_S_StartSound(nullptr, es->number, CHAN_AUTO,
-                              cgs.media.landSound[es->eventParm]);
+            trap_S_StartSoundVControl(
+                nullptr, es->number, CHAN_AUTO,
+                cgs.media.landSound[es->eventParm],
+                static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
           } else {
             bg_character_t *character =
                 CG_CharacterForClientinfo(&cgs.clientinfo[clientNum], cent);
-            trap_S_StartSound(
+            trap_S_StartSoundVControl(
                 nullptr, es->number, CHAN_AUTO,
-                cgs.media.landSound[character->animModelInfo->footsteps]);
+                cgs.media.landSound[character->animModelInfo->footsteps],
+                static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
           }
         }
-        trap_S_StartSound(nullptr, es->number, CHAN_AUTO, cgs.media.landHurt);
+        trap_S_StartSoundVControl(
+            nullptr, es->number, CHAN_AUTO, cgs.media.landHurt,
+            static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
         cent->pe.painTime = cg.time; // don't play a pain sound right after this
         if (clientNum == cg.predictedPlayerState.clientNum) {
           // smooth landing z changes
@@ -1709,17 +1739,22 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       if (!(cg.thisFrameTeleport || cg.nextFrameTeleport)) {
         if (es->eventParm != FOOTSTEP_TOTAL) {
           if (es->eventParm) {
-            trap_S_StartSound(nullptr, es->number, CHAN_AUTO,
-                              cgs.media.landSound[es->eventParm]);
+            trap_S_StartSoundVControl(
+                nullptr, es->number, CHAN_AUTO,
+                cgs.media.landSound[es->eventParm],
+                static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
           } else {
             bg_character_t *character =
                 CG_CharacterForClientinfo(&cgs.clientinfo[clientNum], cent);
-            trap_S_StartSound(
+            trap_S_StartSoundVControl(
                 nullptr, es->number, CHAN_AUTO,
-                cgs.media.landSound[character->animModelInfo->footsteps]);
+                cgs.media.landSound[character->animModelInfo->footsteps],
+                static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
           }
         }
-        trap_S_StartSound(nullptr, es->number, CHAN_AUTO, cgs.media.landHurt);
+        trap_S_StartSoundVControl(
+            nullptr, es->number, CHAN_AUTO, cgs.media.landHurt,
+            static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
         cent->pe.painTime = cg.time; // don't play a pain sound
                                      // right after this splat
       }
@@ -2415,7 +2450,9 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
 
     case EV_GIB_PLAYER:
       DEBUGNAME("EV_GIB_PLAYER");
-      trap_S_StartSound(es->pos.trBase, -1, CHAN_AUTO, cgs.media.gibSound);
+      trap_S_StartSoundVControl(
+          es->pos.trBase, -1, CHAN_AUTO, cgs.media.gibSound,
+          static_cast<int>(DEFAULT_VOLUME * etj_footstepVolume.value));
       ByteToDir(es->eventParm, dir);
       CG_GibPlayer(cent, cent->lerpOrigin, dir);
       break;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2491,6 +2491,7 @@ extern vmCvar_t etj_fireteamAlpha;
 #define CONLOG_BANNERPRINT 1
 extern vmCvar_t etj_logBanner;
 extern vmCvar_t etj_weaponVolume;
+extern vmCvar_t etj_footstepVolume;
 
 extern vmCvar_t etj_noclipScale;
 extern vmCvar_t etj_drawSlick;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -414,6 +414,7 @@ vmCvar_t etj_fireteamAlpha;
 
 vmCvar_t etj_logBanner;
 vmCvar_t etj_weaponVolume;
+vmCvar_t etj_footstepVolume;
 vmCvar_t etj_noclipScale;
 
 vmCvar_t etj_drawSlick;
@@ -913,6 +914,7 @@ cvarTable_t cvarTable[] = {
 
     {&etj_logBanner, "etj_logBanner", "1", CVAR_ARCHIVE},
     {&etj_weaponVolume, "etj_weaponVolume", "1.0", CVAR_ARCHIVE},
+    {&etj_footstepVolume, "etj_footstepVolume", "1.0", CVAR_ARCHIVE},
     {&etj_noclipScale, "etj_noclipScale", "1", CVAR_ARCHIVE},
     {&etj_drawSlick, "etj_drawSlick", "1", CVAR_ARCHIVE},
     {&etj_slickX, "etj_slickX", "304", CVAR_ARCHIVE},


### PR DESCRIPTION
Control sounds generated by movememnt events, including foosteps, landing pain grunts and gib sounds. Gibbing technically isn't related to that exclusively but in ETJump context, it's most likely triggered by falling to your death so makes sense to include.

Closes #937 