### PR TITLE
Add etj_noPanzerAutoswitch to disable autoswitch after firing panzer

### DIFF
--- a/assets/ui/etjump_settings_1.menu
+++ b/assets/ui/etjump_settings_1.menu
@@ -6,7 +6,7 @@
 // Left side menus
 #define SUBW_GENERAL_Y SUBW_Y
 #define SUBW_GENERAL_ITEM_Y SUBW_GENERAL_Y + SUBW_HEADER_HEIGHT
-#define SUBW_GENERAL_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 20)
+#define SUBW_GENERAL_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 21)
 
 #define SUBW_PLAYERS_Y SUBW_GENERAL_Y + SUBW_GENERAL_HEIGHT + SUBW_SPACING_Y
 #define SUBW_PLAYERS_ITEM_Y SUBW_PLAYERS_Y + SUBW_HEADER_HEIGHT
@@ -68,6 +68,7 @@ menuDef {
         YESNO               (SUBW_ITEM_LEFT_X, SUBW_GENERAL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 19), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Optimized Prediction:", 0.2, SUBW_ITEM_HEIGHT, "etj_optimizePrediction", "Enable optimized playerstate prediction\netj_optimizePrediction")
         CVARFLOATLABEL      (SUBW_ITEM_LEFT_X, SUBW_GENERAL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 20), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_menuSensitivity", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
         SLIDER              (SUBW_ITEM_LEFT_X, SUBW_GENERAL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 20), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Menu sensitivity:", 0.2, SUBW_ITEM_HEIGHT, etj_menuSensitivity 1.0 0.05 4.0 0.05, "Sets mouse sensitivity for menus\netj_menuSensitivity")
+        YESNO               (SUBW_ITEM_LEFT_X, SUBW_GENERAL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 21), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "No panzer autoswitch:", 0.2, SUBW_ITEM_HEIGHT, "etj_noPanzerAutoswitch", "Toggle automatic weapon switching after firing a panzerfaust\netj_noPanzerAutoswitch")
 
     SUBWINDOW(SUBW_RECT_LEFT_X, SUBW_PLAYERS_Y, SUBW_WIDTH, SUBW_PLAYERS_HEIGHT, "PLAYERS")
         YESNO               (SUBW_ITEM_LEFT_X, SUBW_PLAYERS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Hide players:", 0.2, SUBW_ITEM_HEIGHT, "etj_hide", "Hides other players when they are too close\netj_hide")

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2717,6 +2717,8 @@ extern vmCvar_t etj_crosshairScaleY;
 extern vmCvar_t etj_crosshairThickness;
 extern vmCvar_t etj_crosshairOutline;
 
+extern vmCvar_t etj_noPanzerAutoswitch;
+
 //
 // cg_main.c
 //

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -626,6 +626,8 @@ vmCvar_t etj_crosshairOutline;
 
 vmCvar_t etj_ftSavelimit;
 
+vmCvar_t etj_noPanzerAutoswitch;
+
 typedef struct {
   vmCvar_t *vmCvar;
   const char *cvarName;
@@ -1150,6 +1152,8 @@ cvarTable_t cvarTable[] = {
     // fireteam savelimit - added here to retain value it's set to
     // upon re-opening the fireteam savelimit menu
     {&etj_ftSavelimit, "etj_ftSavelimit", "-1", CVAR_TEMP},
+
+    {&etj_noPanzerAutoswitch, "etj_noPanzerAutoswitch", "0", CVAR_ARCHIVE},
 };
 
 int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);
@@ -1227,7 +1231,8 @@ void CG_UpdateCvars(void) {
             cv->vmCvar == &etj_noActivateLean ||
             cv->vmCvar == &etj_touchPickupWeapons ||
             cv->vmCvar == &etj_autoLoad || cv->vmCvar == &etj_quickFollow ||
-            cv->vmCvar == &etj_drawSnapHUD) {
+            cv->vmCvar == &etj_drawSnapHUD ||
+            cv->vmCvar == &etj_noPanzerAutoswitch) {
           fSetFlags = qtrue;
         } else if (cv->vmCvar == &cg_rconPassword && *cg_rconPassword.string) {
           trap_SendConsoleCommand(va("rconAuth %s\n", cg_rconPassword.string));
@@ -1288,7 +1293,8 @@ void CG_setClientFlags(void) {
           ((etj_noActivateLean.integer > 0) ? CGF_NOACTIVATELEAN : 0) |
           ((etj_autoLoad.integer > 0) ? CGF_AUTO_LOAD : 0) |
           ((etj_quickFollow.integer > 0) ? CGF_QUICK_FOLLOW : 0) |
-          ((etj_drawSnapHUD.integer > 0) ? CGF_SNAPHUD : 0)
+          ((etj_drawSnapHUD.integer > 0) ? CGF_SNAPHUD : 0) |
+          ((etj_noPanzerAutoswitch.integer > 0) ? CGF_NOPANZERSWITCH : 0)
           // Add more in here, as needed
           ),
 

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -1231,6 +1231,7 @@ void CG_PredictPlayerState() {
 
     // ETJump: client side no activate lean
     cg_pmove.noActivateLean = etj_noActivateLean.integer ? qtrue : qfalse;
+    cg_pmove.noPanzerAutoswitch = etj_noPanzerAutoswitch.integer;
 
     // grab data, we only want the final result
     // rain - copy the pmext as it was just before we

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -4785,7 +4785,7 @@ void CG_OutOfAmmoChange(qboolean allowforceswitch) {
 
     // JPW NERVE -- early out if we just fired Panzerfaust, go
     // to pistola, then grenades
-    if (cg.weaponSelect == WP_PANZERFAUST) {
+    if (cg.weaponSelect == WP_PANZERFAUST && !etj_noPanzerAutoswitch.integer) {
       for (i = 0; i < MAX_WEAPS_IN_BANK_MP; i++) {
         if (CG_WeaponSelectable(weapBanksMultiPlayer[2][i])) // find a pistol
         {

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -4789,7 +4789,8 @@ static void PM_Weapon(void) {
 
   // JPW NERVE -- in multiplayer, pfaust fires once then switches to
   // pistol since it's useless for a while
-  if ((pm->ps->weapon == WP_PANZERFAUST) ||
+  if ((pm->ps->weapon == WP_PANZERFAUST &&
+       (!pm->noPanzerAutoswitch || pm->ps->ammoclip[WP_PANZERFAUST] == 0)) ||
       (pm->ps->weapon == WP_SMOKE_MARKER) || (pm->ps->weapon == WP_DYNAMITE) ||
       (pm->ps->weapon == WP_SMOKE_BOMB) || (pm->ps->weapon == WP_LANDMINE) ||
       (pm->ps->weapon == WP_SATCHEL)) {

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -370,6 +370,7 @@ extern const unsigned int aReinfSeeds[MAX_REINFSEEDS];
 #define CGF_AUTO_LOAD 0x800
 #define CGF_QUICK_FOLLOW 0x1000
 #define CGF_SNAPHUD 0x2000
+#define CGF_NOPANZERSWITCH 0x4000
 
 #define MAX_MOTDLINES 6
 
@@ -682,6 +683,7 @@ typedef struct {
   int shared;
   // ETJump: enable/disable strafe + activate = lean
   qboolean noActivateLean;
+  bool noPanzerAutoswitch;
 
   qboolean walking;
   qboolean groundPlane;

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -481,6 +481,7 @@ void SpectatorThink(gentity_t *ent, usercmd_t *ucmd) {
     pm.trace = trap_TraceCapsuleNoEnts;
     pm.pointcontents = trap_PointContents;
     pm.noActivateLean = client->pers.noActivateLean;
+    pm.noPanzerAutoswitch = client->pers.noPanzerAutoswitch;
 
 #ifdef SAVEGAME_SUPPORT
     if (g_gametype.integer == GT_SINGLE_PLAYER && g_reloading.integer) {
@@ -1171,6 +1172,7 @@ void ClientThink_real(gentity_t *ent) {
   pm.pmove_msec = pmove_msec.integer;
   pm.shared = shared.integer;
   pm.noActivateLean = client->pers.noActivateLean;
+  pm.noPanzerAutoswitch = client->pers.noPanzerAutoswitch;
 
   pm.noWeapClips = qfalse;
 

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -1895,8 +1895,9 @@ void ClientUserinfoChanged(int clientNum) {
       (client->pers.clientFlags & CGF_AUTO_LOAD) != 0 ? qtrue : qfalse;
   client->pers.quickFollow =
       (client->pers.clientFlags & CGF_QUICK_FOLLOW) != 0 ? qtrue : qfalse;
-  client->pers.snaphud =
-      (client->pers.clientFlags & CGF_SNAPHUD) != 0 ? qtrue : qfalse;
+  client->pers.snaphud = (client->pers.clientFlags & CGF_SNAPHUD) != 0;
+  client->pers.noPanzerAutoswitch =
+      (client->pers.clientFlags & CGF_NOPANZERSWITCH) != 0;
 
   // set name
   Q_strncpyz(oldname, client->pers.netname, sizeof(oldname));

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -869,6 +869,7 @@ typedef struct {
   qboolean autoLoad;
   qboolean quickFollow;
   bool snaphud;
+  bool noPanzerAutoswitch;
 
   unsigned int maxFPS;
   char netname[MAX_NETNAME];


### PR DESCRIPTION
When enabled, player won't automatically swap away from panzerfaust after firing, unless completely out of ammo. Allows for much nicer gameplay experience in those few instances where panzerfaust is actually used, as we don't have charge times anyway that would justify the autoswitch.