### PR TITLE
Fix g_blockedMaps blocking maps on partial match

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -42,16 +42,16 @@
 
 typedef std::function<bool(gentity_t *ent, Arguments argv)> Command;
 typedef std::pair<std::function<bool(gentity_t *ent, Arguments argv)>, char>
-AdminCommandPair;
+    AdminCommandPair;
 typedef std::map<std::string,
                  std::function<bool(gentity_t *ent, Arguments argv)>>::
-const_iterator ConstCommandIterator;
+    const_iterator ConstCommandIterator;
 typedef std::map<std::string,
                  std::pair<std::function<bool(gentity_t *ent, Arguments argv)>,
                            char>>::const_iterator ConstAdminCommandIterator;
 typedef std::map<std::string,
                  std::function<bool(gentity_t *ent, Arguments argv)>>::iterator
-CommandIterator;
+    CommandIterator;
 typedef std::map<std::string,
                  std::pair<std::function<bool(gentity_t *ent, Arguments argv)>,
                            char>>::iterator AdminCommandIterator;
@@ -169,12 +169,21 @@ bool Rankings(gentity_t *ent, Arguments argv) {
   }
   auto args = ETJump::Container::skipFirstN(*argv, 1);
 
-  auto optCommand =
-      deprecated_getCommand("rankings", ClientNum(ent),
-      ETJump::CommandParser::CommandDefinition::create("rankings", "Displays the player rankings for a specific season. Uses the overall as the default.\n/rankings --season <season> --page <page> --page-size <page size>")
-          .addOption("season", "Name of the season to list rankings for", ETJump::CommandParser::OptionDefinition::Type::MultiToken, false)
-          .addOption("page", "Which page of rankings to show", ETJump::CommandParser::OptionDefinition::Type::Integer, false)
-          .addOption("page-size", "How many rankings to show per page",ETJump::CommandParser::OptionDefinition::Type::Integer, false),
+  auto optCommand = deprecated_getCommand(
+      "rankings", ClientNum(ent),
+      ETJump::CommandParser::CommandDefinition::create(
+          "rankings", "Displays the player rankings for a specific season. "
+                      "Uses the overall as the default.\n/rankings --season "
+                      "<season> --page <page> --page-size <page size>")
+          .addOption("season", "Name of the season to list rankings for",
+                     ETJump::CommandParser::OptionDefinition::Type::MultiToken,
+                     false)
+          .addOption("page", "Which page of rankings to show",
+                     ETJump::CommandParser::OptionDefinition::Type::Integer,
+                     false)
+          .addOption("page-size", "How many rankings to show per page",
+                     ETJump::CommandParser::OptionDefinition::Type::Integer,
+                     false),
       &args);
 
   if (!optCommand.hasValue()) {
@@ -187,7 +196,10 @@ bool Rankings(gentity_t *ent, Arguments argv) {
   auto optPage = command.getOptional("page");
   auto optPageSize = command.getOptional("page-size");
 
-  ETJump::opt<std::string> season = optSeason.hasValue() ? ETJump::StringUtil::toLowerCase(optSeason.value().text) : ETJump::opt<std::string>();
+  ETJump::opt<std::string> season =
+      optSeason.hasValue()
+          ? ETJump::StringUtil::toLowerCase(optSeason.value().text)
+          : ETJump::opt<std::string>();
   auto page = optPage.hasValue() ? optPage.value().integer - 1 : 0;
   auto pageSize = optPageSize.hasValue() ? optPageSize.value().integer : 20;
 
@@ -195,8 +207,8 @@ bool Rankings(gentity_t *ent, Arguments argv) {
 
   auto userId = ETJump::session->GetId(ent);
 
-  ETJump::Timerun::PrintRankingsParams params{ClientNum(ent), userId, season, page,
-                                              pageSize};
+  ETJump::Timerun::PrintRankingsParams params{ClientNum(ent), userId, season,
+                                              page, pageSize};
 
   game.timerunV2->printRankings(params);
   return true;
@@ -222,30 +234,34 @@ bool Records(gentity_t *ent, Arguments argv) {
   }
   auto args = ETJump::Container::skipFirstN(*argv, 1);
   auto optCommand = deprecated_getCommand(
-      "records",
-      ClientNum(ent),
+      "records", ClientNum(ent),
       ETJump::CommandParser::CommandDefinition::create(
           "records",
-          "Print the timerun records.\n    /records --season <season name> --map <map name> --run <run name>\n\n    Has a shorthand format of:\n    /records <run name>\n    /records <map name> <run name>\n    /records <season name> <map name> <run name>")
-      .addOption("season",
-                 "Name of the season to print the records for. Default is "
-                 "the overall season.",
-                 ETJump::CommandParser::OptionDefinition::Type::MultiToken,
-                 false)
-      .addOption("map",
-                 "Name of the map to print the records for. Default is the "
-                 "current map.",
-                 ETJump::CommandParser::OptionDefinition::Type::MultiToken,
-                 false)
-      .addOption(
-          "run",
-          "Name of the run to print the records for. Default will print "
-          "top 3 records for all runs on specified map and your record.",
-          ETJump::CommandParser::OptionDefinition::Type::MultiToken, false)
-      .addOption("page", "Which page to display starting at 1",
-                 ETJump::CommandParser::OptionDefinition::Type::Integer, false)
-      .addOption("page-size", "How many records to show on a single page",
-                 ETJump::CommandParser::OptionDefinition::Type::Integer, false),
+          "Print the timerun records.\n    /records --season <season name> "
+          "--map <map name> --run <run name>\n\n    Has a shorthand format "
+          "of:\n    /records <run name>\n    /records <map name> <run name>\n  "
+          "  /records <season name> <map name> <run name>")
+          .addOption("season",
+                     "Name of the season to print the records for. Default is "
+                     "the overall season.",
+                     ETJump::CommandParser::OptionDefinition::Type::MultiToken,
+                     false)
+          .addOption("map",
+                     "Name of the map to print the records for. Default is the "
+                     "current map.",
+                     ETJump::CommandParser::OptionDefinition::Type::MultiToken,
+                     false)
+          .addOption(
+              "run",
+              "Name of the run to print the records for. Default will print "
+              "top 3 records for all runs on specified map and your record.",
+              ETJump::CommandParser::OptionDefinition::Type::MultiToken, false)
+          .addOption("page", "Which page to display starting at 1",
+                     ETJump::CommandParser::OptionDefinition::Type::Integer,
+                     false)
+          .addOption("page-size", "How many records to show on a single page",
+                     ETJump::CommandParser::OptionDefinition::Type::Integer,
+                     false),
       &args);
 
   if (!optCommand.hasValue()) {
@@ -290,8 +306,7 @@ bool Records(gentity_t *ent, Arguments argv) {
   }
 
   ETJump::Timerun::PrintRecordsParams params;
-  params.clientNum =
-      ClientNum(ent);
+  params.clientNum = ClientNum(ent);
   params.season = season;
   params.map = map;
   // use exact map search if user did not specify the map
@@ -319,17 +334,17 @@ bool LoadCheckpoints(gentity_t *ent, Arguments argv) {
       "loadcheckpoints", ClientNum(ent),
       ETJump::CommandParser::CommandDefinition::create(
           "loadcheckpoints",
-          "Load checkpoints from a previous record.\n    /loadcheckpoints --run <run name> --rank <rank>\n\n"
+          "Load checkpoints from a previous record.\n    /loadcheckpoints "
+          "--run <run name> --rank <rank>\n\n"
           "    Has a shorthand format of:\n"
           "    /loadcheckpoints <run name> <rank>\n")
-      .addOption(
-          "run",
-          "Name of the run to load the records from.",
-          ETJump::CommandParser::OptionDefinition::Type::Token, true, 0)
-      .addOption("rank", "Rank to load checkpoints from. Defaults to 1",
-                 ETJump::CommandParser::OptionDefinition::Type::Integer, false, 1),
-      &args
-      );
+          .addOption("run", "Name of the run to load the records from.",
+                     ETJump::CommandParser::OptionDefinition::Type::Token, true,
+                     0)
+          .addOption("rank", "Rank to load checkpoints from. Defaults to 1",
+                     ETJump::CommandParser::OptionDefinition::Type::Integer,
+                     false, 1),
+      &args);
 
   if (!optCommand.hasValue()) {
     return true;
@@ -339,7 +354,8 @@ bool LoadCheckpoints(gentity_t *ent, Arguments argv) {
   auto optRank = optCommand.value().getOptional("rank");
   auto rank = optRank.hasValue() ? optRank.value().integer : 1;
 
-  game.timerunV2->loadCheckpoints(ClientNum(ent), level.rawmapname, runName, rank);
+  game.timerunV2->loadCheckpoints(ClientNum(ent), level.rawmapname, runName,
+                                  rank);
 
   return true;
 }
@@ -513,8 +529,8 @@ bool Ball8(gentity_t *ent, Arguments argv) {
     const int remainingSeconds = std::ceil(
         (ent->client->last8BallTime + DELAY_8BALL - level.time) / 1000.0);
     ChatPrintTo(ent, "^3!8ball: ^7you must wait " +
-                     ETJump::getSecondsString(remainingSeconds) +
-                     " before using !8ball again.");
+                         ETJump::getSecondsString(remainingSeconds) +
+                         " before using !8ball again.");
     return false;
   }
 
@@ -625,8 +641,8 @@ bool DeleteLevel(gentity_t *ent, Arguments argv) {
   int usersWithLevel = ETJump::session->LevelDeleted(level);
 
   ChatPrintTo(ent, "^3deletelevel: ^7deleted level. Set " +
-                   ETJump::getPluralizedString(usersWithLevel, "user") +
-                   " to level 0.");
+                       ETJump::getPluralizedString(usersWithLevel, "user") +
+                       " to level 0.");
 
   return true;
 }
@@ -641,7 +657,7 @@ bool EditCommands(gentity_t *ent, Arguments argv) {
   int level = 0;
   if (!ToInt(argv->at(1), level)) {
     ChatPrintTo(ent, "^3editcommands: ^7defined level \"" + (*argv)[1] +
-                     "\" is not an integer.");
+                         "\" is not an integer.");
     return false;
   }
 
@@ -674,7 +690,7 @@ bool EditCommands(gentity_t *ent, Arguments argv) {
     char flag = game.commands->FindCommandFlag(currentCommand);
     if (flag == 0) {
       ChatPrintTo(ent, "^3editcommands: ^7command \"" + currentCommand +
-                       "\" doesn't match any known command.");
+                           "\" doesn't match any known command.");
       continue;
     }
     if (add) {
@@ -723,8 +739,8 @@ bool EditCommands(gentity_t *ent, Arguments argv) {
   game.levels->Edit(level, "", currentPermissions, "", 1);
 
   ChatPrintTo(ent, "^3editcommands: ^7edited level " + (*argv)[1] +
-                   " permissions. New permissions are: " +
-                   game.levels->GetLevel(level)->commands);
+                       " permissions. New permissions are: " +
+                       game.levels->GetLevel(level)->commands);
   return true;
 }
 
@@ -1043,7 +1059,7 @@ bool Kick(gentity_t *ent, Arguments argv) {
   if (argv->size() >= 3) {
     if (!ToInt(argv->at(2), timeout)) {
       ChatPrintTo(ent, "^3kick: ^7invalid timeout \"" + argv->at(2) +
-                       "\" specified.");
+                           "\" specified.");
       return false;
     }
   }
@@ -1110,8 +1126,8 @@ bool LeastPlayed(gentity_t *ent, Arguments argv) {
   auto leastPlayed = game.mapStatistics->getLeastPlayed();
   auto listedMaps = 0;
   std::string buffer = "^zLeast played maps are:\n"
-      "^gMap                    Played                        "
-      " Last played       Times played\n";
+                       "^gMap                    Played                        "
+                       " Last played       Times played\n";
   auto green = false;
   for (auto &map : leastPlayed) {
     if (listedMaps >= mapsToList) {
@@ -1179,7 +1195,7 @@ bool ListMaps(gentity_t *ent, Arguments argv) {
       perRow = std::stoi(argv->at(1), nullptr, 10);
     } catch (const std::invalid_argument &) {
       ChatPrintTo(ent, ETJump::stringFormat(
-                      "^3listmaps: ^7%s^7 is not a number", argv->at(1)));
+                           "^3listmaps: ^7%s^7 is not a number", argv->at(1)));
       return false;
     } catch (const std::out_of_range &) {
       perRow = 5;
@@ -1215,7 +1231,7 @@ bool ListMaps(gentity_t *ent, Arguments argv) {
   buffer += "\n";
 
   buffer += "\n^zFound ^3" + ETJump::getPluralizedString(maps.size(), "^zmap") +
-      " on the server.\n";
+            " on the server.\n";
 
   Printer::SendConsoleMessage(ClientNum(ent), buffer);
 
@@ -1243,12 +1259,12 @@ bool ListPlayers(gentity_t *ent, Arguments argv) {
 
     if (!level.numConnectedClients) {
       BufferPrint(ent, "^7There are currently no "
-                  "connected players.\n");
+                       "connected players.\n");
     } else {
       if (level.numConnectedClients > 1) {
         BufferPrint(ent, ETJump::stringFormat(
-                        "^7There are currently %d connected players.\n",
-                        level.numConnectedClients));
+                             "^7There are currently %d connected players.\n",
+                             level.numConnectedClients));
       } else {
         BufferPrint(ent, "^7There is currently 1 connected player.\n");
       }
@@ -1261,10 +1277,10 @@ bool ListPlayers(gentity_t *ent, Arguments argv) {
       auto id = ETJump::session->GetId(g_entities + clientNum);
 
       BufferPrint(ent, ETJump::stringFormat(
-                      "^7%-2d %-9s %-6d %-s\n", clientNum,
-                      (id == -1 ? "-" : std::to_string(id)),
-                      ETJump::session->GetLevel(g_entities + clientNum),
-                      (g_entities + clientNum)->client->pers.netname));
+                           "^7%-2d %-9s %-6d %-s\n", clientNum,
+                           (id == -1 ? "-" : std::to_string(id)),
+                           ETJump::session->GetLevel(g_entities + clientNum),
+                           (g_entities + clientNum)->client->pers.netname));
     }
 
     FinishBufferPrint(ent);
@@ -1286,12 +1302,9 @@ bool Map(gentity_t *ent, Arguments argv) {
     return false;
   }
 
-  MapStatistics mapStats;
-
-  if (strstr(mapStats.getBlockedMapsStr().c_str(), requestedMap.c_str()) !=
-      nullptr) {
+  if (MapStatistics::isBlockedMap(requestedMap)) {
     ChatPrintTo(ent, "^3map: ^7" + requestedMap +
-                     " cannot be played on this server.");
+                         " cannot be played on this server.");
     return false;
   }
 
@@ -1371,8 +1384,8 @@ bool MostPlayed(gentity_t *ent, Arguments argv) {
   auto mostPlayed = game.mapStatistics->getMostPlayed();
   auto listedMaps = 0;
   std::string buffer = "^zMost played maps are:\n"
-      "^gMap                    Played                        "
-      " Last played       Times played\n";
+                       "^gMap                    Played                        "
+                       " Last played       Times played\n";
   auto green = false;
   for (auto &map : mostPlayed) {
     if (listedMaps >= mapsToList) {
@@ -1434,7 +1447,7 @@ bool Mute(gentity_t *ent, Arguments argv) {
 
   if (target->client->sess.muted == qtrue) {
     ChatPrintTo(ent, "^3mute: " + std::string(target->client->pers.netname) +
-                     " ^7is already muted.");
+                         " ^7is already muted.");
     return false;
   }
 
@@ -1579,7 +1592,7 @@ bool SetLevel(gentity_t *ent, Arguments argv) {
 
       if (level > ETJump::session->GetLevel(ent)) {
         ChatPrintTo(ent, "^3setlevel: ^7you're not allowed to setlevel higher "
-                    "than your own level.");
+                         "than your own level.");
         return false;
       }
     }
@@ -1611,7 +1624,7 @@ bool SetLevel(gentity_t *ent, Arguments argv) {
 
     if (!ETJump::session->UserExists(id)) {
       ChatPrintTo(ent, "^3setlevel: ^7user with id " + argv->at(2) +
-                       " doesn't exist.");
+                           " doesn't exist.");
       return false;
     }
 
@@ -1630,7 +1643,7 @@ bool SetLevel(gentity_t *ent, Arguments argv) {
 
       if (level > ETJump::session->GetLevel(ent)) {
         ChatPrintTo(ent, "^3setlevel: ^7you're not allowed to setlevel higher "
-                    "than your own level.");
+                         "than your own level.");
         return false;
       }
     }
@@ -1709,7 +1722,7 @@ bool createToken(gentity_t *ent, Arguments argv) {
   } else {
     if (argv->size() != 6) {
       ChatPrintTo(ent, "^3usage: ^7!tokens create <easy (e)|medium (m)|hard "
-                  "(h)> <x> <y> <z>");
+                       "(h)> <x> <y> <z>");
       return false;
     }
   }
@@ -1754,7 +1767,7 @@ bool createToken(gentity_t *ent, Arguments argv) {
     difficulty = Tokens::Hard;
   } else {
     ChatPrintTo(ent, "^3tokens: ^7difficulty must be either easy (e), medium "
-                "(m) or hard (h)");
+                     "(m) or hard (h)");
     return false;
   }
 
@@ -1823,7 +1836,7 @@ bool deleteToken(gentity_t *ent, Arguments argv) {
       difficulty = Tokens::Hard;
     } else {
       ChatPrintTo(ent, "^3tokens: ^7difficulty must be either easy (e), medium "
-                  "(m) or hard (h)");
+                       "(m) or hard (h)");
       return false;
     }
 
@@ -1835,7 +1848,7 @@ bool deleteToken(gentity_t *ent, Arguments argv) {
       return false;
     } catch (const std::out_of_range &) {
       ChatPrintTo(ent, "^3tokens: ^7" + (*argv)[3] +
-                       " is out of range (too large).");
+                           " is out of range (too large).");
       return false;
     }
 
@@ -1863,14 +1876,14 @@ bool deleteToken(gentity_t *ent, Arguments argv) {
 bool Tokens(gentity_t *ent, Arguments argv) {
   if (!g_tokensMode.integer) {
     ChatPrintTo(ent, "^3tokens: ^7tokens mode is disabled. Set g_tokensMode "
-                "\"1\" and restart map to enable tokens mode.");
+                     "\"1\" and restart map to enable tokens mode.");
     return false;
   }
 
   if (ent) {
     if (argv->size() < 2) {
       ChatPrintTo(ent, "^3usage: ^7check console for "
-                  "more information");
+                       "more information");
       Printer::SendConsoleMessage(
           ClientNum(ent),
           "^7!tokens create <easy (e)|medium (m)|hard (h)> ^9| Creates a new "
@@ -2056,20 +2069,20 @@ bool TimerunAddSeason(gentity_t *ent, Arguments argv) {
   // this for now
   auto def =
       ETJump::CommandParser::CommandDefinition::create(
-          "add-season",
-          "Adds a new timerun season\n    !add-season --name <name> --start-date <2000-01-01>")
-      .addOption("name", "Name of the season to add",
-                 ETJump::CommandParser::OptionDefinition::Type::MultiToken,
-                 true)
-      .addOption("start-date",
-                 "Start date for the timerun season in YYYY-MM-DD format "
-                 "(e.g. 2000-01-01)",
-                 ETJump::CommandParser::OptionDefinition::Type::Date, true)
-      .addOption("end-date-exclusive",
-                 "End date for the timerun season in YYYY-MM-DD format "
-                 "(e.g. 2000-01-01)",
-                 ETJump::CommandParser::OptionDefinition::Type::Date,
-                 false);
+          "add-season", "Adds a new timerun season\n    !add-season --name "
+                        "<name> --start-date <2000-01-01>")
+          .addOption("name", "Name of the season to add",
+                     ETJump::CommandParser::OptionDefinition::Type::MultiToken,
+                     true)
+          .addOption("start-date",
+                     "Start date for the timerun season in YYYY-MM-DD format "
+                     "(e.g. 2000-01-01)",
+                     ETJump::CommandParser::OptionDefinition::Type::Date, true)
+          .addOption("end-date-exclusive",
+                     "End date for the timerun season in YYYY-MM-DD format "
+                     "(e.g. 2000-01-01)",
+                     ETJump::CommandParser::OptionDefinition::Type::Date,
+                     false);
   auto optCommand = deprecated_getCommand("add-season", clientNum, def, argv);
 
   if (!optCommand.hasValue()) {
@@ -2081,16 +2094,17 @@ bool TimerunAddSeason(gentity_t *ent, Arguments argv) {
   auto name = command.options.at("name").text;
   auto start = command.options.at("start-date").date;
   auto end = command.options.count("end-date-exclusive") > 0
-               ? ETJump::opt<ETJump::Time>(ETJump::Time::fromDate(
-                   command.options.at("end-date-exclusive").date))
-               : ETJump::opt<ETJump::Time>();
+                 ? ETJump::opt<ETJump::Time>(ETJump::Time::fromDate(
+                       command.options.at("end-date-exclusive").date))
+                 : ETJump::opt<ETJump::Time>();
 
   if (end.hasValue()) {
     if ((*end).date < start) {
-      Printer::SendChatMessage(clientNum, ETJump::stringFormat(
-                                   "^3addseason: ^7Start time `%s` is after end time `%s`",
-                                   start.toDateString(),
-                                   end.value().date.toDateString()));
+      Printer::SendChatMessage(
+          clientNum,
+          ETJump::stringFormat(
+              "^3addseason: ^7Start time `%s` is after end time `%s`",
+              start.toDateString(), end.value().date.toDateString()));
       return true;
     }
   }
@@ -2112,18 +2126,18 @@ bool TimerunEditSeason(gentity_t *ent, Arguments argv) {
   auto def =
       ETJump::CommandParser::CommandDefinition::create(
           "edit-season", "Edit an existing timerun season")
-      .addOption("name", "Name of the season to edit",
-                 ETJump::CommandParser::OptionDefinition::Type::MultiToken,
-                 true)
-      .addOption("start-date",
-                 "Start date for the timerun season in YYYY-MM-DD format "
-                 "(e.g. 2000-01-01)",
-                 ETJump::CommandParser::OptionDefinition::Type::Date, false)
-      .addOption(
-          "end-date",
-          "End date for the timerun season in YYYY-MM-DD format "
-          "(e.g. 2000-01-01)",
-          ETJump::CommandParser::OptionDefinition::Type::Date, false);
+          .addOption("name", "Name of the season to edit",
+                     ETJump::CommandParser::OptionDefinition::Type::MultiToken,
+                     true)
+          .addOption("start-date",
+                     "Start date for the timerun season in YYYY-MM-DD format "
+                     "(e.g. 2000-01-01)",
+                     ETJump::CommandParser::OptionDefinition::Type::Date, false)
+          .addOption("end-date",
+                     "End date for the timerun season in YYYY-MM-DD format "
+                     "(e.g. 2000-01-01)",
+                     ETJump::CommandParser::OptionDefinition::Type::Date,
+                     false);
 
   auto optCommand = deprecated_getCommand("edit-season", clientNum, def, argv);
 
@@ -2138,13 +2152,13 @@ bool TimerunEditSeason(gentity_t *ent, Arguments argv) {
   auto end = command.getOptional("end-date");
 
   auto startTime = start.hasValue()
-                     ? ETJump::opt<ETJump::Time>(
-                         ETJump::Time::fromDate(start.value().date))
-                     : ETJump::opt<ETJump::Time>();
-  auto endTime = end.hasValue()
-                   ? ETJump::opt<ETJump::Time>(
-                       ETJump::Time::fromDate(end.value().date))
-                   : ETJump::opt<ETJump::Time>();
+                       ? ETJump::opt<ETJump::Time>(
+                             ETJump::Time::fromDate(start.value().date))
+                       : ETJump::opt<ETJump::Time>();
+  auto endTime =
+      end.hasValue()
+          ? ETJump::opt<ETJump::Time>(ETJump::Time::fromDate(end.value().date))
+          : ETJump::opt<ETJump::Time>();
 
   game.timerunV2->editSeason({clientNum, name, startTime, endTime});
 
@@ -2387,7 +2401,7 @@ bool Commands::AdminCommand(gentity_t *ent) {
 
   if (foundCommands.size() > 1) {
     ChatPrintTo(ent, "^3server: ^7multiple matching commands found. Check "
-                "console for more information");
+                     "console for more information");
     BeginBufferPrint();
     for (size_t i = 0; i < foundCommands.size(); i++) {
       BufferPrint(ent, va("* %s\n", foundCommands.at(i)->first.c_str()));

--- a/src/game/etj_custom_map_votes.cpp
+++ b/src/game/etj_custom_map_votes.cpp
@@ -232,10 +232,10 @@ std::string const CustomMapVotes::RandomMap(std::string const &type) {
   return "";
 }
 
+// FIXME: this should just be nuked and custom map votes should use
+//  MapStatistics::isValidMap but that takes MapInfo as argument
+//  and isn't simple to refactor so bleh
 bool CustomMapVotes::isValidMap(const std::string &mapName) {
-  MapStatistics mapStats;
-
   return G_MapExists(mapName.c_str()) && mapName != level.rawmapname &&
-         strstr(mapStats.getBlockedMapsStr().c_str(), mapName.c_str()) ==
-             nullptr;
+         !MapStatistics::isBlockedMap(mapName);
 }

--- a/src/game/etj_custom_map_votes.h
+++ b/src/game/etj_custom_map_votes.h
@@ -52,7 +52,7 @@ public:
   bool Load();
   TypeInfo GetTypeInfo(const std::string &type) const;
   const std::string RandomMap(const std::string &type);
-  bool isValidMap(const std::string &mapName);
+  static bool isValidMap(const std::string &mapName);
   std::string ListTypes() const;
   std::string ListInfo(const std::string &name);
   void GenerateVotesFile();

--- a/src/game/etj_map_statistics.cpp
+++ b/src/game/etj_map_statistics.cpp
@@ -498,15 +498,15 @@ const char *MapStatistics::randomMap() const {
 }
 
 std::vector<std::string> MapStatistics::blockedMaps() {
-  std::string blockedMapsStr =
+  const std::string blockedMapsStr =
       ETJump::StringUtil::toLowerCase(g_blockedMaps.string);
   return ETJump::StringUtil::split(blockedMapsStr, " ");
 }
 
 bool MapStatistics::isBlockedMap(const std::string &mapName) {
   bool isBlocked = false;
-  auto blockedMaps = MapStatistics::blockedMaps();
-  auto numBlockedMaps = blockedMaps.size();
+  const auto blockedMaps = MapStatistics::blockedMaps();
+  const auto numBlockedMaps = blockedMaps.size();
 
   for (int i = 0; i < numBlockedMaps; i++) {
     if (ETJump::StringUtil::matches(blockedMaps[i], mapName)) {

--- a/src/game/etj_map_statistics.cpp
+++ b/src/game/etj_map_statistics.cpp
@@ -71,8 +71,7 @@ std::vector<std::string> MapStatistics::getMaps() {
   std::vector<std::string> maps;
 
   for (auto &map : _maps) {
-    if (map.isOnServer &&
-        strstr(getBlockedMapsStr().c_str(), map.name.c_str()) == nullptr) {
+    if (map.isOnServer && !MapStatistics::isBlockedMap(map.name)) {
       maps.push_back(map.name);
     }
   }
@@ -498,13 +497,30 @@ const char *MapStatistics::randomMap() const {
   return mapName;
 }
 
-std::string MapStatistics::getBlockedMapsStr() const {
-  return ETJump::StringUtil::toLowerCase(g_blockedMaps.string);
+std::vector<std::string> MapStatistics::blockedMaps() {
+  std::string blockedMapsStr =
+      ETJump::StringUtil::toLowerCase(g_blockedMaps.string);
+  return ETJump::StringUtil::split(blockedMapsStr, " ");
+}
+
+bool MapStatistics::isBlockedMap(const std::string &mapName) {
+  bool isBlocked = false;
+  auto blockedMaps = MapStatistics::blockedMaps();
+  auto numBlockedMaps = blockedMaps.size();
+
+  for (int i = 0; i < numBlockedMaps; i++) {
+    if (ETJump::StringUtil::matches(blockedMaps[i], mapName)) {
+      isBlocked = true;
+      break;
+    }
+  }
+
+  return isBlocked;
 }
 
 bool MapStatistics::isValidMap(const MapInformation *mapInfo) const {
   return mapInfo != _currentMap && mapInfo->isOnServer &&
-         strstr(getBlockedMapsStr().c_str(), mapInfo->name.c_str()) == nullptr;
+         !MapStatistics::isBlockedMap(mapInfo->name);
 }
 
 MapStatistics::~MapStatistics() {}

--- a/src/game/etj_map_statistics.h
+++ b/src/game/etj_map_statistics.h
@@ -69,7 +69,8 @@ public:
   std::vector<const MapInformation *> getLeastPlayed();
   std::vector<std::string> getMaps();
   const std::vector<std::string> *getCurrentMaps();
-  std::string getBlockedMapsStr() const;
+  static std::vector<std::string> blockedMaps();
+  static bool isBlockedMap(const std::string &mapName);
 
 private:
   std::vector<MapInformation> _maps;

--- a/src/game/etj_string_utilities.cpp
+++ b/src/game/etj_string_utilities.cpp
@@ -146,7 +146,7 @@ std::string ETJump::trim(const std::string &input) {
 
 // word-wrapper
 std::vector<std::string> ETJump::wrapWords(std::string &input, char separator,
-                                             size_t maxLength) {
+                                           size_t maxLength) {
   std::vector<std::string> output;
   size_t lastPos = 0;
 
@@ -262,7 +262,7 @@ void ETJump::StringUtil::replaceAll(std::string &input, const std::string &from,
 }
 
 bool ETJump::StringUtil::startsWith(const std::string &str,
-    const std::string &prefix) {
+                                    const std::string &prefix) {
   if (prefix.length() > str.length())
     return false;
 
@@ -279,8 +279,13 @@ bool ETJump::StringUtil::endsWith(const std::string &str,
 }
 
 bool ETJump::StringUtil::contains(const std::string &str,
-    const std::string &text) {
+                                  const std::string &text) {
   return str.find(text) != std::string::npos;
+}
+
+bool ETJump::StringUtil::matches(const std::string &str,
+                                 const std::string &text) {
+  return str == text;
 }
 
 unsigned ETJump::StringUtil::countExtraPadding(const std::string &input) {

--- a/src/game/etj_string_utilities.h
+++ b/src/game/etj_string_utilities.h
@@ -56,7 +56,7 @@ std::string trimEnd(const std::string &input);
 std::string trim(const std::string &input);
 
 std::vector<std::string> wrapWords(std::string &input, char separator,
-                                     size_t maxLength);
+                                   size_t maxLength);
 
 template <typename T>
 std::string getPluralizedString(const T &val, const std::string &str) {
@@ -93,6 +93,7 @@ void replaceAll(std::string &input, const std::string &from,
 bool startsWith(const std::string &str, const std::string &prefix);
 bool endsWith(const std::string &str, const std::string &suffix);
 bool contains(const std::string &str, const std::string &text);
+bool matches(const std::string &str, const std::string &text);
 // Counts the extra padding needed when using format specifiers like
 // %-20s with text that contains ET color codes
 unsigned countExtraPadding(const std::string &input);

--- a/src/game/etj_utilities.cpp
+++ b/src/game/etj_utilities.cpp
@@ -259,7 +259,7 @@ std::vector<std::string> Utilities::getMaps() {
     Q_strncpyz(buf, dirPtr, sizeof(buf));
     Q_strlwr(buf);
 
-    if (strstr(mapStats.getBlockedMapsStr().c_str(), buf) != nullptr) {
+    if (MapStatistics::isBlockedMap(buf)) {
       continue;
     }
 

--- a/src/game/g_vote.cpp
+++ b/src/game/g_vote.cpp
@@ -309,10 +309,7 @@ static bool matchMap(const char *voteArg, std::string &resultedMap,
     return false;
   }
 
-  MapStatistics mapStats;
-
-  if (strstr(mapStats.getBlockedMapsStr().c_str(), resultedMap.c_str()) !=
-      nullptr) {
+  if (MapStatistics::isBlockedMap(resultedMap)) {
     resultedMap = stringFormat("^3callvote: ^7Voting for %s is not allowed.\n",
                                resultedMap);
     return false;

--- a/src/game/g_vote.cpp
+++ b/src/game/g_vote.cpp
@@ -397,11 +397,12 @@ int G_Map_v(gentity_t *ent, unsigned int dwVoteIndex, char *arg, char *arg2,
     char serverinfo[MAX_INFO_STRING];
     trap_GetServerinfo(serverinfo, sizeof(serverinfo));
 
-    if (!g_dedicated.integer && ent) {
-      G_cpmPrintf(
-          ent, "Sorry, [lof]^3%s^7 [lon]voting is disabled on localhost.", arg);
-      return (G_INVALID);
-    }
+    //    if (!g_dedicated.integer && ent) {
+    //      G_cpmPrintf(
+    //          ent, "Sorry, [lof]^3%s^7 [lon]voting is disabled on localhost.",
+    //          arg);
+    //      return (G_INVALID);
+    //    }
     if (vote_allow_map.integer <= 0 && ent) {
       G_voteDisableMessage(ent, arg);
       return (G_INVALID);


### PR DESCRIPTION
`g_blockedMaps` now requires exact string match to block a map, instead of partial.

Fixes #1033 