### PR TITLE
Exclude users with 0 points from rankings

### DIFF
--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -148,6 +148,10 @@ void ETJump::TimerunV2::computeRanks() {
           }
 
           for (const auto &user : season.second) {
+            // exclude users with 0 points from rankings
+            if (user.second == 0) {
+              continue;
+            }
             rankings[season.first].emplace_back(
                 0, user.first, latestName[user.first], user.second);
           }


### PR DESCRIPTION
Doesn't provide anything useful to display users with no points.

Fixes #1067 