### PR TITLE
Force selfkill after noclip before starting a timerun

### DIFF
--- a/src/game/etj_timerun_entities.cpp
+++ b/src/game/etj_timerun_entities.cpp
@@ -94,6 +94,12 @@ bool TargetStartTimer::canStartTimerun(gentity_t *self, gentity_t *activator,
           "^3WARNING: ^7Timerun was not started. Invalid playerstate!");
       return false;
     }
+    if (client->noclipThisLife) {
+      Printer::SendCenterMessage(*clientNum,
+                                 "^3WARNING: ^7Timerun was not started. Noclip "
+                                 "activated this life, ^3/kill ^7required!");
+      return false;
+    }
     if (*speed > self->velocityUpperLimit) {
       Printer::SendCenterMessage(
           *clientNum, stringFormat("^3WARNING: ^7Timerun was not started. Too "

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -1143,21 +1143,10 @@ void Cmd_Noclip_f(gentity_t *ent) {
     ent->client->noclip = !ent->client->noclip ? qtrue : qfalse;
   }
 
-  // ETJump: we don't need noclip messages
-  // const char *message;
-
   if (ent->client->noclip) {
-    // message = "noclip ON\n";
+    ent->client->noclipThisLife = true;
     ETJump::decreaseNoclipCount(ent, "noclip");
   }
-  /*
-  else
-  {
-          message = "noclip OFF\n";
-  }
-
-  trap_SendServerCommand(ent - g_entities, va("print \"%s\"", message));
-  */
 }
 
 /*

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -998,6 +998,7 @@ struct gclient_s {
   clientSession_t sess;
 
   qboolean noclip;
+  bool noclipThisLife;
 
   int lastCmdTime; // level.time of last usercmd_t, for EF_CONNECTION
                    // we can't just use pers.lastCommand.time, because


### PR DESCRIPTION
Forces clients to respawn once after activating noclip, before starting a timerun. This can have some unintended side effects on maps such as AjBallz, where noclip is allowed and there's a timerun for completing the map with no actual timer (start/stop trigger simultaneously), but the positives far outweigh the negatives, especially since runs like that are not really competitive in any way.

Fixes #985 