### PR TITLE
add numPortals to client, add target_portal_relay entity

### DIFF
--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2679,12 +2679,16 @@ void ClearPortals(gentity_t *ent) {
   // Clear portalgun portals
   if (ent->portalBlue) {
     G_FreeEntity(ent->portalBlue);
-    ent->portalBlue = NULL;
+    ent->portalBlue = nullptr;
   }
 
   if (ent->portalRed) {
     G_FreeEntity(ent->portalRed);
-    ent->portalRed = NULL;
+    ent->portalRed = nullptr;
+  }
+
+  if (ent->client) {
+    ent->client->numPortals = 0;
   }
 }
 

--- a/src/game/g_combat.cpp
+++ b/src/game/g_combat.cpp
@@ -578,7 +578,8 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker,
     self->portalRed = nullptr;
   }
 
-  self->client->numPortals = 0;
+  // DON'T clear numPortals here in case player is revived and keeps their position
+  // The whole client struct is initialized when player is gibbed/spawning.
 
   if (nogib) {
     // normal death

--- a/src/game/g_combat.cpp
+++ b/src/game/g_combat.cpp
@@ -578,8 +578,7 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker,
     self->portalRed = nullptr;
   }
 
-  // DON'T clear numPortals here in case player is revived and keeps their position
-  // The whole client struct is initialized when player is gibbed/spawning.
+  self->client->numPortals = 0;
 
   if (nogib) {
     // normal death

--- a/src/game/g_combat.cpp
+++ b/src/game/g_combat.cpp
@@ -578,6 +578,8 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker,
     self->portalRed = nullptr;
   }
 
+  self->client->numPortals = 0;
+
   if (nogib) {
     // normal death
     // for the no-blood option, we need to prevent the health

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1144,6 +1144,9 @@ struct gclient_s {
 
   // Whether the client already activated target_set_health
   qboolean alreadyActivatedSetHealth;
+
+  // Amount of portalgun portals shot since last reset
+  int numPortals;
 };
 
 typedef struct {

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -451,6 +451,7 @@ void SP_target_save(gentity_t *self);
 // Feen: PGM
 void SP_weapon_portalgun(gentity_t *self);
 void SP_target_remove_portals(gentity_t *self);
+void SP_target_portal_relay(gentity_t *self);
 void SP_target_ftrelay(gentity_t *self);
 
 // Savelimit
@@ -700,6 +701,7 @@ spawn_t spawns[] = {
     {"target_increase_ident", SP_target_increase_ident},
     {"target_save", SP_target_save},
     {"target_remove_portals", SP_target_remove_portals},
+    {"target_portal_relay", SP_target_portal_relay},
     {"target_ftrelay", SP_target_ftrelay},
     {"target_savelimit_set", SP_target_savelimit_set},
     {"target_savelimit_inc", SP_target_savelimit_inc},

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1618,6 +1618,26 @@ void SP_target_remove_portals(gentity_t *self) {
   }
 }
 
+void target_portal_relay_use(gentity_t *self, gentity_t *other,
+                               gentity_t *activator) {
+  if (!activator ||
+      !activator->client ||
+      activator->client->sess.sessionTeam == TEAM_SPECTATOR ||
+      !self->target) {
+    return;
+  }
+  // don't need to check health, see comment in player_die
+
+  if (activator->client->numPortals <= self->count) {
+    G_UseTargets(self, activator);
+  }
+}
+
+void SP_target_portal_relay(gentity_t *self) {
+  self->use = target_portal_relay_use;
+  G_SpawnInt("maxportals", "-1", &self->count);
+}
+
 void G_ActivateTarget(gentity_t *self, gentity_t *activator) {
   gentity_t *ent = NULL;
   ent = G_PickTarget(self->target);

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1585,10 +1585,7 @@ void target_remove_portals_use(gentity_t *self, gentity_t *other,
 
   if (hadActivePortals) {
     if (self->spawnflags & SF_REMOVE_PORTALS_ACTIVATE_TARGETS) {
-      gentity_t *ent = G_PickTarget(self->target);
-      if (ent && ent->use) {
-          G_UseEntity(ent, self, activator);
-      }
+      G_UseTargets(self, activator);
     }
 
     // play sound to client

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1595,7 +1595,7 @@ void target_remove_portals_use(gentity_t *self, gentity_t *other,
           EV_GENERAL_CLIENT_SOUND_VOLUME,
           self->noise_index);
 
-      noiseEnt->s.onFireStart = 255;
+      noiseEnt->s.onFireStart = self->s.onFireStart;
     }
 
     if (!(self->spawnflags & SF_REMOVE_PORTALS_NO_TEXT)) {
@@ -1616,6 +1616,10 @@ void SP_target_remove_portals(gentity_t *self) {
     Q_strncpyz(buffer, s, sizeof(buffer));
     self->noise_index = G_SoundIndex(buffer);
   }
+  G_SpawnInt("volume", "255", &self->s.onFireStart);
+  if (!self->s.onFireStart) {
+    self->s.onFireStart = 255;
+  }
 }
 
 void target_portal_relay_use(gentity_t *self, gentity_t *other,
@@ -1623,8 +1627,7 @@ void target_portal_relay_use(gentity_t *self, gentity_t *other,
   if (!activator ||
       !activator->client ||
       activator->client->sess.sessionTeam == TEAM_SPECTATOR ||
-      !self->target ||
-      self->health <= 0) {
+      !self->target) {
     return;
   }
 

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1555,6 +1555,7 @@ void target_save_use(gentity_t *self, gentity_t *other, gentity_t *activator) {
 void SP_target_save(gentity_t *self) { self->use = target_save_use; }
 
 #define SF_REMOVE_PORTALS_NO_TEXT 0x1
+#define SF_REMOVE_PORTALS_ACTIVATE_TARGETS 0x2
 void target_remove_portals_use(gentity_t *self, gentity_t *other,
                                gentity_t *activator) {
   if (!activator || !activator->client) {
@@ -1568,43 +1569,45 @@ void target_remove_portals_use(gentity_t *self, gentity_t *other,
     return;
   }
 
-  auto found = false;
+  auto hadActivePortals = false;
 
   if (activator->portalBlue) {
     G_FreeEntity(activator->portalBlue);
     activator->portalBlue = nullptr;
-    found = true;
+    hadActivePortals = true;
   }
 
   if (activator->portalRed) {
     G_FreeEntity(activator->portalRed);
     activator->portalRed = nullptr;
-    found = true;
+    hadActivePortals = true;
   }
 
-  if (!found) {
-    return;
+  if (hadActivePortals) {
+    if (self->spawnflags & SF_REMOVE_PORTALS_ACTIVATE_TARGETS) {
+      gentity_t *ent = G_PickTarget(self->target);
+      if (ent && ent->use) {
+          G_UseEntity(ent, self, activator);
+      }
+    }
+
+    // play sound to client
+    if (self->noise_index) {
+      gentity_t *noiseEnt = ETJump::soundEvent(
+          activator->r.currentOrigin,
+          EV_GENERAL_CLIENT_SOUND_VOLUME,
+          self->noise_index);
+
+      noiseEnt->s.onFireStart = 255;
+    }
+
+    if (!(self->spawnflags & SF_REMOVE_PORTALS_NO_TEXT)) {
+      Printer::SendCenterMessage(ClientNum(activator), "^7Your portal gun portals have been reset.");
+    }
   }
 
-  // activate targets if any portals were reset
-  gentity_t *ent = G_PickTarget(self->target);
-  if (ent && ent->use) {
-    G_UseEntity(ent, self, activator);
-  }
-
-  // play sound to client
-  if (self->noise_index) {
-    gentity_t *noiseEnt = ETJump::soundEvent(
-        activator->r.currentOrigin,
-        EV_GENERAL_CLIENT_SOUND_VOLUME,
-        self->noise_index);
-
-    noiseEnt->s.onFireStart = 255;
-  }
-
-  if (!(self->spawnflags & SF_REMOVE_PORTALS_NO_TEXT)) {
-    Printer::SendCenterMessage(ClientNum(activator), "^7Your portal gun portals have been reset.");
-  }
+  // reset numPortals after everything else so the targeted entity can potentially use it
+  activator->client->numPortals = 0;
 }
 
 void SP_target_remove_portals(gentity_t *self) {

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1623,10 +1623,10 @@ void target_portal_relay_use(gentity_t *self, gentity_t *other,
   if (!activator ||
       !activator->client ||
       activator->client->sess.sessionTeam == TEAM_SPECTATOR ||
-      !self->target) {
+      !self->target ||
+      self->health <= 0) {
     return;
   }
-  // don't need to check health, see comment in player_die
 
   if (activator->client->numPortals <= self->count) {
     G_UseTargets(self, activator);

--- a/src/game/g_weapon.cpp
+++ b/src/game/g_weapon.cpp
@@ -3673,6 +3673,9 @@ void Weapon_Portal_Fire(gentity_t *ent, int portalNumber) {
   tent->s.otherEntityNum2 = ent->s.number;
   // END - Rail
 
+  // portal fired correctly, increment portal count
+  ent->client->numPortals++;
+
   portal = G_Spawn();
   portal->classname = "portal_gate";
 
@@ -3765,7 +3768,7 @@ void Weapon_Portal_Fire(gentity_t *ent, int portalNumber) {
   portal->s.otherEntityNum =
       ent->s.clientNum; // HACK: Using this for render checks.....
 
-  // Set portal team to shooters team. Anyone with same team can use the portal
+    // Set portal team to shooters team. Anyone with same team can use the portal
   portal->portalTeam = ent->client->sess.portalTeam;
 
   // Set angle of entity based on normal of plane....


### PR DESCRIPTION
- require spawnflag for activating targets of `target_remove_portals` for backwards compatibility
- fire all targets of `target_remove_portals` instead of random one
- add `client->numPortals` to track portalgun portals shot in since last reset (e.g. team change, timerun start, death, reset by entity)
- add entity `target_portal_relay` that fires targets if `numPortals` is <= `"maxportals"` key