### PR TITLE
Remove unnecessary checks from trigger_multiple 512/2048

### DIFF
--- a/src/game/g_trigger.cpp
+++ b/src/game/g_trigger.cpp
@@ -32,14 +32,9 @@ void multiactivator_multi_trigger(gentity_t *ent, gentity_t *activator) {
 
   ent->activator = activator;
 
-  // make sure we only pass in team if the activator is a client
-  if (activator->client) {
-    G_Script_ScriptEvent(
-        ent, "activate",
-        activator->client->sess.sessionTeam == TEAM_AXIS ? "axis" : "allies");
-  } else {
-    G_Script_ScriptEvent(ent, "activate", nullptr);
-  }
+  G_Script_ScriptEvent(
+      ent, "activate",
+      activator->client->sess.sessionTeam == TEAM_AXIS ? "axis" : "allies");
 
   G_UseTargets(ent, ent->activator);
   activator->client->multiTriggerActivationTime = level.time;
@@ -54,14 +49,9 @@ void parallel_multi_trigger(gentity_t *ent, gentity_t *activator) {
 
   ent->activator = activator;
 
-  // make sure we only pass in team if the activator is a client
-  if (activator->client) {
-    G_Script_ScriptEvent(
-        ent, "activate",
-        activator->client->sess.sessionTeam == TEAM_AXIS ? "axis" : "allies");
-  } else {
-    G_Script_ScriptEvent(ent, "activate", nullptr);
-  }
+  G_Script_ScriptEvent(
+      ent, "activate",
+      activator->client->sess.sessionTeam == TEAM_AXIS ? "axis" : "allies");
 
   G_UseTargets(ent, ent->activator);
   activator->client->alreadyActivatedTrigger = qtrue;


### PR DESCRIPTION
These cannot be activated by a non-client entity, as the `use` function of `trigger_multiple` calls `multi_trigger` instead of these, and non-client entities don't run touch functions.

Refs #920 #918 