### PR TITLE
Fix getValidPlayerState for demo playback

### DIFF
--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -643,8 +643,8 @@ void runFrameEnd() {
 }
 
 playerState_t *getValidPlayerState() {
-  return (cg.snap->ps.clientNum != cg.clientNum)
-             // spectating
+  return (cg.snap->ps.clientNum != cg.clientNum || cg.demoPlayback)
+             // spectating/demo playback
              ? &cg.snap->ps
              // playing
              : &cg.predictedPlayerState;


### PR DESCRIPTION
`cg.snap->ps` should be used in demo playback for more accuracy. This fixes OB detector flickering in demo playback for example, as predicted playerstate provides inaccurate origin data.