### PR TITLE
Fix portal shader size compared to actual entity size

### DIFF
--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -2431,7 +2431,7 @@ static void CG_PortalGate(centity_t *cent) {
   vec3_t verts[4];
   vec3_t pushedOrigin, angleInverse;
   vec3_t axis[3];
-  const float radius = 64.0f;
+  const float radius = 48.0f;
   int i;
 
   // not our portal


### PR DESCRIPTION
Matches the entity size more closely now.

![image](https://github.com/etjump/etjump/assets/14221121/a2dc1481-354c-4c15-931e-668f6ba49c0f)

Fixes #1131 