### PR TITLE
Fix checkpoint timer breaking on vid_restart

### DIFF
--- a/src/cgame/etj_timerun.h
+++ b/src/cgame/etj_timerun.h
@@ -40,7 +40,7 @@ class Start;
 class Checkpoint;
 class Interrupt;
 class Stop;
-}
+} // namespace TimerunCommands
 
 class PlayerEventsHandler;
 
@@ -68,8 +68,7 @@ public:
 
   explicit Timerun(int clientNum,
                    std::shared_ptr<PlayerEventsHandler> playerEventsHandler)
-    : _clientNum(clientNum), _playerEventsHandler(playerEventsHandler) {
-  }
+      : _clientNum(clientNum), _playerEventsHandler(playerEventsHandler) {}
 
   void onStop(const TimerunCommands::Stop *stop);
   void onInterrupt(const TimerunCommands::Interrupt *interrupt);
@@ -80,17 +79,18 @@ public:
   void onCompletion(const TimerunCommands::Completion *completion);
   void parseServerCommand(const std::vector<std::string> &args);
   const PlayerTimerunInformation *getTimerunInformationFor(int clientNum);
+  static int getNumCheckpointsHit(
+      const std::array<int, MAX_TIMERUN_CHECKPOINTS> currentRunCheckpoints);
 
 private:
   int _clientNum;
 
-  std::string createCompletionMessage(
-      const clientInfo_t &player,
-      const std::string &runName,
-      int completionTime,
-      ETJump::opt<int> previousTime);
+  std::string createCompletionMessage(const clientInfo_t &player,
+                                      const std::string &runName,
+                                      int completionTime,
+                                      ETJump::opt<int> previousTime);
 
   std::array<PlayerTimerunInformation, MAX_CLIENTS> _playersTimerunInformation;
   std::shared_ptr<PlayerEventsHandler> _playerEventsHandler;
 };
-}
+} // namespace ETJump

--- a/src/game/etj_timerun_shared.h
+++ b/src/game/etj_timerun_shared.h
@@ -45,13 +45,15 @@ public:
   Start();
   Start(int clientNum, int startTime, const std::string &runName,
         const opt<int> &previousRecord,
-        std::array<int, MAX_TIMERUN_CHECKPOINTS> checkpoints);
+        std::array<int, MAX_TIMERUN_CHECKPOINTS> checkpoints,
+        std::array<int, MAX_TIMERUN_CHECKPOINTS> currentRunCheckpoints);
 
   int clientNum{};
   int startTime{};
   std::string runName{};
   opt<int> previousRecord{};
   std::array<int, MAX_TIMERUN_CHECKPOINTS> checkpoints{};
+  std::array<int, MAX_TIMERUN_CHECKPOINTS> currentRunCheckpoints{};
 
   std::string serialize();
 
@@ -64,11 +66,8 @@ public:
 
   Checkpoint(int clientNum, int checkpointIndex, int checkpointTime,
              const std::string &runName)
-    : clientNum(clientNum),
-      checkpointIndex(checkpointIndex),
-      checkpointTime(checkpointTime),
-      runName(runName) {
-  }
+      : clientNum(clientNum), checkpointIndex(checkpointIndex),
+        checkpointTime(checkpointTime), runName(runName) {}
 
   int clientNum{};
   int checkpointIndex{};
@@ -84,9 +83,7 @@ class Interrupt {
 public:
   Interrupt() = default;
 
-  explicit Interrupt(int clientNum)
-    : clientNum(clientNum) {
-  }
+  explicit Interrupt(int clientNum) : clientNum(clientNum) {}
 
   int clientNum{};
 
@@ -100,12 +97,9 @@ public:
   Completion() = default;
 
   Completion(int clientNum, int completionTime, opt<int> previousRecordTime,
-         const std::string &runName)
-    : clientNum(clientNum),
-      completionTime(completionTime),
-      previousRecordTime(previousRecordTime),
-      runName(runName) {
-  }
+             const std::string &runName)
+      : clientNum(clientNum), completionTime(completionTime),
+        previousRecordTime(previousRecordTime), runName(runName) {}
 
   int clientNum{};
   int completionTime{};
@@ -123,11 +117,8 @@ public:
 
   Record(int clientNum, int completionTime, opt<int> previousRecordTime,
          const std::string &runName)
-    : clientNum(clientNum),
-      completionTime(completionTime),
-      previousRecordTime(previousRecordTime),
-      runName(runName) {
-  }
+      : clientNum(clientNum), completionTime(completionTime),
+        previousRecordTime(previousRecordTime), runName(runName) {}
 
   int clientNum{};
   int completionTime{};
@@ -144,10 +135,7 @@ public:
   Stop() = default;
 
   Stop(int clientNum, int time, const std::string &runName)
-    : clientNum(clientNum),
-      completionTime(time),
-      runName(runName) {
-  }
+      : clientNum(clientNum), completionTime(time), runName(runName) {}
 
   int clientNum{};
   int completionTime{};

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -464,10 +464,11 @@ void ETJump::TimerunV2::connectNotify(int clientNum) {
       }
 
       Printer::SendCommand(
-          clientNum, TimerunCommands::Start(idx, player->startTime.value(),
-                                            player->activeRunName,
-                                            fastestCompletionTime, checkpoints)
-                         .serialize());
+          clientNum,
+          TimerunCommands::Start(idx, player->startTime.value(),
+                                 player->activeRunName, fastestCompletionTime,
+                                 checkpoints, player->checkpointTimes)
+              .serialize());
     }
   }
 }
@@ -877,7 +878,7 @@ void ETJump::TimerunV2::startNotify(Player *player) {
   Printer::SendCommandToAll(
       TimerunCommands::Start(player->clientNum, player->startTime.value(),
                              player->activeRunName, fastestCompletionTime,
-                             checkpoints)
+                             checkpoints, player->checkpointTimes)
           .serialize());
 }
 

--- a/tests/timerun_shared_tests.cpp
+++ b/tests/timerun_shared_tests.cpp
@@ -25,7 +25,7 @@ TEST_F(TimerunSharedTests, Start_ShouldSerialize) {
   ASSERT_EQ(
       start.serialize(),
       "timerun start 1 2 \"3\" 4 \"1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1\" "
-      "\"-1,2,3,4,5,6,7,8,9,10,-1,-1,-1,-1,-1,-1\"");
+      "\"1,2,3,4,5,6,7,8,9,10,-1,-1,-1,-1,-1,-1\"");
 }
 
 TEST_F(TimerunSharedTests, Start_ShouldDeserialize) {

--- a/tests/timerun_shared_tests.cpp
+++ b/tests/timerun_shared_tests.cpp
@@ -5,28 +5,39 @@ using namespace ETJump;
 
 class TimerunSharedTests : public testing::Test {
 public:
-  void SetUp() override {
-  }
+  void SetUp() override {}
 
-  void TearDown() override {
-  }
+  void TearDown() override {}
 
   std::array<int, MAX_TIMERUN_CHECKPOINTS> CreateDefaultCheckpoints() {
     return {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, -1, -1};
   }
+
+  std::array<int, MAX_TIMERUN_CHECKPOINTS> CreateDefaultCurrentCheckpoints() {
+    return {-1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, -1, -1};
+  }
 };
 
 TEST_F(TimerunSharedTests, Start_ShouldSerialize) {
-  auto start = TimerunCommands::Start(1, 2, "3", 4, CreateDefaultCheckpoints());
+  auto start = TimerunCommands::Start(1, 2, "3", 4, CreateDefaultCheckpoints(),
+                                      CreateDefaultCurrentCheckpoints());
 
-  ASSERT_EQ(start.serialize(),
-            "timerun start 1 2 \"3\" 4 \"1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1\"");
+  ASSERT_EQ(
+      start.serialize(),
+      "timerun start 1 2 \"3\" 4 \"1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1\" "
+      "\"-1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1\"");
 }
 
 TEST_F(TimerunSharedTests, Start_ShouldDeserialize) {
   auto args =
-      std::vector<std::string>{"timerun", "start", "1", "2", "3", "4",
-                               "1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1"};
+      std::vector<std::string>{"timerun",
+                               "start",
+                               "1",
+                               "2",
+                               "3",
+                               "4",
+                               "1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1",
+                               "-1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1"};
   auto deserialized = TimerunCommands::Start::deserialize(args);
 
   ASSERT_EQ(deserialized.value().clientNum, 1);
@@ -34,24 +45,34 @@ TEST_F(TimerunSharedTests, Start_ShouldDeserialize) {
   ASSERT_EQ(deserialized.value().runName, "3");
   ASSERT_EQ(deserialized.value().previousRecord.value(), 4);
   ASSERT_EQ(deserialized.value().checkpoints[10], 11);
+  ASSERT_EQ(deserialized.value().currentRunCheckpoints[0], -1);
 }
 
 TEST_F(TimerunSharedTests, Start_ShouldSerialize_IfNoPreviousRecord) {
-  auto start = TimerunCommands::Start(1, 2, "3", opt<int>(),
-                                      CreateDefaultCheckpoints());
+  auto start =
+      TimerunCommands::Start(1, 2, "3", opt<int>(), CreateDefaultCheckpoints(),
+                             CreateDefaultCurrentCheckpoints());
 
-  ASSERT_EQ(start.serialize(),
-            "timerun start 1 2 \"3\" -1 \"1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1\"");
+  ASSERT_EQ(
+      start.serialize(),
+      "timerun start 1 2 \"3\" -1 \"1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1\" "
+      "\"-1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1\"");
 }
 
 TEST_F(TimerunSharedTests, Start_ShouldDeserialize_IfNoPreviousRecord) {
-  auto args = std::vector<std::string>{"timerun", "start", "1", "2", "3", "-1",
-                                       "1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1"};
+  auto args =
+      std::vector<std::string>{"timerun",
+                               "start",
+                               "1",
+                               "2",
+                               "3",
+                               "-1",
+                               "1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1",
+                               "-1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1"};
   auto deserialized = TimerunCommands::Start::deserialize(args);
 
   ASSERT_FALSE(deserialized.value().previousRecord.hasValue());
 }
-
 
 TEST_F(TimerunSharedTests, Checkpoint_ShouldSerialize) {
   auto checkpoint = TimerunCommands::Checkpoint(1, 2, 3, "4");
@@ -100,7 +121,8 @@ TEST_F(TimerunSharedTests, Record_ShouldSerialize) {
 }
 
 TEST_F(TimerunSharedTests, Record_ShouldDeserialize) {
-  auto args = std::vector<std::string>{"timerun", "record", "1", "2", "3", "run"};
+  auto args =
+      std::vector<std::string>{"timerun", "record", "1", "2", "3", "run"};
   auto record = TimerunCommands::Record::deserialize(args);
 
   ASSERT_EQ(record.value().clientNum, 1);
@@ -116,7 +138,8 @@ TEST_F(TimerunSharedTests, Completion_ShouldSerialize) {
 }
 
 TEST_F(TimerunSharedTests, Completion_ShouldDeserialize) {
-  auto args = std::vector<std::string>{"timerun", "completion", "1", "2", "3", "run"};
+  auto args =
+      std::vector<std::string>{"timerun", "completion", "1", "2", "3", "run"};
   auto interrupt = TimerunCommands::Completion::deserialize(args);
 
   ASSERT_EQ(interrupt.value().clientNum, 1);

--- a/tests/timerun_shared_tests.cpp
+++ b/tests/timerun_shared_tests.cpp
@@ -14,7 +14,7 @@ public:
   }
 
   std::array<int, MAX_TIMERUN_CHECKPOINTS> CreateDefaultCurrentCheckpoints() {
-    return {-1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, -1, -1};
+    return {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, -1, -1, -1, -1, -1, -1};
   }
 };
 
@@ -25,7 +25,7 @@ TEST_F(TimerunSharedTests, Start_ShouldSerialize) {
   ASSERT_EQ(
       start.serialize(),
       "timerun start 1 2 \"3\" 4 \"1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1\" "
-      "\"-1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1\"");
+      "\"-1,2,3,4,5,6,7,8,9,10,-1,-1,-1,-1,-1,-1\"");
 }
 
 TEST_F(TimerunSharedTests, Start_ShouldDeserialize) {
@@ -37,7 +37,7 @@ TEST_F(TimerunSharedTests, Start_ShouldDeserialize) {
                                "3",
                                "4",
                                "1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1",
-                               "-1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1"};
+                               "1,2,3,4,5,6,7,8,9,10,-1,-1,-1,-1,-1,-1"};
   auto deserialized = TimerunCommands::Start::deserialize(args);
 
   ASSERT_EQ(deserialized.value().clientNum, 1);
@@ -45,7 +45,7 @@ TEST_F(TimerunSharedTests, Start_ShouldDeserialize) {
   ASSERT_EQ(deserialized.value().runName, "3");
   ASSERT_EQ(deserialized.value().previousRecord.value(), 4);
   ASSERT_EQ(deserialized.value().checkpoints[10], 11);
-  ASSERT_EQ(deserialized.value().currentRunCheckpoints[0], -1);
+  ASSERT_EQ(deserialized.value().currentRunCheckpoints[10], -1);
 }
 
 TEST_F(TimerunSharedTests, Start_ShouldSerialize_IfNoPreviousRecord) {
@@ -56,7 +56,7 @@ TEST_F(TimerunSharedTests, Start_ShouldSerialize_IfNoPreviousRecord) {
   ASSERT_EQ(
       start.serialize(),
       "timerun start 1 2 \"3\" -1 \"1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1\" "
-      "\"-1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1\"");
+      "\"1,2,3,4,5,6,7,8,9,10,-1,-1,-1,-1,-1,-1\"");
 }
 
 TEST_F(TimerunSharedTests, Start_ShouldDeserialize_IfNoPreviousRecord) {
@@ -68,7 +68,7 @@ TEST_F(TimerunSharedTests, Start_ShouldDeserialize_IfNoPreviousRecord) {
                                "3",
                                "-1",
                                "1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1",
-                               "-1,2,3,4,5,6,7,8,9,10,11,12,13,14,-1,-1"};
+                               "1,2,3,4,5,6,7,8,9,10,-1,-1,-1,-1,-1,-1"};
   auto deserialized = TimerunCommands::Start::deserialize(args);
 
   ASSERT_FALSE(deserialized.value().previousRecord.hasValue());
@@ -117,7 +117,7 @@ TEST_F(TimerunSharedTests, Interrupt_ShouldDeserialize) {
 TEST_F(TimerunSharedTests, Record_ShouldSerialize) {
   auto record = TimerunCommands::Record(1, 2, 3, "run");
 
-  ASSERT_EQ(record.serialize(), "timerun record 1 2 3 \"run\"");
+  ASSERT_EQ(record.serialize(), "timerun record 1 2 3 \"run\"")
 }
 
 TEST_F(TimerunSharedTests, Record_ShouldDeserialize) {

--- a/tests/timerun_shared_tests.cpp
+++ b/tests/timerun_shared_tests.cpp
@@ -117,7 +117,7 @@ TEST_F(TimerunSharedTests, Interrupt_ShouldDeserialize) {
 TEST_F(TimerunSharedTests, Record_ShouldSerialize) {
   auto record = TimerunCommands::Record(1, 2, 3, "run");
 
-  ASSERT_EQ(record.serialize(), "timerun record 1 2 3 \"run\"")
+  ASSERT_EQ(record.serialize(), "timerun record 1 2 3 \"run\"");
 }
 
 TEST_F(TimerunSharedTests, Record_ShouldDeserialize) {


### PR DESCRIPTION
Send current checkpoint times alongside timerun start, so client can restore checkpoint timer after `vid_restart`.

refs #995 