### PR TITLE
Print top 3 records per run if no params given

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -313,8 +313,11 @@ bool Records(gentity_t *ent, Arguments argv) {
   params.exactMap = exactMap;
   params.run = run;
   params.page = optPage.hasValue() ? optPage.value().integer : 1;
-  params.pageSize = optPageSize.hasValue() ? optPageSize.value().integer : 20;
-
+  if (command.extraArgs.empty()) {
+    params.pageSize = 3;
+  } else {
+    params.pageSize = optPageSize.hasValue() ? optPageSize.value().integer : 20;
+  }
   params.userId = ETJump::session->GetId(ent);
 
   game.timerunV2->printRecords(params);


### PR DESCRIPTION
As was prior to new timerun system, only print top 3 of each run in map if no extra parameters are given to `records` command, so we don't spam console full of records on maps with many runs and records.