### PR TITLE
Add new crosshairs

### DIFF
--- a/assets/ui/etjump_settings_1.menu
+++ b/assets/ui/etjump_settings_1.menu
@@ -25,9 +25,9 @@
 #define SUBW_SOUNDS_ITEM_Y SUBW_SOUNDS_Y + SUBW_HEADER_HEIGHT
 #define SUBW_SOUNDS_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 3)
 
-#define SUBW_SCOREBOARD_Y SUBW_SOUNDS_Y + SUBW_SOUNDS_HEIGHT + SUBW_SPACING_Y
-#define SUBW_SCOREBOARD_ITEM_Y SUBW_SCOREBOARD_Y + SUBW_HEADER_HEIGHT
-#define SUBW_SCOREBOARD_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 1)
+#define SUBW_CROSSHAIR_Y SUBW_SOUNDS_Y + SUBW_SOUNDS_HEIGHT + SUBW_SPACING_Y
+#define SUBW_CROSSHAIR_ITEM_Y SUBW_CROSSHAIR_Y + SUBW_HEADER_HEIGHT
+#define SUBW_CROSSHAIR_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 3)
 
 #define GROUP_NAME "group_etjump_settings_1"
 
@@ -115,9 +115,14 @@ menuDef {
         YESNO               (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Looped sounds:", 0.2, SUBW_ITEM_HEIGHT, "etj_loopedSounds", "Play looping sounds on map\netj_loopedSounds")
         YESNO               (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Uphill step sounds:", 0.2, SUBW_ITEM_HEIGHT, "etj_uphillSteps", "Enable stepsounds on very low impact speeds\netj_uphillSteps")
 
-    SUBWINDOW(SUBW_RECT_RIGHT_X, SUBW_SCOREBOARD_Y, SUBW_WIDTH, SUBW_SCOREBOARD_HEIGHT, "SCOREBOARD")
-        MULTI               (SUBW_ITEM_RIGHT_X, SUBW_SCOREBOARD_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Custom scoreboard:", 0.2, SUBW_ITEM_HEIGHT, "etj_altScoreboard", cvarFloatList { "No" 0 "ETJump 1" 1 "ETJump 2" 2 "ETJump 3" 3 }, "Displays alternative scoreboard\netj_altScoreboard")
-        YESNO               (SUBW_ITEM_RIGHT_X, SUBW_SCOREBOARD_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Draw idle indicator:", 0.2, SUBW_ITEM_HEIGHT, "etj_drawScoreboardInactivity", "Draw idle indicator on inactive clients\netj_drawScoreboardInactivity")
+    SUBWINDOW(SUBW_RECT_RIGHT_X, SUBW_CROSSHAIR_Y, SUBW_WIDTH, SUBW_CROSSHAIR_HEIGHT, "CROSSHAIR")
+        CVARFLOATLABEL      (SUBW_ITEM_RIGHT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_crosshairScaleX", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Scale X:", 0.2, SUBW_ITEM_HEIGHT, etj_crosshairScaleX 1.0 -5.0 5.0 0.1, "Horizontal scale of crosshair, negative values will flip the crosshair\netj_crosshairScaleX")
+        CVARFLOATLABEL      (SUBW_ITEM_RIGHT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_crosshairScaleY", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Scale Y:", 0.2, SUBW_ITEM_HEIGHT, etj_crosshairScaleY 1.0 -5.0 5.0 0.1, "Vertical scale of crosshair, negative values will flip the crosshair\netj_crosshairScaleY")
+        CVARFLOATLABEL      (SUBW_ITEM_RIGHT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_crosshairThickness", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Line thickness:", 0.2, SUBW_ITEM_HEIGHT, etj_crosshairThickness 1.0 0.0 5.0 0.1, "Line thickness of ETJump crosshairs\netj_crosshairThickness")
+        YESNO               (SUBW_ITEM_RIGHT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Crosshair outline:", 0.2, SUBW_ITEM_HEIGHT, "etj_crosshairOutline", "Draw outline on ETJump crosshairs\netj_crosshairOutline")
 
         BUTTON              (ETJ_BUTTON_X + (ETJ_BUTTON_SPACING_X * 0), ETJ_BUTTON_Y, ETJ_BUTTON_WIDTH, ETJ_BUTTON_HEIGHT, "BACK", 0.3, ETJ_BUTTON_ITEM_HEIGHT, close etjump_settings_1; open etjump)
         BUTTONACTIVE        (ETJ_BUTTON_X + (ETJ_BUTTON_SPACING_X * 1), ETJ_BUTTON_Y, ETJ_BUTTON_WIDTH, ETJ_BUTTON_HEIGHT, "TAB 1", 0.3, ETJ_BUTTON_ITEM_HEIGHT, close etjump_settings_1; open etjump_settings_1)

--- a/assets/ui/etjump_settings_2.menu
+++ b/assets/ui/etjump_settings_2.menu
@@ -25,6 +25,10 @@
 #define SUBW_POPUPS_ITEM_Y SUBW_POPUPS_Y + SUBW_HEADER_HEIGHT
 #define SUBW_POPUPS_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 9)
 
+#define SUBW_SCOREBOARD_Y SUBW_POPUPS_Y + SUBW_POPUPS_HEIGHT + SUBW_SPACING_Y
+#define SUBW_SCOREBOARD_ITEM_Y SUBW_SCOREBOARD_Y + SUBW_HEADER_HEIGHT
+#define SUBW_SCOREBOARD_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 1)
+
 #define GROUP_NAME "group_etjump_settings_2"
 
 menuDef {
@@ -119,6 +123,10 @@ menuDef {
         CVARINTLABEL        (SUBW_ITEM_RIGHT_X, SUBW_POPUPS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 8), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_popupFadeTime", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
         SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_POPUPS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 8), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Popup fade time:", 0.2, SUBW_ITEM_HEIGHT, etj_popupFadeTime 2500 0 10000 250, "Duration of fade animation in milliseconds on popup messages\netj_popupFadeTime")
         MULTI               (SUBW_ITEM_RIGHT_X, SUBW_POPUPS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 9), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Group popups:", 0.2, SUBW_ITEM_HEIGHT, "etj_popupGrouped", cvarFloatList { "No" 0 "Popups" 1 "Popups + console" 2 }, "Group identical popups to one message\netj_popupGrouped")
+
+    SUBWINDOW(SUBW_RECT_RIGHT_X, SUBW_SCOREBOARD_Y, SUBW_WIDTH, SUBW_SCOREBOARD_HEIGHT, "SCOREBOARD")
+        MULTI               (SUBW_ITEM_RIGHT_X, SUBW_SCOREBOARD_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Custom scoreboard:", 0.2, SUBW_ITEM_HEIGHT, "etj_altScoreboard", cvarFloatList { "No" 0 "ETJump 1" 1 "ETJump 2" 2 "ETJump 3" 3 }, "Displays alternative scoreboard\netj_altScoreboard")
+        YESNO               (SUBW_ITEM_RIGHT_X, SUBW_SCOREBOARD_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Draw idle indicator:", 0.2, SUBW_ITEM_HEIGHT, "etj_drawScoreboardInactivity", "Draw idle indicator on inactive clients\netj_drawScoreboardInactivity")
         
         BUTTON              (ETJ_BUTTON_X + (ETJ_BUTTON_SPACING_X * 0), ETJ_BUTTON_Y, ETJ_BUTTON_WIDTH, ETJ_BUTTON_HEIGHT, "BACK", 0.3, ETJ_BUTTON_ITEM_HEIGHT, close etjump_settings_2; open etjump)
         BUTTON              (ETJ_BUTTON_X + (ETJ_BUTTON_SPACING_X * 1), ETJ_BUTTON_Y, ETJ_BUTTON_WIDTH, ETJ_BUTTON_HEIGHT, "TAB 1", 0.3, ETJ_BUTTON_ITEM_HEIGHT, close etjump_settings_2; open etjump_settings_1)

--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -47,6 +47,8 @@ add_library(cgame MODULE
 	"etj_client_authentication.cpp"
 	"etj_client_commands_handler.cpp"
 	"etj_console_alpha.cpp"
+	"etj_crosshair.cpp"
+	"etj_crosshair_drawer.cpp"
 	"etj_cvar_master_drawer.cpp"
 	"etj_cvar_shadow.cpp"
 	"etj_cvar_update_handler.cpp"

--- a/src/cgame/cg_commandmap.cpp
+++ b/src/cgame/cg_commandmap.cpp
@@ -1066,7 +1066,7 @@ void CG_DrawAutoMap(void) {
     return;
   }
 
-  if (cg.zoomedScope || cg.zoomedBinoc) {
+  if (cg.zoomedBinoc || BG_IsScopedWeapon(ETJump::weapnumForClient())) {
     return;
   }
 

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -143,6 +143,10 @@ range_t AnglesToRange(float start, float end, float yaw, float fov) {
   return ret;
 }
 
+void DrawLine(float x1, float y1, float x2, float y2, const vec4_t color) {
+  DrawLine(x1, y1, x2, y2, 1, 1, color);
+}
+
 /*
 ==============
 DrawLine
@@ -217,10 +221,10 @@ static Point TranslatePoint(Point p, float angle, const vec2_t origin) {
 /*
 ==============
 EdgeFunction
-Edge function to determine if a point (x, y) lies inside or outside the
-triangle defined by p1, p2, and p3. The function returns a positive value if
-the point is inside the triangle, a negative value if it's outside, and zero
-if the point lies on the triangle's edge.
+Edge function to determine if a point (x, y) lies inside or outside a
+triangle. The function returns a positive value if the point is inside a
+triangle, a negative value if it's outside, and zero if the point lies on a
+triangle's edge. This should be called for each vertex pair of a triangle.
 ==============
 */
 static float EdgeFunction(const Point &a, const Point &b, float x, float y) {

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2763,6 +2763,7 @@ void CG_FillRect(float x, float y, float width, float height,
                  const float *color);
 void CG_FillAngleYaw(float start, float end, float yaw, float y, float h,
                      float fov, vec4_t const color);
+void DrawLine(float x1, float y1, float x2, float y2, const vec4_t color);
 void DrawLine(float x1, float y1, float x2, float y2, float w, float h,
               const vec4_t color);
 void DrawTriangle(float x, float y, float w, float h, float lineW, float angle,

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -71,7 +71,7 @@
 #define GIANT_WIDTH 32
 #define GIANT_HEIGHT 48
 
-#define NUM_CROSSHAIRS 10
+#define NUM_CROSSHAIRS 17
 
 // Ridah, trails
 #define STYPE_STRETCH 0
@@ -2688,6 +2688,11 @@ extern vmCvar_t etj_optimizePrediction;
 
 extern vmCvar_t etj_menuSensitivity;
 
+extern vmCvar_t etj_crosshairScaleX;
+extern vmCvar_t etj_crosshairScaleY;
+extern vmCvar_t etj_crosshairThickness;
+extern vmCvar_t etj_crosshairOutline;
+
 //
 // cg_main.c
 //
@@ -2758,8 +2763,11 @@ void CG_FillRect(float x, float y, float width, float height,
                  const float *color);
 void CG_FillAngleYaw(float start, float end, float yaw, float y, float h,
                      float fov, vec4_t const color);
-void PutPixel(float x, float y);
-void DrawLine(float x1, float y1, float x2, float y2, const vec4_t color);
+void DrawLine(float x1, float y1, float x2, float y2, float w, float h,
+              const vec4_t color);
+void DrawTriangle(float x, float y, float w, float h, float lineW, float angle,
+                  bool fill, const vec4_t color,
+                  const vec4_t fillColor = nullptr);
 float AngleToScreenX(float angle, float fov);
 range_t AnglesToRange(float start, float end, float yaw, float fov);
 void CG_HorizontalPercentBar(float x, float y, float width, float height,
@@ -2922,6 +2930,8 @@ int CG_CalculateReinfTime(qboolean menu);
 float CG_CalculateReinfTime_Float(qboolean menu);
 void CG_Fade(int r, int g, int b, int a, int time, int duration);
 int CG_PlayerAmmoValue(int *ammo, int *clips, int *akimboammo);
+
+void CG_DrawMortarReticle();
 
 //
 // cg_player.c
@@ -4143,6 +4153,7 @@ void addLoopingSound(const vec3_t origin, const vec3_t velocity,
                      sfxHandle_t sfx, int volume, int soundTime);
 bool hideMeCheck(int entityNum);
 int checkExtraTrace(int value);
+int weapnumForClient();
 void onPlayerRespawn(qboolean revived);
 void runFrameEnd();
 playerState_t *getValidPlayerState();

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -611,6 +611,11 @@ vmCvar_t etj_optimizePrediction;
 
 vmCvar_t etj_menuSensitivity;
 
+vmCvar_t etj_crosshairScaleX;
+vmCvar_t etj_crosshairScaleY;
+vmCvar_t etj_crosshairThickness;
+vmCvar_t etj_crosshairOutline;
+
 typedef struct {
   vmCvar_t *vmCvar;
   const char *cvarName;
@@ -1118,6 +1123,11 @@ cvarTable_t cvarTable[] = {
     // END unlagged - optimized prediction
 
     {&etj_menuSensitivity, "etj_menuSensitivity", "1.0", CVAR_ARCHIVE},
+
+    {&etj_crosshairScaleX, "etj_crosshairScaleX", "1.0", CVAR_ARCHIVE},
+    {&etj_crosshairScaleY, "etj_crosshairScaleY", "1.0", CVAR_ARCHIVE},
+    {&etj_crosshairThickness, "etj_crosshairThickness", "1.0", CVAR_ARCHIVE},
+    {&etj_crosshairOutline, "etj_crosshairOutline", "1", CVAR_ARCHIVE},
 };
 
 int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);
@@ -2337,10 +2347,8 @@ static void CG_RegisterGraphics(void) {
   cgs.media.buddyShader = trap_R_RegisterShaderNoMip("sprites/buddy.tga");
 
   for (i = 0; i < NUM_CROSSHAIRS; i++) {
-    cgs.media.crosshairShader[i] =
-        trap_R_RegisterShader(va("gfx/2d/crosshair%c", 'a' + i));
-    cg.crosshairShaderAlt[i] =
-        trap_R_RegisterShader(va("gfx/2d/crosshair%c_alt", 'a' + i));
+    cgs.media.crosshairShader[i] = ETJump::shaderForCrosshair(i, false);
+    cg.crosshairShaderAlt[i] = ETJump::shaderForCrosshair(i, true);
   }
 
   for (i = 0; i < SK_NUM_SKILLS; i++) {

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -258,7 +258,7 @@ void CGaz::render() const {
       scx -= SCREEN_OFFSET_X;
     }
     DrawLine(scx, scy, scx + static_cast<float>(cmd.rightmove),
-             scy - static_cast<float>(cmd.forwardmove), CGaz2Colors[1]);
+             scy - static_cast<float>(cmd.forwardmove), 1, 1, CGaz2Colors[1]);
 
     // When under wishspeed velocity, most accel happens when
     // you move straight towards your current velocity, so skip
@@ -273,14 +273,16 @@ void CGaz::render() const {
     }
 
     DrawLine(scx, scy, scx + velSize * std::sin(drawVel),
-             scy - velSize * std::cos(drawVel), CGaz2Colors[0]);
+             scy - velSize * std::cos(drawVel), 1, 1, CGaz2Colors[0]);
 
     if (drawSides) {
       velSize /= 2;
       DrawLine(scx, scy, scx + velSize * std::sin(drawVel + drawOpt),
-               scy - velSize * std::cos(drawVel + drawOpt), CGaz2Colors[0]);
+               scy - velSize * std::cos(drawVel + drawOpt), 1, 1,
+               CGaz2Colors[0]);
       DrawLine(scx, scy, scx + velSize * std::sin(drawVel - drawOpt),
-               scy - velSize * std::cos(drawVel - drawOpt), CGaz2Colors[0]);
+               scy - velSize * std::cos(drawVel - drawOpt), 1, 1,
+               CGaz2Colors[0]);
     }
 
     if (etj_stretchCgaz.integer) {
@@ -417,7 +419,7 @@ bool CGaz::canSkipDraw() const {
     return true;
   }
 
-  if ((cg.zoomedBinoc || cg.zoomedScope) && !cg.renderingThirdPerson) {
+  if (cg.zoomedBinoc || BG_IsScopedWeapon(weapnumForClient())) {
     return true;
   }
 

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -258,7 +258,7 @@ void CGaz::render() const {
       scx -= SCREEN_OFFSET_X;
     }
     DrawLine(scx, scy, scx + static_cast<float>(cmd.rightmove),
-             scy - static_cast<float>(cmd.forwardmove), 1, 1, CGaz2Colors[1]);
+             scy - static_cast<float>(cmd.forwardmove), CGaz2Colors[1]);
 
     // When under wishspeed velocity, most accel happens when
     // you move straight towards your current velocity, so skip
@@ -273,16 +273,14 @@ void CGaz::render() const {
     }
 
     DrawLine(scx, scy, scx + velSize * std::sin(drawVel),
-             scy - velSize * std::cos(drawVel), 1, 1, CGaz2Colors[0]);
+             scy - velSize * std::cos(drawVel), CGaz2Colors[0]);
 
     if (drawSides) {
       velSize /= 2;
       DrawLine(scx, scy, scx + velSize * std::sin(drawVel + drawOpt),
-               scy - velSize * std::cos(drawVel + drawOpt), 1, 1,
-               CGaz2Colors[0]);
+               scy - velSize * std::cos(drawVel + drawOpt), CGaz2Colors[0]);
       DrawLine(scx, scy, scx + velSize * std::sin(drawVel - drawOpt),
-               scy - velSize * std::cos(drawVel - drawOpt), 1, 1,
-               CGaz2Colors[0]);
+               scy - velSize * std::cos(drawVel - drawOpt), CGaz2Colors[0]);
     }
 
     if (etj_stretchCgaz.integer) {

--- a/src/cgame/etj_crosshair.cpp
+++ b/src/cgame/etj_crosshair.cpp
@@ -55,8 +55,10 @@ void Crosshair::parseColors() {
 }
 
 void Crosshair::adjustSize() {
-  crosshair.w = cg_crosshairSize.value * etj_crosshairScaleX.value;
-  crosshair.h = cg_crosshairSize.value * etj_crosshairScaleY.value;
+  const float scaleX = Numeric::clamp(etj_crosshairScaleX.value, -5, 5);
+  const float scaleY = Numeric::clamp(etj_crosshairScaleY.value, -5, 5);
+  crosshair.w = cg_crosshairSize.value * scaleX;
+  crosshair.h = cg_crosshairSize.value * scaleY;
   crosshair.f = 0.0f;
   crosshair.t = Numeric::clamp(etj_crosshairThickness.value, 0.0f, 5.0f);
 

--- a/src/cgame/etj_crosshair.cpp
+++ b/src/cgame/etj_crosshair.cpp
@@ -62,7 +62,7 @@ void Crosshair::adjustSize() {
   crosshair.f = 0.0f;
   crosshair.t = Numeric::clamp(etj_crosshairThickness.value, 0.0f, 5.0f);
 
-  if (cg_drawCrosshair.integer < 10) {
+  if (crosshair.current < 10) {
     // using abs makes sure negative scale will flip correctly
     crosshair.w = std::abs(crosshair.w);
     crosshair.h = std::abs(crosshair.h);
@@ -86,6 +86,7 @@ void Crosshair::adjustPosition() {
 }
 
 void Crosshair::beforeRender() {
+  crosshair.current = cg_drawCrosshair.integer % NUM_CROSSHAIRS;
   adjustSize();
 
   // crosshair health must be checked here instead of parseColors
@@ -105,14 +106,14 @@ void Crosshair::render() const {
     return;
   }
 
-  const qhandle_t shader = cgs.media.crosshairShader[cg_drawCrosshair.integer];
-  const qhandle_t shaderAlt = cg.crosshairShaderAlt[cg_drawCrosshair.integer];
+  const qhandle_t shader = cgs.media.crosshairShader[crosshair.current];
+  const qhandle_t shaderAlt = cg.crosshairShaderAlt[crosshair.current];
 
   // standard crosshairs (0-9)
-  if (cg_drawCrosshair.integer < 10) {
+  if (crosshair.current < 10) {
     CrosshairDrawer::drawShader(crosshair, shader);
 
-    if (cg.crosshairShaderAlt[cg_drawCrosshair.integer]) {
+    if (cg.crosshairShaderAlt[crosshair.current]) {
       CrosshairDrawer::drawShader(crosshair, shaderAlt);
     }
   } else {
@@ -132,7 +133,7 @@ void Crosshair::render() const {
       Vector4Copy(colorBlack, crosshairOutline.colorAlt);
     }
 
-    switch (static_cast<ETJumpCrosshairs>(cg_drawCrosshair.integer)) {
+    switch (static_cast<ETJumpCrosshairs>(crosshair.current)) {
       case ETJumpCrosshairs::VerticalLine:
         if (outline) {
           CrosshairDrawer::drawLineOutline(crosshairOutline, shader, flipY);

--- a/src/cgame/etj_crosshair.cpp
+++ b/src/cgame/etj_crosshair.cpp
@@ -132,44 +132,44 @@ void Crosshair::render() const {
       Vector4Copy(colorBlack, crosshairOutline.colorAlt);
     }
 
-    switch (cg_drawCrosshair.integer) {
-      case 10: // vertical line
+    switch (static_cast<ETJumpCrosshairs>(cg_drawCrosshair.integer)) {
+      case ETJumpCrosshairs::VerticalLine:
         if (outline) {
           CrosshairDrawer::drawLineOutline(crosshairOutline, shader, flipY);
         }
         CrosshairDrawer::drawLine(crosshair, shader, flipY);
         break;
-      case 11: // cross
+      case ETJumpCrosshairs::Cross:
         if (outline) {
           CrosshairDrawer::drawCrossOutline(crosshairOutline, shader);
         }
         CrosshairDrawer::drawCross(crosshair, shader);
         break;
-      case 12: // 45-degree cross
+      case ETJumpCrosshairs::DiagonalCross:
         if (outline) {
           CrosshairDrawer::drawDiagCross(crosshairOutline);
         }
         CrosshairDrawer::drawDiagCross(crosshair);
         break;
-      case 13: // upward pointing 'V'
+      case ETJumpCrosshairs::V:
         if (outline) {
           CrosshairDrawer::drawV(crosshairOutline);
         }
         CrosshairDrawer::drawV(crosshair);
         break;
-      case 14: // upward pointing triangle
+      case ETJumpCrosshairs::Triangle:
         if (outline) {
           CrosshairDrawer::drawTriangle(crosshairOutline, false);
         }
         CrosshairDrawer::drawTriangle(crosshair, fill);
         break;
-      case 15: // T-shaped
+      case ETJumpCrosshairs::T:
         if (outline) {
           CrosshairDrawer::drawTOutline(crosshairOutline, shader, flipX, flipY);
         }
         CrosshairDrawer::drawT(crosshair, shader, flipX, flipY);
         break;
-      case 16: // double vertical lines
+      case ETJumpCrosshairs::TwoVerticalLines:
         if (outline) {
           CrosshairDrawer::drawTwoLinesOutline(crosshairOutline, shader);
         }

--- a/src/cgame/etj_crosshair.cpp
+++ b/src/cgame/etj_crosshair.cpp
@@ -1,0 +1,218 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_crosshair.h"
+#include "etj_crosshair_drawer.h"
+#include "etj_cvar_update_handler.h"
+#include "etj_utilities.h"
+#include "../game/etj_numeric_utilities.h"
+
+namespace ETJump {
+Crosshair::Crosshair() {
+  startListeners();
+  parseColors();
+  adjustPosition();
+}
+
+void Crosshair::startListeners() {
+  // colors
+  cvarUpdateHandler->subscribe(&cg_crosshairColor,
+                               [&](const vmCvar_t *cvar) { parseColors(); });
+  cvarUpdateHandler->subscribe(&cg_crosshairColorAlt,
+                               [&](const vmCvar_t *cvar) { parseColors(); });
+
+  // position
+  cvarUpdateHandler->subscribe(&cg_crosshairX,
+                               [&](const vmCvar_t *cvar) { adjustPosition(); });
+  cvarUpdateHandler->subscribe(&cg_crosshairY,
+                               [&](const vmCvar_t *cvar) { adjustPosition(); });
+}
+
+void Crosshair::parseColors() {
+  parseColorString(cg_crosshairColor.string, crosshair.color);
+  parseColorString(cg_crosshairColorAlt.string, crosshair.colorAlt);
+}
+
+void Crosshair::adjustSize() {
+  crosshair.w = cg_crosshairSize.value * etj_crosshairScaleX.value;
+  crosshair.h = cg_crosshairSize.value * etj_crosshairScaleY.value;
+  crosshair.f = 0.0f;
+  crosshair.t = Numeric::clamp(etj_crosshairThickness.value, 0.0f, 5.0f);
+
+  if (cg_drawCrosshair.integer < 10) {
+    // using abs makes sure negative scale will flip correctly
+    crosshair.w = std::abs(crosshair.w);
+    crosshair.h = std::abs(crosshair.h);
+  } else {
+    // most other crosshairs are "half-height" crosshairs, so we halve the size
+    // to make them work better with cg_crosshairSize
+    crosshair.w *= 0.5f;
+    crosshair.h *= 0.5f;
+  }
+
+  if (cg_crosshairPulse.integer) {
+    crosshair.f = static_cast<float>(cg.snap->ps.aimSpreadScale) / 255.0f;
+    crosshair.w *= 1 + crosshair.f * 2.0f;
+    crosshair.h = crosshair.w;
+  }
+}
+
+void Crosshair::adjustPosition() {
+  crosshair.x = cg_crosshairX.value + (SCREEN_WIDTH * 0.5f);
+  crosshair.y = cg_crosshairY.value + (SCREEN_HEIGHT * 0.5f);
+}
+
+void Crosshair::beforeRender() {
+  adjustSize();
+
+  // crosshair health must be checked here instead of parseColors
+  // to make sure we have a valid snapshot
+  if (cg_crosshairHealth.integer) {
+    CG_ColorForHealth(crosshair.color);
+  }
+
+  // alpha adjustment here to make it work with crosshair health too
+  crosshair.color[3] = Numeric::clamp(cg_crosshairAlpha.value, 0.0f, 1.0f);
+  crosshair.colorAlt[3] =
+      Numeric::clamp(cg_crosshairAlphaAlt.value, 0.0f, 1.0f);
+}
+
+void Crosshair::render() const {
+  if (canSkipDraw()) {
+    return;
+  }
+
+  const qhandle_t shader = cgs.media.crosshairShader[cg_drawCrosshair.integer];
+  const qhandle_t shaderAlt = cg.crosshairShaderAlt[cg_drawCrosshair.integer];
+
+  // standard crosshairs (0-9)
+  if (cg_drawCrosshair.integer < 10) {
+    CrosshairDrawer::drawShader(crosshair, shader);
+
+    if (cg.crosshairShaderAlt[cg_drawCrosshair.integer]) {
+      CrosshairDrawer::drawShader(crosshair, shaderAlt);
+    }
+  } else {
+    // because engine always wants to draw up->down/left->right even when
+    // width/height is negative, we need to do some manual x/y coordinate
+    // shifting for some crosshairs to ensure negative x/y scale will flip
+    // the crosshair correctly instead of shifting its position
+    const bool flipX = crosshair.w < 0;
+    const bool flipY = crosshair.h < 0;
+    const bool outline = etj_crosshairOutline.integer;
+    const bool fill = cg_crosshairAlphaAlt.value != 0;
+    auto crosshairOutline = crosshair;
+
+    if (outline) {
+      crosshairOutline.t += 1;
+      Vector4Copy(colorBlack, crosshairOutline.color);
+      Vector4Copy(colorBlack, crosshairOutline.colorAlt);
+    }
+
+    switch (cg_drawCrosshair.integer) {
+      case 10: // vertical line
+        if (outline) {
+          CrosshairDrawer::drawLineOutline(crosshairOutline, shader, flipY);
+        }
+        CrosshairDrawer::drawLine(crosshair, shader, flipY);
+        break;
+      case 11: // cross
+        if (outline) {
+          CrosshairDrawer::drawCrossOutline(crosshairOutline, shader);
+        }
+        CrosshairDrawer::drawCross(crosshair, shader);
+        break;
+      case 12: // 45-degree cross
+        if (outline) {
+          CrosshairDrawer::drawDiagCross(crosshairOutline);
+        }
+        CrosshairDrawer::drawDiagCross(crosshair);
+        break;
+      case 13: // upward pointing 'V'
+        if (outline) {
+          CrosshairDrawer::drawV(crosshairOutline);
+        }
+        CrosshairDrawer::drawV(crosshair);
+        break;
+      case 14: // upward pointing triangle
+        if (outline) {
+          CrosshairDrawer::drawTriangle(crosshairOutline, false);
+        }
+        CrosshairDrawer::drawTriangle(crosshair, fill);
+        break;
+      case 15: // T-shaped
+        if (outline) {
+          CrosshairDrawer::drawTOutline(crosshairOutline, shader, flipX, flipY);
+        }
+        CrosshairDrawer::drawT(crosshair, shader, flipX, flipY);
+        break;
+      case 16: // double vertical lines
+        if (outline) {
+          CrosshairDrawer::drawTwoLinesOutline(crosshairOutline, shader);
+        }
+        CrosshairDrawer::drawTwoLines(crosshair, shader);
+        break;
+    }
+  }
+}
+
+bool Crosshair::canSkipDraw() {
+  if (cg_drawCrosshair.integer < 0) {
+    return true;
+  }
+
+  if (showingScores()) {
+    return true;
+  }
+
+  if (cg.snap->ps.leanf != 0) {
+    return true;
+  }
+
+  if (cg.renderingThirdPerson) {
+    return true;
+  }
+
+  if (cg.zoomedBinoc && cg.snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR) {
+    return true;
+  }
+
+  if (BG_IsScopedWeapon(weapnumForClient())) {
+    return true;
+  }
+
+  if (cg.predictedPlayerState.weapon == WP_MORTAR_SET &&
+      cg.predictedPlayerState.weaponstate != WEAPON_RAISING) {
+    return true;
+  }
+
+  // pretty sure these hints are bogus but keeping it here just in case
+  if (cg.snap->ps.serverCursorHint >= HINT_EXIT &&
+      cg.snap->ps.serverCursorHint <= HINT_NOEXIT) {
+    return true;
+  }
+
+  return false;
+}
+} // namespace ETJump

--- a/src/cgame/etj_crosshair.h
+++ b/src/cgame/etj_crosshair.h
@@ -47,6 +47,8 @@ class Crosshair : public IRenderable {
 
 protected:
   typedef struct {
+    int current;
+
     vec4_t color;
     vec4_t colorAlt;
 

--- a/src/cgame/etj_crosshair.h
+++ b/src/cgame/etj_crosshair.h
@@ -1,0 +1,59 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "cg_local.h"
+#include "etj_irenderable.h"
+
+namespace ETJump {
+class Crosshair : public IRenderable {
+  void startListeners();
+  void parseColors();
+  void adjustSize();
+  void adjustPosition();
+  static bool canSkipDraw();
+
+protected:
+  typedef struct {
+    vec4_t color;
+    vec4_t colorAlt;
+
+    float x;
+    float y;
+    float w;
+    float h;
+    float t; // crosshair thickness
+
+    float f; // cg_crosshairPulse size modifier
+  } crosshair_t;
+
+  crosshair_t crosshair{};
+
+public:
+  Crosshair();
+  void render() const override;
+  void beforeRender() override;
+};
+} // namespace ETJump

--- a/src/cgame/etj_crosshair.h
+++ b/src/cgame/etj_crosshair.h
@@ -35,6 +35,16 @@ class Crosshair : public IRenderable {
   void adjustPosition();
   static bool canSkipDraw();
 
+  enum class ETJumpCrosshairs {
+    VerticalLine = 10,
+    Cross = 11,
+    DiagonalCross = 12,
+    V = 13,
+    Triangle = 14,
+    T = 15,
+    TwoVerticalLines = 16
+  };
+
 protected:
   typedef struct {
     vec4_t color;

--- a/src/cgame/etj_crosshair_drawer.cpp
+++ b/src/cgame/etj_crosshair_drawer.cpp
@@ -1,0 +1,162 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_crosshair_drawer.h"
+
+namespace ETJump {
+void CrosshairDrawer::drawShader(const crosshair_t &crosshair,
+                                 qhandle_t shader) {
+  drawPic(crosshair.x - (crosshair.w * 0.5f),
+          crosshair.y - (crosshair.h * 0.5f), crosshair.w, crosshair.h, shader,
+          crosshair.color);
+}
+
+void CrosshairDrawer::drawLineOutline(crosshair_t &crosshair, qhandle_t shader,
+                                      bool flipY) {
+  crosshair.w += crosshair.w > 0 ? 0.5f : -0.5f;
+  crosshair.h += crosshair.h > 0 ? 0.5f : -0.5f;
+  drawLine(crosshair, shader, flipY);
+}
+
+void CrosshairDrawer::drawLine(const crosshair_t &crosshair, qhandle_t shader,
+                               bool flipY) {
+  if (flipY) {
+    drawPic(crosshair.x - (crosshair.t * 0.5f), crosshair.y, crosshair.t,
+            crosshair.h * 0.5f, shader, crosshair.color);
+    drawPic(crosshair.x - (crosshair.t * 0.5f),
+            crosshair.y + (crosshair.h * 0.5f), crosshair.t, crosshair.h * 0.5f,
+            shader, crosshair.colorAlt);
+  } else {
+    drawPic(crosshair.x - (crosshair.t * 0.5f),
+            crosshair.y - (crosshair.h * 0.5f), crosshair.t, crosshair.h * 0.5f,
+            shader, crosshair.color);
+    drawPic(crosshair.x - (crosshair.t * 0.5f), crosshair.y, crosshair.t,
+            crosshair.h * 0.5f, shader, crosshair.colorAlt);
+  }
+}
+
+void CrosshairDrawer::drawCrossOutline(crosshair_t &crosshair,
+                                       qhandle_t shader) {
+  crosshair.w += crosshair.w > 0 ? 0.5f : -0.5f;
+  crosshair.h += crosshair.h > 0 ? 0.5f : -0.5f;
+  drawCross(crosshair, shader);
+}
+
+void CrosshairDrawer::drawCross(const crosshair_t &crosshair,
+                                qhandle_t shader) {
+  // horizontal line
+  drawPic(crosshair.x - std::abs(crosshair.w * 0.5f),
+          crosshair.y - (crosshair.t * 0.5f), crosshair.w, crosshair.t, shader,
+          crosshair.color);
+  // vertical line
+  drawPic(crosshair.x - (crosshair.t * 0.5f),
+          crosshair.y - std::abs(crosshair.h * 0.5f), crosshair.t, crosshair.h,
+          shader, crosshair.colorAlt);
+}
+
+void CrosshairDrawer::drawDiagCross(const crosshair_t &crosshair) {
+  // top-left -> bottom-right
+  DrawLine(crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+           crosshair.y - (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
+           crosshair.x + (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+           crosshair.y + (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
+           crosshair.t, crosshair.t, crosshair.color);
+  // top-right -> bottom-left
+  DrawLine(crosshair.x + (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+           crosshair.y - (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
+           crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+           crosshair.y + (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
+           crosshair.t, crosshair.t, crosshair.colorAlt);
+}
+
+void CrosshairDrawer::drawV(const crosshair_t &crosshair) {
+  // left line
+  DrawLine(crosshair.x - (crosshair.t * 0.5f),
+           crosshair.y - (crosshair.t * 0.5f),
+           crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+           crosshair.y + crosshair.h - (crosshair.t * 0.5f), crosshair.t,
+           crosshair.t, crosshair.color);
+  // right line
+  DrawLine(crosshair.x - (crosshair.t * 0.5f),
+           crosshair.y - (crosshair.t * 0.5f),
+           crosshair.x + (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+           crosshair.y + crosshair.h - (crosshair.t * 0.5f), crosshair.t,
+           crosshair.t, crosshair.colorAlt);
+}
+
+void CrosshairDrawer::drawTriangle(const crosshair_t &crosshair,
+                                   const bool fill) {
+  DrawTriangle(crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+               crosshair.y - (crosshair.t * 0.5f), crosshair.w, crosshair.h,
+               crosshair.t, 0, fill, crosshair.color, crosshair.colorAlt);
+}
+
+void CrosshairDrawer::drawTOutline(crosshair_t &crosshair, qhandle_t shader,
+                                   bool flipX, bool flipY) {
+  crosshair.w += crosshair.w > 0 ? 0.5f : -0.5f;
+  crosshair.h += crosshair.h > 0 ? 0.5f : -0.5f;
+  crosshair.y += flipY ? -0.5f : 0.5f;
+  drawT(crosshair, shader, flipX, flipY);
+}
+
+void CrosshairDrawer::drawT(const crosshair_t &crosshair, qhandle_t shader,
+                            bool flipX, bool flipY) {
+  // middle line
+  if (flipY) {
+    drawPic(crosshair.x - (crosshair.t * 0.5f), crosshair.y, crosshair.t,
+            crosshair.h, shader, crosshair.color);
+  } else {
+    drawPic(crosshair.x - (crosshair.t * 0.5f), crosshair.y - crosshair.h,
+            crosshair.t, crosshair.h, shader, crosshair.color);
+  }
+  // top line
+  if (flipX) {
+    drawPic(crosshair.x + (crosshair.w * 0.5f),
+            crosshair.y - crosshair.h - (crosshair.t * 0.5f), crosshair.w,
+            crosshair.t, shader, crosshair.colorAlt);
+  } else {
+    drawPic(crosshair.x - (crosshair.w * 0.5f),
+            crosshair.y - crosshair.h - (crosshair.t * 0.5f), crosshair.w,
+            crosshair.t, shader, crosshair.colorAlt);
+  }
+}
+
+void CrosshairDrawer::drawTwoLinesOutline(crosshair_t &crosshair,
+                                          qhandle_t shader) {
+  crosshair.h += crosshair.h > 0 ? 0.5f : -0.5f;
+  drawTwoLines(crosshair, shader);
+}
+
+void CrosshairDrawer::drawTwoLines(const crosshair_t &crosshair,
+                                   qhandle_t shader) {
+  // left line
+  drawPic(crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+          crosshair.y - std::abs(crosshair.h * 0.5f), crosshair.t, crosshair.h,
+          shader, crosshair.color);
+  // right line
+  drawPic(crosshair.x + (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+          crosshair.y - std::abs(crosshair.h * 0.5f), crosshair.t, crosshair.h,
+          shader, crosshair.colorAlt);
+}
+} // namespace ETJump

--- a/src/cgame/etj_crosshair_drawer.h
+++ b/src/cgame/etj_crosshair_drawer.h
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "etj_crosshair.h"
+
+namespace ETJump {
+class CrosshairDrawer : public Crosshair {
+public:
+  static void drawShader(const crosshair_t &crosshair, qhandle_t shader);
+  static void drawLine(const crosshair_t &crosshair, qhandle_t shader,
+                       bool flipY);
+  static void drawLineOutline(crosshair_t &crosshair, qhandle_t shader,
+                              bool flipY);
+  static void drawCross(const crosshair_t &crosshair, qhandle_t shader);
+  static void drawCrossOutline(crosshair_t &crosshair, qhandle_t shader);
+  static void drawDiagCross(const crosshair_t &crosshair);
+  static void drawV(const crosshair_t &crosshair);
+  static void drawTriangle(const crosshair_t &crosshair, bool fill);
+  static void drawT(const crosshair_t &crosshair, qhandle_t shader, bool flipX,
+                    bool flipY);
+  static void drawTOutline(crosshair_t &crosshair, qhandle_t shader, bool flipX,
+                           bool flipY);
+  static void drawTwoLines(const crosshair_t &crosshair, qhandle_t shader);
+  static void drawTwoLinesOutline(crosshair_t &crosshair, qhandle_t shader);
+};
+} // namespace ETJump

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -53,6 +53,7 @@
 #include "etj_upper_right_drawable.h"
 #include "etj_upmove_meter_drawable.h"
 #include "etj_spectatorinfo_drawable.h"
+#include "etj_crosshair.h"
 
 namespace ETJump {
 std::shared_ptr<ClientCommandsHandler> serverCommandsHandler;
@@ -111,6 +112,14 @@ int checkExtraTrace(int value) {
   }
 
   return CONTENTS_SOLID;
+}
+
+int weapnumForClient() {
+  if (cg.snap->ps.pm_flags & PMF_FOLLOW || cg.demoPlayback) {
+    return cg.snap->ps.weapon;
+  }
+
+  return cg.weaponSelect;
 }
 
 void initTimer() {
@@ -231,6 +240,8 @@ void init() {
       std::shared_ptr<ETJump::IRenderable>(keySetSystem));
   ETJump::initDrawKeys(keySetSystem);
   ETJump::autoDemoRecorder = std::make_shared<ETJump::AutoDemoRecorder>();
+
+  ETJump::renderables.push_back(std::make_shared<Crosshair>());
 
   const std::vector<std::pair<const vmCvar_t *, const std::string>> cvars{
       {&etj_drawFoliage, "r_drawfoliage"},

--- a/src/cgame/etj_jump_speeds.cpp
+++ b/src/cgame/etj_jump_speeds.cpp
@@ -217,10 +217,6 @@ bool JumpSpeeds::canSkipDraw() const {
     return true;
   }
 
-  if ((cg.zoomedBinoc || cg.zoomedScope) && !cg.renderingThirdPerson) {
-    return true;
-  }
-
   if (showingScores()) {
     return true;
   }

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -427,7 +427,7 @@ bool Snaphud::canSkipDraw() const {
     return true;
   }
 
-  if ((cg.zoomedBinoc || cg.zoomedScope) && !cg.renderingThirdPerson) {
+  if (cg.zoomedBinoc || BG_IsScopedWeapon(weapnumForClient())) {
     return true;
   }
 

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -363,19 +363,10 @@ void AssetCache() {
 
   for (n = 0; n < NUM_CROSSHAIRS; n++) {
     uiInfo.uiDC.Assets.crosshairShader[n] =
-        trap_R_RegisterShaderNoMip(va("gfx/2d/crosshair%c", 'a' + n));
+        ETJump::shaderForCrosshair(n, false);
     uiInfo.uiDC.Assets.crosshairAltShader[n] =
-        trap_R_RegisterShaderNoMip(va("gfx/2d/crosshair%c_alt", 'a' + n));
+        ETJump::shaderForCrosshair(n, true);
   }
-
-  // uiInfo.newHighScoreSound =
-  // trap_S_RegisterSound("sound/feedback/voc_newhighscore.wav");
-
-  /*	for ( n = 1; weaponTypes[n].shadername; n++ ) {
-          if ( weaponTypes[n].shadername )
-              trap_R_RegisterShaderNoMip( weaponTypes[n].shadername );
-      }*/
-  // -NERVE - SMF
 }
 
 void _UI_DrawSides(float x, float y, float w, float h, float size) {
@@ -2533,7 +2524,7 @@ static void UI_DrawRedBlue(rectDef_t *rect, float scale, vec4_t color,
 }
 
 static void UI_DrawCrosshair(rectDef_t *rect, float scale, vec4_t color) {
-  float size = cg_crosshairSize.integer;
+  float size = cg_crosshairSize.value;
 
   // Make sure currentCrosshair is updated if crosshair is changed via
   // console
@@ -2549,23 +2540,36 @@ static void UI_DrawCrosshair(rectDef_t *rect, float scale, vec4_t color) {
 
   vec4_t crosshairColor = {1.0, 1.0, 1.0, 1.0};
 
-  ETJump::parseColorString(cg_crosshairColor.string, crosshairColor);
-  crosshairColor[3] = Numeric::clamp(cg_crosshairAlpha.value, 0.0f, 1.0f);
-  trap_R_SetColor(crosshairColor);
-  UI_DrawHandlePic(rect->x + (rect->w - size) / 2,
-                   rect->y + (rect->h - size) / 2, size, size,
-                   uiInfo.uiDC.Assets.crosshairShader[uiInfo.currentCrosshair]);
+  if (uiInfo.currentCrosshair < 10) {
+    ETJump::parseColorString(cg_crosshairColor.string, crosshairColor);
+    crosshairColor[3] = Numeric::clamp(cg_crosshairAlpha.value, 0.0f, 1.0f);
+    trap_R_SetColor(crosshairColor);
+    UI_DrawHandlePic(
+        rect->x + (rect->w - size) / 2, rect->y + (rect->h - size) / 2, size,
+        size, uiInfo.uiDC.Assets.crosshairShader[uiInfo.currentCrosshair]);
 
-  vec4_t crosshairColorAlt = {1.0, 1.0, 1.0, 1.0};
+    vec4_t crosshairColorAlt = {1.0, 1.0, 1.0, 1.0};
 
-  ETJump::parseColorString(cg_crosshairColorAlt.string, crosshairColorAlt);
-  crosshairColorAlt[3] = Numeric::clamp(cg_crosshairAlphaAlt.value, 0.0f, 1.0f);
-  trap_R_SetColor(crosshairColorAlt);
-  UI_DrawHandlePic(
-      rect->x + (rect->w - size) / 2, rect->y + (rect->h - size) / 2, size,
-      size, uiInfo.uiDC.Assets.crosshairAltShader[uiInfo.currentCrosshair]);
+    ETJump::parseColorString(cg_crosshairColorAlt.string, crosshairColorAlt);
+    crosshairColorAlt[3] =
+        Numeric::clamp(cg_crosshairAlphaAlt.value, 0.0f, 1.0f);
+    trap_R_SetColor(crosshairColorAlt);
+    UI_DrawHandlePic(
+        rect->x + (rect->w - size) / 2, rect->y + (rect->h - size) / 2, size,
+        size, uiInfo.uiDC.Assets.crosshairAltShader[uiInfo.currentCrosshair]);
+  } else {
+    const auto text = va("Crosshair %d", uiInfo.currentCrosshair);
+    const auto width = static_cast<float>(
+        Text_Width_Ext(text, 0.12f, 0, &uiInfo.loadscreenfont1));
+    const auto height = static_cast<float>(
+        Text_Height_Ext(text, 0.12f, 0, &uiInfo.loadscreenfont1));
+    Text_Paint_Ext(rect->x + (rect->w - width) * 0.5f,
+                   rect->y + (rect->h + height) * 0.5f, 0.12f, 0.12f,
+                   colorWhite, text, 0, 0, ITEM_TEXTSTYLE_SHADOWED,
+                   &uiInfo.loadscreenfont1);
+  }
 
-  trap_R_SetColor(NULL);
+  trap_R_SetColor(nullptr);
 }
 
 /*

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -7762,6 +7762,27 @@ void scaleMenuSensitivity(int x, int y, float *mdx, float *mdy) {
   mouseMenuBuffer[0] = modff(mouseMenuBuffer[0], mdx);
   mouseMenuBuffer[1] = modff(mouseMenuBuffer[1], mdy);
 }
+
+// this is kinda terrible, but it ensures simple-ish expansion
+// if we ever add more shader-based crosshairs
+qhandle_t shaderForCrosshair(const int crosshairNum, const bool isAltShader) {
+  qhandle_t shader;
+
+  // default crosshairs (0-9)
+  if (crosshairNum >= 0 && crosshairNum < 10) {
+    if (isAltShader) {
+      shader = trap_R_RegisterShaderNoMip(
+          va("gfx/2d/crosshair%c_alt", 'a' + crosshairNum));
+    } else {
+      shader = trap_R_RegisterShaderNoMip(
+          va("gfx/2d/crosshair%c", 'a' + crosshairNum));
+    }
+  } else { // this should change if more shader-based crosshairs are added
+    shader = trap_R_RegisterShaderNoMip("white");
+  }
+
+  return shader;
+}
 } // namespace ETJump
 
 // FIXME:

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -16,7 +16,7 @@
 #define MAX_MENUDEFFILE 4096
 #define MAX_MENUFILE 32768
 #define MAX_MENUS 128
-//#define MAX_MENUITEMS 256
+// #define MAX_MENUITEMS 256
 #define MAX_MENUITEMS 128 // JPW NERVE q3ta was 96
 #define MAX_COLOR_RANGES 10
 #define MAX_MODAL_MENUS 16
@@ -105,7 +105,7 @@
 #define SLIDER_HEIGHT 10.0 // 16.0
 #define SLIDER_THUMB_WIDTH 12.0
 #define SLIDER_THUMB_HEIGHT 12.0 // 20.0
-#define NUM_CROSSHAIRS 10
+#define NUM_CROSSHAIRS 17
 
 typedef struct scriptDef_s {
   const char *command;
@@ -547,6 +547,7 @@ qboolean PC_Char_Parse(int handle, char *out); // NERVE - SMF
 namespace ETJump {
 bool PC_hasFloat(int handle);
 void scaleMenuSensitivity(int x, int y, float *mdx, float *mdy);
+qhandle_t shaderForCrosshair(int crosshairNum, bool isAltShader);
 } // namespace ETJump
 
 int Menu_Count();


### PR DESCRIPTION
Adds 7 new crosshairs, drawn as "vector graphics" by using cgame drawing functions rather than actual image files. These are extension to `cg_drawCrosshair`, occupying values **10-16**.

![1](https://github.com/etjump/etjump/assets/14221121/f9acaa0a-12eb-4162-a89b-d2bb194993bc) ![2](https://github.com/etjump/etjump/assets/14221121/972fd26a-7b9e-4f1e-a61b-c47978b1b149) ![3](https://github.com/etjump/etjump/assets/14221121/29f1ea9b-a01c-4182-8cfd-2521b5d86425) ![4](https://github.com/etjump/etjump/assets/14221121/b4956570-400b-4328-9747-5353c6ce7794) ![5](https://github.com/etjump/etjump/assets/14221121/39932216-b2ec-4fa2-8df6-49a6967962c1) ![6](https://github.com/etjump/etjump/assets/14221121/c0314810-74b8-444c-ad35-c1ed0ff4f3a5) ![7](https://github.com/etjump/etjump/assets/14221121/44a79569-b202-4ccd-8efb-11651c86cea0)

In these previews, white color is primary color (`cg_crosshairColor`) and green is secondary color (`cg_crosshairColorAlt`).

Together with these, there are 4 new cvars:
* `etj_crosshairScaleX/Y` - scales crosshairsize on X/Y axis, range **-5 - 5** (this also works for old crosshairs)
  * This does NOT thicken the lines on new crosshairs, for example scaling X value for crosshair 16 will instead move the lines further apart
  * Negative scale values flip the crosshairs, allowing you to for example flip the triangle, V and T crosshairs upside down
* `etj_crosshairThickness` - adjusts the line thickness of the new crosshairs (range **0-5**)
* `etj_crosshairOutline` - toggles drawing the black outline around the crosshair (default on)

Additionally, this PR fixes/changes the following:
* `cg_crosshairHealth` now respects `cg_crosshairAlpha`
* `cg_crosshairSize` and `cg_crosshairX/Y` now accept floating point values
* CGaz/snaphud no longer draw while zooming (binoc/scope) on 3rd person, or for spectators when a client is zoomed with a sniper 
* Fixes #946 - scoreboard and the rest of the HUD elements are no longer drawn behind binoc/sniper reticles
* Jump speeds list is no longer hidden when zooming with binocs/sniper

Known regressions:
* ~~`cg_drawCrosshair` no longer "loops around" - setting the value to an invalid crosshair number (> 16) won't display any crosshair.~~ None
