### PR TITLE
Fix wrapWords sometimes producing splits longer than max specified length

### DIFF
--- a/src/game/etj_string_utilities.cpp
+++ b/src/game/etj_string_utilities.cpp
@@ -146,11 +146,9 @@ std::string ETJump::trim(const std::string &input) {
 
 // word-wrapper
 std::vector<std::string> ETJump::wrapWords(std::string &input, char separator,
-                                             size_t maxLength) {
+                                           size_t maxLength) {
   std::vector<std::string> output;
   size_t lastPos = 0;
-  // make sure separator char won't result in exceeding maxLength
-  maxLength -= std::strlen(&separator);
 
   if (input.size() <= maxLength) {
     output.push_back(input);
@@ -159,6 +157,13 @@ std::vector<std::string> ETJump::wrapWords(std::string &input, char separator,
 
   while (true) {
     auto pos = input.rfind(separator, lastPos + maxLength);
+
+    // if we landed on a separator char, back off one char and re-search,
+    // otherwise we'll exceed maxLength as pos is incremented
+    if (input[pos] == separator) {
+      pos = input.rfind(separator, lastPos + maxLength - 1);
+    }
+
     /* separator not found */
     if (pos == std::string::npos) {
       /* split by length; */
@@ -264,7 +269,7 @@ void ETJump::StringUtil::replaceAll(std::string &input, const std::string &from,
 }
 
 bool ETJump::StringUtil::startsWith(const std::string &str,
-    const std::string &prefix) {
+                                    const std::string &prefix) {
   if (prefix.length() > str.length())
     return false;
 
@@ -281,7 +286,7 @@ bool ETJump::StringUtil::endsWith(const std::string &str,
 }
 
 bool ETJump::StringUtil::contains(const std::string &str,
-    const std::string &text) {
+                                  const std::string &text) {
   return str.find(text) != std::string::npos;
 }
 

--- a/src/game/etj_string_utilities.cpp
+++ b/src/game/etj_string_utilities.cpp
@@ -149,6 +149,8 @@ std::vector<std::string> ETJump::wrapWords(std::string &input, char separator,
                                              size_t maxLength) {
   std::vector<std::string> output;
   size_t lastPos = 0;
+  // make sure separator char won't result in exceeding maxLength
+  maxLength -= std::strlen(&separator);
 
   if (input.size() <= maxLength) {
     output.push_back(input);

--- a/tests/string_utilities_tests.cpp
+++ b/tests/string_utilities_tests.cpp
@@ -3,106 +3,114 @@
 
 using namespace ETJump;
 
-class StringUtilitiesTests : public testing::Test
-{
-    void SetUp() override
-    {
-        
-    }
+class StringUtilitiesTests : public testing::Test {
+  void SetUp() override {}
 
-    void TearDown() override
-    {
-        
-    }
+  void TearDown() override {}
 };
 
-TEST_F(StringUtilitiesTests, trimStart_ShouldRemoveWhitespaceFromTheBeginingOfString)
-{
-    std::string inputStr{ "  foo bar" };
-    std::string expectedStr{ "foo bar" };
+TEST_F(StringUtilitiesTests,
+       trimStart_ShouldRemoveWhitespaceFromTheBeginingOfString) {
+  std::string inputStr{"  foo bar"};
+  std::string expectedStr{"foo bar"};
 
-    auto outputStr = trimStart(inputStr);
-   	
-    EXPECT_EQ(outputStr, expectedStr);
+  auto outputStr = trimStart(inputStr);
+
+  EXPECT_EQ(outputStr, expectedStr);
 }
 
-TEST_F(StringUtilitiesTests, trimEnd_ShouldRemoveWhitespaceFromTheEndOfString)
-{
-    std::string inputStr{ "foo bar  " };
-    std::string expectedStr{ "foo bar" };
+TEST_F(StringUtilitiesTests, trimEnd_ShouldRemoveWhitespaceFromTheEndOfString) {
+  std::string inputStr{"foo bar  "};
+  std::string expectedStr{"foo bar"};
 
-    auto outputStr = trimEnd(inputStr);
-   	
-    EXPECT_EQ(outputStr, expectedStr);
+  auto outputStr = trimEnd(inputStr);
+
+  EXPECT_EQ(outputStr, expectedStr);
 }
 
-TEST_F(StringUtilitiesTests, trim_ShouldRemoveWhitespaceFromBothStartAndEndOfString)
-{
-    std::string inputStr{ "   foo bar  " };
-    std::string expectedStr{ "foo bar" };
+TEST_F(StringUtilitiesTests,
+       trim_ShouldRemoveWhitespaceFromBothStartAndEndOfString) {
+  std::string inputStr{"   foo bar  "};
+  std::string expectedStr{"foo bar"};
 
-    auto outputStr = trim(inputStr);
-   	
-    EXPECT_EQ(outputStr, expectedStr);
+  auto outputStr = trim(inputStr);
+
+  EXPECT_EQ(outputStr, expectedStr);
 }
 
-TEST_F(StringUtilitiesTests, splitString_ShouldEffectivelySplitStringOnSeparatorEncounter)
-{
-    std::string input = "Lorem ipsum \ndolor sit amet, \nconsectetur \nadipisicing elit. \nTenetur, fuga!";
-    std::vector<std::string> expectedSplits { 
-    	"Lorem ipsum \ndolor sit amet, \n", "consectetur \nadipisicing elit. \n", "Tenetur, fuga!" };
-	auto splits = wrapWords(input, '\n', 40);
-   	EXPECT_EQ(splits.size(), expectedSplits.size());
-   	for (int i = 0; i < static_cast<int>(splits.size()); i++) 
-	{
-	    EXPECT_EQ(splits[i], expectedSplits[i]);
-	}
+TEST_F(StringUtilitiesTests,
+       wrapWords_ShouldEffectivelySplitStringOnSeparatorEncounter) {
+  std::string input = "Lorem ipsum \ndolor sit amet, \nconsectetur "
+                      "\nadipisicing elit. \nTenetur, fuga!";
+  std::vector<std::string> expectedSplits{"Lorem ipsum \ndolor sit amet, \n",
+                                          "consectetur \nadipisicing elit. \n",
+                                          "Tenetur, fuga!"};
+  auto splits = wrapWords(input, '\n', 40);
+  EXPECT_EQ(splits.size(), expectedSplits.size());
+  for (int i = 0; i < static_cast<int>(splits.size()); i++) {
+    EXPECT_EQ(splits[i], expectedSplits[i]);
+  }
 }
 
-TEST_F(StringUtilitiesTests, splitString_ShouldEffectivelySplitStringOnMaxWidthExceed)
-{
-    std::string input = "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tenetur, fuga!";
-    std::vector<std::string> expectedSplits { 
-		"Lorem ipsum dolor sit amet, consectetur ", "adipisicing elit. Tenetur, fuga!"};
-	auto splits = wrapWords(input, '\n', 40);
-   	EXPECT_EQ(splits.size(), expectedSplits.size());
-   	for (int i = 0; i < static_cast<int>(splits.size()); i++) 
-	{
-	    EXPECT_EQ(splits[i], expectedSplits[i]);
-	}
+TEST_F(StringUtilitiesTests,
+       wrapWords_ShouldEffectivelySplitStringOnMaxWidthExceed) {
+  std::string input = "Lorem ipsum dolor sit amet, consectetur adipisicing "
+                      "elit. Tenetur, fuga!";
+  std::vector<std::string> expectedSplits{
+      "Lorem ipsum dolor sit amet, consectetur ",
+      "adipisicing elit. Tenetur, fuga!"};
+  auto splits = wrapWords(input, '\n', 40);
+  EXPECT_EQ(splits.size(), expectedSplits.size());
+  for (int i = 0; i < static_cast<int>(splits.size()); i++) {
+    EXPECT_EQ(splits[i], expectedSplits[i]);
+  }
 }
 
-TEST_F(StringUtilitiesTests, toLowerCase_ShouldConvertStringIntoLowercasedCopy)
-{
-    std::string input = "HELLO WORLD";
-    auto fixedString = StringUtil::toLowerCase(input);
-    EXPECT_EQ(fixedString, "hello world");
+TEST_F(StringUtilitiesTests,
+       wrapWords_SplitShouldNotExceedMaxLengthIfLandingOnSeparator) {
+  std::string input = "Lorem ipsum \ndolor sit amet, \nconsectetur "
+                      "\nadipisicing elit. \nTenetur, fuga!";
+  std::vector<std::string> expectedSplits{
+      "Lorem ipsum \ndolor sit amet, \n", "consectetur \n",
+      "adipisicing elit. \n", "Tenetur, fuga!"};
+  auto splits = wrapWords(input, '\n', 31);
+  EXPECT_EQ(splits.size(), expectedSplits.size());
+  for (int i = 0; i < static_cast<int>(splits.size()); i++) {
+    EXPECT_EQ(splits[i], expectedSplits[i]);
+  }
 }
 
-TEST_F(StringUtilitiesTests, toLowerCase_ShouldConvertStringIntoUppercasedCopy)
-{
-    std::string input = "hello world";
-    auto fixedString = StringUtil::toUpperCase(input);
-    EXPECT_EQ(fixedString, "HELLO WORLD");
+TEST_F(StringUtilitiesTests,
+       toLowerCase_ShouldConvertStringIntoLowercasedCopy) {
+  std::string input = "HELLO WORLD";
+  auto fixedString = StringUtil::toLowerCase(input);
+  EXPECT_EQ(fixedString, "hello world");
 }
 
-TEST_F(StringUtilitiesTests, eraseLast_ShouldEraseLastSubstringOccurenceFromInputStringCopy)
-{
-    std::string input = "hello world, hello world";
-    auto fixedString = StringUtil::eraseLast(input, "hello");
-    EXPECT_EQ(fixedString, "hello world,  world");
+TEST_F(StringUtilitiesTests,
+       toLowerCase_ShouldConvertStringIntoUppercasedCopy) {
+  std::string input = "hello world";
+  auto fixedString = StringUtil::toUpperCase(input);
+  EXPECT_EQ(fixedString, "HELLO WORLD");
 }
 
-TEST_F(StringUtilitiesTests, join_ShouldConcatenateStringChunksIntoOneDelimitedPiece)
-{
-    std::vector<std::string> input = { "hello world", "hello world" };
-    auto fixedString = StringUtil::join(input, ", ");
-    EXPECT_EQ(fixedString, "hello world, hello world");
+TEST_F(StringUtilitiesTests,
+       eraseLast_ShouldEraseLastSubstringOccurenceFromInputStringCopy) {
+  std::string input = "hello world, hello world";
+  auto fixedString = StringUtil::eraseLast(input, "hello");
+  EXPECT_EQ(fixedString, "hello world,  world");
+}
+
+TEST_F(StringUtilitiesTests,
+       join_ShouldConcatenateStringChunksIntoOneDelimitedPiece) {
+  std::vector<std::string> input = {"hello world", "hello world"};
+  auto fixedString = StringUtil::join(input, ", ");
+  EXPECT_EQ(fixedString, "hello world, hello world");
 }
 
 TEST_F(StringUtilitiesTests, countExtraPadding_ShouldWorkCorrectly) {
-    EXPECT_EQ(StringUtil::countExtraPadding("123"), 0);
-    EXPECT_EQ(StringUtil::countExtraPadding("^1123"), 2);
-    EXPECT_EQ(StringUtil::countExtraPadding("^^1123"), 2);
-    EXPECT_EQ(StringUtil::countExtraPadding("^1t^2e^3s^4t"), 8);
+  EXPECT_EQ(StringUtil::countExtraPadding("123"), 0);
+  EXPECT_EQ(StringUtil::countExtraPadding("^1123"), 2);
+  EXPECT_EQ(StringUtil::countExtraPadding("^^1123"), 2);
+  EXPECT_EQ(StringUtil::countExtraPadding("^1t^2e^3s^4t"), 8);
 }


### PR DESCRIPTION
`wrapWords` wasn't taking into account the length of the separator character when it split strings. This caused issue when the given input string had a separator character at the `maxLength` position, as this would cause the `input.rfind` call to just assign `maxLength` as `pos`, which then would get incremented by 1 before it was pushed to the output vector, causing longer than specified messages to be returned.

Fixes #971 