### PR TITLE
Initalize Clock and Date structs to avoid uninitialized comparison

### DIFF
--- a/src/game/etj_time_utilities.h
+++ b/src/game/etj_time_utilities.h
@@ -24,12 +24,6 @@
 
 #pragma once
 
-#ifdef min
-  #undef min
-#endif
-#ifdef max
-  #undef max
-#endif
 #include <iomanip>
 #include <string>
 #include <sstream>
@@ -102,8 +96,7 @@ struct Date {
   }
 
   std::string toDateString() const {
-    return stringFormat("%04d-%02d-%02d", this->year,
-                        this->mon, this->day);
+    return stringFormat("%04d-%02d-%02d", this->year, this->mon, this->day);
   }
 
   int year; // year
@@ -112,8 +105,8 @@ struct Date {
 };
 
 struct Time {
-  Clock clock;
-  Date date;
+  Clock clock{};
+  Date date{};
 
   bool operator==(const Time &other) const {
     return (clock.hours == other.clock.hours && clock.min == other.clock.min &&
@@ -162,7 +155,7 @@ struct Time {
 
   static Time fromInt(int input) {
     time_t value = input;
-    tm* t = std::gmtime(&value);
+    tm *t = std::gmtime(&value);
 
     Time time;
     time.date.year = t->tm_year + 1900;
@@ -185,8 +178,7 @@ struct Time {
 
     Time time;
     time.date.year = t.tm_year + 1900;
-    time.date.mon =
-        t.tm_mon + 1;
+    time.date.mon = t.tm_mon + 1;
     time.date.day = t.tm_mday;
 
     time.clock.hours = t.tm_hour;
@@ -197,7 +189,7 @@ struct Time {
   }
 
   static Time fromDate(const Date &date) {
-    Time time{};
+    Time time;
     time.date.year = date.year;
     time.date.mon = date.mon;
     time.date.day = date.day;


### PR DESCRIPTION
If these are not initialized, we get a "Conditional jump or move depends on uninitialized value(s)" warning in `getMostRelevantSeason` with Valgrind.