### PR TITLE
Fix runtimer colors breaking when run name has spaces

### DIFF
--- a/src/game/etj_timerun.cpp
+++ b/src/game/etj_timerun.cpp
@@ -181,10 +181,11 @@ void Timerun::connectNotify(int clientNum) {
       if (previousRecord) {
         fastestCompletionTime = previousRecord->time;
       }
-      Printer::SendCommand(
-          clientNum, ETJump::stringFormat(
-                         "timerun start %d %d %s %d", idx, player->runStartTime,
-                         player->currentRunName, fastestCompletionTime));
+      Printer::SendCommand(clientNum,
+                           ETJump::stringFormat("timerun start %d %d \"%s\" %d",
+                                                idx, player->runStartTime,
+                                                player->currentRunName,
+                                                fastestCompletionTime));
     }
   }
 }
@@ -198,17 +199,17 @@ void Timerun::startNotify(int clientNum) {
   if (previousRecord) {
     fastestCompletionTime = previousRecord->time;
   }
-  Printer::SendCommand(clientNum, ETJump::stringFormat("timerun_start %d %s %d",
-                                                       player->runStartTime,
-                                                       player->currentRunName,
-                                                       fastestCompletionTime));
-  Printer::SendCommand(spectators,
-                       ETJump::stringFormat("timerun_start_spec %d %d %s %d",
-                                            clientNum, player->runStartTime,
-                                            player->currentRunName,
-                                            fastestCompletionTime));
+  Printer::SendCommand(
+      clientNum,
+      ETJump::stringFormat("timerun_start %d \"%s\" %d", player->runStartTime,
+                           player->currentRunName, fastestCompletionTime));
+  Printer::SendCommand(
+      spectators,
+      ETJump::stringFormat("timerun_start_spec %d %d \"%s\" %d", clientNum,
+                           player->runStartTime, player->currentRunName,
+                           fastestCompletionTime));
   Printer::SendCommandToAll(ETJump::stringFormat(
-      "timerun start %d %d %s %d", clientNum, player->runStartTime,
+      "timerun start %d %d \"%s\" %d", clientNum, player->runStartTime,
       player->currentRunName, fastestCompletionTime));
 }
 
@@ -256,15 +257,16 @@ void Timerun::stopTimer(int clientNum, int commandTime, std::string runName) {
     player->racing = false;
 
     Printer::SendCommand(clientNum,
-                         ETJump::stringFormat("timerun_stop %d %s", millis,
+                         ETJump::stringFormat("timerun_stop %d \"%s\"", millis,
                                               player->currentRunName));
     auto spectators = Utilities::getSpectators(clientNum);
     Printer::SendCommand(spectators,
-                         ETJump::stringFormat("timerun_stop_spec %d %d %s",
+                         ETJump::stringFormat("timerun_stop_spec %d %d \"%s\"",
                                               clientNum, millis,
                                               player->currentRunName));
-    Printer::SendCommandToAll(ETJump::stringFormat(
-        "timerun stop %d %d %s", clientNum, millis, player->currentRunName));
+    Printer::SendCommandToAll(ETJump::stringFormat("timerun stop %d %d \"%s\"",
+                                                   clientNum, millis,
+                                                   player->currentRunName));
 
     player->currentRunName = "";
     Utilities::stopRun(clientNum);


### PR DESCRIPTION
Since space is a delimiter for arg parsing, timerun names must be sent inside quotes from servers, otherwise the argument parsing will break on client and run name will only contain the first word of the run name, and run timer will not display red/green colors correctly, because client has no information about a previous record even if there is one.

Perhaps related to #846, still not sure how to exactly reproduce that.