### PR TITLE
Improve !seasons output + refactor active seasons handling

### DIFF
--- a/src/game/etj_time_utilities.h
+++ b/src/game/etj_time_utilities.h
@@ -24,15 +24,10 @@
 
 #pragma once
 
-#ifdef min
-  #undef min
-#endif
-#ifdef max
-  #undef max
-#endif
 #include <iomanip>
 #include <string>
 #include <sstream>
+#include <array>
 
 #include "etj_string_utilities.h"
 
@@ -102,13 +97,15 @@ struct Date {
   }
 
   std::string toDateString() const {
-    return stringFormat("%04d-%02d-%02d", this->year,
-                        this->mon, this->day);
+    return stringFormat("%04d-%02d-%02d", this->year, this->mon, this->day);
   }
 
-  int year; // year
-  int mon;  // month
-  int day;  // day of the month
+  int year{}; // year
+  int mon{};  // month
+  int day{};  // day of the month
+  std::array<std::string, 12> abbrevMonths = {"Jan", "Feb", "Mar", "Apr",
+                                              "May", "Jun", "Jul", "Aug",
+                                              "Sep", "Oct", "Nov", "Dec"};
 };
 
 struct Time {
@@ -160,9 +157,15 @@ struct Time {
                         this->clock.min, this->clock.sec);
   }
 
+  // date with abbreviated month, e.g. 01 Jan 1970
+  std::string toAbbrevMonthDateString() const {
+    return stringFormat("%02d %s %04d", this->date.day,
+                        date.abbrevMonths[this->date.mon - 1], this->date.year);
+  }
+
   static Time fromInt(int input) {
     time_t value = input;
-    tm* t = std::gmtime(&value);
+    tm *t = std::gmtime(&value);
 
     Time time;
     time.date.year = t->tm_year + 1900;
@@ -185,8 +188,7 @@ struct Time {
 
     Time time;
     time.date.year = t.tm_year + 1900;
-    time.date.mon =
-        t.tm_mon + 1;
+    time.date.mon = t.tm_mon + 1;
     time.date.day = t.tm_mday;
 
     time.clock.hours = t.tm_hour;

--- a/src/game/etj_timerun_repository.cpp
+++ b/src/game/etj_timerun_repository.cpp
@@ -59,29 +59,6 @@ void ETJump::TimerunRepository::initialize() { migrate(); }
 
 void ETJump::TimerunRepository::shutdown() { _database = nullptr; }
 
-std::vector<ETJump::Timerun::Season>
-ETJump::TimerunRepository::getActiveSeasons(const Time &currentTime) const {
-  std::vector<Timerun::Season> activeSeasons;
-
-  auto currentTimeStr = currentTime.toDateTimeString();
-
-  _database->sql << "select id, name, start_time, end_time from season where "
-                    "start_time <= ? and (end_time is null or end_time > ?);"
-                 << currentTimeStr << currentTimeStr >>
-      [this, &activeSeasons](int id, std::string name, std::string startTimeStr,
-                             std::string endTimeStr) {
-        auto startTime = Time::fromString(startTimeStr);
-        opt<Time> endTime;
-        if (endTimeStr.length() != 0) {
-          endTime = opt<Time>(Time::fromString(endTimeStr));
-        }
-
-        activeSeasons.push_back(Timerun::Season{id, name, startTime, endTime});
-      };
-
-  return activeSeasons;
-}
-
 std::vector<ETJump::Timerun::Record>
 ETJump::TimerunRepository::getRecordsForPlayer(
     const std::vector<int> activeSeasons, const std::string &map, int userId) {
@@ -371,8 +348,8 @@ void ETJump::TimerunRepository::editSeason(
     anythingToUpdate = true;
     updatedFields.emplace_back("start_time");
     updatedParams.push_back(params.startTime.value().toDateTimeString());
-
-  } if (params.endTime.hasValue()) {
+  }
+  if (params.endTime.hasValue()) {
     newEndTime = params.endTime;
     anythingToUpdate = true;
     updatedFields.emplace_back("end_time");

--- a/src/game/etj_timerun_repository.h
+++ b/src/game/etj_timerun_repository.h
@@ -43,7 +43,6 @@ public:
   void initialize();
   void shutdown();
 
-  std::vector<Timerun::Season> getActiveSeasons(const Time &currentTime) const;
   std::vector<Timerun::Record>
   getRecordsForPlayer(const std::vector<int> activeSeasons,
                       const std::string &map, int userId);

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -187,18 +187,54 @@ void ETJump::TimerunV2::computeRanks() {
       });
 }
 
+void ETJump::TimerunV2::updateSeasonStates() {
+  const auto seasons = _repository->getSeasons();
+  const auto currentTime = getCurrentTime();
+
+  _activeSeasonsIds = std::vector<int>();
+  _activeSeasons = std::vector<Timerun::Season>();
+
+  _pastSeasonsIds = std::vector<int>();
+  _pastSeasons = std::vector<Timerun::Season>();
+
+  _upcomingSeasonsIds = std::vector<int>();
+  _upcomingSeasons = std::vector<Timerun::Season>();
+
+  for (const auto &season : seasons) {
+    // upcoming seasons
+    if (season.startTime > currentTime) {
+      _upcomingSeasons.push_back(season);
+    }
+    // active seasons
+    else if (!season.endTime.hasValue() ||
+             season.endTime.value() > currentTime) {
+      _activeSeasons.push_back(season);
+    }
+    // past seasons
+    else {
+      _pastSeasons.push_back(season);
+    }
+  }
+
+  auto getSeasonId = [](const Timerun::Season &s) { return s.id; };
+
+  _activeSeasonsIds = Container::map(_activeSeasons, getSeasonId);
+  _pastSeasonsIds = Container::map(_pastSeasons, getSeasonId);
+  _upcomingSeasonsIds = Container::map(_upcomingSeasons, getSeasonId);
+
+  _logger->info("Successfully updated season states: Active seasons: (%d), "
+                "Upcoming seasons: (%d) Past seasons: (%d)",
+                _activeSeasonsIds.size(), _upcomingSeasonsIds.size(),
+                _pastSeasonsIds.size());
+}
+
 void ETJump::TimerunV2::initialize() {
   try {
-    _activeSeasonsIds = std::vector<int>();
-    _activeSeasons = std::vector<Timerun::Season>();
-
     _repository->initialize();
-    _activeSeasons = _repository->getActiveSeasons(getCurrentTime());
+
+    updateSeasonStates();
 
     _mostRelevantSeason = getMostRelevantSeason();
-
-    _activeSeasonsIds = Container::map(
-        _activeSeasons, [](const Timerun::Season &s) { return s.id; });
 
     _logger->info("Active seasons: %s",
                   StringUtil::join(Container::map(_activeSeasons,
@@ -383,6 +419,7 @@ void ETJump::TimerunV2::addSeason(Timerun::AddSeasonParams season) {
       [this, season]() {
         try {
           _repository->addSeason(season);
+          updateSeasonStates();
           return std::make_unique<AddSeasonResult>(
               stringFormat("Successfully added season `%s`", season.name));
         } catch (const std::runtime_error &e) {
@@ -420,6 +457,7 @@ void ETJump::TimerunV2::editSeason(Timerun::EditSeasonParams params) {
       [this, params]() {
         try {
           _repository->editSeason(params);
+          updateSeasonStates();
           return std::make_unique<EditSeasonResult>(
               stringFormat("Successfully edited season `%s`", params.name));
         } catch (const std::runtime_error &e) {
@@ -894,24 +932,65 @@ void ETJump::TimerunV2::printRankings(Timerun::PrintRankingsParams params) {
 void ETJump::TimerunV2::printSeasons(int clientNum) {
   _sc->postTask(
       [this] {
-        auto seasons = _repository->getSeasons();
+        std::string seasonHeader = stringFormat(
+            "\n^g %-30s %-15s%s\n", "Season", "Start Date", "End date");
 
         // clang-format off
         std::string message =
-            "^g=============================================================\n"
-            " ^gSeasons^7\n"
-            "^g=============================================================\n"
-            "^g Season                         From -> To\n";
+            "\n ^2Seasons^7\n"
+            "^g------------------------------------------------------------\n";
         // clang-format on
 
-        for (const auto &s : seasons) {
+        message += " ^gActive seasons\n" + seasonHeader;
+
+        for (const auto &s : _activeSeasons) {
+          // default season is always active and cannot be deleted,
+          // don't bother listing it
+          if (s.id == defaultSeasonId) {
+            continue;
+          }
+
           std::string formatString =
-              stringFormat(" ^2%%-%ds ^7(%%s -> %%s^7)\n",
+              stringFormat(" ^7%%-%ds ^7%%-15s%%s\n",
                            30 + StringUtil::countExtraPadding(s.name));
 
           message += stringFormat(
-              formatString, s.name, s.startTime.toDateTimeString(),
-              s.endTime.hasValue() ? s.endTime.value().toDateTimeString()
+              formatString, s.name, s.startTime.toAbbrevMonthDateString(),
+              s.endTime.hasValue() ? s.endTime.value().toAbbrevMonthDateString()
+                                   : "*");
+        }
+
+        // clang-format off
+        message += "\n^g------------------------------------------------------------\n";
+        // clang-format on
+
+        message += " ^gUpcoming seasons\n" + seasonHeader;
+
+        for (const auto &s : _upcomingSeasons) {
+          std::string formatString =
+              stringFormat(" ^7%%-%ds ^7%%-15s%%s\n",
+                           30 + StringUtil::countExtraPadding(s.name));
+
+          message += stringFormat(
+              formatString, s.name, s.startTime.toAbbrevMonthDateString(),
+              s.endTime.hasValue() ? s.endTime.value().toAbbrevMonthDateString()
+                                   : "*");
+        }
+
+        // clang-format off
+        message += "\n^g------------------------------------------------------------\n";
+        // clang-format on
+
+        message += " ^gPast seasons\n" + seasonHeader;
+
+        for (const auto &s : _pastSeasons) {
+          std::string formatString =
+              stringFormat(" ^9%%-%ds ^9%%-15s%%s\n",
+                           30 + StringUtil::countExtraPadding(s.name));
+
+          message += stringFormat(
+              formatString, s.name, s.startTime.toAbbrevMonthDateString(),
+              s.endTime.hasValue() ? s.endTime.value().toAbbrevMonthDateString()
                                    : "*");
         }
 
@@ -941,6 +1020,7 @@ void ETJump::TimerunV2::deleteSeason(int clientNum, const std::string &name) {
       [this, name]() {
         try {
           _repository->deleteSeason(name);
+          updateSeasonStates();
           return std::make_unique<DeleteSeasonResult>(
               stringFormat("Successfully deleted season `%s`", name));
         } catch (const std::runtime_error &e) {

--- a/src/game/etj_timerun_v2.h
+++ b/src/game/etj_timerun_v2.h
@@ -104,7 +104,7 @@ public:
                        int rank);
   void printRankings(Timerun::PrintRankingsParams params);
   void printSeasons(int clientNum);
-  void deleteSeason(int clientNum, const std::string & name);
+  void deleteSeason(int clientNum, const std::string &name);
 
 private:
   void startNotify(Player *player) const;
@@ -118,6 +118,7 @@ private:
    * figure out which one is the most relevant for the user
    */
   const Timerun::Season *getMostRelevantSeason();
+  void updateSeasonStates();
   static std::string
   getRankingsStringFor(const std::vector<Ranking> *vector,
                        const Timerun::PrintRankingsParams &params);
@@ -127,8 +128,14 @@ private:
   std::unique_ptr<Log> _logger;
   std::unique_ptr<SynchronizationContext> _sc;
   std::array<std::unique_ptr<Player>, 64> _players;
+
   std::vector<int> _activeSeasonsIds;
   std::vector<Timerun::Season> _activeSeasons;
+  std::vector<int> _pastSeasonsIds;
+  std::vector<Timerun::Season> _pastSeasons;
+  std::vector<int> _upcomingSeasonsIds;
+  std::vector<Timerun::Season> _upcomingSeasons;
+
   const Timerun::Season *_mostRelevantSeason{};
   std::map<int, std::vector<Ranking>> _rankingsPerSeason;
 };


### PR DESCRIPTION
New format for `!seasons` command output.

![image](https://github.com/etjump/etjump/assets/14221121/d2f89ae2-062a-4bd1-ac22-6fcd0bba66b6)

* Seasons grouped to active/upcoming/past seasons
* Default season is no longer visible
* Start/end dates are now displayed in a more legible format - time is also no longer displayed as it will always be `00:00:00` anyway, and one can reasonably assume that is the case always.

This also refactors the way active seasons are parsed. On init, we now parse all seasons, and group them into active, upcoming and past seasons. `!seasons` command parses all these separately to group the output to active, upcoming and past seasons. `!add/edit/delete-season` commands call this parsing function, so the vectors that hold the seasons per state are updated on the fly, and `!seasons` command will always be up to date.

refs #1114 