### PR TITLE
Fix 1ms error in relative checkpoint timer

### DIFF
--- a/src/cgame/etj_timerun_view.cpp
+++ b/src/cgame/etj_timerun_view.cpp
@@ -209,11 +209,21 @@ void ETJump::TimerunView::draw() {
           run->previousRecordCheckpoints[i] == TIMERUN_CHECKPOINT_NOT_SET
               ? run->previousRecord
               : run->previousRecordCheckpoints[i];
+      bool noRecordCheckpoint =
+          recordCheckpointTime == TIMERUN_CHECKPOINT_NOT_SET;
 
       bool checkpointTimeNotSet = checkpointTime == TIMERUN_CHECKPOINT_NOT_SET;
-      int relativeTime = checkpointTimeNotSet
-                             ? currentTime - recordCheckpointTime
-                             : checkpointTime - recordCheckpointTime;
+
+      // make sure we don't subtract -1 from timestamp if we don't
+      // have a checkpoint time set at all
+      int relativeTime;
+      if (checkpointTimeNotSet) {
+        relativeTime =
+            currentTime - (noRecordCheckpoint ? 0 : recordCheckpointTime);
+      } else {
+        relativeTime =
+            checkpointTime - (noRecordCheckpoint ? 0 : recordCheckpointTime);
+      }
 
       // if we don't have current or next checkpoint set, just display the
       // runtimer


### PR DESCRIPTION
In scenarios where player had no record set on a run, and was using relative checkpoint timer (`etj_checkpointsStyle 0`), the timestamps were off by -1ms because `recordCheckpointTime` was subtracted from the timestamp, even though it was -1 (no record set).

Fixes #1064 