### PR TITLE
Fix array out of bounds read in fireteam menus

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -368,10 +368,12 @@ static void CG_QuickFireteams_f() {
       CG_EventHandling(CGAME_EVENT_NONE, qfalse);
     } else {
       cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_VSAY);
+      cgs.ftMenuPos = static_cast<int>(FTMenuPos::FT_MENUPOS_NONE);
     }
   } else if (CG_IsOnFireteam(cg.clientNum)) {
     CG_EventHandling(CGAME_EVENT_FIRETEAMMSG, qfalse);
     cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_VSAY);
+    cgs.ftMenuPos = static_cast<int>(FTMenuPos::FT_MENUPOS_NONE);
   }
 }
 

--- a/src/cgame/cg_fireteamoverlay.cpp
+++ b/src/cgame/cg_fireteamoverlay.cpp
@@ -533,15 +533,15 @@ qboolean CG_FireteamHasClass(int classnum, qboolean selectedonly) {
   return qfalse;
 }
 
-const char *CG_BuildSelectedFirteamString(void) {
+const char *CG_BuildSelectedFirteamString() {
   char buffer[256];
   clientInfo_t *ci;
   int cnt = 0;
   int i;
 
   *buffer = '\0';
-  for (i = 0; i < 6; i++) {
-    ci = CG_SortedFireTeamPlayerForPosition(i, 6);
+  for (i = 0; i < MAX_FIRETEAM_USERS; i++) {
+    ci = CG_SortedFireTeamPlayerForPosition(i, MAX_FIRETEAM_USERS);
     if (!ci) {
       break;
     }

--- a/src/cgame/cg_fireteamoverlay.cpp
+++ b/src/cgame/cg_fireteamoverlay.cpp
@@ -3,6 +3,7 @@
 ****/
 
 #include "cg_local.h"
+#include "etj_utilities.h"
 #include "../game/etj_numeric_utilities.h"
 #include "../game/etj_string_utilities.h"
 
@@ -503,6 +504,12 @@ qboolean CG_FireteamHasClass(int classnum, qboolean selectedonly) {
 
   ft = CG_IsOnFireteam(cg.clientNum);
   if (!ft) {
+    return qfalse;
+  }
+
+  // spectators are soldiers, but doesn't make much sense
+  // to let them access class-specifc vsay strings
+  if (!ETJump::isPlaying(cg.clientNum)) {
     return qfalse;
   }
 

--- a/src/cgame/cg_fireteams.cpp
+++ b/src/cgame/cg_fireteams.cpp
@@ -602,8 +602,8 @@ void CG_Fireteams_MenuText_Draw(panel_button_t *button) {
         }
 
         // sanity check, cls should be valid but let's make sure
-        int idx = Numeric::clamp(cgs.clientinfo[cg.clientNum].cls, 0,
-                                 NUM_PLAYER_CLASSES - 1);
+        const int idx = Numeric::clamp(cgs.clientinfo[cg.clientNum].cls, 0,
+                                       NUM_PLAYER_CLASSES - 1);
         const char **strings = ftMenuStrings[idx];
 
         for (i = 0; strings[i]; i++) {
@@ -844,8 +844,8 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
         }
 
         // sanity check, cls should be valid but let's make sure
-        int idx = Numeric::clamp(cgs.clientinfo[cg.clientNum].cls, 0,
-                                 NUM_PLAYER_CLASSES - 1);
+        const int idx = Numeric::clamp(cgs.clientinfo[cg.clientNum].cls, 0,
+                                       NUM_PLAYER_CLASSES - 1);
 
         if (cg_quickMessageAlt.integer) {
           if (key >= '0' && key <= '9') {

--- a/src/cgame/cg_fireteams.cpp
+++ b/src/cgame/cg_fireteams.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 
 #include "cg_local.h"
+#include "etj_utilities.h"
 #include "../game/etj_numeric_utilities.h"
 
 panel_button_text_t fireteamTitleFont = {
@@ -575,7 +576,7 @@ void CG_Fireteams_MenuText_Draw(panel_button_t *button) {
         for (i = 0; ftMenuRootStrings[i]; i++) {
           const char *str;
 
-          if (i < 5) {
+          if (i < NUM_PLAYER_CLASSES) {
             if (!CG_FireteamHasClass(i, qtrue)) {
               continue;
             }
@@ -595,40 +596,30 @@ void CG_Fireteams_MenuText_Draw(panel_button_t *button) {
           y += button->rect.h;
         }
       } else {
-        // FT_MENUPOS_NONE or out of enum range
-        if (cgs.ftMenuPos < 0 || cgs.ftMenuPos > 5) {
+        // spectators don't get class-specific vsays
+        if (!ETJump::isPlaying(cg.clientNum)) {
           return;
-        } else {
-          int ftMenuStringsIdx = cgs.ftMenuPos;
-          int ftMenuStringsAlphacharsIdx = cgs.ftMenuPos;
-          ftMenuStringsIdx = Numeric::clamp(
-              ftMenuStringsIdx, 0,
-              (sizeof(ftMenuStrings) / sizeof(ftMenuStrings[0]) - 1));
-          ftMenuStringsAlphacharsIdx =
-              Numeric::clamp(ftMenuStringsAlphacharsIdx, 0,
-                             (sizeof(ftMenuStringsAlphachars) /
-                              sizeof(ftMenuStringsAlphachars[0])) -
-                                 1);
+        }
 
-          const char **strings = ftMenuStrings[ftMenuStringsIdx];
+        // sanity check, cls should be valid but let's make sure
+        int idx = Numeric::clamp(cgs.clientinfo[cg.clientNum].cls, 0,
+                                 NUM_PLAYER_CLASSES - 1);
+        const char **strings = ftMenuStrings[idx];
 
-          for (i = 0; strings[i]; i++) {
-            const char *str;
+        for (i = 0; strings[i]; i++) {
+          const char *str;
 
-            if (cg_quickMessageAlt.integer) {
-              str = va("%i. %s", (i + 1) % 10, strings[i]);
-            } else {
-              str = va("%s. %s",
-                       (ftMenuStringsAlphachars[ftMenuStringsAlphacharsIdx])[i],
-                       strings[i]);
-            }
-
-            CG_Text_Paint_Ext(button->rect.x, y, button->font->scalex,
-                              button->font->scaley, button->font->colour, str,
-                              0, 0, button->font->style, button->font->font);
-
-            y += button->rect.h;
+          if (cg_quickMessageAlt.integer) {
+            str = va("%i. %s", (i + 1) % 10, strings[i]);
+          } else {
+            str = va("%s. %s", (ftMenuStringsAlphachars[idx])[i], strings[i]);
           }
+
+          CG_Text_Paint_Ext(button->rect.x, y, button->font->scalex,
+                            button->font->scaley, button->font->colour, str, 0,
+                            0, button->font->style, button->font->font);
+
+          y += button->rect.h;
         }
       }
       break;
@@ -792,7 +783,7 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
           if (key >= '0' && key <= '9') {
             int i = ((key - '0') + 9) % 10;
 
-            if (i < 5) {
+            if (i < NUM_PLAYER_CLASSES) {
               if (!CG_FireteamHasClass(i, qtrue)) {
                 return qfalse;
               }
@@ -803,7 +794,8 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
             }
 
             if (doaction) {
-              if (i < 5) {
+              // class-specific vsays
+              if (i < NUM_PLAYER_CLASSES) {
                 cgs.ftMenuPos = i;
               } else if (i == 5) {
                 CG_QuickFireteamMessage_f();
@@ -822,14 +814,15 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
 
           for (i = 0; ftMenuRootStrings[i]; i++) {
             if (key == tolower(*ftMenuRootStringsAlphachars[i])) {
-              if (i < 5) {
+              if (i < NUM_PLAYER_CLASSES) {
                 if (!CG_FireteamHasClass(i, qtrue)) {
                   return qfalse;
                 }
               }
 
               if (doaction) {
-                if (i < 5) {
+                // class-specifc vsays
+                if (i < NUM_PLAYER_CLASSES) {
                   cgs.ftMenuPos = i;
                 } else if (i == 5) {
                   CG_QuickFireteamMessage_f();
@@ -845,34 +838,29 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
           }
         }
       } else {
-        // FT_MENUPOS_NONE or out of enum range
-        if (cgs.ftMenuPos < 0 || cgs.ftMenuPos > 5) {
+        // spectators don't get class-specific vsays
+        if (!ETJump::isPlaying(cg.clientNum)) {
           return qfalse;
         }
 
-        int ftMenuStringsIdx = cgs.ftMenuPos;
-        int ftMenuStringsMsgIdx = cgs.ftMenuPos;
-        ftMenuStringsIdx = Numeric::clamp(
-            ftMenuStringsIdx, 0,
-            (sizeof(ftMenuStrings) / sizeof(ftMenuStrings[0]) - 1));
-        ftMenuStringsMsgIdx = Numeric::clamp(
-            ftMenuStringsMsgIdx, 0,
-            (sizeof(ftMenuStringsMsg) / sizeof(ftMenuStringsMsg[0]) - 1));
+        // sanity check, cls should be valid but let's make sure
+        int idx = Numeric::clamp(cgs.clientinfo[cg.clientNum].cls, 0,
+                                 NUM_PLAYER_CLASSES - 1);
 
         if (cg_quickMessageAlt.integer) {
           if (key >= '0' && key <= '9') {
             int i = ((key - '0') + 9) % 10;
             int x;
 
-            const char **strings = ftMenuStrings[ftMenuStringsIdx];
+            const char **strings = ftMenuStrings[idx];
 
             for (x = 0; strings[x]; x++) {
               if (x == i) {
                 if (doaction) {
-                  trap_SendClientCommand(
-                      va("vsay_buddy %i %s %s", cgs.ftMenuPos,
-                         CG_BuildSelectedFirteamString(),
-                         (ftMenuStringsMsg[ftMenuStringsMsgIdx])[i]));
+                  trap_SendClientCommand(va("vsay_buddy %i %s %s",
+                                            cgs.ftMenuPos,
+                                            CG_BuildSelectedFirteamString(),
+                                            (ftMenuStringsMsg[idx])[i]));
                   CG_EventHandling(CGAME_EVENT_NONE, qfalse);
                 }
 
@@ -882,26 +870,16 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
           }
         } else {
           int i;
-          const char **strings = ftMenuStrings[ftMenuStringsIdx];
-
-          int ftMenuStringsAlphacharsIdx = cgs.ftMenuPos;
-          ftMenuStringsAlphacharsIdx =
-              Numeric::clamp(ftMenuStringsAlphacharsIdx, 0,
-                             (sizeof(ftMenuStringsAlphachars) /
-                                  sizeof(ftMenuStringsAlphachars[0]) -
-                              1));
+          const char **strings = ftMenuStrings[idx];
 
           for (i = 0; strings[i]; i++) {
-            if (key ==
-                tolower(
-                    *ftMenuStringsAlphachars[ftMenuStringsAlphacharsIdx][i])) {
+            if (key == tolower(*ftMenuStringsAlphachars[idx][i])) {
 
               if (doaction) {
 
-                trap_SendClientCommand(
-                    va("vsay_buddy %i %s %s", cgs.ftMenuPos,
-                       CG_BuildSelectedFirteamString(),
-                       (ftMenuStringsMsg[ftMenuStringsMsgIdx])[i]));
+                trap_SendClientCommand(va("vsay_buddy %i %s %s", cgs.ftMenuPos,
+                                          CG_BuildSelectedFirteamString(),
+                                          (ftMenuStringsMsg[idx])[i]));
                 CG_EventHandling(CGAME_EVENT_NONE, qfalse);
               }
               return qtrue;

--- a/src/cgame/cg_fireteams.cpp
+++ b/src/cgame/cg_fireteams.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 
 #include "cg_local.h"
+#include "../game/etj_numeric_utilities.h"
 
 panel_button_text_t fireteamTitleFont = {
     0.19f, 0.19f, {0.6f, 0.6f, 0.6f, 1.f}, 0, 0, &cgs.media.limboFont1_lo,
@@ -598,7 +599,18 @@ void CG_Fireteams_MenuText_Draw(panel_button_t *button) {
         if (cgs.ftMenuPos < 0 || cgs.ftMenuPos > 5) {
           return;
         } else {
-          const char **strings = ftMenuStrings[cgs.ftMenuPos];
+          int ftMenuStringsIdx = cgs.ftMenuPos;
+          int ftMenuStringsAlphacharsIdx = cgs.ftMenuPos;
+          ftMenuStringsIdx = Numeric::clamp(
+              ftMenuStringsIdx, 0,
+              (sizeof(ftMenuStrings) / sizeof(ftMenuStrings[0]) - 1));
+          ftMenuStringsAlphacharsIdx =
+              Numeric::clamp(ftMenuStringsAlphacharsIdx, 0,
+                             (sizeof(ftMenuStringsAlphachars) /
+                              sizeof(ftMenuStringsAlphachars[0])) -
+                                 1);
+
+          const char **strings = ftMenuStrings[ftMenuStringsIdx];
 
           for (i = 0; strings[i]; i++) {
             const char *str;
@@ -606,7 +618,8 @@ void CG_Fireteams_MenuText_Draw(panel_button_t *button) {
             if (cg_quickMessageAlt.integer) {
               str = va("%i. %s", (i + 1) % 10, strings[i]);
             } else {
-              str = va("%s. %s", (ftMenuStringsAlphachars[cgs.ftMenuPos])[i],
+              str = va("%s. %s",
+                       (ftMenuStringsAlphachars[ftMenuStringsAlphacharsIdx])[i],
                        strings[i]);
             }
 
@@ -837,12 +850,21 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
           return qfalse;
         }
 
+        int ftMenuStringsIdx = cgs.ftMenuPos;
+        int ftMenuStringsMsgIdx = cgs.ftMenuPos;
+        ftMenuStringsIdx = Numeric::clamp(
+            ftMenuStringsIdx, 0,
+            (sizeof(ftMenuStrings) / sizeof(ftMenuStrings[0]) - 1));
+        ftMenuStringsMsgIdx = Numeric::clamp(
+            ftMenuStringsMsgIdx, 0,
+            (sizeof(ftMenuStringsMsg) / sizeof(ftMenuStringsMsg[0]) - 1));
+
         if (cg_quickMessageAlt.integer) {
           if (key >= '0' && key <= '9') {
             int i = ((key - '0') + 9) % 10;
             int x;
 
-            const char **strings = ftMenuStrings[cgs.ftMenuPos];
+            const char **strings = ftMenuStrings[ftMenuStringsIdx];
 
             for (x = 0; strings[x]; x++) {
               if (x == i) {
@@ -850,7 +872,7 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
                   trap_SendClientCommand(
                       va("vsay_buddy %i %s %s", cgs.ftMenuPos,
                          CG_BuildSelectedFirteamString(),
-                         (ftMenuStringsMsg[cgs.ftMenuPos])[i]));
+                         (ftMenuStringsMsg[ftMenuStringsMsgIdx])[i]));
                   CG_EventHandling(CGAME_EVENT_NONE, qfalse);
                 }
 
@@ -860,17 +882,26 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
           }
         } else {
           int i;
-          const char **strings = ftMenuStrings[cgs.ftMenuPos];
+          const char **strings = ftMenuStrings[ftMenuStringsIdx];
+
+          int ftMenuStringsAlphacharsIdx = cgs.ftMenuPos;
+          ftMenuStringsAlphacharsIdx =
+              Numeric::clamp(ftMenuStringsAlphacharsIdx, 0,
+                             (sizeof(ftMenuStringsAlphachars) /
+                                  sizeof(ftMenuStringsAlphachars[0]) -
+                              1));
 
           for (i = 0; strings[i]; i++) {
-            if (key == tolower(*ftMenuStringsAlphachars[cgs.ftMenuPos][i])) {
+            if (key ==
+                tolower(
+                    *ftMenuStringsAlphachars[ftMenuStringsAlphacharsIdx][i])) {
 
               if (doaction) {
 
                 trap_SendClientCommand(
                     va("vsay_buddy %i %s %s", cgs.ftMenuPos,
                        CG_BuildSelectedFirteamString(),
-                       (ftMenuStringsMsg[cgs.ftMenuPos])[i]));
+                       (ftMenuStringsMsg[ftMenuStringsMsgIdx])[i]));
                 CG_EventHandling(CGAME_EVENT_NONE, qfalse);
               }
               return qtrue;

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -203,7 +203,7 @@ void ETJump::execFile(const std::string &filename) {
   trap_SendConsoleCommand(va("exec \"%s.cfg\"\n", filename.c_str()));
 }
 
-bool ETJump::isPlaying(int clientNum) {
+bool ETJump::isPlaying(const int clientNum) {
   return (cgs.clientinfo[clientNum].team == TEAM_ALLIES ||
           cgs.clientinfo[clientNum].team == TEAM_AXIS);
 }

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -203,4 +203,9 @@ void ETJump::execFile(const std::string &filename) {
   trap_SendConsoleCommand(va("exec \"%s.cfg\"\n", filename.c_str()));
 }
 
+bool ETJump::isPlaying(int clientNum) {
+  return (cgs.clientinfo[clientNum].team == TEAM_ALLIES ||
+          cgs.clientinfo[clientNum].team == TEAM_AXIS);
+}
+
 #endif

--- a/src/cgame/etj_utilities.h
+++ b/src/cgame/etj_utilities.h
@@ -63,5 +63,8 @@ bool configFileExists(const std::string &filename);
 // executes a cfg file with given name, omit .cfg extension
 void execFile(const std::string &filename);
 
+// returns true if client is currently playing (team axis/allies)
+bool isPlaying(int clientNum);
+
 #endif
 } // namespace ETJump


### PR DESCRIPTION
Fireteam menu string indexing was reliant to there being max 5 menu options, as it was using the last pressed menu as the index. Now that there are 6 after adding rules, this no longer works and causes out of bounds reads if pressing 6th option in the menu, then opening the fireteam vsay menu. Now the indexing is still taken from the last pressed menu option, but is clamped to last element of the array to prevent out of bounds access.

Additionally correction to selecting fireteam members, was using old max limit of 6.

refs #1026 