### PR TITLE
Fix issues in checkRecord

### DIFF
--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -981,16 +981,17 @@ public:
 };
 
 void ETJump::TimerunV2::checkRecord(Player *player) {
-  auto clientNum = player->clientNum;
-  auto activeRunName = player->activeRunName;
-  auto userId = player->userId;
-  auto completionTime = player->completionTime;
-  std::map<std::string, std::string> metadata = {{"mod_version", GAME_VERSION}};
-  std::string playerName = player->name;
-  auto checkpoints =
+  const auto clientNum = player->clientNum;
+  const auto activeRunName = player->activeRunName;
+  const auto userId = player->userId;
+  const auto completionTime = player->completionTime;
+  const std::map<std::string, std::string> metadata = {
+      {"mod_version", GAME_VERSION}};
+  const std::string playerName = player->name;
+  const auto checkpoints =
       Container::map(player->checkpointTimes, [](int time) { return time; });
 
-  auto topRecords =
+  const auto topRecords =
       _repository->getTopRecords(_activeSeasonsIds, _currentMap, activeRunName);
 
   _sc->postTask(

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -1077,7 +1077,7 @@ void ETJump::TimerunV2::checkRecord(Player *player) {
         auto result = std::make_unique<CheckRecordResult>();
         result->clientNum = clientNum;
 
-        // setup new records for any of our old records we beat
+        // go through old records and update any records we might have beaten
         for (const auto &s : isNewRecordForSeason) {
           if (!s.second) {
             continue;
@@ -1121,7 +1121,6 @@ void ETJump::TimerunV2::checkRecord(Player *player) {
           }
         }
 
-        // this seems redundant...? aren't these false by default anyway?
         for (const auto &seasonId : _activeSeasonsIds) {
           if (result->isTopRecordPerSeason.count(seasonId) == 0) {
             result->isTopRecordPerSeason[seasonId] = false;


### PR DESCRIPTION
* Fix banner prints using wrong time for diff print - was using players own previous best, now uses rank 1 time that was beaten
* Fix `etj_ad_savePBOnly 1` not saving demos when a player made a new personal best while a season was active, but that record wasn't a new overall record (fixes #1065)
* Fix banners not displaying if a player has no previous record set on a run, but breaks either overall or seasonal record as their first record time