### PR TITLE
Add etjump_game_manager entity to map if no scriptable entities are present

### DIFF
--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -453,3 +453,23 @@ bool allTokensCollected(gentity_t *ent) {
   return tokenCounts[0] == easyCount && tokenCounts[1] == mediumCount &&
          tokenCounts[2] == hardCount;
 }
+
+namespace ETJump {
+bool checkEntsForScriptname() {
+  // clients and bodyqueue don't have scriptname set
+  const int startEnt = MAX_CLIENTS + BODY_QUEUE_SIZE;
+
+  for (int i = startEnt; i < level.num_entities; i++) {
+    gentity_t *current = &g_entities[i];
+    if (!current->scriptName) {
+      continue;
+    } else {
+      G_Printf("^2FOUND\n");
+      return true; // ent with scriptname found, we can exit
+    }
+  }
+
+  G_Printf("^1NOT FOUND\n");
+  return false;
+}
+} // namespace ETJump

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2875,6 +2875,14 @@ void G_increaseCallvoteCount(const char *mapName);
 void G_increasePassedCount(const char *mapName);
 void LogServerState();
 
+namespace ETJump {
+// finds an entity with a scriptname, if not found,
+// we spawn in 'etjump_game_manager' so we always have
+// access to mapscripting
+bool checkEntsForScriptname();
+void spawnGameManager();
+} // namespace ETJump
+
 qboolean G_IsOnFireteam(int entityNum, fireteamData_t **teamNum);
 
 namespace ETJump {

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -2005,12 +2005,6 @@ void G_InitGame(int levelTime, int randomSeed, int restart) {
 
   BG_LoadSpeakerScript(va("sound/maps/%s.sps", level.rawmapname));
 
-  // ===================
-
-  if (!level.gameManager) {
-    G_Printf("^1ERROR No 'script_multiplayer' found in map\n");
-  }
-
   level.tracemapLoaded = qfalse;
   if (!BG_LoadTraceMap(level.rawmapname, level.mapcoordsMins,
                        level.mapcoordsMaxs)) {

--- a/src/game/g_script.cpp
+++ b/src/game/g_script.cpp
@@ -1454,3 +1454,32 @@ void SP_script_multiplayer(gentity_t *ent) {
 
   trap_LinkEntity(ent);
 }
+
+namespace ETJump {
+void spawnGameManager() {
+  gentity_t *ent = G_Spawn();
+  ent->classname = "etjump_game_manager";
+  ent->scriptName = "etjump_manager";
+  ent->s.eType = ET_GAMEMANAGER;
+  ent->r.svFlags = SVF_BROADCAST;
+
+  // sanity check, should not happen
+  if (level.gameManager) {
+    G_Error("^1ERROR: multiple etjump_game_managers found\n");
+  }
+
+  level.gameManager = ent;
+  level.gameManager->s.otherEntityNum =
+      MAX_TEAM_LANDMINES; // axis landmine count
+  level.gameManager->s.otherEntityNum2 =
+      MAX_TEAM_LANDMINES;                    // allies landmine count
+  level.gameManager->s.modelindex = qfalse;  // axis HQ doesn't exist
+  level.gameManager->s.modelindex2 = qfalse; // allied HQ doesn't exist
+
+  trap_LinkEntity(ent);
+
+  // call the mapscript spawn functions, so we can spawn in entities
+  G_Script_ScriptParse(ent);
+  G_Script_ScriptEvent(ent, "spawn", "");
+}
+} // namespace ETJump

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -1316,6 +1316,20 @@ void G_SpawnEntitiesFromString(void) {
     G_SpawnGEntityFromSpawnVars();
   }
 
+  if (!level.gameManager) {
+    G_Printf("^3WARNING: ^7No ^3'script_multiplayer' ^7found in the map, "
+             "checking for other entities with scriptname... ");
+
+    if (!ETJump::checkEntsForScriptname()) {
+      G_Printf("^7No scriptable entities found, spawning "
+               "^3'etjump_game_manager'^7... ");
+
+      ETJump::spawnGameManager();
+
+      G_Printf("^2DONE\n");
+    }
+  }
+
   G_Printf("Disable spawning!\n");
   level.spawning = qfalse; // any future calls to G_Spawn*() will be errors
 }


### PR DESCRIPTION
Automatically spawn `etjump_game_manager` entity with `etjump_manager` scriptname if a map contains no `script_multiplayer` or an entity with a scriptname set. This makes sure we can always do mapscripting on any map, regardless of the entities that are present on the map.