### PR TITLE
Fix tracker_not_eq being treated as OR instead of AND

### DIFF
--- a/src/game/etj_progression_tracker.cpp
+++ b/src/game/etj_progression_tracker.cpp
@@ -115,20 +115,35 @@ void ETJump::ProgressionTrackers::useTracker(
   }
 
   auto activate = true;
+  int clientTracker;
 
   for (idx = 0; idx < MaxProgressionTrackers; ++idx) {
-    auto clientTracker = activator->client->sess.progression[idx];
+    clientTracker = activator->client->sess.progression[idx];
 
     if ((tracker.equal[idx] != ProgressionTrackerValueNotSet &&
          tracker.equal[idx] != clientTracker) ||
-        (tracker.notEqual[idx] != ProgressionTrackerValueNotSet &&
-         tracker.notEqual[idx] == clientTracker) ||
         (tracker.lessThan[idx] != ProgressionTrackerValueNotSet &&
          tracker.lessThan[idx] <= clientTracker) ||
         (tracker.greaterThan[idx] != ProgressionTrackerValueNotSet &&
          tracker.greaterThan[idx] >= clientTracker)) {
       activate = false;
       break;
+    }
+  }
+
+  // notEqual must be checked in a separate loop, otherwise it will work
+  // as an OR statement instead of AND
+  for (idx = 0; idx < MaxProgressionTrackers; ++idx) {
+    clientTracker = activator->client->sess.progression[idx];
+
+    if (tracker.notEqual[idx] != ProgressionTrackerValueNotSet) {
+      if (tracker.notEqual[idx] == clientTracker) {
+        activate = false;
+        continue;
+      } else { // value set but not matched - break and fire targets
+        activate = true;
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
`tracker_not_eq` will now require all specified indices to not match for targets to fire as is documented and intended, instead of any of them. Previously setting `tracker_not_eq 1,1|2,1` would not fire targets if client had either `1,1` or `2,1`, instead of both.

Fixes #960 