### PR TITLE
Optimize IRenderable system to reduce unnecessary computation

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -4481,8 +4481,9 @@ static void CG_Draw2D() {
     // crosshair is the only renderable that should be drawn here
     for (const auto &r : ETJump::renderables) {
       if (auto crosshair = std::dynamic_pointer_cast<ETJump::Crosshair>(r)) {
-        crosshair->beforeRender();
-        crosshair->render();
+        if (crosshair->beforeRender()) {
+          crosshair->render();
+        }
       }
     }
     CG_DrawFlashFade();
@@ -4591,8 +4592,9 @@ static void CG_Draw2D() {
     ETJump_DrawDrawables();
 
     for (const auto &r : ETJump::renderables) {
-      r->beforeRender();
-      r->render();
+      if (r->beforeRender()) {
+        r->render();
+      }
     }
   }
 

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -169,7 +169,11 @@ float CGaz::GetSlickGravity() {
   return 0;
 }
 
-void CGaz::beforeRender() {
+bool CGaz::beforeRender() {
+  if (canSkipDraw()) {
+    return false;
+  }
+
   const auto uCmdScale = static_cast<int8_t>(ps->stats[STAT_USERCMD_BUTTONS] &
                                                      (BUTTON_WALKING << 8)
                                                  ? CMDSCALE_WALK
@@ -178,6 +182,13 @@ void CGaz::beforeRender() {
 
   // get correct pmove state
   pm = PmoveUtils::getPmove(cmd);
+
+  // water and ladder movement are not important
+  // since speed is capped anyway
+  // check this only after we have a valid pmove
+  if (pm->pmext->waterlevel > 1 || pm->pmext->ladder) {
+    return false;
+  }
 
   // show upmove influence?
   const float scale =
@@ -207,13 +218,11 @@ void CGaz::beforeRender() {
     default:
       break;
   }
+
+  return true;
 }
 
 void CGaz::render() const {
-  if (canSkipDraw()) {
-    return;
-  }
-
   // DeFRaG proxymod CGaz by Jelvan1
   if (etj_drawCGaz.integer == 1) {
     const auto y =
@@ -417,12 +426,6 @@ bool CGaz::canSkipDraw() const {
 
   if (BG_PlayerMounted(ps->eFlags) || ps->weapon == WP_MOBILE_MG42_SET ||
       ps->weapon == WP_MORTAR_SET) {
-    return true;
-  }
-
-  // water and ladder movement are not important
-  // since speed is capped anyway
-  if (pm->pmext->waterlevel > 1 || pm->pmext->ladder) {
     return true;
   }
 

--- a/src/cgame/etj_cgaz.h
+++ b/src/cgame/etj_cgaz.h
@@ -37,7 +37,7 @@ public:
   ~CGaz() override = default;
 
   void render() const override;
-  void beforeRender() override;
+  bool beforeRender() override;
 
 private:
   enum class CGazTrueness { CGAZ_JUMPCROUCH = 1, CGAZ_GROUND = 2 };

--- a/src/cgame/etj_crosshair.cpp
+++ b/src/cgame/etj_crosshair.cpp
@@ -85,7 +85,11 @@ void Crosshair::adjustPosition() {
   crosshair.y = cg_crosshairY.value + (SCREEN_HEIGHT * 0.5f);
 }
 
-void Crosshair::beforeRender() {
+bool Crosshair::beforeRender() {
+  if (canSkipDraw()) {
+    return false;
+  }
+
   crosshair.current = cg_drawCrosshair.integer % NUM_CROSSHAIRS;
   adjustSize();
 
@@ -99,13 +103,11 @@ void Crosshair::beforeRender() {
   crosshair.color[3] = Numeric::clamp(cg_crosshairAlpha.value, 0.0f, 1.0f);
   crosshair.colorAlt[3] =
       Numeric::clamp(cg_crosshairAlphaAlt.value, 0.0f, 1.0f);
+
+  return true;
 }
 
 void Crosshair::render() const {
-  if (canSkipDraw()) {
-    return;
-  }
-
   const qhandle_t shader = cgs.media.crosshairShader[crosshair.current];
   const qhandle_t shaderAlt = cg.crosshairShaderAlt[crosshair.current];
 

--- a/src/cgame/etj_crosshair.h
+++ b/src/cgame/etj_crosshair.h
@@ -66,6 +66,6 @@ protected:
 public:
   Crosshair();
   void render() const override;
-  void beforeRender() override;
+  bool beforeRender() override;
 };
 } // namespace ETJump

--- a/src/cgame/etj_cvar_master_drawer.cpp
+++ b/src/cgame/etj_cvar_master_drawer.cpp
@@ -36,10 +36,12 @@ void ETJump::CvarBasedMasterDrawer::updateCurrentIndex(int index) {
   currentIndex = Numeric::clamp(index, 1, renderables.size()) - 1;
 }
 
-void ETJump::CvarBasedMasterDrawer::beforeRender() {
+bool ETJump::CvarBasedMasterDrawer::beforeRender() {
   if (shouldRender()) {
-    renderables[currentIndex]->beforeRender();
+    return renderables[currentIndex]->beforeRender();
   }
+
+  return false;
 }
 
 void ETJump::CvarBasedMasterDrawer::render() const {

--- a/src/cgame/etj_cvar_master_drawer.h
+++ b/src/cgame/etj_cvar_master_drawer.h
@@ -48,7 +48,7 @@ class CvarBasedMasterDrawer : public IRenderable {
 public:
   explicit CvarBasedMasterDrawer(const vmCvar_t &cvar);
   virtual ~CvarBasedMasterDrawer() {}
-  void beforeRender() override;
+  bool beforeRender() override;
   void render() const override;
   void push(IRenderable *renderable);
 };

--- a/src/cgame/etj_irenderable.h
+++ b/src/cgame/etj_irenderable.h
@@ -27,7 +27,7 @@ namespace ETJump {
 class IRenderable {
 public:
   virtual ~IRenderable(){};
-  virtual void beforeRender() = 0;
+  virtual bool beforeRender() = 0;
   virtual void render() const = 0;
 };
 } // namespace ETJump

--- a/src/cgame/etj_jump_speeds.cpp
+++ b/src/cgame/etj_jump_speeds.cpp
@@ -49,6 +49,13 @@ JumpSpeeds::~JumpSpeeds() {
   _entityEventsHandler->unsubscribe(EV_JUMP);
 }
 
+bool JumpSpeeds::beforeRender() {
+  if (canSkipDraw()) {
+    return false;
+  }
+  return true;
+}
+
 void JumpSpeeds::render() const {
   float x1 = 6 + etj_jumpSpeedsX.value;
   float x2 = 6 + 30 + etj_jumpSpeedsX.value;
@@ -60,10 +67,6 @@ void JumpSpeeds::render() const {
   bool horizontal = etj_jumpSpeedsStyle.integer &
                     static_cast<int>(jumpSpeedStyle::Horizontal);
   int numJumps = static_cast<int>(jumpSpeeds.size());
-
-  if (canSkipDraw()) {
-    return;
-  }
 
   x1 = ETJump_AdjustPosition(x1);
   x2 = ETJump_AdjustPosition(x2);

--- a/src/cgame/etj_jump_speeds.h
+++ b/src/cgame/etj_jump_speeds.h
@@ -35,7 +35,7 @@ public:
   ~JumpSpeeds();
 
   void render() const override;
-  void beforeRender() override{};
+  bool beforeRender() override;
 
 private:
   EntityEventsHandler *_entityEventsHandler;

--- a/src/cgame/etj_keyset_drawer.h
+++ b/src/cgame/etj_keyset_drawer.h
@@ -68,7 +68,9 @@ public:
   KeySetDrawer(const std::vector<KeyShader> &keyShaders);
   virtual ~KeySetDrawer(){};
   void render() const override;
-  void beforeRender() override{};
+  // FIXME: this should to be refactored, see etj_cvar_master_drawer.cpp/h,
+  //  this whole system with keysets is more complex than it needs to be
+  bool beforeRender() override { return true; }
   static std::string keyNameToString(KeyNames keyName);
 
 protected:

--- a/src/cgame/etj_keyset_system.cpp
+++ b/src/cgame/etj_keyset_system.cpp
@@ -42,7 +42,9 @@ void ETJump::KeySetSystem::addKeyBindSet(const std::string &keySetName) {
       createKeyPressSet(keySetName), createKeyBindSet(keySetName)));
 }
 
-void ETJump::KeySetSystem::beforeRender() { keySetMasterDrawer.beforeRender(); }
+bool ETJump::KeySetSystem::beforeRender() {
+  return keySetMasterDrawer.beforeRender();
+}
 
 void ETJump::KeySetSystem::render() const {
   if (canSkipDraw()) {

--- a/src/cgame/etj_keyset_system.h
+++ b/src/cgame/etj_keyset_system.h
@@ -58,7 +58,7 @@ public:
   ~KeySetSystem();
   void addSet(const std::string &keySetName);
   void addKeyBindSet(const std::string &keySetName);
-  void beforeRender() override;
+  bool beforeRender() override;
   void render() const override;
 };
 } // namespace ETJump

--- a/src/cgame/etj_maxspeed.cpp
+++ b/src/cgame/etj_maxspeed.cpp
@@ -67,19 +67,22 @@ void ETJump::DisplayMaxSpeed::parseColor(const std::string &color,
   out[3] *= etj_speedAlpha.value;
 }
 
-void ETJump::DisplayMaxSpeed::beforeRender() {
+bool ETJump::DisplayMaxSpeed::beforeRender() {
+  if (canSkipDraw()) {
+    return false;
+  }
+
   auto speed = sqrt(cg.snap->ps.velocity[0] * cg.snap->ps.velocity[0] +
                     cg.snap->ps.velocity[1] * cg.snap->ps.velocity[1]);
 
   if (speed >= _maxSpeed) {
     _maxSpeed = speed;
   }
+
+  return true;
 }
 
 void ETJump::DisplayMaxSpeed::render() const {
-  if (canSkipDraw()) {
-    return;
-  }
 
   vec4_t color;
   auto fade = CG_FadeAlpha(_animationStartTime, etj_maxSpeedDuration.integer);

--- a/src/cgame/etj_maxspeed.h
+++ b/src/cgame/etj_maxspeed.h
@@ -44,6 +44,6 @@ public:
   explicit DisplayMaxSpeed(EntityEventsHandler *entityEventsHandler);
   ~DisplayMaxSpeed();
   void render() const override;
-  void beforeRender() override;
+  bool beforeRender() override;
 };
 } // namespace ETJump

--- a/src/cgame/etj_overbounce_detector.h
+++ b/src/cgame/etj_overbounce_detector.h
@@ -29,7 +29,7 @@
 
 namespace ETJump {
 class OverbounceDetector : public IRenderable {
-  void beforeRender() override;
+  bool beforeRender() override;
   void render() const override;
   static bool canSkipDraw();
 

--- a/src/cgame/etj_overbounce_watcher.cpp
+++ b/src/cgame/etj_overbounce_watcher.cpp
@@ -111,9 +111,9 @@ OverbounceWatcher::~OverbounceWatcher() {
   _clientCommandsHandler->unsubcribe("ob_list");
 }
 
-void OverbounceWatcher::beforeRender() {
+bool OverbounceWatcher::beforeRender() {
   if (canSkipDraw()) {
-    return;
+    return false;
   }
 
   ps = getValidPlayerState();
@@ -153,13 +153,11 @@ void OverbounceWatcher::beforeRender() {
       Overbounce::surfaceAllowsOverbounce(&trace)) {
     overbounce = true;
   }
+
+  return overbounce;
 }
 
 void OverbounceWatcher::render() const {
-  if (canSkipDraw() || !overbounce) {
-    return;
-  }
-
   DrawString(x, etj_obWatcherY.value, sizeX, sizeY, _color, qfalse, "OB", 0,
              ITEM_TEXTSTYLE_SHADOWED);
 }
@@ -207,6 +205,10 @@ bool OverbounceWatcher::canSkipDraw() const {
   }
 
   if (ps->pm_type == PM_NOCLIP) {
+    return true;
+  }
+
+  if (showingScores()) {
     return true;
   }
 

--- a/src/cgame/etj_overbounce_watcher.h
+++ b/src/cgame/etj_overbounce_watcher.h
@@ -37,7 +37,7 @@ public:
 
 private:
   void render() const override;
-  void beforeRender() override;
+  bool beforeRender() override;
   bool canSkipDraw() const;
 
   ClientCommandsHandler *_clientCommandsHandler;

--- a/src/cgame/etj_quick_follow_drawable.cpp
+++ b/src/cgame/etj_quick_follow_drawable.cpp
@@ -29,13 +29,15 @@ char *BindingFromName(const char *cvar);
 
 ETJump::QuickFollowDrawer::QuickFollowDrawer() {}
 
-void ETJump::QuickFollowDrawer::beforeRender() {}
-
-void ETJump::QuickFollowDrawer::render() const {
+bool ETJump::QuickFollowDrawer::beforeRender() {
   if (canSkipDraw()) {
-    return;
+    return false;
   }
 
+  return true;
+}
+
+void ETJump::QuickFollowDrawer::render() const {
   float *color = CG_FadeColor(cg.crosshairClientTime, 1000);
   if (!color) {
     return;

--- a/src/cgame/etj_quick_follow_drawable.h
+++ b/src/cgame/etj_quick_follow_drawable.h
@@ -43,7 +43,7 @@ class QuickFollowDrawer : public IRenderable {
 public:
   explicit QuickFollowDrawer();
   virtual ~QuickFollowDrawer() {}
-  void beforeRender() override;
+  bool beforeRender() override;
   void render() const override;
 };
 } // namespace ETJump

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -31,7 +31,7 @@ namespace ETJump {
 class Snaphud : public IRenderable {
 public:
   void render() const override;
-  void beforeRender() override;
+  bool beforeRender() override;
   static bool inMainAccelZone(const playerState_t &ps, pmove_t *pm);
 
   Snaphud();

--- a/src/cgame/etj_spectatorinfo_drawable.cpp
+++ b/src/cgame/etj_spectatorinfo_drawable.cpp
@@ -25,18 +25,22 @@
 #include "etj_spectatorinfo_drawable.h"
 
 namespace ETJump {
-void SpectatorInfo::beforeRender() {
+bool SpectatorInfo::beforeRender() {
   // poll for updates every 3 seconds to refresh list
+  // do this before checking if we should render, just to keep it up to date
   if (cg.time > cg.lastScoreTime + 3000) {
     trap_SendClientCommand("score");
     cg.lastScoreTime = cg.time;
   }
+
+  if (canSkipDraw()) {
+    return false;
+  }
+
+  return true;
 }
 
 void SpectatorInfo::render() const {
-  if (canSkipDraw()) {
-    return;
-  }
 
   float x = etj_spectatorInfoX.value;
   float y = etj_spectatorInfoY.value;

--- a/src/cgame/etj_spectatorinfo_drawable.h
+++ b/src/cgame/etj_spectatorinfo_drawable.h
@@ -32,7 +32,7 @@ class SpectatorInfo : public IRenderable {
   static bool canSkipDraw();
 
 public:
-  void beforeRender() override;
+  bool beforeRender() override;
   void render() const override;
 };
 } // namespace ETJump

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -62,7 +62,11 @@ void ETJump::DisplaySpeed::startListeners() {
       [&](const std::vector<std::string> &args) { resetMaxSpeed(); });
 }
 
-void ETJump::DisplaySpeed::beforeRender() {
+bool ETJump::DisplaySpeed::beforeRender() {
+  if (canSkipDraw()) {
+    return false;
+  }
+
   auto speed = std::sqrt(cg.predictedPlayerState.velocity[0] *
                              cg.predictedPlayerState.velocity[0] +
                          cg.predictedPlayerState.velocity[1] *
@@ -76,6 +80,8 @@ void ETJump::DisplaySpeed::beforeRender() {
   } else if (!_storedSpeeds.empty()) {
     _storedSpeeds.clear();
   }
+
+  return true;
 }
 
 void ETJump::DisplaySpeed::resetMaxSpeed() {
@@ -88,10 +94,6 @@ void ETJump::DisplaySpeed::checkShadow() {
 }
 
 void ETJump::DisplaySpeed::render() const {
-  if (canSkipDraw()) {
-    return;
-  }
-
   float size = 0.1f * etj_speedSize.value;
   float x = etj_speedX.integer;
   float y = etj_speedY.integer;

--- a/src/cgame/etj_speed_drawable.h
+++ b/src/cgame/etj_speed_drawable.h
@@ -52,6 +52,6 @@ public:
   DisplaySpeed();
   ~DisplaySpeed();
   void render() const override;
-  void beforeRender() override;
+  bool beforeRender() override;
 };
 } // namespace ETJump

--- a/src/cgame/etj_strafe_quality_drawable.h
+++ b/src/cgame/etj_strafe_quality_drawable.h
@@ -53,7 +53,7 @@ class StrafeQuality : public IRenderable {
 
 public:
   StrafeQuality();
-  void beforeRender() override;
+  bool beforeRender() override;
   void render() const override;
 };
 } // namespace ETJump

--- a/src/cgame/etj_upmove_meter_drawable.h
+++ b/src/cgame/etj_upmove_meter_drawable.h
@@ -80,7 +80,7 @@ class UpmoveMeter : public IRenderable {
 
 public:
   UpmoveMeter();
-  void beforeRender() override;
+  bool beforeRender() override;
   void render() const override;
 };
 } // namespace ETJump

--- a/src/cgame/etj_upper_right_drawable.cpp
+++ b/src/cgame/etj_upper_right_drawable.cpp
@@ -30,7 +30,11 @@ ETJump::UpperRight::UpperRight() {
   FPSLastUpdate = FPSLastTime = fps = 0;
 }
 
-void ETJump::UpperRight::beforeRender() {
+bool ETJump::UpperRight::beforeRender() {
+  if (cg_paused.integer || ETJump::showingScores()) {
+    return false;
+  }
+
   // FPS meter
   const long long currentTime = getCurrentTimestamp();
   if (FPSInit < FPSFrames + 1) {
@@ -54,13 +58,11 @@ void ETJump::UpperRight::beforeRender() {
   }
 
   FPSLastTime = currentTime;
+
+  return true;
 }
 
 void ETJump::UpperRight::render() const {
-  if (cg_paused.integer || ETJump::showingScores()) {
-    return;
-  }
-
   if (etj_HUD_fireteam.integer && CG_IsOnFireteam(cg.clientNum)) {
     rectDef_t rect = {10, 10, 100, 100};
     CG_DrawFireTeamOverlay(&rect);

--- a/src/cgame/etj_upper_right_drawable.h
+++ b/src/cgame/etj_upper_right_drawable.h
@@ -53,6 +53,6 @@ class UpperRight : public IRenderable {
 public:
   UpperRight();
   void render() const override;
-  void beforeRender() override;
+  bool beforeRender() override;
 };
 } // namespace ETJump


### PR DESCRIPTION
`IRenderable::beforeRender` is now a boolean function, and `IRenderable::render` will not execute if it returns false. This makes it easier to optimize drawing functions by reducing the amount of complex math that needs to be done to setup renderable drawing in beforeRender, since we can just easily return false now to skip most of the stuff that's being done, and just skip the render that way.

Tested with `timedemo`, a random demo I had from a full map timerun of sunrise with toggling the following cvars (the most complex ones to render), rough average of five runs:

* `etj_drawCGaz`
* `etj_drawSnapHUD`
* `etj_drawJumpSpeeds`
* `etj_drawStrafeQuality`
* `etj_drawUpmoveMeter`

FPS before refactor:
* renderables off: ~1080fps
* renderables on: ~1050fps

FPS after refactor:
* renderables off: ~1350fps
* rennderables on: ~1060fps

This also fixes ob detector/watcher drawing while scoreboard is up, a small bug as a result of the recent refactor