### PR TITLE
Fix incorrect printf formatting in players command

### DIFF
--- a/src/game/g_cmds_ext.cpp
+++ b/src/game/g_cmds_ext.cpp
@@ -262,7 +262,8 @@ void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
 
     Q_strncpyz(name, client->pers.netname, sizeof(name));
     // exclude color codes from the max string length
-    const auto colorChars = strlen(name) - Q_PrintStrlen(name);
+    const auto colorChars =
+        static_cast<int>(strlen(name)) - Q_PrintStrlen(name);
     name[23 + colorChars] = 0;
 
     // player info


### PR DESCRIPTION
`colorChars` was `unsigned long`, but formatting expected `int`.

refs #1089 