### PR TITLE
Don't compute scores for maps that are not on server

### DIFF
--- a/src/game/etj_map_statistics.cpp
+++ b/src/game/etj_map_statistics.cpp
@@ -523,4 +523,10 @@ bool MapStatistics::isValidMap(const MapInformation *mapInfo) const {
          !MapStatistics::isBlockedMap(mapInfo->name);
 }
 
+bool MapStatistics::mapExists(const std::string &mapName) {
+  auto maps = MapStatistics::getMaps();
+  auto it = std::find(maps.begin(), maps.end(), mapName);
+  return it != maps.end();
+}
+
 MapStatistics::~MapStatistics() {}

--- a/src/game/etj_map_statistics.h
+++ b/src/game/etj_map_statistics.h
@@ -71,6 +71,7 @@ public:
   const std::vector<std::string> *getCurrentMaps();
   static std::vector<std::string> blockedMaps();
   static bool isBlockedMap(const std::string &mapName);
+  bool mapExists(const std::string &mapName);
 
 private:
   std::vector<MapInformation> _maps;

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -30,9 +30,10 @@
 #include "etj_log.h"
 #include "etj_printer.h"
 #include "etj_synchronization_context.h"
-#include "etj_synchronization_context.h"
 #include "etj_timerun_repository.h"
 #include "etj_timerun_shared.h"
+#include "etj_local.h"
+#include "etj_map_statistics.h"
 
 ETJump::TimerunV2::TimerunV2(
     std::string currentMap, std::unique_ptr<TimerunRepository> repository,
@@ -87,6 +88,11 @@ void ETJump::TimerunV2::computeRanks() {
         const double maxPointsPerRun = 1000.0;
 
         for (const auto &r : records) {
+          // we don't want to compute score for maps not on the server,
+          // e.g. when a new version of a map is released
+          if (!game.mapStatistics->mapExists(r.map)) {
+            continue;
+          }
           if (scores.count(r.seasonId) == 0) {
             scores[r.seasonId] = {};
           }


### PR DESCRIPTION
Exclude maps that are not on server from ranks computation, as this can provide unfair scores when maps get updated and old versions are deprecated.