### PR TITLE
Remove scope from SnapVector macro

### DIFF
--- a/src/game/g_missile.cpp
+++ b/src/game/g_missile.cpp
@@ -391,7 +391,8 @@ void G_ExplodeMissile(gentity_t *ent) {
 
   BG_EvaluateTrajectory(&ent->s.pos, level.time, origin, qfalse,
                         ent->s.effect2Time);
-  SnapVector(origin) G_SetOrigin(ent, origin);
+  SnapVector(origin);
+  G_SetOrigin(ent, origin);
 
   // we don't have a valid direction, so just point straight up
   dir[0] = dir[1] = 0;

--- a/src/game/g_weapon.cpp
+++ b/src/game/g_weapon.cpp
@@ -1949,7 +1949,8 @@ void Weapon_Engineer(gentity_t *ent) {
         }
 
         VectorCopy(traceEnt->r.currentOrigin, origin);
-        SnapVector(origin) VectorAdd(origin, traceEnt->r.mins, mins);
+        SnapVector(origin);
+        VectorAdd(origin, traceEnt->r.mins, mins);
         VectorAdd(origin, traceEnt->r.maxs, maxs);
         num = trap_EntitiesInBox(mins, maxs, touch, MAX_GENTITIES);
         VectorAdd(origin, traceEnt->r.mins, mins);
@@ -2029,7 +2030,8 @@ void Weapon_Engineer(gentity_t *ent) {
         // NERVE - SMF - made this the actual bounding box of dynamite
         // instead of range, also must snap origin to line up properly
         VectorCopy(traceEnt->r.currentOrigin, origin);
-        SnapVector(origin) VectorAdd(origin, traceEnt->r.mins, mins);
+        SnapVector(origin);
+        VectorAdd(origin, traceEnt->r.mins, mins);
         VectorAdd(origin, traceEnt->r.maxs, maxs);
         num = trap_EntitiesInBox(mins, maxs, touch, MAX_GENTITIES);
 
@@ -2197,7 +2199,8 @@ void Weapon_Engineer(gentity_t *ent) {
           traceEnt->nextthink = level.time + FRAMETIME;
 
           VectorCopy(traceEnt->r.currentOrigin, origin);
-          SnapVector(origin) VectorAdd(origin, traceEnt->r.mins, mins);
+          SnapVector(origin);
+          VectorAdd(origin, traceEnt->r.mins, mins);
           VectorAdd(origin, traceEnt->r.maxs, maxs);
           num = trap_EntitiesInBox(mins, maxs, touch, MAX_GENTITIES);
 

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -625,13 +625,9 @@ typedef struct {
    (o)[3] = ((v)[3] * (1 - (s))) + ((b)[3] * (s)))
 
 #define SnapVector(v)                                                          \
-  {                                                                            \
-    v[0] = ((int)(v[0]));                                                      \
-    v[1] = ((int)(v[1]));                                                      \
-    v[2] = ((int)(v[2]));                                                      \
-  }
+  (v[0] = ((int)(v[0])), v[1] = ((int)(v[1])), v[2] = ((int)(v[2])))
 
-// just in case you do't want to use the macros
+// just in case you don't want to use the macros
 vec_t _DotProduct(const vec3_t v1, const vec3_t v2);
 void _VectorSubtract(const vec3_t veca, const vec3_t vecb, vec3_t out);
 void _VectorAdd(const vec3_t veca, const vec3_t vecb, vec3_t out);


### PR DESCRIPTION
It now behaves like other vector macros where it requires a semicolon at the end.