### PR TITLE
Fix players not drowning with pmove_fixed 1 and high fps

### DIFF
--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1178,6 +1178,11 @@ void ClientThink_real(gentity_t *ent) {
   VectorCopy(ent->r.mins, pm.mins);
   VectorCopy(ent->r.maxs, pm.maxs);
 
+  // save waterlevel/type in case we skip Pmove this frame
+  // (>125fps & pmove_fixed 1) so P_WorldEffects doesn't reset pmext->airLeft
+  pm.waterlevel = ent->waterlevel;
+  pm.watertype = ent->watertype;
+
   // NERVE - SMF
   pm.gametype = g_gametype.integer;
   pm.ltChargeTime = level.lieutenantChargeTime[client->sess.sessionTeam - 1];


### PR DESCRIPTION
Similar issue to player collision, Pmove struct gets cleared each client frame, but we only run Pmove at 125fps with `pmove_fixed 1`, resulting in waterlevel getting nulled sometimes at > 125fps, which caused `P_WorldEffects` to reset `pmext->airLeft` which prevented drowning.

Fixes #497 