### PR TITLE
Improve spectator info list

### DIFF
--- a/assets/ui/etjump_settings_5.menu
+++ b/assets/ui/etjump_settings_5.menu
@@ -8,11 +8,11 @@
 #define SUBW_SNAPHUD_ITEM_Y SUBW_SNAPHUD_Y + SUBW_HEADER_HEIGHT
 #define SUBW_SNAPHUD_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 9)
 
-#define SUBW_SPECTATOR_Y SUBW_SNAPHUD_Y + SUBW_SNAPHUD_HEIGHT + SUBW_SPACING_Y
-#define SUBW_SPECTATOR_ITEM_Y SUBW_SPECTATOR_Y + SUBW_HEADER_HEIGHT
-#define SUBW_SPECTATOR_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 2)
+#define SUBW_SPECINFO_Y SUBW_SNAPHUD_Y + SUBW_SNAPHUD_HEIGHT + SUBW_SPACING_Y
+#define SUBW_SPECINFO_ITEM_Y SUBW_SPECINFO_Y + SUBW_HEADER_HEIGHT
+#define SUBW_SPECINFO_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 4)
 
-#define SUBW_JUMPSPEEDS_Y SUBW_SPECTATOR_Y + SUBW_SPECTATOR_HEIGHT + SUBW_SPACING_Y
+#define SUBW_JUMPSPEEDS_Y SUBW_SPECINFO_Y + SUBW_SPECINFO_HEIGHT + SUBW_SPACING_Y
 #define SUBW_JUMPSPEEDS_ITEM_Y SUBW_JUMPSPEEDS_Y + SUBW_HEADER_HEIGHT
 #define SUBW_JUMPSPEEDS_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 9)
 
@@ -54,12 +54,15 @@ menuDef {
         MULTI               (SUBW_ITEM_LEFT_X, SUBW_SNAPHUD_ITEM_Y + (SUBW_ITEM_SPACING_Y * 8), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Highlight color 1:", 0.2, SUBW_ITEM_HEIGHT, "etj_snapHUDHLColor1", cvarStrList { "White"; "white"; "Yellow"; "yellow"; "Red"; "red"; "Green"; "green"; "Blue"; "blue"; "Magenta"; "magenta"; "Cyan"; "cyan"; "Orange"; "orange"; "Light Blue"; "0xa0c0ff"; "Medium Blue"; "mdblue"; "Light Red"; "0xffc0a0"; "Medium Red"; "mdred"; "Light Green"; "0xa0ffc0"; "Medium Green"; "mdgreen"; "Dark Green"; "dkgreen"; "Medium Cyan"; "mdcyan"; "Medium Yellow"; "mdyellow"; "Medium Orange"; "mdorange"; "Light Grey"; "ltgrey"; "Medium Grey"; "mdgrey"; "Dark Grey"; "dkgrey"; "Black"; "black" }, "Sets color of active primary snapzone\netj_snapHUDHLColor1")
         MULTI               (SUBW_ITEM_LEFT_X, SUBW_SNAPHUD_ITEM_Y + (SUBW_ITEM_SPACING_Y * 9), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Highlight color 2:", 0.2, SUBW_ITEM_HEIGHT, "etj_snapHUDHLColor2", cvarStrList { "White"; "white"; "Yellow"; "yellow"; "Red"; "red"; "Green"; "green"; "Blue"; "blue"; "Magenta"; "magenta"; "Cyan"; "cyan"; "Orange"; "orange"; "Light Blue"; "0xa0c0ff"; "Medium Blue"; "mdblue"; "Light Red"; "0xffc0a0"; "Medium Red"; "mdred"; "Light Green"; "0xa0ffc0"; "Medium Green"; "mdgreen"; "Dark Green"; "dkgreen"; "Medium Cyan"; "mdcyan"; "Medium Yellow"; "mdyellow"; "Medium Orange"; "mdorange"; "Light Grey"; "ltgrey"; "Medium Grey"; "mdgrey"; "Dark Grey"; "dkgrey"; "Black"; "black" }, "Sets color of active secondary snapzone\netj_snapHUDHLColor2")
 
-    SUBWINDOW(SUBW_RECT_LEFT_X, SUBW_SPECTATOR_Y, SUBW_WIDTH, SUBW_SPECTATOR_HEIGHT, "SPECTATOR")
-        YESNO               (SUBW_ITEM_LEFT_X, SUBW_SPECTATOR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Spectator list:", 0.2, SUBW_ITEM_HEIGHT, "etj_drawSpectatorInfo", "Draw a list of people spectating you\netj_drawSpectatorInfo")
-        CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_SPECTATOR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_spectatorInfoX", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
-        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_SPECTATOR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Spec list X:", 0.2, SUBW_ITEM_HEIGHT, etj_spectatorInfoX 320 0 640 10, "Sets X position of spectator list\netj_spectatorInfoX")
-        CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_SPECTATOR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_spectatorInfoY", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
-        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_SPECTATOR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Spec list Y:", 0.2, SUBW_ITEM_HEIGHT, etj_spectatorInfoY 40 0 480 10, "Sets Y position of spectator list\netj_spectatorInfoY")
+    SUBWINDOW(SUBW_RECT_LEFT_X, SUBW_SPECINFO_Y, SUBW_WIDTH, SUBW_SPECINFO_HEIGHT, "SPECTATOR INFO")
+        MULTI               (SUBW_ITEM_LEFT_X, SUBW_SPECINFO_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Spectator list:", 0.2, SUBW_ITEM_HEIGHT, "etj_drawSpectatorInfo", cvarFloatList { "Off" 0 "Left aligned" 1 "Center Aligned" 2 "Right aligned" 3 }, "Draw a list of people spectating you\netj_drawSpectatorInfo")
+        CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_SPECINFO_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_spectatorInfoX", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_SPECINFO_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Spec list X:", 0.2, SUBW_ITEM_HEIGHT, etj_spectatorInfoX 320 0 640 10, "Sets X position of spectator list\netj_spectatorInfoX")
+        CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_SPECINFO_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_spectatorInfoY", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_SPECINFO_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Spec list Y:", 0.2, SUBW_ITEM_HEIGHT, etj_spectatorInfoY 30 0 480 10, "Sets Y position of spectator list\netj_spectatorInfoY")
+        YESNO               (SUBW_ITEM_LEFT_X, SUBW_SPECINFO_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Spec list shadow:", 0.2, SUBW_ITEM_HEIGHT, "etj_spectatorInfoShadow", "Draw shadow on spectator list\netj_spectatorInfoShadow")
+        CVARFLOATLABEL      (SUBW_ITEM_LEFT_X, SUBW_SPECINFO_ITEM_Y + (SUBW_ITEM_SPACING_Y * 4), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_spectatorInfoSize", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_SPECINFO_ITEM_Y + (SUBW_ITEM_SPACING_Y * 4), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Spec list size:", 0.2, SUBW_ITEM_HEIGHT, etj_spectatorInfoSize 2.3 0 10 0.1, "Size of spectator list\netj_spectatorInfoSize")
 
     SUBWINDOW(SUBW_RECT_LEFT_X, SUBW_JUMPSPEEDS_Y, SUBW_WIDTH, SUBW_JUMPSPEEDS_HEIGHT, "JUMP SPEEDS")
         YESNO               (SUBW_ITEM_LEFT_X, SUBW_JUMPSPEEDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Jump speeds:", 0.2, SUBW_ITEM_HEIGHT, "etj_drawJumpSpeeds", "Draw jump speed list\netj_drawJumpSpeeds")

--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(cgame MODULE
 	"etj_quick_follow_drawable.cpp"
 	"etj_snaphud.cpp"
 	"etj_speed_drawable.cpp"
+	"etj_spectatorinfo_drawable.cpp"
 	"etj_strafe_quality_drawable.cpp"
 	"etj_upper_right_drawable.cpp"
 	"etj_upmove_meter_drawable.cpp"

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -4733,42 +4733,6 @@ void CG_DrawDemoRecording(void) {
                     status, 0, 0, 0, &cgs.media.limboFont2);
 }
 
-void CG_DrawSpectatorInfo(void) {
-  int i = 0;
-  int y = etj_spectatorInfoY.integer;
-
-  if (etj_drawSpectatorInfo.integer == 0) {
-    return;
-  }
-
-  if (cgs.clientinfo[cg.clientNum].team == TEAM_SPECTATOR) {
-    // don't do anything if we're spectating
-    return;
-  }
-
-  if (cg.time > cg.lastScoreTime + 3000) {
-    trap_SendClientCommand("score");
-    cg.lastScoreTime = cg.time;
-  }
-
-  for (; i < cg.numScores; i++) {
-    if (cg.snap->ps.clientNum == cg.scores[i].client) {
-      // ignore self
-      continue;
-    }
-    if (cgs.clientinfo[cg.scores[i].client].team == TEAM_SPECTATOR) {
-      if (cg.scores[i].followedClient == cg.snap->ps.clientNum) {
-        float x = etj_spectatorInfoX.integer;
-        ETJump_AdjustPosition(&x);
-        // spectating me
-        ETJump::DrawSmallString(
-            x, y, va("%s", cgs.clientinfo[cg.scores[i].client].name), 1);
-        y += 12;
-      }
-    }
-  }
-}
-
 /*
 =================
 CG_Draw2D
@@ -4889,8 +4853,6 @@ static void CG_Draw2D(void) {
     }
 
     CG_DrawCHS();
-
-    CG_DrawSpectatorInfo();
   } else {
     if (cgs.eventHandling != CGAME_EVENT_NONE) {
       //			qboolean old =

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2504,6 +2504,8 @@ extern vmCvar_t etj_altScoreboard;
 extern vmCvar_t etj_drawSpectatorInfo;
 extern vmCvar_t etj_spectatorInfoX;
 extern vmCvar_t etj_spectatorInfoY;
+extern vmCvar_t etj_spectatorInfoSize;
+extern vmCvar_t etj_spectatorInfoShadow;
 
 extern vmCvar_t etj_drawRunTimer;
 extern vmCvar_t etj_runTimerX;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -426,6 +426,8 @@ vmCvar_t etj_altScoreboard;
 vmCvar_t etj_drawSpectatorInfo;
 vmCvar_t etj_spectatorInfoX;
 vmCvar_t etj_spectatorInfoY;
+vmCvar_t etj_spectatorInfoSize;
+vmCvar_t etj_spectatorInfoShadow;
 
 vmCvar_t etj_drawRunTimer;
 vmCvar_t etj_runTimerX;
@@ -924,7 +926,9 @@ cvarTable_t cvarTable[] = {
     {&etj_altScoreboard, "etj_altScoreboard", "0", CVAR_ARCHIVE},
     {&etj_drawSpectatorInfo, "etj_drawSpectatorInfo", "0", CVAR_ARCHIVE},
     {&etj_spectatorInfoX, "etj_spectatorInfoX", "320", CVAR_ARCHIVE},
-    {&etj_spectatorInfoY, "etj_spectatorInfoY", "40", CVAR_ARCHIVE},
+    {&etj_spectatorInfoY, "etj_spectatorInfoY", "30", CVAR_ARCHIVE},
+    {&etj_spectatorInfoSize, "etj_spectatorInfoSize", "2.3", CVAR_ARCHIVE},
+    {&etj_spectatorInfoShadow, "etj_spectatorInfoShadow", "1", CVAR_ARCHIVE},
     {&etj_drawRunTimer, "etj_drawRunTimer", "1", CVAR_ARCHIVE},
     {&etj_runTimerX, "etj_runTimerX", "320", CVAR_ARCHIVE},
     {&etj_runTimerY, "etj_runTimerY", "360", CVAR_ARCHIVE},

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -52,6 +52,7 @@
 #include "etj_autodemo_recorder.h"
 #include "etj_upper_right_drawable.h"
 #include "etj_upmove_meter_drawable.h"
+#include "etj_spectatorinfo_drawable.h"
 
 namespace ETJump {
 std::shared_ptr<ClientCommandsHandler> serverCommandsHandler;
@@ -210,6 +211,7 @@ void init() {
   ETJump::renderables.push_back(
       std::make_shared<JumpSpeeds>(ETJump::entityEventsHandler.get()));
   ETJump::renderables.push_back(std::make_shared<QuickFollowDrawer>());
+  ETJump::renderables.push_back(std::make_shared<SpectatorInfo>());
 
   if (etj_CGazOnTop.integer) {
     ETJump::renderables.push_back(std::make_shared<Snaphud>());

--- a/src/cgame/etj_spectatorinfo_drawable.cpp
+++ b/src/cgame/etj_spectatorinfo_drawable.cpp
@@ -1,0 +1,100 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_spectatorinfo_drawable.h"
+
+namespace ETJump {
+void SpectatorInfo::beforeRender() {
+  // poll for updates every 3 seconds to refresh list
+  if (cg.time > cg.lastScoreTime + 3000) {
+    trap_SendClientCommand("score");
+    cg.lastScoreTime = cg.time;
+  }
+}
+
+void SpectatorInfo::render() const {
+  if (canSkipDraw()) {
+    return;
+  }
+
+  float x = etj_spectatorInfoX.value;
+  float y = etj_spectatorInfoY.value;
+  const float size = 0.1f * etj_spectatorInfoSize.value;
+  float w;
+  const char *spectator;
+  const int textStyle = etj_spectatorInfoShadow.integer
+                            ? ITEM_TEXTSTYLE_SHADOWED
+                            : ITEM_TEXTSTYLE_NORMAL;
+
+  ETJump_AdjustPosition(&x);
+
+  for (auto i = 0; i < cg.numScores; i++) {
+    if (cg.snap->ps.clientNum == cg.scores[i].client) {
+      // ignore self
+      continue;
+    }
+
+    if (cgs.clientinfo[cg.scores[i].client].team == TEAM_SPECTATOR) {
+      if (cg.scores[i].followedClient == cg.snap->ps.clientNum) {
+        spectator = cgs.clientinfo[cg.scores[i].client].name;
+
+        switch (etj_drawSpectatorInfo.integer) {
+          case 2: // center align
+            w = static_cast<float>(CG_Text_Width_Ext(spectator, size, 0,
+                                                     &cgs.media.limboFont2)) *
+                0.5f;
+            break;
+          case 3: // right align
+            w = static_cast<float>(
+                CG_Text_Width_Ext(spectator, size, 0, &cgs.media.limboFont2));
+            break;
+          default: // left align
+            w = 0.0f;
+            break;
+        }
+
+        // for consistent line height, use pre-defined string
+        // for height calculation instead of current spectators name
+        y += static_cast<float>(
+                 CG_Text_Height_Ext("Yy", size, 0, &cgs.media.limboFont2)) *
+             1.75f;
+
+        DrawString(x - w, y, size, size, colorWhite, qfalse, spectator, 0,
+                   textStyle);
+      }
+    }
+  }
+}
+bool SpectatorInfo::canSkipDraw() {
+  if (!etj_drawSpectatorInfo.integer) {
+    return true;
+  }
+
+  if (cgs.clientinfo[cg.clientNum].team == TEAM_SPECTATOR) {
+    return true;
+  }
+
+  return false;
+}
+} // namespace ETJump

--- a/src/cgame/etj_spectatorinfo_drawable.h
+++ b/src/cgame/etj_spectatorinfo_drawable.h
@@ -1,0 +1,38 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "etj_irenderable.h"
+#include "cg_local.h"
+
+namespace ETJump {
+class SpectatorInfo : public IRenderable {
+  static bool canSkipDraw();
+
+public:
+  void beforeRender() override;
+  void render() const override;
+};
+} // namespace ETJump


### PR DESCRIPTION
* New cvars: `etj_spectatorInfoSize` and `etj_spectatorInfoShadow`
* List can now be either left, center or right aligned by setting `etj_drawSpectatorInfo 1/2/3` respectively
* `etj_spectatorInfoY` is now calculated from top-left of first name instead of bottom left -> `etj_spectatorInfoY 0` will no longer put the first name off screen
  * Default was changed from `40` to `30` so it's roughly on the same spot on default settings
* Renamed the submenu from `SPECTATOR` -> `SPECTATOR INFO`
* Moved the code from `cg_draw.cpp` into it's own file