### PR TITLE
Support partial matching for loadcheckpoints + allow cp clearing

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -343,14 +343,17 @@ bool LoadCheckpoints(gentity_t *ent, Arguments argv) {
       "loadcheckpoints", ClientNum(ent),
       ETJump::CommandParser::CommandDefinition::create(
           "loadcheckpoints",
-          "Load checkpoints from a previous record.\n    /loadcheckpoints "
+          "Load checkpoints from an existing record.\n    /loadcheckpoints "
           "--run <run name> --rank <rank>\n\n"
           "    Has a shorthand format of:\n"
-          "    /loadcheckpoints <run name> <rank>\n")
+          "    /loadcheckpoints <run name> <rank>\n"
+          "    /loadcheckpoints <run name>")
           .addOption("run", "Name of the run to load the records from.",
                      ETJump::CommandParser::OptionDefinition::Type::Token, true,
                      0)
-          .addOption("rank", "Rank to load checkpoints from. Defaults to 1",
+          .addOption("rank",
+                     "Rank to load checkpoints from. Defaults to 1. Value -1 "
+                     "clears loaded checkpoints.",
                      ETJump::CommandParser::OptionDefinition::Type::Integer,
                      false, 1),
       &args);

--- a/src/game/etj_timerun_repository.cpp
+++ b/src/game/etj_timerun_repository.cpp
@@ -430,9 +430,10 @@ ETJump::TimerunRepository::getMapsForName(const std::string &map, bool exact) {
 
 std::vector<std::string>
 ETJump::TimerunRepository::getRunsForName(const std::string &map,
-                                          const std::string &run, bool exact) {
+                                          const std::string &run, bool exact,
+                                          bool shouldSanitize) {
 
-  std::string runFilter = exact ? "run=?" : "run like ?";
+  std::string runFilter = exact ? "lsanitize(run)=?" : "lsanitize(run) like ?";
   std::string runSearchString = exact ? run : "%" + run + "%";
 
   std::vector<std::string> runs;
@@ -446,7 +447,9 @@ ETJump::TimerunRepository::getRunsForName(const std::string &map,
   )",
                                  runFilter)
                  << runSearchString << map >>
-      [&runs](const std::string &run) { runs.push_back(run); };
+      [&runs, shouldSanitize](const std::string &run) {
+        runs.push_back(shouldSanitize ? sanitize(run, true) : run);
+      };
   return runs;
 }
 

--- a/src/game/etj_timerun_repository.cpp
+++ b/src/game/etj_timerun_repository.cpp
@@ -431,7 +431,7 @@ ETJump::TimerunRepository::getMapsForName(const std::string &map, bool exact) {
 std::vector<std::string>
 ETJump::TimerunRepository::getRunsForName(const std::string &map,
                                           const std::string &run, bool exact,
-                                          bool shouldSanitize) {
+                                          bool sanitizeResults) {
 
   std::string runFilter = exact ? "lsanitize(run)=?" : "lsanitize(run) like ?";
   std::string runSearchString = exact ? run : "%" + run + "%";
@@ -447,8 +447,8 @@ ETJump::TimerunRepository::getRunsForName(const std::string &map,
   )",
                                  runFilter)
                  << runSearchString << map >>
-      [&runs, shouldSanitize](const std::string &run) {
-        runs.push_back(shouldSanitize ? sanitize(run, true) : run);
+      [&runs, sanitizeResults](const std::string &run) {
+        runs.push_back(sanitizeResults ? sanitize(run, true) : run);
       };
   return runs;
 }

--- a/src/game/etj_timerun_repository.cpp
+++ b/src/game/etj_timerun_repository.cpp
@@ -59,15 +59,15 @@ void ETJump::TimerunRepository::initialize() { migrate(); }
 
 void ETJump::TimerunRepository::shutdown() { _database = nullptr; }
 
-std::vector<ETJump::Timerun::Season> ETJump::TimerunRepository::
-getActiveSeasons(const Time &currentTime) const {
+std::vector<ETJump::Timerun::Season>
+ETJump::TimerunRepository::getActiveSeasons(const Time &currentTime) const {
   std::vector<Timerun::Season> activeSeasons;
 
   auto currentTimeStr = currentTime.toDateTimeString();
 
   _database->sql << "select id, name, start_time, end_time from season where "
-      "start_time <= ? and (end_time is null or end_time > ?);"
-      << currentTimeStr << currentTimeStr >>
+                    "start_time <= ? and (end_time is null or end_time > ?);"
+                 << currentTimeStr << currentTimeStr >>
       [this, &activeSeasons](int id, std::string name, std::string startTimeStr,
                              std::string endTimeStr) {
         auto startTime = Time::fromString(startTimeStr);
@@ -90,7 +90,8 @@ ETJump::TimerunRepository::getRecordsForPlayer(
                      [](int season) { return std::to_string(season); }),
       ", ");
 
-  auto binder = _database->sql << stringFormat(R"(
+  auto binder = _database->sql
+                << stringFormat(R"(
           select
             %s
           from record
@@ -98,8 +99,7 @@ ETJump::TimerunRepository::getRecordsForPlayer(
             map=? and
             user_id=?;
         )",
-                                               _defaultRecordFieldsStr,
-                                               parameters)
+                                _defaultRecordFieldsStr, parameters)
                 << map << userId;
 
   auto records = getRecordsFromQuery(binder);
@@ -113,13 +113,12 @@ ETJump::TimerunRepository::addSeason(Timerun::AddSeasonParams params) {
   _database->sql << R"(
                       select count(name) from season where name=? collate nocase;
                     )"
-      << params.name >>
+                 << params.name >>
       count;
 
   if (count > 0) {
-    throw std::runtime_error(
-        stringFormat("Cannot add season `%s` as it already exists.",
-                     params.name));
+    throw std::runtime_error(stringFormat(
+        "Cannot add season `%s` as it already exists.", params.name));
   }
 
   if (params.endTime.hasValue()) {
@@ -142,20 +141,20 @@ ETJump::TimerunRepository::addSeason(Timerun::AddSeasonParams params) {
 
   if (params.endTime.hasValue())
     _database->sql << insert << params.name
-        << params.startTime.toDateTimeString()
-        << (*params.endTime).toDateTimeString();
+                   << params.startTime.toDateTimeString()
+                   << (*params.endTime).toDateTimeString();
   else
     _database->sql << insert << params.name
-        << params.startTime.toDateTimeString() << nullptr;
+                   << params.startTime.toDateTimeString() << nullptr;
 
   return Timerun::Season{static_cast<int>(_database->sql.last_insert_rowid()),
                          params.name, params.startTime, params.endTime};
 }
 
-std::vector<ETJump::Timerun::Record> ETJump::TimerunRepository::
-getRecordsForPlayer(const std::vector<int> &activeSeasons,
-                    const std::string &map, const std::string &run,
-                    int userId) {
+std::vector<ETJump::Timerun::Record>
+ETJump::TimerunRepository::getRecordsForPlayer(
+    const std::vector<int> &activeSeasons, const std::string &map,
+    const std::string &run, int userId) {
   auto records = std::vector<Timerun::Record>();
 
   _database->sql << stringFormat(R"(
@@ -176,11 +175,11 @@ getRecordsForPlayer(const std::vector<int> &activeSeasons,
       user_id=?;
     )",
                                  StringUtil::join(activeSeasons, ", "))
-      << map << run << userId >>
+                 << map << run << userId >>
       [&records](int seasonId, std::string map, std::string runName, int userId,
                  int time, std::string checkpointsString,
-                 std::string recordDate,
-                 std::string playerName, std::string metadataString) {
+                 std::string recordDate, std::string playerName,
+                 std::string metadataString) {
         auto record = getRecordFromStandardQueryResult(
             seasonId, map, runName, userId, time, checkpointsString, recordDate,
             playerName, metadataString);
@@ -192,8 +191,8 @@ getRecordsForPlayer(const std::vector<int> &activeSeasons,
 }
 
 std::vector<ETJump::Timerun::Record>
-ETJump::TimerunRepository::getRecordsForRun(
-    const std::string &map, const std::string &run) const {
+ETJump::TimerunRepository::getRecordsForRun(const std::string &map,
+                                            const std::string &run) const {
   throw std::runtime_error("Not implemented");
 }
 
@@ -220,10 +219,11 @@ void ETJump::TimerunRepository::insertRecord(const Timerun::Record &record) {
       ?,
       ?
     );
-  )" << record.seasonId << record.map << record.run << record.userId << record.
-      time << StringUtil::join(record.checkpoints, ",") << record.recordDate.
-      toDateTimeString() << record.playerName << serializeMetadata(
-          record.metadata);
+  )" << record.seasonId
+                 << record.map << record.run << record.userId << record.time
+                 << StringUtil::join(record.checkpoints, ",")
+                 << record.recordDate.toDateTimeString() << record.playerName
+                 << serializeMetadata(record.metadata);
 }
 
 void ETJump::TimerunRepository::updateRecord(const Timerun::Record &record) {
@@ -242,15 +242,14 @@ void ETJump::TimerunRepository::updateRecord(const Timerun::Record &record) {
       run=? and
       user_id=?;
   )" << record.time
-      << StringUtil::join(record.checkpoints, ",") << record.recordDate.
-      toDateTimeString() << record.playerName << serializeMetadata(
-          record.metadata) << record.seasonId << record.map << record.run <<
-      record.userId;
+                 << StringUtil::join(record.checkpoints, ",")
+                 << record.recordDate.toDateTimeString() << record.playerName
+                 << serializeMetadata(record.metadata) << record.seasonId
+                 << record.map << record.run << record.userId;
 }
 
 ETJump::opt<ETJump::Timerun::Record>
-ETJump::TimerunRepository::getTopRecord(int seasonId,
-                                        const std::string &map,
+ETJump::TimerunRepository::getTopRecord(int seasonId, const std::string &map,
                                         const std::string &run) {
   opt<Timerun::Record> record;
   _database->sql << R"(
@@ -271,12 +270,11 @@ ETJump::TimerunRepository::getTopRecord(int seasonId,
       run=?
     order by time asc
     limit 1
-    )"
-      << seasonId << map << run >>
+    )" << seasonId
+                 << map << run >>
       [&record](int seasonId, std::string map, std::string runName, int userId,
-                int time, std::string checkpointsString,
-                std::string recordDate, std::string playerName,
-                std::string metadataString) {
+                int time, std::string checkpointsString, std::string recordDate,
+                std::string playerName, std::string metadataString) {
         record = opt<Timerun::Record>(getRecordFromStandardQueryResult(
             seasonId, map, runName, userId, time, checkpointsString, recordDate,
             playerName, metadataString));
@@ -285,9 +283,10 @@ ETJump::TimerunRepository::getTopRecord(int seasonId,
   return record;
 }
 
-std::vector<ETJump::Timerun::Record> ETJump::TimerunRepository::getTopRecords(
-    const std::vector<int> &seasonIds, const std::string &map,
-    const std::string &run) const {
+std::vector<ETJump::Timerun::Record>
+ETJump::TimerunRepository::getTopRecords(const std::vector<int> &seasonIds,
+                                         const std::string &map,
+                                         const std::string &run) const {
   auto seasonIdsPlaceholder = DatabaseV2::createPlaceholderString(seasonIds);
 
   std::string query = stringFormat(
@@ -320,15 +319,14 @@ std::vector<ETJump::Timerun::Record> ETJump::TimerunRepository::getTopRecords(
   binder << map << run;
 
   std::vector<Timerun::Record> records;
-  binder >>
-      [&records](int seasonId, std::string map, std::string runName, int userId,
-                 int time, std::string checkpointsString,
-                 std::string recordDate,
-                 std::string playerName, std::string metadataString, int rank) {
-        records.push_back(getRecordFromStandardQueryResult(
-            seasonId, map, runName, userId, time, checkpointsString, recordDate,
-            playerName, metadataString));
-      };
+  binder >> [&records](int seasonId, std::string map, std::string runName,
+                       int userId, int time, std::string checkpointsString,
+                       std::string recordDate, std::string playerName,
+                       std::string metadataString, int rank) {
+    records.push_back(getRecordFromStandardQueryResult(
+        seasonId, map, runName, userId, time, checkpointsString, recordDate,
+        playerName, metadataString));
+  };
 
   return records;
 }
@@ -389,10 +387,8 @@ void ETJump::TimerunRepository::editSeason(
     return;
   }
 
-  std::string updatedFieldsString =
-      StringUtil::join(Container::map(updatedFields, [](auto a) {
-        return a + "=?";
-      }), ",");
+  std::string updatedFieldsString = StringUtil::join(
+      Container::map(updatedFields, [](auto a) { return a + "=?"; }), ",");
 
   auto query = stringFormat(R"(
     update
@@ -401,7 +397,8 @@ void ETJump::TimerunRepository::editSeason(
       %s
     where
       id=?
-  )", updatedFieldsString);
+  )",
+                            updatedFieldsString);
 
   auto q = _database->sql << query;
 
@@ -411,8 +408,8 @@ void ETJump::TimerunRepository::editSeason(
   q << seasonId;
 }
 
-std::vector<std::string> ETJump::TimerunRepository::getMapsForName(
-    const std::string &map, bool exact) {
+std::vector<std::string>
+ETJump::TimerunRepository::getMapsForName(const std::string &map, bool exact) {
 
   std::string mapFilter = exact ? "map=?" : "map like ?";
   std::string mapSearchString = exact ? map : "%" + map + "%";
@@ -426,9 +423,31 @@ std::vector<std::string> ETJump::TimerunRepository::getMapsForName(
     collate nocase
   )",
                                  mapFilter)
-      << mapSearchString >>
+                 << mapSearchString >>
       [&maps](std::string map) { maps.push_back(map); };
   return maps;
+}
+
+std::vector<std::string>
+ETJump::TimerunRepository::getRunsForName(const std::string &map,
+                                          const std::string &run, bool exact) {
+
+  std::string runFilter = exact ? "run=?" : "run like ?";
+  std::string runSearchString = exact ? run : "%" + run + "%";
+
+  std::vector<std::string> runs;
+  _database->sql << stringFormat(R"(
+    select
+      distinct run
+    from record
+    where %s
+      and map = ?
+    collate nocase
+  )",
+                                 runFilter)
+                 << runSearchString << map >>
+      [&runs](const std::string &run) { runs.push_back(run); };
+  return runs;
 }
 
 std::vector<ETJump::Timerun::Record> ETJump::TimerunRepository::getRecords() {
@@ -465,9 +484,9 @@ std::vector<ETJump::Timerun::Record> ETJump::TimerunRepository::getRecords(
 
   auto maps = getMapsForName(params.map, params.exactMap);
   if (maps.size() > 1) {
-    std::string error = stringFormat(
-        "^3records: ^7found %d maps matching ^3%s^7\n",
-        maps.size(), params.map);
+    std::string error =
+        stringFormat("^3records: ^7found %d maps matching ^3%s^7\n",
+                     maps.size(), params.map);
 
     const int perRow = 3;
     int i = 0;
@@ -483,10 +502,9 @@ std::vector<ETJump::Timerun::Record> ETJump::TimerunRepository::getRecords(
     throw std::runtime_error(error);
   }
 
-  std::string seasonPlaceholders =
-      StringUtil::join(Container::map(seasons, [](const auto &s) {
-        return "season_id=?";
-      }), " or ");
+  std::string seasonPlaceholders = StringUtil::join(
+      Container::map(seasons, [](const auto &s) { return "season_id=?"; }),
+      " or ");
 
   std::string runPlaceholder = runSpecified ? "and lsanitize(run) like ?" : "";
 
@@ -540,8 +558,8 @@ std::vector<ETJump::Timerun::Record> ETJump::TimerunRepository::getRecords(
 }
 
 std::vector<ETJump::Timerun::Season>
-ETJump::TimerunRepository::getSeasonsForName(
-    const std::string &name, bool exact) {
+ETJump::TimerunRepository::getSeasonsForName(const std::string &name,
+                                             bool exact) {
   std::string query;
 
   std::vector<Timerun::Season> seasons;
@@ -549,10 +567,9 @@ ETJump::TimerunRepository::getSeasonsForName(
   auto handler = [&seasons](int id, const std::string &name,
                             const std::string &startTime,
                             std::unique_ptr<std::string> endTime) {
-    seasons.push_back(Timerun::Season{id, name, Time::fromString(startTime),
-                                      (endTime
-                                         ? opt<Time>(Time::fromString(*endTime))
-                                         : opt<Time>())});
+    seasons.push_back(Timerun::Season{
+        id, name, Time::fromString(startTime),
+        (endTime ? opt<Time>(Time::fromString(*endTime)) : opt<Time>())});
   };
 
   if (exact) {
@@ -586,8 +603,9 @@ ETJump::TimerunRepository::getSeasonsForName(
   return seasons;
 }
 
-ETJump::opt<ETJump::Timerun::Record> ETJump::TimerunRepository::getRecord(
-    const std::string &map, const std::string &run, int rank) {
+ETJump::opt<ETJump::Timerun::Record>
+ETJump::TimerunRepository::getRecord(const std::string &map,
+                                     const std::string &run, int rank) {
   opt<Timerun::Record> record;
 
   _database->sql << R"(
@@ -609,7 +627,7 @@ ETJump::opt<ETJump::Timerun::Record> ETJump::TimerunRepository::getRecord(
       ) as ranked_records
       where rank = ?;
   )" << map << run
-      << rank >>
+                 << rank >>
       [&record](int seasonId, std::string map, std::string runName, int userId,
                 int time, std::string checkpointsString, std::string recordDate,
                 std::string playerName, std::string metadataString, int rank) {
@@ -651,7 +669,10 @@ void ETJump::TimerunRepository::deleteSeason(const std::string &name) {
     throw std::runtime_error("Cannot delete default season.");
   }
   int id = 0;
-  _database->sql << "select coalesce((select id from season where name=? collate nocase), -1);" << name >> id;
+  _database->sql << "select coalesce((select id from season where name=? "
+                    "collate nocase), -1);"
+                 << name >>
+      id;
   if (id < 0) {
     throw std::runtime_error(stringFormat("Season `%s` does not exist.", name));
   }
@@ -667,8 +688,9 @@ void ETJump::TimerunRepository::deleteSeason(const std::string &name) {
 
 void ETJump::TimerunRepository::tryToMigrateRecords() {
   int count = 0;
-  _oldDatabase->sql <<
-      "select count(*) from sqlite_master where tbl_name='records'" >> count;
+  _oldDatabase->sql
+          << "select count(*) from sqlite_master where tbl_name='records'" >>
+      count;
   if (count == 0) {
     return;
   }

--- a/src/game/etj_timerun_repository.h
+++ b/src/game/etj_timerun_repository.h
@@ -65,7 +65,7 @@ public:
   std::vector<std::string> getMapsForName(const std::string &map, bool exact);
   std::vector<std::string> getRunsForName(const std::string &map,
                                           const std::string &run, bool exact,
-                                          bool shouldSanitize);
+                                          bool sanitizeResults);
   std::vector<Timerun::Record> getRecords();
   std::vector<Timerun::Record>
   getRecords(const Timerun::PrintRecordsParams &params);

--- a/src/game/etj_timerun_repository.h
+++ b/src/game/etj_timerun_repository.h
@@ -38,55 +38,60 @@ class TimerunRepository {
 public:
   explicit TimerunRepository(std::unique_ptr<DatabaseV2> database,
                              std::unique_ptr<DatabaseV2> oldDatabase)
-    : _database(std::move(database)), _oldDatabase(std::move(oldDatabase)) {
-  }
+      : _database(std::move(database)), _oldDatabase(std::move(oldDatabase)) {}
 
   void initialize();
   void shutdown();
 
   std::vector<Timerun::Season> getActiveSeasons(const Time &currentTime) const;
-  std::vector<Timerun::Record> getRecordsForPlayer(
-      const std::vector<int> activeSeasons, const std::string &map, int userId);
+  std::vector<Timerun::Record>
+  getRecordsForPlayer(const std::vector<int> activeSeasons,
+                      const std::string &map, int userId);
   Timerun::Season addSeason(Timerun::AddSeasonParams params);
-  std::vector<Timerun::Record> getRecordsForPlayer(
-      const std::vector<int> &activeSeasons,
-      const std::string &map, const std::string &run, int userId);
+  std::vector<Timerun::Record>
+  getRecordsForPlayer(const std::vector<int> &activeSeasons,
+                      const std::string &map, const std::string &run,
+                      int userId);
   std::vector<Timerun::Record> getRecordsForRun(const std::string &map,
                                                 const std::string &run) const;
   void insertRecord(const Timerun::Record &record);
   void updateRecord(const Timerun::Record &record);
-  opt<Timerun::Record>
-  getTopRecord(int seasonId, const std::string &map,
-               const std::string &run);
-  std::vector<Timerun::Record> getTopRecords(const std::vector<int>& seasonIds,
+  opt<Timerun::Record> getTopRecord(int seasonId, const std::string &map,
+                                    const std::string &run);
+  std::vector<Timerun::Record> getTopRecords(const std::vector<int> &seasonIds,
                                              const std::string &map,
                                              const std::string &run) const;
   void editSeason(const Timerun::EditSeasonParams &params);
   std::vector<std::string> getMapsForName(const std::string &map, bool exact);
+  std::vector<std::string> getRunsForName(const std::string &map,
+                                          const std::string &run, bool exact);
   std::vector<Timerun::Record> getRecords();
-  std::vector<Timerun::Record> getRecords(
-      const Timerun::PrintRecordsParams &params);
-  std::vector<Timerun::Season> getSeasonsForName(
-      const std::string &name, bool exact);
-  opt<Timerun::Record> getRecord(const std::string & map, const std::string & run, int rank);
+  std::vector<Timerun::Record>
+  getRecords(const Timerun::PrintRecordsParams &params);
+  std::vector<Timerun::Season> getSeasonsForName(const std::string &name,
+                                                 bool exact);
+  opt<Timerun::Record> getRecord(const std::string &map, const std::string &run,
+                                 int rank);
   std::vector<Timerun::Season> getSeasons();
-  void deleteSeason(const std::string & name);
+  void deleteSeason(const std::string &name);
 
 private:
   void tryToMigrateRecords();
   void migrate();
 
   const std::vector<std::string> _defaultSeasonFields{"id", "name",
-    "start_time", "end_time"};
+                                                      "start_time", "end_time"};
   const std::string _defaultSeasonFieldsStr =
       StringUtil::join(_defaultSeasonFields, ",");
-  const std::string _defaultSeasonQueryBase = stringFormat(R"(
+  const std::string _defaultSeasonQueryBase =
+      stringFormat(R"(
     select
       %s
     from season    
-  )", _defaultSeasonFieldsStr);
+  )",
+                   _defaultSeasonFieldsStr);
   const std::vector<std::string> _defaultRecordFields{
-      "season_id", "map", "run", "user_id", "time",
+      "season_id",   "map",         "run",         "user_id", "time",
       "checkpoints", "record_date", "player_name", "metadata"};
   const std::string _defaultRecordFieldsStr =
       StringUtil::join(_defaultRecordFields, ",");
@@ -95,13 +100,14 @@ private:
         select
           %s
         from record
-      )", _defaultRecordFieldsStr);
+      )",
+                   _defaultRecordFieldsStr);
 
-  static std::vector<Timerun::Record> getRecordsFromQuery(
-      sqlite::database_binder &binder);
+  static std::vector<Timerun::Record>
+  getRecordsFromQuery(sqlite::database_binder &binder);
 
   std::string serializeMetadata(std::map<std::string, std::string> metadata);
   std::unique_ptr<DatabaseV2> _database;
   std::unique_ptr<DatabaseV2> _oldDatabase;
 };
-}
+} // namespace ETJump

--- a/src/game/etj_timerun_repository.h
+++ b/src/game/etj_timerun_repository.h
@@ -64,7 +64,8 @@ public:
   void editSeason(const Timerun::EditSeasonParams &params);
   std::vector<std::string> getMapsForName(const std::string &map, bool exact);
   std::vector<std::string> getRunsForName(const std::string &map,
-                                          const std::string &run, bool exact);
+                                          const std::string &run, bool exact,
+                                          bool shouldSanitize);
   std::vector<Timerun::Record> getRecords();
   std::vector<Timerun::Record>
   getRecords(const Timerun::PrintRecordsParams &params);

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -673,7 +673,8 @@ void ETJump::TimerunV2::loadCheckpoints(int clientNum, std::string mapName,
   std::string matchedRun;
   std::string errMsg;
   int matchedCount = 0;
-  const auto matchedRuns = _repository->getRunsForName(mapName, runName, false);
+  const auto matchedRuns =
+      _repository->getRunsForName(mapName, runName, false, true);
   auto it = std::find(matchedRuns.cbegin(), matchedRuns.cend(), runName);
 
   if (it != matchedRuns.cend()) {

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -736,11 +736,7 @@ void ETJump::TimerunV2::loadCheckpoints(int clientNum, std::string mapName,
         const auto runName = result->matchedRun;
 
         // bail out if no checkpoints are present
-        const int noCheckpointSet = TIMERUN_CHECKPOINT_NOT_SET;
-        if (std::all_of(result->checkpoints.begin(), result->checkpoints.end(),
-                        [noCheckpointSet](int checkpoints) {
-                          return checkpoints == noCheckpointSet;
-                        })) {
+        if (result->checkpoints[0] == TIMERUN_CHECKPOINT_NOT_SET) {
           throw std::runtime_error(
               stringFormat("^7No checkpoint times found for run ^3`%s`^7 "
                            "from rank ^3`%d`^7 record.",


### PR DESCRIPTION
* Support `/loadcheckpoints <partial runname>` so full run name doesn't need to be typed out
* Allow clearing loaded checkpoints more easily by specifying rank `-1`
* Checkpoint loading will now fail if requested run has no checkpoint times