### PR TITLE
Prevent multiple votes by reconnecting

### DIFF
--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -3,6 +3,7 @@
 #include "etj_inactivity_timer.h"
 #include "etj_string_utilities.h"
 #include "etj_numeric_utilities.h"
+#include "etj_printer.h"
 
 // g_client.c -- client functions that don't happen every frame
 
@@ -2836,6 +2837,25 @@ void ClientDisconnect(int clientNum) {
   trap_SetConfigstring(CS_PLAYERS + clientNum, "");
 
   CalculateRanks();
+
+  // disconnecting does not trigger vote cancel due to team switch in checkVote
+  // note: after CalculateRanks so level.numConnectedClients is up-to-date
+  if (level.voteInfo.voter_cn == clientNum) {
+    Printer::BroadcastPopupMessage("^7Vote canceled: caller disconnected.");
+    G_LogPrintf("Vote canceled: %s (caller %s disconnected)\n",
+                level.voteInfo.voteString, ent->client->pers.netname);
+    resetVote();
+    level.voteInfo.voteYes = 0;
+    level.voteInfo.voteNo = level.numConnectedClients;
+  } else if (ent->client->ps.eFlags & EF_VOTED) {
+    if (ent->client->pers.votingInfo.isVotedYes) {
+      level.voteInfo.voteYes--;
+      trap_SetConfigstring(CS_VOTE_YES, va("%i", level.voteInfo.voteYes));
+    } else {
+      level.voteInfo.voteNo--;
+      trap_SetConfigstring(CS_VOTE_NO, va("%i", level.voteInfo.voteNo));
+    }
+  }
 
   // OSP
   G_verifyMatchState(i);

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1824,6 +1824,7 @@ void QDECL G_DPrintf(const char *fmt, ...);
 void QDECL G_Error(const char *fmt, ...);
 // Is this a single player type game - sp or coop?
 qboolean G_IsSinglePlayerGame();
+void resetVote();
 
 //
 // g_client.c


### PR DESCRIPTION
Decrement vote counts correctly if a client disconnects after voting, and additionally cancel a vote if it was called by the client who disconnected.