### PR TITLE
Fireteam UI improvements + fixes

### DIFF
--- a/assets/ui/ingame_ft_savelimit.menu
+++ b/assets/ui/ingame_ft_savelimit.menu
@@ -1,0 +1,40 @@
+#include "ui/menudef.h"
+#include "ui/menudef_ext.h"
+
+// Macros //
+
+#include "ui/menumacros.h"
+#include "ui/menumacros_ext.h"
+
+// Fireteam savelimit menu //
+
+menuDef {
+	name		"ingame_ft_savelimit"
+	visible		0
+	fullscreen	0
+	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
+	style		WINDOW_STYLE_FILLED
+
+	onESC {
+		close ingame_ft_savelimit ;
+	}
+
+	onEnter	{
+		close ingame_ft_savelimit ;
+		exec ftSaveLimitSet ;
+	}
+
+// Subwindows //
+
+#define SUBWINDOW_WIDTH		224
+#define SUBWINDOW_HEIGHT	64
+#define SUBWINDOW_X			0.5 * (WINDOW_WIDTH - SUBWINDOW_WIDTH)
+#define SUBWINDOW_Y			0.5 * (WINDOW_HEIGHT - SUBWINDOW_HEIGHT)
+
+	SUBWINDOWBLACK( SUBWINDOW_X, SUBWINDOW_Y, SUBWINDOW_WIDTH, SUBWINDOW_HEIGHT, "SAVE LIMIT" )
+	CVARINTLABEL (SUBWINDOW_X - 64, SUBWINDOW_Y + 22, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_ftSavelimit", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+	SLIDER ( SUBWINDOW_X - 64, SUBWINDOW_Y + 22, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Savelimit:", 0.2, SUBW_ITEM_HEIGHT, etj_ftSavelimit -1 -1 100 1, "Fireteam save limit")
+
+	BUTTON( SUBWINDOW_X + 6, SUBWINDOW_Y + SUBWINDOW_HEIGHT - 24, 0.5 * (SUBWINDOW_WIDTH - 18), 18, "SET", .3, 14, close ingame_ft_savelimit ; exec ftSaveLimitSet )
+	BUTTON( SUBWINDOW_X + 6 + 0.5 * (SUBWINDOW_WIDTH - 18) + 6, SUBWINDOW_Y + SUBWINDOW_HEIGHT - 24, 0.5 * (SUBWINDOW_WIDTH - 18), 18, "CANCEL", .3, 14, close ingame_ft_savelimit )
+}

--- a/assets/ui/menus.txt
+++ b/assets/ui/menus.txt
@@ -78,4 +78,5 @@
 	loadMenu { "ui/etjump_controls.menu" }
 	loadMenu { "ui/etjump_credits.menu" }
 	loadMenu { "ui/ingame_map_details.menu" }
+	loadMenu { "ui/ingame_ft_savelimit.menu" }
 }

--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -1154,16 +1154,6 @@ void listSpawnPoints() {
     }
   }
 }
-
-static void ftSaveLimitSet() {
-  char buffer[MAX_CVAR_VALUE_STRING];
-  int limit;
-
-  trap_Cvar_VariableStringBuffer("etj_ftSaveLimit", buffer, sizeof(buffer));
-  limit = Q_atoi(buffer);
-
-  trap_SendConsoleCommand(va("fireteam rules savelimit %i\n", limit));
-}
 } // namespace ETJump
 
 typedef struct {
@@ -1294,8 +1284,6 @@ static const consoleCommand_t anyTimeCommands[] = {
     {"incrementVar", CG_IncrementVar_f},
     {"extraTrace", CG_ExtraTrace_f},
     {"listspawnpt", ETJump::listSpawnPoints},
-
-    {"ftSaveLimitSet", ETJump::ftSaveLimitSet},
 };
 
 /*

--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -347,31 +347,31 @@ void CG_QuickFireteamMessage_f(void) {
   }
 }
 
-void CG_QuickFireteamAdmin_f(void) {
+void CG_QuickFireteamAdmin_f() {
   trap_UI_Popup(UIMENU_NONE);
 
   if (cg.showFireteamMenu) {
-    if (cgs.ftMenuMode == 1) {
+    if (cgs.ftMenuMode == static_cast<int>(FTMenuMode::FT_MANAGE)) {
       CG_EventHandling(CGAME_EVENT_NONE, qfalse);
     } else {
-      cgs.ftMenuMode = 1;
+      cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_MANAGE);
     }
   } else {
     CG_EventHandling(CGAME_EVENT_FIRETEAMMSG, qfalse);
-    cgs.ftMenuMode = 1;
+    cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_MANAGE);
   }
 }
 
-static void CG_QuickFireteams_f(void) {
+static void CG_QuickFireteams_f() {
   if (cg.showFireteamMenu) {
-    if (cgs.ftMenuMode == 0) {
+    if (cgs.ftMenuMode == static_cast<int>(FTMenuMode::FT_VSAY)) {
       CG_EventHandling(CGAME_EVENT_NONE, qfalse);
     } else {
-      cgs.ftMenuMode = 0;
+      cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_VSAY);
     }
   } else if (CG_IsOnFireteam(cg.clientNum)) {
     CG_EventHandling(CGAME_EVENT_FIRETEAMMSG, qfalse);
-    cgs.ftMenuMode = 0;
+    cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_VSAY);
   }
 }
 
@@ -1154,6 +1154,16 @@ void listSpawnPoints() {
     }
   }
 }
+
+static void ftSaveLimitSet() {
+  char buffer[MAX_CVAR_VALUE_STRING];
+  int limit;
+
+  trap_Cvar_VariableStringBuffer("etj_ftSaveLimit", buffer, sizeof(buffer));
+  limit = Q_atoi(buffer);
+
+  trap_SendConsoleCommand(va("fireteam rules savelimit %i\n", limit));
+}
 } // namespace ETJump
 
 typedef struct {
@@ -1284,6 +1294,8 @@ static const consoleCommand_t anyTimeCommands[] = {
     {"incrementVar", CG_IncrementVar_f},
     {"extraTrace", CG_ExtraTrace_f},
     {"listspawnpt", ETJump::listSpawnPoints},
+
+    {"ftSaveLimitSet", ETJump::ftSaveLimitSet},
 };
 
 /*

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -5105,4 +5105,10 @@ void CG_DrawActive(stereoFrame_t stereoView) {
   } else {
     CG_LimboPanel_Draw();
   }
+
+  if (cg_blood.integer == 999) {
+
+    CG_Printf("\nftMenuPos: %d\nftMenuModeEx: %d\n", cgs.ftMenuPos,
+              cgs.ftMenuModeEx);
+  }
 }

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -5105,10 +5105,4 @@ void CG_DrawActive(stereoFrame_t stereoView) {
   } else {
     CG_LimboPanel_Draw();
   }
-
-  if (cg_blood.integer == 999) {
-
-    CG_Printf("\nftMenuPos: %d\nftMenuModeEx: %d\n", cgs.ftMenuPos,
-              cgs.ftMenuModeEx);
-  }
 }

--- a/src/cgame/cg_fireteamoverlay.cpp
+++ b/src/cgame/cg_fireteamoverlay.cpp
@@ -312,10 +312,12 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect) {
 
   if (saveLimit) {
     if (f->saveLimit == 0) {
+      vec4_t friendShaderColor = {1.0f, 1.0f, 1.0f, fireteamAlpha};
       ETJump::drawPic(rect->x + FT_WIDTH - 4 - 8 + fireteamOffsetX,
                       y + FT_BAR_HEIGHT - 8, 8, 8, cgs.media.saveIcon, tclr);
       ETJump::drawPic(rect->x + FT_WIDTH - 4 - 8 + fireteamOffsetX,
-                      y + FT_BAR_HEIGHT - 8, 8, 8, cgs.media.friendShader);
+                      y + FT_BAR_HEIGHT - 8, 8, 8, cgs.media.friendShader,
+                      friendShaderColor);
 
     } else {
       buffer = ETJump::stringFormat("%i", f->saveLimit);
@@ -362,11 +364,10 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect) {
       CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, tclr, "^3S", 0, 0,
                         ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
     } else {
-      vec4_t healthColor;
+      vec4_t healthColor = {0.6f, 0.6f, 0.6f, 1.0f};
       const char *healthStr;
 
       if (ci->health > 80) {
-        Vector4Copy(tclr, healthColor);
         healthStr = va("%i", ci->health);
       } else if (ci->health > 0) {
         Vector4Copy(colorYellow, healthColor);

--- a/src/cgame/cg_fireteamoverlay.cpp
+++ b/src/cgame/cg_fireteamoverlay.cpp
@@ -4,6 +4,7 @@
 
 #include "cg_local.h"
 #include "../game/etj_numeric_utilities.h"
+#include "../game/etj_string_utilities.h"
 
 /******************************************************************************
 ***** Defines, constants, etc
@@ -86,14 +87,6 @@ void CG_ParseFireteams() {
   int clnts[2];
   unsigned int tmp;
 
-  // qboolean onFireteam2;
-  // qboolean isLeader2;
-
-  //	qboolean onFireteam =	CG_IsOnFireteam( cg.clientNum ) ? qtrue
-  //:
-  // qfalse; 	qboolean isLeader =		CG_IsFireTeamLeader(
-  // cg.clientNum ) ? qtrue : qfalse;
-
   for (i = 0; i < MAX_CLIENTS; i++) {
     cgs.clientinfo[i].fireteamData = NULL;
   }
@@ -101,18 +94,6 @@ void CG_ParseFireteams() {
   for (i = 0; i < MAX_FIRETEAMS; i++) {
     char hexbuffer[11] = "0x00000000";
     p = CG_ConfigString(CS_FIRETEAMS + i);
-
-    /*		s = Info_ValueForKey(p, "n");
-            if(!s || !*s) {
-                cg.fireTeams[i].inuse = qfalse;
-                continue;
-            } else {
-                cg.fireTeams[i].inuse = qtrue;
-            }*/
-
-    //		Q_strncpyz(cg.fireTeams[i].name, s, 32);
-    //		CG_Printf("Fireteam: %s\n",
-    // cg.fireTeams[i].name);
 
     j = Q_atoi(Info_ValueForKey(p, "id"));
     if (j == -1) {
@@ -126,6 +107,9 @@ void CG_ParseFireteams() {
     s = Info_ValueForKey(p, "l");
     cg.fireTeams[i].leader = Q_atoi(s);
 
+    s = Info_ValueForKey(p, "sl");
+    cg.fireTeams[i].saveLimit = Q_atoi(s);
+
     s = Info_ValueForKey(p, "c");
     Q_strncpyz(hexbuffer + 2, s, 9);
     sscanf(hexbuffer, "%x", &tmp);
@@ -138,8 +122,6 @@ void CG_ParseFireteams() {
       if (COM_BitCheck(clnts, j)) {
         cg.fireTeams[i].joinOrder[j] = qtrue;
         cgs.clientinfo[j].fireteamData = &cg.fireTeams[i];
-        //				CG_Printf("%s\n",
-        // cgs.clientinfo[j].name);
       } else {
         cg.fireTeams[i].joinOrder[j] = qfalse;
       }
@@ -147,9 +129,6 @@ void CG_ParseFireteams() {
   }
 
   CG_SortClientFireteam();
-
-  // onFireteam2 = CG_IsOnFireteam(cg.clientNum) ? qtrue : qfalse;
-  // isLeader2   = CG_IsFireTeamLeader(cg.clientNum) ? qtrue : qfalse;
 }
 
 // Fireteam that both specified clients are on, if they both are on the same
@@ -266,16 +245,19 @@ clientInfo_t *CG_SortedFireTeamPlayerForPosition(int pos, int max) {
 ***** Main Functions
 ****/
 
-#define FT_BAR_YSPACING 2.f
-#define FT_BAR_HEIGHT 10.f
+constexpr float FT_BAR_YSPACING = 2.0f;
+constexpr float FT_BAR_HEIGHT = 10.0f;
+constexpr int FT_WIDTH = 204;
+constexpr int FT_HEADER_HEIGHT = 12;
+
 void CG_DrawFireTeamOverlay(rectDef_t *rect) {
   float x = rect->x;
   float y = rect->y + 1 +
             etj_fireteamPosY.value; // +1, jitter it into place in 1024 :)
   float h;
-  clientInfo_t *ci = nullptr;
-  char buffer[64];
-  fireteamData_t *f = nullptr;
+  clientInfo_t *ci;
+  std::string buffer;
+  fireteamData_t *f;
   int i;
   vec4_t clr1 = {.16f, .2f, .17f, .8f};
   vec4_t clr2 = {0.f, 0.f, 0.f, .2f};
@@ -284,12 +266,11 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect) {
   vec4_t bgColor = {0.0f, 0.0f, 0.0f, 0.6f};     // window
   vec4_t borderColor = {0.5f, 0.5f, 0.5f, 0.5f}; // window
 
-  float fireteamAlpha = etj_fireteamAlpha.value;
-  float fireteamOffsetX = ETJump_AdjustPosition(etj_fireteamPosX.value);
-
+  const float fireteamOffsetX = ETJump_AdjustPosition(etj_fireteamPosX.value);
   x += fireteamOffsetX;
 
-  fireteamAlpha = Numeric::clamp(fireteamAlpha, 0.0f, 1.0f);
+  const float fireteamAlpha =
+      Numeric::clamp(etj_fireteamAlpha.value, 0.0f, 1.0f);
 
   clr1[3] *= fireteamAlpha;
   clr2[3] *= fireteamAlpha;
@@ -304,10 +285,11 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect) {
     return;
   }
 
-  h = 12 + 2 + 2;
-  // Changed i < 6 to i < 15, should allow 15 ppl to FT now.
-  for (i = 0; i < 15; i++) {
-    ci = CG_SortedFireTeamPlayerForPosition(i, 15);
+  const bool saveLimit = f->saveLimit != FT_SAVELIMIT_NOT_SET;
+  h = FT_HEADER_HEIGHT + 2 + 2;
+
+  for (i = 0; i < MAX_FIRETEAM_USERS; i++) {
+    ci = CG_SortedFireTeamPlayerForPosition(i, MAX_FIRETEAM_USERS);
     if (!ci) {
       break;
     }
@@ -315,90 +297,95 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect) {
     h += FT_BAR_HEIGHT + FT_BAR_YSPACING;
   }
 
-  CG_DrawRect(x, y, 204, h, 1, borderColor);
-  CG_FillRect(x + 1, y + 1, 204 - 2, h - 2, bgColor);
+  CG_DrawRect(x, y, FT_WIDTH, h, 1, borderColor);
+  CG_FillRect(x + 1, y + 1, FT_WIDTH - 2, h - 2, bgColor);
 
   x += 2;
   y += 2;
 
-  CG_FillRect(x, y, 204 - 4, 12, clr1);
+  CG_FillRect(x, y, FT_WIDTH - 4, FT_HEADER_HEIGHT, clr1);
 
-  sprintf(buffer, "Fireteam: %s", bg_fireteamNames[f->ident]);
-  Q_strupr(buffer);
+  buffer = ETJump::StringUtil::toUpperCase(
+      ETJump::stringFormat("Fireteam: %s", bg_fireteamNames[f->ident]));
   CG_Text_Paint_Ext(x + 3, y + FT_BAR_HEIGHT, .19f, .19f, tclr, buffer, 0, 0, 0,
                     &cgs.media.limboFont1);
 
+  if (saveLimit) {
+    if (f->saveLimit == 0) {
+      ETJump::drawPic(rect->x + FT_WIDTH - 4 - 8 + fireteamOffsetX,
+                      y + FT_BAR_HEIGHT - 8, 8, 8, cgs.media.saveIcon, tclr);
+      ETJump::drawPic(rect->x + FT_WIDTH - 4 - 8 + fireteamOffsetX,
+                      y + FT_BAR_HEIGHT - 8, 8, 8, cgs.media.friendShader);
+
+    } else {
+      buffer = ETJump::stringFormat("%i", f->saveLimit);
+      auto textW = static_cast<float>(
+          CG_Text_Width_Ext(buffer, 0.19f, 0, &cgs.media.limboFont1));
+      CG_Text_Paint_RightAligned_Ext(
+          rect->x + FT_WIDTH - 4 + fireteamOffsetX, y + FT_BAR_HEIGHT, .19f,
+          .19f, tclr, va("%i", f->saveLimit), 0, 0, 0, &cgs.media.limboFont1);
+      ETJump::drawPic(rect->x + FT_WIDTH - 4 - textW - 12 + fireteamOffsetX,
+                      y + FT_BAR_HEIGHT - 8, 8, 8, cgs.media.saveIcon, tclr);
+    }
+  }
+
   x += 2;
 
-  for (i = 0; i < 15; i++) {
+  for (i = 0; i < MAX_FIRETEAM_USERS; i++) {
     y += FT_BAR_HEIGHT + FT_BAR_YSPACING;
     x = rect->x + 2 + fireteamOffsetX;
 
-    ci = CG_SortedFireTeamPlayerForPosition(i, 15);
+    ci = CG_SortedFireTeamPlayerForPosition(i, MAX_FIRETEAM_USERS);
     if (!ci) {
       break;
     }
 
     if (ci->selected) {
-      CG_FillRect(x, y + FT_BAR_YSPACING, 204 - 4, FT_BAR_HEIGHT, clr3);
+      CG_FillRect(x, y + FT_BAR_YSPACING, FT_WIDTH - 4, FT_BAR_HEIGHT, clr3);
     } else {
-      CG_FillRect(x, y + FT_BAR_YSPACING, 204 - 4, FT_BAR_HEIGHT, clr2);
+      CG_FillRect(x, y + FT_BAR_YSPACING, FT_WIDTH - 4, FT_BAR_HEIGHT, clr2);
     }
 
     x += 4;
 
-    CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, tclr,
-                      BG_ClassLetterForNumber(ci->cls), 0, 0,
-                      ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
-    x += 10;
+    CG_Text_Paint_Ext(
+        x, y + FT_BAR_HEIGHT, .2f, .2f, tclr,
+        ci->team != TEAM_SPECTATOR ? BG_ClassLetterForNumber(ci->cls) : "", 0,
+        0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
+    x += 12;
 
-    CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, tclr,
-                      ci->team == TEAM_AXIS ? miniRankNames_Axis[ci->rank]
-                                            : miniRankNames_Allies[ci->rank],
-                      0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
-    x += 22;
-
-    CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, tclr, ci->name, 0, 17,
+    CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, tclr, ci->name, 0, 25,
                       ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
-    x += 110;
+    x += 176;
 
     if (ci->team == TEAM_SPECTATOR) {
       CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, tclr, "^3S", 0, 0,
                         ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
     } else {
+      vec4_t healthColor;
+      const char *healthStr;
 
       if (ci->health > 80) {
-        CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, tclr,
-                          va("%i", ci->health), 0, 0, ITEM_TEXTSTYLE_SHADOWED,
-                          &cgs.media.limboFont2);
+        Vector4Copy(tclr, healthColor);
+        healthStr = va("%i", ci->health);
       } else if (ci->health > 0) {
-        CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, colorYellow,
-                          va("%i", ci->health), 0, 0, ITEM_TEXTSTYLE_SHADOWED,
-                          &cgs.media.limboFont2);
+        Vector4Copy(colorYellow, healthColor);
+        healthStr = va("%i", ci->health);
       } else {
-        CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, colorRed,
-                          va("%i", ci->health < 0 ? 0 : ci->health), 0, 0,
-                          ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
+        Vector4Copy(colorRed, healthColor);
+        healthStr = va("%i", ci->health < 0 ? 0 : ci->health);
       }
-    }
-    {
-      vec2_t loc;
-      char *s;
 
-      loc[0] = static_cast<float>(ci->location[0]);
-      loc[1] = static_cast<float>(ci->location[1]);
-
-      s = va("^3(%s)", BG_GetLocationString(loc));
+      healthColor[3] *= fireteamAlpha;
 
       x = rect->x +
-          (204 - 4 -
+          (FT_WIDTH - 4 -
            static_cast<float>(
-               CG_Text_Width_Ext(s, .2f, 0, &cgs.media.limboFont2))) +
+               CG_Text_Width_Ext(healthStr, .2f, 0, &cgs.media.limboFont2))) +
           fireteamOffsetX;
 
-      CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, tclr,
-                        va("^3(%s)", BG_GetLocationString(loc)), 0, 0,
-                        ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
+      CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, healthColor, healthStr,
+                        0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
     }
   }
 }

--- a/src/cgame/cg_fireteams.cpp
+++ b/src/cgame/cg_fireteams.cpp
@@ -170,50 +170,62 @@ const char **ftMenuStringsMsg[] = {
 };
 
 void CG_Fireteams_MenuTitleText_Draw(panel_button_t *button) {
-  switch (cgs.ftMenuMode) {
-    case 0:
-      CG_Text_Paint_Ext(button->rect.x, button->rect.y + button->data[0],
-                        button->font->scalex, button->font->scaley,
-                        button->font->colour, "MESSAGE", 0, 0,
-                        button->font->style, button->font->font);
+  switch (static_cast<FTMenuMode>(cgs.ftMenuMode)) {
+    case FTMenuMode::FT_VSAY:
+      CG_Text_Paint_Ext(
+          button->rect.x, button->rect.y + static_cast<float>(button->data[0]),
+          button->font->scalex, button->font->scaley, button->font->colour,
+          "MESSAGE", 0, 0, button->font->style, button->font->font);
       break;
-    case 1:
-      CG_Text_Paint_Ext(button->rect.x, button->rect.y + button->data[0],
-                        button->font->scalex, button->font->scaley,
-                        button->font->colour, "FIRETEAMS", 0, 0,
-                        button->font->style, button->font->font);
+    case FTMenuMode::FT_MANAGE:
+      CG_Text_Paint_Ext(
+          button->rect.x, button->rect.y + static_cast<float>(button->data[0]),
+          button->font->scalex, button->font->scaley, button->font->colour,
+          "FIRETEAMS", 0, 0, button->font->style, button->font->font);
       break;
-    case 2:
-      CG_Text_Paint_Ext(button->rect.x, button->rect.y + button->data[0],
-                        button->font->scalex, button->font->scaley,
-                        button->font->colour, "JOIN", 0, 0, button->font->style,
-                        button->font->font);
+    case FTMenuMode::FT_APPLY:
+      CG_Text_Paint_Ext(
+          button->rect.x, button->rect.y + static_cast<float>(button->data[0]),
+          button->font->scalex, button->font->scaley, button->font->colour,
+          "JOIN", 0, 0, button->font->style, button->font->font);
       break;
-    case 3:
-      CG_Text_Paint_Ext(button->rect.x, button->rect.y + button->data[0],
-                        button->font->scalex, button->font->scaley,
-                        button->font->colour, "PROPOSE", 0, 0,
-                        button->font->style, button->font->font);
+    case FTMenuMode::FT_PROPOSE:
+      CG_Text_Paint_Ext(
+          button->rect.x, button->rect.y + static_cast<float>(button->data[0]),
+          button->font->scalex, button->font->scaley, button->font->colour,
+          "PROPOSE", 0, 0, button->font->style, button->font->font);
       break;
-    case 4:
-      switch (cgs.ftMenuPos) {
-        case 2:
-          CG_Text_Paint_Ext(button->rect.x, button->rect.y + button->data[0],
-                            button->font->scalex, button->font->scaley,
-                            button->font->colour, "INVITE", 0, 0,
-                            button->font->style, button->font->font);
+    case FTMenuMode::FT_ADMIN:
+      switch (static_cast<FTMenuPos>(cgs.ftMenuPos)) {
+        case FTMenuPos::FT_MENUPOS_INVITE:
+          CG_Text_Paint_Ext(
+              button->rect.x,
+              button->rect.y + static_cast<float>(button->data[0]),
+              button->font->scalex, button->font->scaley, button->font->colour,
+              "INVITE", 0, 0, button->font->style, button->font->font);
           break;
-        case 3:
-          CG_Text_Paint_Ext(button->rect.x, button->rect.y + button->data[0],
-                            button->font->scalex, button->font->scaley,
-                            button->font->colour, "KICK", 0, 0,
-                            button->font->style, button->font->font);
+        case FTMenuPos::FT_MENUPOS_KICK:
+          CG_Text_Paint_Ext(
+              button->rect.x,
+              button->rect.y + static_cast<float>(button->data[0]),
+              button->font->scalex, button->font->scaley, button->font->colour,
+              "KICK", 0, 0, button->font->style, button->font->font);
           break;
-        case 4:
-          CG_Text_Paint_Ext(button->rect.x, button->rect.y + button->data[0],
-                            button->font->scalex, button->font->scaley,
-                            button->font->colour, "WARN", 0, 0,
-                            button->font->style, button->font->font);
+        case FTMenuPos::FT_MENUPOS_WARN:
+          CG_Text_Paint_Ext(
+              button->rect.x,
+              button->rect.y + static_cast<float>(button->data[0]),
+              button->font->scalex, button->font->scaley, button->font->colour,
+              "WARN", 0, 0, button->font->style, button->font->font);
+          break;
+        case FTMenuPos::FT_MENUPOS_RULES:
+          CG_Text_Paint_Ext(
+              button->rect.x,
+              button->rect.y + static_cast<float>(button->data[0]),
+              button->font->scalex, button->font->scaley, button->font->colour,
+              "RULES", 0, 0, button->font->style, button->font->font);
+          break;
+        default:
           break;
       }
   }
@@ -222,33 +234,45 @@ void CG_Fireteams_MenuTitleText_Draw(panel_button_t *button) {
 const char *ftOffMenuList[] = {
     "Apply",
     "Create",
-    NULL,
+    nullptr,
 };
 
 const char *ftOffMenuListAlphachars[] = {
     "A",
     "C",
-    NULL,
+    nullptr,
 };
 
 const char *ftOnMenuList[] = {
     "Propose",
     "Leave",
-    NULL,
+    nullptr,
 };
 
 const char *ftOnMenuListAlphachars[] = {
     "P",
     "L",
-    NULL,
+    nullptr,
+};
+
+const char *ftOnMenuRulesList[] = {
+    "Reset",
+    "Savelimit",
+    nullptr,
+};
+
+const char *ftOnMenuRulesListAlphaChars[] = {
+    "R",
+    "S",
+    nullptr,
 };
 
 const char *ftLeaderMenuList[] = {
-    "Disband", "Leave", "Invite", "Kick", "Warn", NULL,
+    "Disband", "Leave", "Invite", "Kick", "Warn", "Rules", nullptr,
 };
 
 const char *ftLeaderMenuListAlphachars[] = {
-    "D", "L", "I", "K", "W", NULL,
+    "D", "L", "I", "K", "W", "R", nullptr,
 };
 
 int CG_CountFireteamsByTeam(team_t t) {
@@ -520,13 +544,33 @@ void CG_DrawPlayerNF(panel_button_t *button, int *pageofs) {
   }
 }
 
+void CG_DrawFireteamRules(panel_button_t *button) {
+  float y = button->rect.y;
+  const char *str;
+  int i;
+
+  for (i = 0; ftOnMenuRulesList[i]; i++) {
+    if (cg_quickMessageAlt.integer) {
+      str = va("%i. %s", (i + 1) % 10, ftOnMenuRulesList[i]);
+    } else {
+      str = va("%s. %s", ftOnMenuRulesListAlphaChars[i], ftOnMenuRulesList[i]);
+    }
+
+    CG_Text_Paint_Ext(button->rect.x, y, button->font->scalex,
+                      button->font->scaley, button->font->colour, str, 0, 0,
+                      button->font->style, button->font->font);
+
+    y += button->rect.h;
+  }
+}
+
 void CG_Fireteams_MenuText_Draw(panel_button_t *button) {
   float y = button->rect.y;
   int i;
 
-  switch (cgs.ftMenuMode) {
-    case 0:
-      if (cgs.ftMenuPos == -1) {
+  switch (static_cast<FTMenuMode>(cgs.ftMenuMode)) {
+    case FTMenuMode::FT_VSAY:
+      if (cgs.ftMenuPos == static_cast<int>(FTMenuPos::FT_MENUPOS_NONE)) {
         for (i = 0; ftMenuRootStrings[i]; i++) {
           const char *str;
 
@@ -550,7 +594,8 @@ void CG_Fireteams_MenuText_Draw(panel_button_t *button) {
           y += button->rect.h;
         }
       } else {
-        if (cgs.ftMenuPos < 0 || cgs.ftMenuPos > 4) {
+        // FT_MENUPOS_NONE or out of enum range
+        if (cgs.ftMenuPos < 0 || cgs.ftMenuPos > 5) {
           return;
         } else {
           const char **strings = ftMenuStrings[cgs.ftMenuPos];
@@ -559,13 +604,10 @@ void CG_Fireteams_MenuText_Draw(panel_button_t *button) {
             const char *str;
 
             if (cg_quickMessageAlt.integer) {
-              str = va("%i. "
-                       "%s",
-                       (i + 1) % 10, strings[i]);
+              str = va("%i. %s", (i + 1) % 10, strings[i]);
             } else {
-              str = va("%s. "
-                       "%s",
-                       (ftMenuStringsAlphachars[cgs.ftMenuPos])[i], strings[i]);
+              str = va("%s. %s", (ftMenuStringsAlphachars[cgs.ftMenuPos])[i],
+                       strings[i]);
             }
 
             CG_Text_Paint_Ext(button->rect.x, y, button->font->scalex,
@@ -577,7 +619,7 @@ void CG_Fireteams_MenuText_Draw(panel_button_t *button) {
         }
       }
       break;
-    case 1:
+    case FTMenuMode::FT_MANAGE:
       if (!CG_IsOnFireteam(cg.clientNum)) {
         for (i = 0; ftOffMenuList[i]; i++) {
           const char *str;
@@ -609,13 +651,9 @@ void CG_Fireteams_MenuText_Draw(panel_button_t *button) {
             }
 
             if (cg_quickMessageAlt.integer) {
-              str = va("%i. "
-                       "%s",
-                       (i + 1) % 10, ftOnMenuList[i]);
+              str = va("%i. %s", (i + 1) % 10, ftOnMenuList[i]);
             } else {
-              str = va("%s. "
-                       "%s",
-                       ftOnMenuListAlphachars[i], ftOnMenuList[i]);
+              str = va("%s. %s", ftOnMenuListAlphachars[i], ftOnMenuList[i]);
             }
 
             CG_Text_Paint_Ext(button->rect.x, y, button->font->scalex,
@@ -637,13 +675,10 @@ void CG_Fireteams_MenuText_Draw(panel_button_t *button) {
             }
 
             if (cg_quickMessageAlt.integer) {
-              str = va("%i. "
-                       "%s",
-                       (i + 1) % 10, ftLeaderMenuList[i]);
+              str = va("%i. %s", (i + 1) % 10, ftLeaderMenuList[i]);
             } else {
-              str = va("%s. "
-                       "%s",
-                       ftLeaderMenuListAlphachars[i], ftLeaderMenuList[i]);
+              str = va("%s. %s", ftLeaderMenuListAlphachars[i],
+                       ftLeaderMenuList[i]);
             }
 
             CG_Text_Paint_Ext(button->rect.x, y, button->font->scalex,
@@ -656,43 +691,48 @@ void CG_Fireteams_MenuText_Draw(panel_button_t *button) {
       }
       break;
 
-    case 2:
+    case FTMenuMode::FT_APPLY:
       if (!CG_CountFireteamsByTeam(cgs.clientinfo[cg.clientNum].team) ||
           CG_IsOnFireteam(cg.clientNum)) {
-        cgs.ftMenuMode = 1;
+        cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_MANAGE);
         break;
       }
 
       CG_DrawFireteamsByTeam(button, cgs.clientinfo[cg.clientNum].team);
       break;
 
-    case 3:
+    case FTMenuMode::FT_PROPOSE:
       if (!CG_CountPlayersNF()) {
-        cgs.ftMenuMode = 1;
+        cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_MANAGE);
         break;
       }
 
       CG_DrawPlayerNF(button, &cgs.ftMenuModeEx);
       break;
 
-    case 4:
-      switch (cgs.ftMenuPos) {
-        case 2:
+    case FTMenuMode::FT_ADMIN:
+      switch (static_cast<FTMenuPos>(cgs.ftMenuPos)) {
+        case FTMenuPos::FT_MENUPOS_INVITE:
           if (!CG_CountPlayersNF()) {
-            cgs.ftMenuMode = 1;
+            cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_MANAGE);
             break;
           }
 
           CG_DrawPlayerNF(button, &cgs.ftMenuModeEx);
           break;
-        case 3:
-        case 4:
+        case FTMenuPos::FT_MENUPOS_KICK:
+        case FTMenuPos::FT_MENUPOS_WARN:
           if (!CG_CountPlayersSF()) {
-            cgs.ftMenuMode = 1;
+            cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_MANAGE);
             break;
           }
 
           CG_DrawPlayerSF(button, &cgs.ftMenuModeEx);
+          break;
+        case FTMenuPos::FT_MENUPOS_RULES:
+          CG_DrawFireteamRules(button);
+          break;
+        default:
           break;
       }
       break;
@@ -732,9 +772,9 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
 
   key &= ~K_CHAR_FLAG;
 
-  switch (cgs.ftMenuMode) {
-    case 0:
-      if (cgs.ftMenuPos == -1) {
+  switch (static_cast<FTMenuMode>(cgs.ftMenuMode)) {
+    case FTMenuMode::FT_VSAY:
+      if (cgs.ftMenuPos == static_cast<int>(FTMenuPos::FT_MENUPOS_NONE)) {
         if (cg_quickMessageAlt.integer) {
           if (key >= '0' && key <= '9') {
             int i = ((key - '0') + 9) % 10;
@@ -767,34 +807,33 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
         } else {
           int i;
 
-          if (key >= 'a' || key <= 'z') {
-            for (i = 0; ftMenuRootStrings[i]; i++) {
-              if (key == tolower(*ftMenuRootStringsAlphachars[i])) {
-                if (i < 5) {
-                  if (!CG_FireteamHasClass(i, qtrue)) {
-                    return qfalse;
-                  }
+          for (i = 0; ftMenuRootStrings[i]; i++) {
+            if (key == tolower(*ftMenuRootStringsAlphachars[i])) {
+              if (i < 5) {
+                if (!CG_FireteamHasClass(i, qtrue)) {
+                  return qfalse;
                 }
-
-                if (doaction) {
-                  if (i < 5) {
-                    cgs.ftMenuPos = i;
-                  } else if (i == 5) {
-                    CG_QuickFireteamMessage_f();
-                  } else {
-                    trap_SendClientCommand(va("vsay_buddy -1 %s %s",
-                                              CG_BuildSelectedFirteamString(),
-                                              ftMenuRootStringsMsg[i]));
-                    CG_EventHandling(CGAME_EVENT_NONE, qfalse);
-                  }
-                }
-                return qtrue;
               }
+
+              if (doaction) {
+                if (i < 5) {
+                  cgs.ftMenuPos = i;
+                } else if (i == 5) {
+                  CG_QuickFireteamMessage_f();
+                } else {
+                  trap_SendClientCommand(va("vsay_buddy -1 %s %s",
+                                            CG_BuildSelectedFirteamString(),
+                                            ftMenuRootStringsMsg[i]));
+                  CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+                }
+              }
+              return qtrue;
             }
           }
         }
       } else {
-        if (cgs.ftMenuPos < 0 || cgs.ftMenuPos > 4) {
+        // FT_MENUPOS_NONE or out of enum range
+        if (cgs.ftMenuPos < 0 || cgs.ftMenuPos > 5) {
           return qfalse;
         }
 
@@ -823,26 +862,24 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
           int i;
           const char **strings = ftMenuStrings[cgs.ftMenuPos];
 
-          if (key >= 'a' || key <= 'z') {
-            for (i = 0; strings[i]; i++) {
-              if (key == tolower(*ftMenuStringsAlphachars[cgs.ftMenuPos][i])) {
+          for (i = 0; strings[i]; i++) {
+            if (key == tolower(*ftMenuStringsAlphachars[cgs.ftMenuPos][i])) {
 
-                if (doaction) {
+              if (doaction) {
 
-                  trap_SendClientCommand(
-                      va("vsay_buddy %i %s %s", cgs.ftMenuPos,
-                         CG_BuildSelectedFirteamString(),
-                         (ftMenuStringsMsg[cgs.ftMenuPos])[i]));
-                  CG_EventHandling(CGAME_EVENT_NONE, qfalse);
-                }
-                return qtrue;
+                trap_SendClientCommand(
+                    va("vsay_buddy %i %s %s", cgs.ftMenuPos,
+                       CG_BuildSelectedFirteamString(),
+                       (ftMenuStringsMsg[cgs.ftMenuPos])[i]));
+                CG_EventHandling(CGAME_EVENT_NONE, qfalse);
               }
+              return qtrue;
             }
           }
         }
       }
       break;
-    case 1: {
+    case FTMenuMode::FT_MANAGE: {
       int i = -1, x;
 
       if (cg_quickMessageAlt.integer) {
@@ -862,12 +899,10 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
           }
         }
 
-        if (key >= 'a' || key <= 'z') {
-          for (x = 0; strings[x]; x++) {
-            if (key == tolower(*strings[x])) {
-              i = x;
-              break;
-            }
+        for (x = 0; strings[x]; x++) {
+          if (key == tolower(*strings[x])) {
+            i = x;
+            break;
           }
         }
       }
@@ -891,7 +926,7 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
             trap_SendConsoleCommand("fireteam create\n");
             CG_EventHandling(CGAME_EVENT_NONE, qfalse);
           } else {
-            cgs.ftMenuMode = 2;
+            cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_APPLY);
             cgs.ftMenuModeEx = 0;
             cgs.ftMenuPos = i;
           }
@@ -913,7 +948,7 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
               trap_SendConsoleCommand("fireteam leave\n");
               CG_EventHandling(CGAME_EVENT_NONE, qfalse);
             } else {
-              cgs.ftMenuMode = 3;
+              cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_PROPOSE);
               cgs.ftMenuModeEx = 0;
               cgs.ftMenuPos = i;
             }
@@ -921,7 +956,7 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
 
           return qtrue;
         } else {
-          if (i >= 5) {
+          if (i >= 6) {
             break;
           }
 
@@ -941,7 +976,7 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
               trap_SendConsoleCommand("fireteam leave\n");
               CG_EventHandling(CGAME_EVENT_NONE, qfalse);
             } else {
-              cgs.ftMenuMode = 4;
+              cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_ADMIN);
               cgs.ftMenuModeEx = 0;
               cgs.ftMenuPos = i;
             }
@@ -951,7 +986,7 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
         }
       }
     } break;
-    case 2: {
+    case FTMenuMode::FT_APPLY: {
       int i;
 
       for (i = 0; i < MAX_FIRETEAMS; i++) {
@@ -970,19 +1005,17 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
             }
           }
         } else {
-          if (key >= 'a' || key <= 'z') {
-            if (key - 'a' == cg.fireTeams[i].ident) {
-              if (doaction) {
-                trap_SendConsoleCommand(va("fireteam apply %i\n", i + 1));
-                CG_EventHandling(CGAME_EVENT_NONE, qfalse);
-              }
-              return qtrue;
+          if (key - 'a' == cg.fireTeams[i].ident) {
+            if (doaction) {
+              trap_SendConsoleCommand(va("fireteam apply %i\n", i + 1));
+              CG_EventHandling(CGAME_EVENT_NONE, qfalse);
             }
+            return qtrue;
           }
         }
       }
     } break;
-    case 3: {
+    case FTMenuMode::FT_PROPOSE: {
       int i = -1, x;
 
       if (cg_quickMessageAlt.integer) {
@@ -990,9 +1023,7 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
           i = ((key - '0') + 9) % 10;
         }
       } else {
-        if (key >= 'a' || key <= 'g') {
-          i = key - 'a';
-        }
+        i = key - 'a';
 
         if (key == 'n') {
           i = 9;
@@ -1027,8 +1058,8 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
         return qtrue;
       }
       break;
-    } break;
-    case 4: {
+    }
+    case FTMenuMode::FT_ADMIN: {
       int i = -1, x;
 
       if (cg_quickMessageAlt.integer) {
@@ -1036,9 +1067,7 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
           i = ((key - '0') + 9) % 10;
         }
       } else {
-        if (key >= 'a' || key <= 'g') {
-          i = key - 'a';
-        }
+        i = key - 'a';
 
         if (key == 'n') {
           i = 9;
@@ -1053,8 +1082,8 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
         break;
       }
 
-      switch (cgs.ftMenuPos) {
-        case 2:
+      switch (static_cast<FTMenuPos>(cgs.ftMenuPos)) {
+        case FTMenuPos::FT_MENUPOS_INVITE:
           if (CG_CountPlayersNF() > (cgs.ftMenuModeEx + 1) * 8) {
             if (i == 9) {
               if (doaction) {
@@ -1083,8 +1112,8 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
             return qtrue;
           }
           break;
-        case 3:
-        case 4:
+        case FTMenuPos::FT_MENUPOS_KICK:
+        case FTMenuPos::FT_MENUPOS_WARN:
           if (CG_CountPlayersSF() > (cgs.ftMenuModeEx + 1) * 8) {
             if (i == 0) {
               cgs.ftMenuModeEx++;
@@ -1098,20 +1127,36 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
           x = CG_PlayerSFFromPos(i, &cgs.ftMenuModeEx);
           if (x != -1) {
             if (doaction) {
-              switch (cgs.ftMenuPos) {
-                case 4:
+              switch (static_cast<FTMenuPos>(cgs.ftMenuPos)) {
+                case FTMenuPos::FT_MENUPOS_KICK:
+                  trap_SendConsoleCommand(va("fireteam kick %i\n", x));
+                  CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+                  break;
+                case FTMenuPos::FT_MENUPOS_WARN:
                   trap_SendConsoleCommand(va("fireteam warn %i\n", x));
                   CG_EventHandling(CGAME_EVENT_NONE, qfalse);
                   break;
-                case 3:
-                  trap_SendConsoleCommand(va("fireteam kick %i\n", x));
-                  CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+                default:
                   break;
               }
             }
 
             return qtrue;
           }
+          break;
+        case FTMenuPos::FT_MENUPOS_RULES:
+          if (doaction) {
+            if (i == 0) {
+              trap_SendConsoleCommand("fireteam rules savelimit reset\n");
+              CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+            } else if (i == 1) {
+              trap_UI_Popup(UIMENU_INGAME_FT_SAVELIMIT);
+              CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+            }
+          }
+
+          return qtrue;
+        default:
           break;
       }
     } break;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1842,7 +1842,6 @@ typedef struct {
   qhandle_t simplePlayersShader;
   qhandle_t saveIcon;
   qhandle_t proneIcon;
-  qhandle_t forbidIcon;
   qhandle_t stopwatchIcon;
   qhandle_t stopwatchIconGreen;
   qhandle_t stopwatchIconRed;
@@ -2154,6 +2153,23 @@ struct range_t {
   bool split;
 };
 // End CGaz 5
+
+enum class FTMenuMode {
+  FT_VSAY = 0,
+  FT_MANAGE = 1, // create, leave, disband
+  FT_APPLY = 2,
+  FT_PROPOSE = 3,
+  FT_ADMIN = 4
+};
+
+// sub-pages of fireteam menus
+enum class FTMenuPos {
+  FT_MENUPOS_NONE = -1,
+  FT_MENUPOS_INVITE = 2,
+  FT_MENUPOS_KICK = 3,
+  FT_MENUPOS_WARN = 4,
+  FT_MENUPOS_RULES = 5
+};
 
 //==============================================================================
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -624,6 +624,8 @@ vmCvar_t etj_crosshairScaleY;
 vmCvar_t etj_crosshairThickness;
 vmCvar_t etj_crosshairOutline;
 
+vmCvar_t etj_ftSavelimit;
+
 typedef struct {
   vmCvar_t *vmCvar;
   const char *cvarName;
@@ -1144,6 +1146,10 @@ cvarTable_t cvarTable[] = {
     {&etj_crosshairScaleY, "etj_crosshairScaleY", "1.0", CVAR_ARCHIVE},
     {&etj_crosshairThickness, "etj_crosshairThickness", "1.0", CVAR_ARCHIVE},
     {&etj_crosshairOutline, "etj_crosshairOutline", "1", CVAR_ARCHIVE},
+
+    // fireteam savelimit - added here to retain value it's set to
+    // upon re-opening the fireteam savelimit menu
+    {&etj_ftSavelimit, "etj_ftSavelimit", "-1", CVAR_TEMP},
 };
 
 int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);

--- a/src/cgame/cg_newDraw.cpp
+++ b/src/cgame/cg_newDraw.cpp
@@ -738,8 +738,8 @@ void CG_EventHandling(int type, qboolean fForced) {
     CG_LimboPanel_Setup();
     trap_Key_SetCatcher(KEYCATCH_CGAME);
   } else if (type == CGAME_EVENT_FIRETEAMMSG) {
-    cgs.ftMenuPos = -1;
-    cgs.ftMenuMode = 0;
+    cgs.ftMenuPos = static_cast<int>(FTMenuPos::FT_MENUPOS_NONE);
+    cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_VSAY);
     cg.showFireteamMenu = qtrue;
     trap_Cvar_Set("cl_bypassmouseinput", "1");
     trap_Key_SetCatcher(KEYCATCH_CGAME);

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -534,6 +534,17 @@ qboolean CG_ConsoleCommandExt(const char *cmd) {
       return qtrue;
     }
   }
+
+  if (command == "ftSaveLimitSet") {
+    char buffer[MAX_CVAR_VALUE_STRING];
+    int limit;
+
+    trap_Cvar_VariableStringBuffer("etj_ftSaveLimit", buffer, sizeof(buffer));
+    limit = Q_atoi(buffer);
+
+    trap_SendConsoleCommand(va("fireteam rules savelimit %i\n", limit));
+    return qtrue;
+  }
   return qfalse;
 }
 

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -381,6 +381,7 @@ extern const unsigned int aReinfSeeds[MAX_REINFSEEDS];
 
 #define MAX_FIRETEAMS 12
 #define MAX_FIRETEAM_USERS 15
+constexpr int FT_SAVELIMIT_NOT_SET = -1;
 
 extern const char *bg_fireteamNames[MAX_FIRETEAMS];
 
@@ -2481,6 +2482,9 @@ typedef enum {
 
   // ydnar: say, team say, etc
   UIMENU_INGAME_MESSAGEMODE,
+
+  // fireteam savelimit input box
+  UIMENU_INGAME_FT_SAVELIMIT,
 } uiMenuCommand_t;
 
 void BG_AdjustAAGunMuzzleForBarrel(vec_t *origin, vec_t *forward, vec_t *right,

--- a/src/game/etj_save_system.cpp
+++ b/src/game/etj_save_system.cpp
@@ -164,8 +164,7 @@ void ETJump::SaveSystem::save(gentity_t *ent) {
     } else {
       if (client->pers.race.isRacing) {
         if (client->pers.race.saveLimit == 0) {
-          CPTo(ent, "^7You've used all "
-                    "your saves.");
+          CPTo(ent, "^7You've used all your saves.");
           return;
         }
 
@@ -174,26 +173,14 @@ void ETJump::SaveSystem::save(gentity_t *ent) {
         }
       } else {
         fireteamData_t *ft;
-        if (G_IsOnFireteam(ent - g_entities, &ft)) {
-          if (ft->saveLimit < 0) {
-            client->sess.saveLimitFt = 0;
-          }
-          if (ft->saveLimit) {
+        if (G_IsOnFireteam(ClientNum(ent), &ft)) {
+          if (ft->saveLimit == FT_SAVELIMIT_NOT_SET) {
+            client->sess.saveLimitFt = FT_SAVELIMIT_NOT_SET;
+          } else {
             if (client->sess.saveLimitFt) {
               client->sess.saveLimitFt--;
             } else {
-              CPTo(ent, "^7Yo"
-                        "u'"
-                        "ve "
-                        "used"
-                        " all"
-                        " you"
-                        "r "
-                        "fire"
-                        "team"
-                        " sav"
-                        "es"
-                        ".");
+              CPTo(ent, "^7You've used all your fireteam saves.");
               return;
             }
           }

--- a/src/game/g_session.cpp
+++ b/src/game/g_session.cpp
@@ -307,7 +307,7 @@ G_InitWorldSession
 
 ==================
 */
-void G_InitWorldSession(void) {
+void G_InitWorldSession() {
   char s[MAX_STRING_CHARS];
   int gt;
   int i, j;
@@ -339,13 +339,12 @@ void G_InitWorldSession(void) {
     // See if we need to clear player stats
     // FIXME: deal with the multi-map missions
     if (g_gametype.integer != GT_WOLF_CAMPAIGN) {
-      if ((tmp = strchr(va("%s", tmp), ' ')) != NULL) {
+      if ((tmp = strchr(va("%s", tmp), ' ')) != nullptr) {
         tmp++;
         trap_GetServerinfo(s, sizeof(s));
         if (Q_stricmp(tmp, Info_ValueForKey(s, "mapname"))) {
           level.fResetStats = qtrue;
-          G_Printf("Map changed, clearing "
-                   "player stats.\n");
+          G_Printf("Map changed, clearing player stats.\n");
         }
       }
     }
@@ -355,16 +354,6 @@ void G_InitWorldSession(void) {
     char *p, *c;
 
     trap_Cvar_VariableStringBuffer(va("fireteam%i", i), s, sizeof(s));
-
-    /*		p = Info_ValueForKey( s, "n" );
-
-            if(p && *p) {
-                Q_strncpyz( level.fireTeams[i].name, p, 32 );
-                level.fireTeams[i].inuse = qtrue;
-            } else {
-                *level.fireTeams[i].name = '\0';
-                level.fireTeams[i].inuse = qfalse;
-            }*/
 
     p = Info_ValueForKey(s, "id");
     j = Q_atoi(p);
@@ -399,6 +388,10 @@ void G_InitWorldSession(void) {
     for (; j < MAX_CLIENTS; j++) {
       level.fireTeams[i].joinOrder[j] = -1;
     }
+
+    // fireteam savelimit should not linger around from previous map
+    level.fireTeams[i].saveLimit = FT_SAVELIMIT_NOT_SET;
+
     G_UpdateFireteamConfigString(&level.fireTeams[i]);
   }
 }

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -8464,6 +8464,11 @@ void _UI_SetActiveMenu(uiMenuCommand_t menu) {
         Menus_OpenByName("ingame_messagemode");
         return;
 
+      case UIMENU_INGAME_FT_SAVELIMIT:
+        trap_Key_SetCatcher(KEYCATCH_UI);
+        Menus_OpenByName("ingame_ft_savelimit");
+        return;
+
       default:
         return; // TTimo: a lot of not handled
     }


### PR DESCRIPTION
Various improvements and fixes to FT UI.

![image](https://github.com/etjump/etjump/assets/14221121/f7656c67-3dc3-4f7e-a7b9-edc6482561e5)

* Removed ranks and locations
* Spectators are no longer drawn as having soldier as class
* Health colors now respect `etj_fireteamAlpha`
* New fireteam admin menu addition to set rules

![image](https://github.com/etjump/etjump/assets/14221121/623a8c24-bd7d-4acc-bfea-8d5730814335) ![image](https://github.com/etjump/etjump/assets/14221121/5d5017c3-878e-4b88-9f8f-022d6f8e1e43)

* Selecting savelimit will now open up a slider which allows the savelimit to be adjusted

![image](https://github.com/etjump/etjump/assets/14221121/85dc2803-66d5-4b34-a8ba-fcca5b271d5e)

* Savelimited fireteam is now indicated with an icon, and any rule changes are notified to all fireteam members

![image](https://github.com/etjump/etjump/assets/14221121/5b315546-ec66-4dcf-93a7-1a11c2785e3c) ![image](https://github.com/etjump/etjump/assets/14221121/7f389cf9-0615-4624-91ff-8cbb32ba56ee)
![image](https://github.com/etjump/etjump/assets/14221121/96ba7bae-e5e1-4da6-9e6f-9492912bec2e)

Other fixes:
* Fireteam savelimit is now correctly set to fireteam configstrings, and configstrings are updated whenever required
* Fireteam savelimit no longer carries on from previous map
* Changed savelimit `-1` to be unlimited saves and `0` to be nosave, as opposed to before, makes more sense
* Cleaned up fireteam drawing and key handling code up a bit

fixes #819