### PR TITLE
play short fall footstep on cushions

### DIFF
--- a/assets/ui/etjump_settings_1.menu
+++ b/assets/ui/etjump_settings_1.menu
@@ -8,9 +8,9 @@
 #define SUBW_GENERAL_ITEM_Y SUBW_GENERAL_Y + SUBW_HEADER_HEIGHT
 #define SUBW_GENERAL_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 22)
 
-#define SUBW_CROSSHAIR_Y SUBW_GENERAL_Y + SUBW_GENERAL_HEIGHT + SUBW_SPACING_Y
-#define SUBW_CROSSHAIR_ITEM_Y SUBW_CROSSHAIR_Y + SUBW_HEADER_HEIGHT
-#define SUBW_CROSSHAIR_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 3)
+#define SUBW_SOUNDS_Y SUBW_GENERAL_Y + SUBW_GENERAL_HEIGHT + SUBW_SPACING_Y
+#define SUBW_SOUNDS_ITEM_Y SUBW_SOUNDS_Y + SUBW_HEADER_HEIGHT
+#define SUBW_SOUNDS_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 4)
 
 // Right side menus
 #define SUBW_CHAT_Y SUBW_Y
@@ -21,13 +21,13 @@
 #define SUBW_CONSOLE_ITEM_Y SUBW_CONSOLE_Y + SUBW_HEADER_HEIGHT
 #define SUBW_CONSOLE_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 2)
 
-#define SUBW_SOUNDS_Y SUBW_CONSOLE_Y + SUBW_CONSOLE_HEIGHT + SUBW_SPACING_Y
-#define SUBW_SOUNDS_ITEM_Y SUBW_SOUNDS_Y + SUBW_HEADER_HEIGHT
-#define SUBW_SOUNDS_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 3)
-
-#define SUBW_PLAYERS_Y SUBW_SOUNDS_Y + SUBW_SOUNDS_HEIGHT + SUBW_SPACING_Y
+#define SUBW_PLAYERS_Y SUBW_CONSOLE_Y + SUBW_CONSOLE_HEIGHT + SUBW_SPACING_Y
 #define SUBW_PLAYERS_ITEM_Y SUBW_PLAYERS_Y + SUBW_HEADER_HEIGHT
 #define SUBW_PLAYERS_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 6)
+
+#define SUBW_CROSSHAIR_Y SUBW_PLAYERS_Y + SUBW_PLAYERS_HEIGHT + SUBW_SPACING_Y
+#define SUBW_CROSSHAIR_ITEM_Y SUBW_CROSSHAIR_Y + SUBW_HEADER_HEIGHT
+#define SUBW_CROSSHAIR_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 3)
 
 #define GROUP_NAME "group_etjump_settings_1"
 
@@ -71,14 +71,14 @@ menuDef {
         YESNO               (SUBW_ITEM_LEFT_X, SUBW_GENERAL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 21), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "No panzer autoswitch:", 0.2, SUBW_ITEM_HEIGHT, "etj_noPanzerAutoswitch", "Toggle automatic weapon switching after firing a panzerfaust\netj_noPanzerAutoswitch")
         YESNO               (SUBW_ITEM_LEFT_X, SUBW_GENERAL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 22), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Portalgun auto binds:", 0.2, SUBW_ITEM_HEIGHT, "etj_autoPortalBinds", "Automatically set 'weapalt' bindings to '+attack2' and back when switching to/from portalgun\netj_autoPortalBinds")
 
-    SUBWINDOW(SUBW_RECT_LEFT_X, SUBW_CROSSHAIR_Y, SUBW_WIDTH, SUBW_CROSSHAIR_HEIGHT, "CROSSHAIR")
-        CVARFLOATLABEL      (SUBW_ITEM_LEFT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_crosshairScaleX", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
-        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Scale X:", 0.2, SUBW_ITEM_HEIGHT, etj_crosshairScaleX 1.0 -5.0 5.0 0.1, "Horizontal scale of crosshair, negative values will flip the crosshair\netj_crosshairScaleX")
-        CVARFLOATLABEL      (SUBW_ITEM_LEFT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_crosshairScaleY", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
-        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Scale Y:", 0.2, SUBW_ITEM_HEIGHT, etj_crosshairScaleY 1.0 -5.0 5.0 0.1, "Vertical scale of crosshair, negative values will flip the crosshair\netj_crosshairScaleY")
-        CVARFLOATLABEL      (SUBW_ITEM_LEFT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_crosshairThickness", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
-        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Line thickness:", 0.2, SUBW_ITEM_HEIGHT, etj_crosshairThickness 1.0 0.0 5.0 0.1, "Line thickness of ETJump crosshairs\netj_crosshairThickness")
-        YESNO               (SUBW_ITEM_LEFT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Crosshair outline:", 0.2, SUBW_ITEM_HEIGHT, "etj_crosshairOutline", "Draw outline on ETJump crosshairs\netj_crosshairOutline")
+    SUBWINDOW(SUBW_RECT_LEFT_X, SUBW_SOUNDS_Y, SUBW_WIDTH, SUBW_SOUNDS_HEIGHT, "SOUNDS")
+        CVARFLOATLABEL      (SUBW_ITEM_LEFT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_weaponVolume", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Weapon sound volume:", 0.2, SUBW_ITEM_HEIGHT, etj_weaponVolume 1 0 5 0.1, "Scale weapon sound volume\netj_weaponVolume")
+        CVARFLOATLABEL      (SUBW_ITEM_LEFT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_footstepVolume", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Footstep sound volume:", 0.2, SUBW_ITEM_HEIGHT, etj_footstepVolume 1 0 5 0.1, "Scale footstep and landing sound volume\netj_footstepVolume")
+        YESNO               (SUBW_ITEM_LEFT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Looped sounds:", 0.2, SUBW_ITEM_HEIGHT, "etj_loopedSounds", "Play looping sounds on map\netj_loopedSounds")
+        YESNO               (SUBW_ITEM_LEFT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Uphill step sounds:", 0.2, SUBW_ITEM_HEIGHT, "etj_uphillSteps", "Enable stepsounds on very low impact speeds\netj_uphillSteps")
+        YESNO               (SUBW_ITEM_LEFT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 4), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Fixed cushion steps:", 0.2, SUBW_ITEM_HEIGHT, "etj_fixedCushionSteps", "Play proper stepsounds when falling onto cushion surfaces\netj_fixedCushionSteps")
 
     SUBWINDOW(SUBW_RECT_RIGHT_X, SUBW_CHAT_Y, SUBW_WIDTH, SUBW_CHAT_HEIGHT, "CHAT")
         CVARFLOATLABEL      (SUBW_ITEM_RIGHT_X, SUBW_CHAT_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_chatAlpha", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
@@ -106,14 +106,6 @@ menuDef {
         YESNO               (SUBW_ITEM_RIGHT_X, SUBW_CONSOLE_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Console shader:", 0.2, SUBW_ITEM_HEIGHT, "etj_consoleShader", "Draw console background shader (vid_restart required)\netj_consoleShader")
         MULTI               (SUBW_ITEM_RIGHT_X, SUBW_CONSOLE_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Console color:", 0.2, SUBW_ITEM_HEIGHT, "etj_consoleColor", cvarStrList { "White"; "white"; "Yellow"; "yellow"; "Red"; "red"; "Green"; "green"; "Blue"; "blue"; "Magenta"; "magenta"; "Cyan"; "cyan"; "Orange"; "orange"; "Light Blue"; "0xa0c0ff"; "Medium Blue"; "mdblue"; "Light Red"; "0xffc0a0"; "Medium Red"; "mdred"; "Light Green"; "0xa0ffc0"; "Medium Green"; "mdgreen"; "Dark Green"; "dkgreen"; "Medium Cyan"; "mdcyan"; "Medium Yellow"; "mdyellow"; "Medium Orange"; "mdorange"; "Light Grey"; "ltgrey"; "Medium Grey"; "mdgrey"; "Dark Grey"; "dkgrey"; "Black"; "black" }, "Sets console color when console shader is disabled (vid_restart required)\netj_consoleColor")
 
-    SUBWINDOW(SUBW_RECT_RIGHT_X, SUBW_SOUNDS_Y, SUBW_WIDTH, SUBW_SOUNDS_HEIGHT, "SOUNDS")
-        CVARFLOATLABEL      (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_weaponVolume", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
-        SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Weapon sound volume:", 0.2, SUBW_ITEM_HEIGHT, etj_weaponVolume 1 0 5 0.1, "Scale weapon sound volume\netj_weaponVolume")
-        CVARFLOATLABEL      (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_footstepVolume", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
-        SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Footstep sound volume:", 0.2, SUBW_ITEM_HEIGHT, etj_footstepVolume 1 0 5 0.1, "Scale footstep and landing sound volume\netj_footstepVolume")
-        YESNO               (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Looped sounds:", 0.2, SUBW_ITEM_HEIGHT, "etj_loopedSounds", "Play looping sounds on map\netj_loopedSounds")
-        YESNO               (SUBW_ITEM_RIGHT_X, SUBW_SOUNDS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Uphill step sounds:", 0.2, SUBW_ITEM_HEIGHT, "etj_uphillSteps", "Enable stepsounds on very low impact speeds\netj_uphillSteps")
-
     SUBWINDOW(SUBW_RECT_RIGHT_X, SUBW_PLAYERS_Y, SUBW_WIDTH, SUBW_PLAYERS_HEIGHT, "PLAYERS")
         YESNO               (SUBW_ITEM_RIGHT_X, SUBW_PLAYERS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Hide players:", 0.2, SUBW_ITEM_HEIGHT, "etj_hide", "Hides other players when they are too close\netj_hide")
         CVARINTLABEL        (SUBW_ITEM_RIGHT_X, SUBW_PLAYERS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_hideDistance", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
@@ -125,6 +117,15 @@ menuDef {
         SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_PLAYERS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 4), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Player opacity:", 0.2, SUBW_ITEM_HEIGHT, etj_playerOpacity 1 0 1 0.05, "Sets transparency of other players\netj_playerOpacity")
         YESNO               (SUBW_ITEM_RIGHT_X, SUBW_PLAYERS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 5), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Simple player shader:", 0.2, SUBW_ITEM_HEIGHT, "etj_drawSimplePlayers", "Draw other players as solid color\netj_drawSimplePlayers")
         MULTI               (SUBW_ITEM_RIGHT_X, SUBW_PLAYERS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 6), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Player shader color:", 0.2, SUBW_ITEM_HEIGHT, "etj_simplePlayersColor", cvarStrList { "White"; "white"; "Yellow"; "yellow"; "Red"; "red"; "Green"; "green"; "Blue"; "blue"; "Magenta"; "magenta"; "Cyan"; "cyan"; "Orange"; "orange"; "Light Blue"; "0xa0c0ff"; "Medium Blue"; "mdblue"; "Light Red"; "0xffc0a0"; "Medium Red"; "mdred"; "Light Green"; "0xa0ffc0"; "Medium Green"; "mdgreen"; "Dark Green"; "dkgreen"; "Medium Cyan"; "mdcyan"; "Medium Yellow"; "mdyellow"; "Medium Orange"; "mdorange"; "Light Grey"; "ltgrey"; "Medium Grey"; "mdgrey"; "Dark Grey"; "dkgrey"; "Black"; "black" }, "Sets color of simple player shader\netj_simplePlayersColor")
+
+    SUBWINDOW(SUBW_RECT_RIGHT_X, SUBW_CROSSHAIR_Y, SUBW_WIDTH, SUBW_CROSSHAIR_HEIGHT, "CROSSHAIR")
+        CVARFLOATLABEL      (SUBW_ITEM_RIGHT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_crosshairScaleX", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Scale X:", 0.2, SUBW_ITEM_HEIGHT, etj_crosshairScaleX 1.0 -5.0 5.0 0.1, "Horizontal scale of crosshair, negative values will flip the crosshair\netj_crosshairScaleX")
+        CVARFLOATLABEL      (SUBW_ITEM_RIGHT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_crosshairScaleY", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Scale Y:", 0.2, SUBW_ITEM_HEIGHT, etj_crosshairScaleY 1.0 -5.0 5.0 0.1, "Vertical scale of crosshair, negative values will flip the crosshair\netj_crosshairScaleY")
+        CVARFLOATLABEL      (SUBW_ITEM_RIGHT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_crosshairThickness", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Line thickness:", 0.2, SUBW_ITEM_HEIGHT, etj_crosshairThickness 1.0 0.0 5.0 0.1, "Line thickness of ETJump crosshairs\netj_crosshairThickness")
+        YESNO               (SUBW_ITEM_RIGHT_X, SUBW_CROSSHAIR_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Crosshair outline:", 0.2, SUBW_ITEM_HEIGHT, "etj_crosshairOutline", "Draw outline on ETJump crosshairs\netj_crosshairOutline")
 
         BUTTON              (ETJ_BUTTON_X + (ETJ_BUTTON_SPACING_X * 0), ETJ_BUTTON_Y, ETJ_BUTTON_WIDTH, ETJ_BUTTON_HEIGHT, "BACK", 0.3, ETJ_BUTTON_ITEM_HEIGHT, close etjump_settings_1; open etjump)
         BUTTONACTIVE        (ETJ_BUTTON_X + (ETJ_BUTTON_SPACING_X * 1), ETJ_BUTTON_Y, ETJ_BUTTON_WIDTH, ETJ_BUTTON_HEIGHT, "TAB 1", 0.3, ETJ_BUTTON_ITEM_HEIGHT, close etjump_settings_1; open etjump_settings_1)

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -1532,16 +1532,20 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
     clientNum = 0;
   }
 
+  if (event == EV_CUSHIONFALLSTEP) {
+    if (!etj_fixedCushionSteps.integer) {
+      event = EV_FOOTSTEP;
+    }
+  } else if (event == EV_UPHILLSTEP && !etj_uphillSteps.integer) {
+    return;
+  }
+
   switch (event) {
     //
     // movement generated events
     //
-    case EV_UPHILLSTEP:
-      if (!etj_uphillSteps.integer) {
-        break;
-      }
-      // fall through
     case EV_FOOTSTEP:
+    case EV_UPHILLSTEP:
       DEBUGNAME("EV_FOOTSTEP");
       if (es->eventParm != FOOTSTEP_TOTAL && cg_footsteps.integer) {
         if (es->eventParm) {
@@ -1586,6 +1590,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       break;
 
     case EV_FALL_SHORT:
+    case EV_CUSHIONFALLSTEP:
       DEBUGNAME("EV_FALL_SHORT");
       if (es->eventParm != FOOTSTEP_TOTAL) {
         if (es->eventParm) {

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2631,6 +2631,7 @@ extern vmCvar_t etj_drawLeaves;
 extern vmCvar_t etj_touchPickupWeapons;
 extern vmCvar_t etj_autoLoad;
 extern vmCvar_t etj_uphillSteps;
+extern vmCvar_t etj_fixedCushionSteps;
 extern vmCvar_t etj_quickFollow;
 extern vmCvar_t etj_chatLineWidth;
 extern vmCvar_t etj_loopedSounds;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1053,7 +1053,7 @@ cvarTable_t cvarTable[] = {
     {&etj_proneIndicatorX, "etj_proneIndicatorX", "615", CVAR_ARCHIVE},
     {&etj_proneIndicatorY, "etj_proneIndicatorY", "338", CVAR_ARCHIVE},
     {&etj_uphillSteps, "etj_uphillSteps", "1", CVAR_ARCHIVE},
-    {&etj_fixedCushionSteps, "etj_fixedCushionSteps", "1", CVAR_ARCHIVE},
+    {&etj_fixedCushionSteps, "etj_fixedCushionSteps", "0", CVAR_ARCHIVE},
     {&etj_chatLineWidth, "etj_chatLineWidth", "62", CVAR_ARCHIVE},
     {&etj_loopedSounds, "etj_loopedSounds", "1", CVAR_ARCHIVE},
     {&etj_onRunStart, "etj_onRunStart", "", CVAR_ARCHIVE},

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -533,6 +533,7 @@ vmCvar_t etj_drawLeaves;
 vmCvar_t etj_touchPickupWeapons;
 vmCvar_t etj_autoLoad;
 vmCvar_t etj_uphillSteps;
+vmCvar_t etj_fixedCushionSteps;
 vmCvar_t etj_quickFollow;
 vmCvar_t etj_chatLineWidth;
 vmCvar_t etj_loopedSounds;
@@ -1052,6 +1053,7 @@ cvarTable_t cvarTable[] = {
     {&etj_proneIndicatorX, "etj_proneIndicatorX", "615", CVAR_ARCHIVE},
     {&etj_proneIndicatorY, "etj_proneIndicatorY", "338", CVAR_ARCHIVE},
     {&etj_uphillSteps, "etj_uphillSteps", "1", CVAR_ARCHIVE},
+    {&etj_fixedCushionSteps, "etj_fixedCushionSteps", "1", CVAR_ARCHIVE},
     {&etj_chatLineWidth, "etj_chatLineWidth", "62", CVAR_ARCHIVE},
     {&etj_loopedSounds, "etj_loopedSounds", "1", CVAR_ARCHIVE},
     {&etj_onRunStart, "etj_onRunStart", "", CVAR_ARCHIVE},

--- a/src/game/bg_misc.cpp
+++ b/src/game/bg_misc.cpp
@@ -4043,6 +4043,7 @@ const char *eventnames[] = {
     "EV_LOAD_TELEPORT",
     "EV_UPHILLSTEP",
     "EV_SAVE",
+    "EV_CUSHIONFALLSTEP",
     "EV_MAX_EVENTS",
 };
 

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -1851,7 +1851,7 @@ static int PM_FootstepForSurface(void) {
 * Play step or short fall footstep depending on fall speed.
 */
 static void PM_GetCushionFootstep(const float delta) {
-  PM_AddEventExt(delta > 7 ? EV_FALL_SHORT : EV_FOOTSTEP,
+  PM_AddEventExt(delta > 7 ? EV_CUSHIONFALLSTEP : EV_FOOTSTEP,
                  PM_FootstepForSurface());
 }
 

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -1848,14 +1848,6 @@ static int PM_FootstepForSurface(void) {
 }
 
 /*
-* Play step or short fall footstep depending on fall speed.
-*/
-static void PM_GetCushionFootstep(const float delta) {
-  PM_AddEventExt(delta > 7 ? EV_CUSHIONFALLSTEP : EV_FOOTSTEP,
-                 PM_FootstepForSurface());
-}
-
-/*
 =============
 PM_CheckFallDamage
 
@@ -1976,22 +1968,27 @@ static void PM_CrashLand(void) {
 
   // End PGM Test
 
+  static const auto PM_AddCushionFootstep = [&delta]() {
+    PM_AddEventExt(delta > 7 ? EV_CUSHIONFALLSTEP : EV_FOOTSTEP,
+                   PM_FootstepForSurface());
+  };
+
   // Aciz: moved fall damage and stepsound handling into
   // PM_CheckFallDamage to avoid very messy code when checking whether
   // nofalldamage is enabled/disabled.
   if (pm->shared & BG_LEVEL_NO_FALLDAMAGE_FORCE) {
-    PM_GetCushionFootstep(delta);
+    PM_AddCushionFootstep();
   } else if (pm->shared & BG_LEVEL_NO_FALLDAMAGE) {
     if (pm->groundTrace.surfaceFlags & SURF_NODAMAGE) {
       PM_CheckFallDamage(delta);
     } else {
-      PM_GetCushionFootstep(delta);
+      PM_AddCushionFootstep();
     }
   } else {
     if (!(pm->groundTrace.surfaceFlags & SURF_NODAMAGE)) {
       PM_CheckFallDamage(delta);
     } else {
-      PM_GetCushionFootstep(delta);
+      PM_AddCushionFootstep();
     }
   }
 

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -1848,6 +1848,14 @@ static int PM_FootstepForSurface(void) {
 }
 
 /*
+* Play step or short fall footstep depending on fall speed.
+*/
+static void PM_GetCushionFootstep(const float delta) {
+  PM_AddEventExt(delta > 7 ? EV_FALL_SHORT : EV_FOOTSTEP,
+                 PM_FootstepForSurface());
+}
+
+/*
 =============
 PM_CheckFallDamage
 
@@ -1972,18 +1980,18 @@ static void PM_CrashLand(void) {
   // PM_CheckFallDamage to avoid very messy code when checking whether
   // nofalldamage is enabled/disabled.
   if (pm->shared & BG_LEVEL_NO_FALLDAMAGE_FORCE) {
-    PM_AddEventExt(EV_FOOTSTEP, PM_FootstepForSurface());
+    PM_GetCushionFootstep(delta);
   } else if (pm->shared & BG_LEVEL_NO_FALLDAMAGE) {
     if (pm->groundTrace.surfaceFlags & SURF_NODAMAGE) {
       PM_CheckFallDamage(delta);
     } else {
-      PM_AddEventExt(EV_FOOTSTEP, PM_FootstepForSurface());
+      PM_GetCushionFootstep(delta);
     }
   } else {
     if (!(pm->groundTrace.surfaceFlags & SURF_NODAMAGE)) {
       PM_CheckFallDamage(delta);
     } else {
-      PM_AddEventExt(EV_FOOTSTEP, PM_FootstepForSurface());
+      PM_GetCushionFootstep(delta);
     }
   }
 

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -1274,6 +1274,7 @@ typedef enum {
   EV_LOAD_TELEPORT,
   EV_UPHILLSTEP,
   EV_PORTAL_TRAIL,
+  EV_CUSHIONFALLSTEP,
   EV_MAX_EVENTS // just added as an 'endcap'
 } entity_event_t;
 


### PR DESCRIPTION
The footstep sound for heavy landing (but without taking damage), such as jumping in place, is never played on cushions. Changed to play normal footstep only until the threshold where the sound associated with `EV_FALL_SHORT` is played without cushion.