### PR TITLE
Allow fast respawn + load after gib

### DIFF
--- a/src/game/etj_save_system.cpp
+++ b/src/game/etj_save_system.cpp
@@ -280,6 +280,11 @@ void ETJump::SaveSystem::load(gentity_t *ent) {
             static_cast<int>(ETJump::TimerunSpawnflags::NoSave)) {
       InterruptRun(ent);
     }
+    // allow fast respawn + load if we got gibbed to skip death sequence
+    if (ent->client->ps.stats[STAT_HEALTH] <= GIB_HEALTH) {
+      ent->client->ps.pm_flags &= ~PMF_LIMBO;
+      ClientSpawn(ent, qfalse);
+    }
     teleportPlayer(ent, validSave);
   } else {
     CPTo(ent, "^7Use ^3save ^7first.");


### PR DESCRIPTION
Allow skipping the 800ms gib death camera by loading position.

Closes #961 