### PR TITLE
Disable link time optimizations for MSVC

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -38,9 +38,11 @@ function(create_compiler_opts target)
 			-ggdb3>)           # generate gdb friendly debug info
 
 	# MSVC flags
-	set(MSVC_LINK_FLAGS 
-		$<$<CONFIG:Release>:
-			/LTCG>) # perform link time optimizations
+	# link time optimizations disabled for now, possibly due to MSVC 2019-specific bug
+	
+	# set(MSVC_LINK_FLAGS 
+	# 	$<$<CONFIG:Release>:
+	# 		/LTCG>) # perform link time optimizations
 
 	set(MSVC_CXX_FLAGS
 		/wd4068                # ignore GCC pragmas
@@ -52,7 +54,7 @@ function(create_compiler_opts target)
 		$<$<CONFIG:Release>:
 			/MT                # use static runtime
 			/O2                # max optimizations
-			/GL                # full exe/dll optimization
+			# /GL                # full exe/dll optimization
 			/Gy                # generate useful information for optimizer
 			/Ob2               # let compiler inline freely
 			/fp:fast>          # fast floating point math


### PR DESCRIPTION
MSVC 2019 potentially has a bug that affects 64-bit Windows.