### PR TITLE
Add warning about running server with fixed patch collision

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1425,8 +1425,6 @@ typedef struct {
   char timerunNames[MAX_TIMERUNS][MAX_TIMERUN_NAME_LENGTH];
   bool hasTimerun;
   int saveLoadRestrictions;
-
-  bool patchFixWarned; // Warning about ET:L/ETe patch collision fix is printed
 } level_locals_t;
 
 typedef struct {

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1425,6 +1425,8 @@ typedef struct {
   char timerunNames[MAX_TIMERUNS][MAX_TIMERUN_NAME_LENGTH];
   bool hasTimerun;
   int saveLoadRestrictions;
+
+  bool patchFixWarned; // Warning about ET:L/ETe patch collision fix is printed
 } level_locals_t;
 
 typedef struct {

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -1757,12 +1757,13 @@ void ResetNumSpawnTargets();
 void ETJump_InitGame(int levelTime, int randomSeed, int restart);
 
 static bool G_PatchFixEnabled() {
-  char cs[MAX_INFO_STRING];
-  trap_GetConfigstring(CS_SYSTEMINFO, cs, sizeof(cs));
-  const char *sysInfo = Info_ValueForKey(cs, "cm_optimizePatchPlanes");
+  char patchFix[MAX_QPATH];
+  trap_Cvar_VariableStringBuffer("cm_optimizePatchPlanes", patchFix,
+                                 sizeof(patchFix));
 
-  // cm_optimizePatchPlanes 0 = fixed patch collision
-  if (sysInfo[0] == '0') {
+  // if the cvar doesn't exist (2.60b/old versions of ETL/ETe),
+  // we get a null char
+  if (patchFix[0] != '\0' && Q_atoi(patchFix) == 0) {
     return true;
   }
 
@@ -2088,6 +2089,14 @@ void G_InitGame(int levelTime, int randomSeed, int restart) {
 
   OnGameInit();
   ETJump_InitGame(levelTime, randomSeed, restart);
+
+  if (G_PatchFixEnabled()) {
+    G_Printf("\n^7--------- ^1!!! WARNING !!! ^7---------\n\n^7Server started "
+             "with ^3cm_optimizePatchPlanes 0\n^7Patch collision is different "
+             "from vanilla and prediction errors might occur!\n\n^7Please "
+             "start the server with ^3+set cm_optimizePatchPlanes "
+             "1\n\n^7-----------------------------------\n");
+  }
 
   G_Printf(S_COLOR_LTGREY GAME_NAME " " S_COLOR_GREEN GAME_VERSION
                                     " " S_COLOR_LTGREY GAME_BINARY_NAME
@@ -3886,15 +3895,6 @@ uebrgpiebrpgibqeripgubeqrpigubqifejbgipegbrtibgurepqgbn%i", level.time)
   G_CheckReloadStatus();
 #endif // SAVEGAME_SUPPORT
   ETJump_RunFrame(levelTime);
-
-  if (!level.patchFixWarned && G_PatchFixEnabled()) {
-    G_Printf("\n^7--------- ^1!!! WARNING !!! ^7---------\n\n^7Server started "
-             "with ^3cm_optimizePatchPlanes 0\n^7Patch collision is different "
-             "from vanilla and prediction errors might occur!\n\n^7Please "
-             "start the server with ^3+set cm_optimizePatchPlanes "
-             "1\n\n^7-----------------------------------\n");
-    level.patchFixWarned = true;
-  }
 }
 
 // Is this a single player type game - sp or coop?

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -1756,6 +1756,19 @@ void InitGhosting() {
 void ResetNumSpawnTargets();
 void ETJump_InitGame(int levelTime, int randomSeed, int restart);
 
+static bool G_PatchFixEnabled() {
+  char cs[MAX_INFO_STRING];
+  trap_GetConfigstring(CS_SYSTEMINFO, cs, sizeof(cs));
+  const char *sysInfo = Info_ValueForKey(cs, "cm_optimizePatchPlanes");
+
+  // cm_optimizePatchPlanes 0 = fixed patch collision
+  if (sysInfo[0] == '0') {
+    return true;
+  }
+
+  return false;
+}
+
 /*
 ============
 G_InitGame
@@ -3873,6 +3886,15 @@ uebrgpiebrpgibqeripgubeqrpigubqifejbgipegbrtibgurepqgbn%i", level.time)
   G_CheckReloadStatus();
 #endif // SAVEGAME_SUPPORT
   ETJump_RunFrame(levelTime);
+
+  if (!level.patchFixWarned && G_PatchFixEnabled()) {
+    G_Printf("\n^7--------- ^1!!! WARNING !!! ^7---------\n\n^7Server started "
+             "with ^3cm_optimizePatchPlanes 0\n^7Patch collision is different "
+             "from vanilla and prediction errors might occur!\n\n^7Please "
+             "start the server with ^3+set cm_optimizePatchPlanes "
+             "1\n\n^7-----------------------------------\n");
+    level.patchFixWarned = true;
+  }
 }
 
 // Is this a single player type game - sp or coop?


### PR DESCRIPTION
Warns once per level about running the server with ET:L/ETe patch collision fix as this is not wanted for TJ maps.