### PR TITLE
Disable clang-tidy checks about pass-by-ref for async functions

### DIFF
--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -377,6 +377,7 @@ public:
 
 // do not pass by ref! postTask runs asynchronously and passing by
 // ref will lead to undefined behavior
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void ETJump::TimerunV2::addSeason(Timerun::AddSeasonParams season) {
   _sc->postTask(
       [this, season]() {
@@ -413,6 +414,7 @@ public:
 
 // do not pass by ref! postTask runs asynchronously and passing by
 // ref will lead to undefined behavior
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void ETJump::TimerunV2::editSeason(Timerun::EditSeasonParams params) {
   _sc->postTask(
       [this, params]() {
@@ -510,6 +512,7 @@ std::string rankToString(int rank) {
 
 // do not pass by ref! postTask runs asynchronously and passing by
 // ref will lead to undefined behavior
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void ETJump::TimerunV2::printRecords(Timerun::PrintRecordsParams params) {
   _sc->postTask(
       [this, params] {
@@ -675,6 +678,7 @@ public:
 
 // do not pass by ref! postTask runs asynchronously and passing by
 // ref will lead to undefined behavior
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void ETJump::TimerunV2::loadCheckpoints(int clientNum, std::string mapName,
                                         std::string runName, int rank) {
   _sc->postTask(
@@ -823,6 +827,7 @@ std::string ETJump::TimerunV2::getRankingsStringFor(
 
 // do not pass by ref! postTask runs asynchronously and passing by
 // ref will lead to undefined behavior
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void ETJump::TimerunV2::printRankings(Timerun::PrintRankingsParams params) {
   _sc->postTask(
       [this, params] {
@@ -884,6 +889,7 @@ void ETJump::TimerunV2::printRankings(Timerun::PrintRankingsParams params) {
 
 // do not pass by ref! postTask runs asynchronously and passing by
 // ref will lead to undefined behavior
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void ETJump::TimerunV2::printSeasons(int clientNum) {
   _sc->postTask(
       [this] {

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -678,9 +678,10 @@ public:
 
 // do not pass by ref! postTask runs asynchronously and passing by
 // ref will lead to undefined behavior
-// NOLINTNEXTLINE(performance-unnecessary-value-param)
+// NOLINTBEGIN(performance-unnecessary-value-param)
 void ETJump::TimerunV2::loadCheckpoints(int clientNum, std::string mapName,
                                         std::string runName, int rank) {
+  // NOLINTEND(performance-unnecessary-value-param)
   _sc->postTask(
       [this, clientNum, mapName, runName, rank] {
         std::string matchedRun;


### PR DESCRIPTION
As per comments, these cannot use const references due to running async, just adding a clang-tidy comment that disables check for `performance-unnecessary-value-param` on these.