### PR TITLE
improve target_remove_portals

### DIFF
--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1586,9 +1586,20 @@ void target_remove_portals_use(gentity_t *self, gentity_t *other,
     return;
   }
 
+  // activate targets if any portals were reset
   gentity_t *ent = G_PickTarget(self->target);
   if (ent && ent->use) {
     G_UseEntity(ent, self, activator);
+  }
+
+  // play sound to client
+  if (self->noise_index) {
+    gentity_t *noiseEnt = ETJump::soundEvent(
+        activator->r.currentOrigin,
+        EV_GENERAL_CLIENT_SOUND_VOLUME,
+        self->noise_index);
+
+    noiseEnt->s.onFireStart = 255;
   }
 
   if (self->spawnflags & SF_REMOVE_PORTALS_NO_TEXT) {
@@ -1601,6 +1612,13 @@ void target_remove_portals_use(gentity_t *self, gentity_t *other,
 
 void SP_target_remove_portals(gentity_t *self) {
   self->use = target_remove_portals_use;
+
+  char *s;
+  if (G_SpawnString("noise", "NOSOUND", &s)) {
+    char buffer[MAX_QPATH];
+    Q_strncpyz(buffer, s, sizeof(buffer));
+    self->noise_index = G_SoundIndex(buffer);
+  }
 }
 
 void G_ActivateTarget(gentity_t *self, gentity_t *activator) {

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1568,14 +1568,23 @@ void target_remove_portals_use(gentity_t *self, gentity_t *other,
     return;
   }
 
+  qboolean found = qfalse;
+
   if (activator->portalBlue) {
     G_FreeEntity(activator->portalBlue);
     activator->portalBlue = NULL;
+    found = qtrue;
   }
 
   if (activator->portalRed) {
     G_FreeEntity(activator->portalRed);
     activator->portalRed = NULL;
+    found = qtrue;
+  }
+
+  if (!found) {
+    return;
+  }
   }
 
   if (self->spawnflags & SF_REMOVE_PORTALS_NO_TEXT) {

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1568,18 +1568,18 @@ void target_remove_portals_use(gentity_t *self, gentity_t *other,
     return;
   }
 
-  qboolean found = qfalse;
+  auto found = false;
 
   if (activator->portalBlue) {
     G_FreeEntity(activator->portalBlue);
-    activator->portalBlue = NULL;
-    found = qtrue;
+    activator->portalBlue = nullptr;
+    found = true;
   }
 
   if (activator->portalRed) {
     G_FreeEntity(activator->portalRed);
-    activator->portalRed = NULL;
-    found = qtrue;
+    activator->portalRed = nullptr;
+    found = true;
   }
 
   if (!found) {
@@ -1602,12 +1602,9 @@ void target_remove_portals_use(gentity_t *self, gentity_t *other,
     noiseEnt->s.onFireStart = 255;
   }
 
-  if (self->spawnflags & SF_REMOVE_PORTALS_NO_TEXT) {
-    return;
+  if (!(self->spawnflags & SF_REMOVE_PORTALS_NO_TEXT)) {
+    Printer::SendCenterMessage(ClientNum(activator), "^7Your portal gun portals have been reset.");
   }
-
-  trap_SendServerCommand(activator - g_entities,
-                         "cp \"^7Your portal gun portals have been reset.\n\"");
 }
 
 void SP_target_remove_portals(gentity_t *self) {

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1585,6 +1585,10 @@ void target_remove_portals_use(gentity_t *self, gentity_t *other,
   if (!found) {
     return;
   }
+
+  gentity_t *ent = G_PickTarget(self->target);
+  if (ent && ent->use) {
+    G_UseEntity(ent, self, activator);
   }
 
   if (self->spawnflags & SF_REMOVE_PORTALS_NO_TEXT) {


### PR DESCRIPTION
- allow `target_remove_portals` to activate targets if portals were removed
- add a `noise`-key to play a sound if portals were removed
- don't show portal remove print if no portals were removed
