### PR TITLE
Fix crash with await command

### DIFF
--- a/src/cgame/etj_awaited_command_handler.cpp
+++ b/src/cgame/etj_awaited_command_handler.cpp
@@ -106,11 +106,11 @@ void ETJump::AwaitedCommandHandler::awaitCommand(
     return;
   }
 
-  auto waitedFramesStr = args[0];
-  int waitedFrames = 0;
+  const auto &waitedFramesStr = args[0];
+  int waitedFrames;
   std::string outOfRangeError =
       stringFormat("^3Error: ^7First parameter (number of frames) must be "
-                   "between ^31 ^7and ^3%s^7.",
+                   "between ^31 ^7and ^3%i^7.",
                    std::numeric_limits<int>::max());
   try {
     waitedFrames = std::stoi(waitedFramesStr);


### PR DESCRIPTION
Error string was using wrong argument format type. Not sure how this ever worked since it's been `%s` from the get go, maybe our `stringFormat` used a boost lib or something that handled it correctly.