### PR TITLE
Allow wounded state in timeruns

### DIFF
--- a/src/game/g_combat.cpp
+++ b/src/game/g_combat.cpp
@@ -617,12 +617,8 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker,
 
   CalculateRanks();
 
-  if (self->client->sess.timerunActive) {
-    limbo(self, qfalse);
-  }
-
   // Gordon: automatically go to limbo from tank
-  else if (killedintank) {
+  if (killedintank) {
     limbo(self, qfalse); // but no corpse
   } else if ((meansOfDeath == MOD_SUICIDE &&
               g_gamestate.integer == GS_PLAYING)) {


### PR DESCRIPTION
Still prevents corpse creation, but won't make timeruns that require wounded state impossible, like the one on `2weeks`.

Fixes #1124 