### PR TITLE
Support autoexec_default on client

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -3967,7 +3967,13 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum,
 
   ETJump::init();
 
-  ETJump::execFile(va("autoexec_%s", cgs.rawmapname));
+  // map-specific autoexec
+  const auto mapConfig = va("autoexec_%s", cgs.rawmapname);
+  if (ETJump::configFileExists(mapConfig)) {
+    ETJump::execFile(mapConfig);
+  } else if (ETJump::configFileExists("autoexec_default")) {
+    ETJump::execFile("autoexec_default");
+  }
 
   Com_Printf("CG_Init... DONE\n");
 }

--- a/src/cgame/cg_playerstate.cpp
+++ b/src/cgame/cg_playerstate.cpp
@@ -269,8 +269,12 @@ void CG_Respawn(qboolean revived) {
   CG_ResetTransitionEffects();
 
   if (!revived && cgs.clientinfo[cg.clientNum].team != oldTeam) {
-    ETJump::execFile(va("autoexec_%s", BG_TeamnameForNumber(
-                                           cgs.clientinfo[cg.clientNum].team)));
+    const auto teamConfig = va(
+        "autoexec_%s", BG_TeamnameForNumber(cgs.clientinfo[cg.clientNum].team));
+    if (ETJump::configFileExists(teamConfig)) {
+      ETJump::execFile(teamConfig);
+    }
+
     oldTeam = cgs.clientinfo[cg.clientNum].team;
   }
 

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -183,19 +183,24 @@ bool ETJump::clearImmediate(int handle) {
 
 void ETJump::executeTimeout(int handle) { eventLoop->execute(handle); }
 
-void ETJump::execFile(const std::string &filename) {
+bool ETJump::configFileExists(const std::string &filename) {
+  bool fileExists = true;
   int len;
   fileHandle_t f;
   std::string str = filename + ".cfg";
 
   len = trap_FS_FOpenFile(str.c_str(), &f, FS_READ);
   if (!f || len < 0) {
-    return; // file not found
+    // file not found
+    fileExists = false;
   }
 
-  str = "exec \"" + str + "\"\n";
-  trap_SendConsoleCommand(str.c_str());
   trap_FS_FCloseFile(f);
+  return fileExists;
+}
+
+void ETJump::execFile(const std::string &filename) {
+  trap_SendConsoleCommand(va("exec \"%s.cfg\"\n", filename.c_str()));
 }
 
 #endif

--- a/src/cgame/etj_utilities.h
+++ b/src/cgame/etj_utilities.h
@@ -57,6 +57,9 @@ bool clearImmediate(int handle);
 
 void executeTimeout(int handle);
 
+// checks if a cfg file with given name exists, omit .cfg extension
+bool configFileExists(const std::string &filename);
+
 // executes a cfg file with given name, omit .cfg extension
 void execFile(const std::string &filename);
 


### PR DESCRIPTION
This was only supported on server side, and not client, making it rather inconvenient to use since regular `autoexec.cfg` is not executed on every map load.

refs #867 