### PR TITLE
Fix possible heap buffer overflow on wrapWords

### DIFF
--- a/src/game/etj_string_utilities.cpp
+++ b/src/game/etj_string_utilities.cpp
@@ -158,12 +158,6 @@ std::vector<std::string> ETJump::wrapWords(std::string &input, char separator,
   while (true) {
     auto pos = input.rfind(separator, lastPos + maxLength);
 
-    // if we landed on a separator char, back off one char and re-search,
-    // otherwise we'll exceed maxLength as pos is incremented
-    if (input[pos] == separator) {
-      pos = input.rfind(separator, lastPos + maxLength - 1);
-    }
-
     /* separator not found */
     if (pos == std::string::npos) {
       /* split by length; */
@@ -174,6 +168,13 @@ std::vector<std::string> ETJump::wrapWords(std::string &input, char separator,
       }
       break;
     }
+
+    // if we landed on a separator char, back off one char and re-search,
+    // otherwise we'll exceed maxLength as pos is incremented
+    if (input[pos] == separator) {
+      pos = input.rfind(separator, lastPos + maxLength - 1);
+    }
+
     pos += 1;
     /* no new separators were found */
     if (pos == lastPos) {


### PR DESCRIPTION
If separator char isn't found, `input[pos]` would cause heap overflow since `pos` exceeds the string length.

refs #1038 