### PR TITLE
Rework g_blockCheatCvars

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1273,9 +1273,7 @@ void CG_setClientFlags(void) {
           ((etj_nofatigue.integer > 0) ? CGF_NOFATIGUE : 0) |
           ((pmove_fixed.integer > 0) ? CGF_PMOVEFIXED : 0) |
           ((etj_drawCGaz.integer > 0) ? CGF_CGAZ : 0) |
-          ((cl_yawspeed.integer > 0 ||
-            (int_m_pitch.value < 0.01 && int_m_pitch.value > -0.01) ||
-            cl_freelook.integer == 0)
+          ((cl_yawspeed.integer != 0 || cl_freelook.integer == 0)
                ? CGF_CHEATCVARSON
                : 0) |
           ((etj_loadviewangles.integer > 0) ? CGF_LOADVIEWANGLES : 0) |

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -2314,8 +2314,11 @@ static void CG_ServerCommand(void) {
   if (!Q_stricmp(cmd, "cheatCvarsOff")) {
     trap_SendConsoleCommand("set cl_freelook 1\n");
     trap_SendConsoleCommand("set cl_yawspeed 0\n");
+    return;
+  }
+
+  if (!Q_stricmp(cmd, "cheatCvarsOffAggressive")) {
     trap_SendConsoleCommand("set pmove_fixed 1\n");
-    trap_SendConsoleCommand("set m_pitch 0.022\n");
     return;
   }
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -2311,14 +2311,18 @@ static void CG_ServerCommand(void) {
     return;
   }
 
-  if (!Q_stricmp(cmd, "cheatCvarsOff")) {
-    trap_SendConsoleCommand("set cl_freelook 1\n");
-    trap_SendConsoleCommand("set cl_yawspeed 0\n");
-    return;
-  }
+  if (!Q_stricmpn(cmd, "cheatCvarsOff",
+                  static_cast<int>(strlen("cheatCvarsOff")))) {
+    const int flags = Q_atoi(CG_Argv(1));
 
-  if (!Q_stricmp(cmd, "cheatCvarsOffAggressive")) {
-    trap_SendConsoleCommand("set pmove_fixed 1\n");
+    if (flags & static_cast<int>(ETJump::CheatCvarFlags::LookYaw)) {
+      trap_SendConsoleCommand("set cl_freelook 1\n");
+      trap_SendConsoleCommand("set cl_yawspeed 0\n");
+    }
+
+    if (flags & static_cast<int>(ETJump::CheatCvarFlags::PmoveFPS)) {
+      trap_SendConsoleCommand("set pmove_fixed 1\n");
+    }
     return;
   }
 

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2785,4 +2785,12 @@ const int BG_LEVEL_NO_PRONE = 1 << 5;
 // Nodrop is enabled
 const int BG_LEVEL_NO_DROP = 1 << 6;
 
+namespace ETJump {
+enum class CheatCvarFlags {
+  None = 0,
+  LookYaw = 1,
+  PmoveFPS = 2,
+};
+}
+
 #endif // __BG_PUBLIC_H__

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -88,6 +88,41 @@ void WriteSessionData() {
   }
 }
 
+namespace ETJump {
+bool checkCheatCvars(gclient_s *client, bool aggressive) {
+  bool cheatCvarsEnabled = false;
+  const int clientNum = ClientNum(client);
+  std::string message =
+      "^gThe following cvars are not allowed on this server:\n"
+      "^3cl_yawspeed != 0\n"
+      "^3cl_freelook 0\n";
+
+  if (client->pers.clientFlags & CGF_CHEATCVARSON) {
+    cheatCvarsEnabled = true;
+    trap_SendServerCommand(clientNum, "cheatCvarsOff");
+  }
+
+  if (aggressive) {
+    message += "^3pmove_fixed 0 ^gwith:\n"
+               "^3com_maxfps ^g< ^325 ^gor ^3com_maxfps ^g> ^3125\n\"";
+    if ((client->pers.maxFPS > 125 || client->pers.maxFPS < 25) &&
+        !client->pers.pmoveFixed) {
+      cheatCvarsEnabled = true;
+      trap_SendServerCommand(clientNum, "cheatCvarsOffAggressive");
+    }
+  }
+
+  if (cheatCvarsEnabled) {
+    Printer::SendChatMessage(clientNum,
+                             "^gCheat cvars are not allowed on this server, "
+                             "check console for more information.\n");
+    Printer::SendConsoleMessage(clientNum, message);
+  }
+
+  return cheatCvarsEnabled;
+}
+} // namespace ETJump
+
 /*
 Changes map to a random map
 */

--- a/src/game/etj_public.h
+++ b/src/game/etj_public.h
@@ -1,4 +1,4 @@
-/*
+/*< ^325 ^gor ^3com_maxfps ^g> ^3125
  * MIT License
  *
  * Copyright (c) 2023 ETJump team <zero@etjump.com>

--- a/src/game/etj_public.h
+++ b/src/game/etj_public.h
@@ -1,4 +1,4 @@
-/*< ^325 ^gor ^3com_maxfps ^g> ^3125
+/*
  * MIT License
  *
  * Copyright (c) 2023 ETJump team <zero@etjump.com>

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1467,21 +1467,7 @@ void ClientThink_real(gentity_t *ent) {
   CheckForEvents(ent);
 
   if (g_blockCheatCvars.integer) {
-    if (client->pers.clientFlags & CGF_CHEATCVARSON ||
-        (client->pers.maxFPS > 125 && !client->pers.pmoveFixed) ||
-        (client->pers.maxFPS < 25)) {
-      const char *message = "print \"^gThe following cvar values are not "
-                            "allowed on this server:\n"
-                            "^7m_pitch:      (-0.01 <= x <= 0.01)\n"
-                            "^7cl_yawspeed:  (not 0)\n"
-                            "^7cl_freelook:  (0)\n"
-                            "^7pmove_Fixed:  (0) with "
-                            "^7com_maxFPS:   (25 < x or x > 125)\n\"";
-      CP("chat \"^3Notification: ^7cheat cvars are "
-         "disabled on this server. "
-         "Check console for more information");
-      CP(message);
-      trap_SendServerCommand(ent - g_entities, "cheatCvarsOff");
+    if (ETJump::checkCheatCvars(client, g_blockCheatCvars.integer > 1)) {
       SetTeam(ent, "s", qtrue, static_cast<weapon_t>(-1),
               static_cast<weapon_t>(-1), qfalse);
     }

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1467,7 +1467,7 @@ void ClientThink_real(gentity_t *ent) {
   CheckForEvents(ent);
 
   if (g_blockCheatCvars.integer) {
-    if (ETJump::checkCheatCvars(client, g_blockCheatCvars.integer > 1)) {
+    if (ETJump::checkCheatCvars(client, g_blockCheatCvars.integer)) {
       SetTeam(ent, "s", qtrue, static_cast<weapon_t>(-1),
               static_cast<weapon_t>(-1), qfalse);
     }

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2929,7 +2929,7 @@ enum class TimerunSpawnflags {
   NoSave = 128,
 };
 
-bool checkCheatCvars(gclient_s *client, bool aggressive);
+bool checkCheatCvars(gclient_s *client, int flags);
 } // namespace ETJump
 
 void TimerunConnectNotify(gentity_t *ent);

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2928,7 +2928,9 @@ enum class TimerunSpawnflags {
   NoPortalgunPickup = 64,
   NoSave = 128,
 };
-}
+
+bool checkCheatCvars(gclient_s *client, bool aggressive);
+} // namespace ETJump
 
 void TimerunConnectNotify(gentity_t *ent);
 


### PR DESCRIPTION
Rework `g_blockCheatCvars`.

* `m_pitch` is no longer enforced, this never made much sense and is even more useless nowadays due to most mice being capable of separate X/Y DPI
* cvar now works a a bitflag:
  * value **1** will enforce `cl_yawspeed 0` and `cl_freelook 1`
  * value **2** will enforce `com_maxfps 25 .. x .. 125` with `pmove_fixed 0`