### PR TITLE
Display client engine in /players output

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -3832,8 +3832,11 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum,
   if (strcmp(s, GAME_NAME)) {
     CG_Error("Client/Server game mismatch: '%s/%s'", GAME_NAME, s);
   }
-  trap_Cvar_Set("cg_etVersion",
-                GAME_VERSION_DATED); // So server can check
+
+  // detect engine version
+  char versionStr[MAX_CVAR_VALUE_STRING];
+  trap_Cvar_VariableStringBuffer("version", versionStr, sizeof(versionStr));
+  trap_Cvar_Set("cg_etVersion", versionStr[0] ? versionStr : "(undetected)");
 
   s = CG_ConfigString(CS_LEVEL_START_TIME);
   cgs.levelStartTime = Q_atoi(s);

--- a/src/game/g_cmds_ext.cpp
+++ b/src/game/g_cmds_ext.cpp
@@ -242,12 +242,12 @@ void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
 
   if (ent) {
     Printer::SendConsoleMessage(
-        clientNum, va("\n^g  %-4s%-25s%-7s%-6s%-9s%-7s%s\n", header.id,
+        clientNum, va("\n^g  %-4s%-25s%-8s%-6s%-9s%-7s%s\n", header.id,
                       header.player, header.nudge, header.rate,
                       header.maxPackets, header.snaps, header.engine));
     Printer::SendConsoleMessage(clientNum, va("^g%s\n", header.divider));
   } else {
-    G_Printf("  %-4s%-25s%-7s%-6s%-9s%-7s%s\n", header.id, header.player,
+    G_Printf("  %-4s%-25s%-8s%-6s%-9s%-7s%s\n", header.id, header.player,
              header.nudge, header.rate, header.maxPackets, header.snaps,
              header.engine);
     G_Printf("%s\n", header.divider);
@@ -271,7 +271,7 @@ void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
     } else {
       trap_GetUserinfo(idnum, userinfo, sizeof(userinfo));
       s = Info_ValueForKey(userinfo, "rate");
-      userRate = (maxRate != 0 && Q_atoi(s) > maxRate) ? maxRate : Q_atoi(s);
+      userRate = (maxRate > 0 && Q_atoi(s) > maxRate) ? maxRate : Q_atoi(s);
       s = Info_ValueForKey(userinfo, "snaps");
       userSnaps = Q_atoi(s);
 
@@ -285,13 +285,13 @@ void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
 
       if (ent) {
         Q_strncpyz(info,
-                   va("%5d%6d%9d%s%7d  ^9%s", client->pers.clientTimeNudge,
+                   va("%5d%7d%9d%s%7d  ^9%s", client->pers.clientTimeNudge,
                       userRate, client->pers.clientMaxPackets,
                       userSnaps < svFps ? "^1" : "^7", userSnaps, userEngine),
                    sizeof(info));
       } else {
         Q_strncpyz(info,
-                   va("%5d%6d%9d%7d  %s", client->pers.clientTimeNudge,
+                   va("%5d%7d%9d%7d  %s", client->pers.clientTimeNudge,
                       userRate, client->pers.clientMaxPackets, userSnaps,
                       userEngine),
                    sizeof(info));

--- a/src/game/g_cmds_ext.cpp
+++ b/src/game/g_cmds_ext.cpp
@@ -229,7 +229,7 @@ struct playersCmdHeader {
 //
 // Show client info
 void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
-  int i, idnum, maxRate, count = 0;
+  int idNum, count = 0;
   int userRate, userSnaps;
   gclient_t *client;
   char name[MAX_NETNAME], info[256];
@@ -253,12 +253,12 @@ void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
     G_Printf("%s\n", header.divider);
   }
 
-  maxRate = trap_Cvar_VariableIntegerValue("sv_maxrate");
+  const int maxRate = trap_Cvar_VariableIntegerValue("sv_maxrate");
   const int svFps = trap_Cvar_VariableIntegerValue("sv_fps");
 
-  for (i = 0; i < level.numConnectedClients; i++) {
-    idnum = level.sortedClients[i]; // level.sortedNames[i];
-    client = &level.clients[idnum];
+  for (int i = 0; i < level.numConnectedClients; i++) {
+    idNum = level.sortedClients[i]; // level.sortedNames[i];
+    client = &level.clients[idNum];
 
     Q_strncpyz(name, client->pers.netname, sizeof(name));
     // exclude color codes from the max string length
@@ -269,7 +269,7 @@ void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
     if (client->pers.connected == CON_CONNECTING) {
       Q_strncpyz(info, va("%s", "^3>>> CONNECTING <<<"), sizeof(info));
     } else {
-      trap_GetUserinfo(idnum, userinfo, sizeof(userinfo));
+      trap_GetUserinfo(idNum, userinfo, sizeof(userinfo));
       s = Info_ValueForKey(userinfo, "rate");
       userRate = (maxRate > 0 && Q_atoi(s) > maxRate) ? maxRate : Q_atoi(s);
       s = Info_ValueForKey(userinfo, "snaps");
@@ -313,9 +313,9 @@ void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
     if (ent) {
       Printer::SendConsoleMessage(
           clientNum,
-          va("%s%2d  %-*s^7%s\n", team, idnum, 25 + colorChars, name, info));
+          va("%s%2d  %-*s^7%s\n", team, idNum, 25 + colorChars, name, info));
     } else {
-      G_Printf("%s%2d  %-25s%s\n", team, idnum,
+      G_Printf("%s%2d  %-25s%s\n", team, idNum,
                ETJump::sanitize(name, false).c_str(), info);
     }
 


### PR DESCRIPTION
Show clients engine version in the output of `players` command, and make the player list overall more in line with our other mod prints (formatting, color scheme etc). Also clean up bunch of unused code in the command.

`snaps` is also now displayed in red if it's below the value of `sv_fps`.

![image](https://github.com/etjump/etjump/assets/14221121/be2ca22d-795a-47a6-ba1e-f3fc6f3c0fe3)
