### PR TITLE
Fix portals rendering when not in PVS

### DIFF
--- a/src/game/g_weapon.cpp
+++ b/src/game/g_weapon.cpp
@@ -4124,8 +4124,6 @@ void Weapon_Portal_Fire(gentity_t *ent, int portalNumber) {
   portal->nextthink =
       level.time + 100; //.1 sec til next think - mainly used for bbox dbug
 
-  portal->r.svFlags = SVF_BROADCAST; // broadcast ent to all players
-
   portal->r.ownerNum = ent->s.number;
   portal->parent = ent;
 


### PR DESCRIPTION
Portal entities do not need to be broadcasted to all clients, they will render and function just fine even when not broadcasted, even when teleporting from one PVS to another. This fixes portals drawing "in the sky" in some maps, when somebody fires portals in an entirely different PVS and it happens to align with the skybox of your current PVS, due to skybox being sorted last always.