### PR TITLE
Runtimer fixes + refactoring

### DIFF
--- a/src/cgame/etj_timerun_view.cpp
+++ b/src/cgame/etj_timerun_view.cpp
@@ -215,26 +215,31 @@ void ETJump::TimerunView::draw() {
           comparisonTime == currentTime) {
         checkpointColor = &colorWhite;
       } else {
+        bool isFasterCheckpoint;
         // if we've hit max checkpoints, checkpointTime will be 0,
-        // so we need to compare against the comparisonTime, which will be
-        // previously set record in this scenario
+        // so we need to compare currentTime against the comparisonTime,
+        // which will be previously set record in this scenario
         if (maxCheckpointsHit) {
           if (currentTime < comparisonTime) {
-            checkpointColor = &colorSuccess;
-            dir = "-";
+            isFasterCheckpoint = true;
           } else {
-            checkpointColor = &colorFail;
-            dir = "+";
+            isFasterCheckpoint = false;
           }
         } else {
           if ((noCheckpointTimeSet && currentTime < comparisonTime) ||
               (!noCheckpointTimeSet && checkpointTime < comparisonTime)) {
-            checkpointColor = &colorSuccess;
-            dir = "-";
+            isFasterCheckpoint = true;
           } else {
-            checkpointColor = &colorFail;
-            dir = "+";
+            isFasterCheckpoint = false;
           }
+        }
+
+        if (isFasterCheckpoint) {
+          checkpointColor = &colorSuccess;
+          dir = "-";
+        } else {
+          checkpointColor = &colorFail;
+          dir = "+";
         }
       }
 

--- a/src/cgame/etj_timerun_view.cpp
+++ b/src/cgame/etj_timerun_view.cpp
@@ -220,27 +220,15 @@ void ETJump::TimerunView::draw() {
         // so we need to compare currentTime against the comparisonTime,
         // which will be previously set record in this scenario
         if (maxCheckpointsHit) {
-          if (currentTime < comparisonTime) {
-            isFasterCheckpoint = true;
-          } else {
-            isFasterCheckpoint = false;
-          }
+          isFasterCheckpoint = currentTime < comparisonTime;
         } else {
-          if ((noCheckpointTimeSet && currentTime < comparisonTime) ||
-              (!noCheckpointTimeSet && checkpointTime < comparisonTime)) {
-            isFasterCheckpoint = true;
-          } else {
-            isFasterCheckpoint = false;
-          }
+          isFasterCheckpoint =
+              (noCheckpointTimeSet ? currentTime : checkpointTime) <
+              comparisonTime;
         }
 
-        if (isFasterCheckpoint) {
-          checkpointColor = &colorSuccess;
-          dir = "-";
-        } else {
-          checkpointColor = &colorFail;
-          dir = "+";
-        }
+        checkpointColor = isFasterCheckpoint ? &colorSuccess : &colorFail;
+        dir = isFasterCheckpoint ? "-" : "+";
       }
 
       const int absoluteTime = noCheckpointTimeSet || maxCheckpointsHit

--- a/src/cgame/etj_timerun_view.h
+++ b/src/cgame/etj_timerun_view.h
@@ -32,27 +32,36 @@ namespace ETJump {
 class TimerunView : public Drawable {
 public:
   explicit TimerunView(std::shared_ptr<Timerun> timerun);
-  ~TimerunView();
-  
-  void draw();
+  ~TimerunView() override;
 
-  int getTransitionRange(int previousRunTime);
+  void draw() override;
 
-  void pastRecordAnimation(vec4_t *color, const char *text, int timerTime,
-                           int record);
-
+private:
   // returns the currently active run if there's any
   // e.g. if player is running => return player's run,
-  // else if player is running and we're speccing the player
+  // else if player is running, and we're speccing the player
   // => return that player's run
   const Timerun::PlayerTimerunInformation *currentRun() const;
 
-private:
-  std::string getTimerString(const int msec);
+  static std::string getTimerString(int msec);
 
-  vec4_t inactiveTimerColor;
+  static int getTransitionRange(int previousTime);
+
+  static void pastRecordAnimation(vec4_t *color, const char *text,
+                                  int timerTime, int record);
+
+  // returns the alpha value of runtimer
+  static float getTimerAlpha(bool running, int lastRunTimer, int timeVar);
+
+  vec4_t inactiveTimerColor{};
   std::shared_ptr<Timerun> _timerun;
 
-  bool canSkipDraw() const;
+  vec4_t colorSuccess = {0.627f, 0.941f, 0.349f, 1.0f};
+  vec4_t colorFail = {0.976f, 0.262f, 0.262f, 1.0f};
+  static const int animationTime = 300;
+  static const int fadeOut = 2000;  // 2s fade out
+  static const int fadeHold = 5000; // 5s pause
+
+  static bool canSkipDraw();
 };
 } // namespace ETJump


### PR DESCRIPTION
* Fix checkpoints not fading with runtimer
* Adjust runtime color transition range - no longer hardcoded, starts at the last 10% of the run (capped to 10s)
* Fix checkpoint Y coordinates not adjusting correctly on non-default checkpoint text size
* Refactoring
* Fix checkpoint timer breaking when hitting max checkpoints

Fixes #1072 