### PR TITLE
Remove non-C/C++ standard strnlen function

### DIFF
--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -2039,27 +2039,24 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
   char name[64];
   // don't let text be too long for malicious reasons
   char text[MAX_CHAT_TEXT];
-  const char *escapedName = NULL;
+  const char *escapedName = nullptr;
   qboolean localize = qfalse;
   char *loc;
-  const char *printText = NULL;
+  const char *printText = nullptr;
+  const int clientNum = ClientNum(ent);
 
   switch (mode) {
     default:
     case SAY_ALL:
       G_LogPrintf("say: %s: %s\n", ent->client->pers.netname, chatText);
-      Com_sprintf(name, sizeof(name), "%s%c%c: ", ent->client->pers.netname,
-                  Q_COLOR_ESCAPE, COLOR_WHITE);
+      Com_sprintf(name, sizeof(name), "%s^7: ", ent->client->pers.netname);
       color = COLOR_GREEN;
       break;
     case SAY_BUDDY:
       localize = qtrue;
-      // G_LogPrintf("saybuddy: %s: %s\n",
-      // ent->client->pers.netname, chatText);
       loc = BG_GetLocationString(ent->r.currentOrigin);
       Com_sprintf(name, sizeof(name),
-                  "[lof](%s%c%c) (%s): ", ent->client->pers.netname,
-                  Q_COLOR_ESCAPE, COLOR_WHITE, loc);
+                  "[lof](%s^7) (%s): ", ent->client->pers.netname, loc);
       color = COLOR_YELLOW;
       break;
     case SAY_TEAM:
@@ -2067,8 +2064,7 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
       G_LogPrintf("sayteam: %s: %s\n", ent->client->pers.netname, chatText);
       loc = BG_GetLocationString(ent->r.currentOrigin);
       Com_sprintf(name, sizeof(name),
-                  "[lof](%s%c%c) (%s): ", ent->client->pers.netname,
-                  Q_COLOR_ESCAPE, COLOR_WHITE, loc);
+                  "[lof](%s^7) (%s): ", ent->client->pers.netname, loc);
       color = COLOR_CYAN;
       break;
     case SAY_TEAMNL:
@@ -2081,9 +2077,9 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
   len = sizeof(text);
   Q_strncpyz(text, chatText, len);
 
-  // if chat message is too long, e.g. being send from console
+  // if chat message is too long, e.g. being sent from console
   // cut it and put ellipsis at the end
-  if (static_cast<int>(strnlen(chatText, 256)) > len) {
+  if (std::strlen(chatText) > len) {
     text[len - 2] = '.';
     text[len - 3] = '.';
     text[len - 4] = '.';
@@ -2097,24 +2093,17 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
   }
 
   if (target) {
-    if (!COM_BitCheck(target->client->sess.ignoreClients, ent - g_entities)) {
+    if (!COM_BitCheck(target->client->sess.ignoreClients, clientNum)) {
       G_SayTo(ent, target, mode, color, escapedName, printText, localize,
               encoded);
     }
     return;
   }
 
-  // Zero: do we really need double text on console?
-  //// echo the text to the console
-  // if (g_dedicated.integer)
-  //{
-  //	G_Printf("%s%s\n", name, text);
-  // }
-
-  // send it to all the apropriate clients
+  // send it to all the appropriate clients
   for (j = 0; j < level.numConnectedClients; j++) {
     other = &g_entities[level.sortedClients[j]];
-    if (!COM_BitCheck(other->client->sess.ignoreClients, ent - g_entities)) {
+    if (!COM_BitCheck(other->client->sess.ignoreClients, clientNum)) {
       G_SayTo(ent, other, mode, color, escapedName, printText, localize,
               encoded);
     }

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -2079,7 +2079,7 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
 
   // if chat message is too long, e.g. being sent from console
   // cut it and put ellipsis at the end
-  if (std::strlen(chatText) > len) {
+  if (Q_strnlen(chatText, MAX_SAY_TEXT) > len) {
     text[len - 2] = '.';
     text[len - 3] = '.';
     text[len - 4] = '.';

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -2077,13 +2077,9 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
   len = sizeof(text);
   Q_strncpyz(text, chatText, len);
 
-  // chat messages should be always null terminated but let's make sure
-  char chatSafeBuf[MAX_SAY_TEXT];
-  Q_strncpyz(chatSafeBuf, chatText, sizeof(chatSafeBuf));
-
   // if chat message is too long, e.g. being sent from console
   // cut it and put ellipsis at the end
-  if (std::strlen(chatSafeBuf) > len) {
+  if (std::strlen(chatText) > len) {
     text[len - 2] = '.';
     text[len - 3] = '.';
     text[len - 4] = '.';

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -2077,9 +2077,13 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
   len = sizeof(text);
   Q_strncpyz(text, chatText, len);
 
+  // chat messages should be always null terminated but let's make sure
+  char chatSafeBuf[MAX_SAY_TEXT];
+  Q_strncpyz(chatSafeBuf, chatText, sizeof(chatSafeBuf));
+
   // if chat message is too long, e.g. being sent from console
   // cut it and put ellipsis at the end
-  if (std::strlen(chatText) > len) {
+  if (std::strlen(chatSafeBuf) > len) {
     text[len - 2] = '.';
     text[len - 3] = '.';
     text[len - 4] = '.';

--- a/src/game/q_shared.cpp
+++ b/src/game/q_shared.cpp
@@ -942,7 +942,7 @@ char *Q_CleanDirName(char *dirname) {
 size_t Q_strnlen(const char *str, size_t maxlen) {
   if (!str) {
     Com_Error(ERR_FATAL, "Q_strnlen: NULL str");
-    return -1; // blah blah silence warning about str being null
+    return 0; // blah blah silence warning about str being null
   }
 
   auto *p = static_cast<const char *>(std::memchr(str, 0, maxlen));

--- a/src/game/q_shared.cpp
+++ b/src/game/q_shared.cpp
@@ -2,6 +2,7 @@
 //
 // q_shared.c -- stateless support routines that are included in each code dll
 #include "q_shared.h"
+#include <cstring>
 
 float Com_Clamp(float min, float max, float value) {
   if (value < min) {
@@ -936,6 +937,16 @@ char *Q_CleanDirName(char *dirname) {
   *d = '\0';
 
   return dirname;
+}
+
+size_t Q_strnlen(const char *str, size_t maxlen) {
+  if (!str) {
+    Com_Error(ERR_FATAL, "Q_strnlen: NULL str");
+    return -1; // blah blah silence warning about str being null
+  }
+
+  auto *p = static_cast<const char *>(std::memchr(str, 0, maxlen));
+  return p == nullptr ? maxlen : p - str;
 }
 
 void QDECL Com_sprintf(char *dest, int size, const char *fmt, ...) {

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -823,6 +823,8 @@ int Q_PrintStrlen(const char *string);
 char *Q_CleanStr(char *string);
 // removes whitespaces and other bad directory characters
 char *Q_CleanDirName(char *dirname);
+// safe strlen up to N chars
+size_t Q_strnlen(const char *str, size_t maxlan);
 
 // #define _vsnprintf use_Q_vsnprintf
 // #define vsnprintf use_Q_vsnprintf

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -824,7 +824,7 @@ char *Q_CleanStr(char *string);
 // removes whitespaces and other bad directory characters
 char *Q_CleanDirName(char *dirname);
 // safe strlen up to N chars
-size_t Q_strnlen(const char *str, size_t maxlan);
+size_t Q_strnlen(const char *str, size_t maxlen);
 
 // #define _vsnprintf use_Q_vsnprintf
 // #define vsnprintf use_Q_vsnprintf


### PR DESCRIPTION
~~Replaced with `std::strlen`, we don't really need to care about counting only N chars here~~
Replaced with `Q_strnlen` implementation which does effectively the same, but is C/C++ standard compliant.