### PR TITLE
Fix EV_LOAD_TELEPORT getting processed on wrong client

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -2798,6 +2798,10 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       break;
 
     case EV_LOAD_TELEPORT:
+      if (es->clientNum != cg.snap->ps.clientNum) {
+        return;
+      }
+
       // should refactor users to playereventshandler
       DEBUGNAME("EV_LOAD_TELEPORT");
       ETJump::entityEventsHandler->check(EV_LOAD_TELEPORT, cent);


### PR DESCRIPTION
Do not process `EV_LOAD_TELEPORT` unless it's our event - this prevents it from firing actions that are triggered by the event, if the event comes from another player. This is really a band-aid fix I think, pretty sure the issue is actually somewhere else as these events should not be sent to other clients in the first place.

refs #572 