### PR TITLE
Add checkpoint timer popups

### DIFF
--- a/assets/ui/etjump_settings_6.menu
+++ b/assets/ui/etjump_settings_6.menu
@@ -7,7 +7,7 @@
 
 #define SUBW_TIMERUN_Y SUBW_Y
 #define SUBW_TIMERUN_ITEM_Y SUBW_TIMERUN_Y + SUBW_HEADER_HEIGHT
-#define SUBW_TIMERUN_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 13)
+#define SUBW_TIMERUN_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 19)
 
 #define GROUP_NAME "group_etjump_settings_6"
 
@@ -39,9 +39,18 @@ menuDef {
         CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 10), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_checkpointsX", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
         SLIDER              (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 10), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Checkpoints X:", 0.2, SUBW_ITEM_HEIGHT, etj_checkpointsX 320 0 640 10, "Sets X position of checkpoint timer, no effect unless checkpoint timer is in detached mode\netj_checkpointsX")
         CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 11), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_checkpointsY", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
-        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 11), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Checkpoints Y:", 0.2, SUBW_ITEM_HEIGHT, etj_checkpointsY 320 0 640 10, "Sets Y position of checkpoint timer, no effect unless checkpoint timer is in detached mode\netj_checkpointsY")
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 11), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Checkpoints Y:", 0.2, SUBW_ITEM_HEIGHT, etj_checkpointsY 380 0 480 10, "Sets Y position of checkpoint timer, no effect unless checkpoint timer is in detached mode\netj_checkpointsY")
         MULTI               (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 12), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Checkpoints size:", 0.2, SUBW_ITEM_HEIGHT, "etj_checkpointsSize", cvarFloatList { "Tiny" 1 "Small" 2 "Medium" 3 "Big" 4 }, "Sets size of checkpoint timer\netj_checkpointsSize")
         YESNO               (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 13), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Checkpoints shadow:", 0.2, SUBW_ITEM_HEIGHT, "etj_checkpointsShadow", "Draw shadow on checkpoint timer\netj_checkpointsShadow")
+        YESNO               (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 14), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Checkpoint popups:", 0.2, SUBW_ITEM_HEIGHT, "etj_checkpointsPopup", "Draw a checkpoint popup when hitting a checkpoint\netj_checkpointsPopup")
+        CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 15), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_checkpointsPopupDuration", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 15), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Popup Duration:", 0.2, SUBW_ITEM_HEIGHT, etj_checkpointsPopupDuration 1000 0 5000 100, "How long a checkpoint popup stays on screen, in milliseconds\netj_checkpointsPopupDuration")
+        CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 16), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_checkpointsPopupX", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 16), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Popup X:", 0.2, SUBW_ITEM_HEIGHT, etj_checkpointsPopupX 320 0 640 10, "Sets X position of checkpoint popup\netj_checkpointsPopupX")
+        CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 17), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_checkpointsPopupY", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 17), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Popup Y:", 0.2, SUBW_ITEM_HEIGHT, etj_checkpointsPopupY 200 0 480 10, "Sets Y position of checkpoint popup\netj_checkpointsPopupY")
+        MULTI               (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 18), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Popup size:", 0.2, SUBW_ITEM_HEIGHT, "etj_checkpointsPopupSize", cvarFloatList { "Tiny" 1 "Small" 2 "Medium" 3 "Big" 4 }, "Sets size of checkpoint popups\netj_checkpointsPopupSize")
+        YESNO               (SUBW_ITEM_LEFT_X, SUBW_TIMERUN_ITEM_Y + (SUBW_ITEM_SPACING_Y * 19), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Popup shadow:", 0.2, SUBW_ITEM_HEIGHT, "etj_checkpointsPopupShadow", "Draw shadow on checkpoint popups\netj_checkpointsPopupShadow")
 
         BUTTON              (ETJ_BUTTON_X + (ETJ_BUTTON_SPACING_X * 0), ETJ_BUTTON_Y, ETJ_BUTTON_WIDTH, ETJ_BUTTON_HEIGHT, "BACK", 0.3, ETJ_BUTTON_ITEM_HEIGHT, close etjump_settings_6; open etjump)
         BUTTON              (ETJ_BUTTON_X + (ETJ_BUTTON_SPACING_X * 1), ETJ_BUTTON_Y, ETJ_BUTTON_WIDTH, ETJ_BUTTON_HEIGHT, "TAB 1", 0.3, ETJ_BUTTON_ITEM_HEIGHT, close etjump_settings_6; open etjump_settings_1)

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -4589,13 +4589,13 @@ static void CG_Draw2D() {
   }
 
   if (!cgs.demoCam.renderingFreeCam) {
-    ETJump_DrawDrawables();
-
     for (const auto &r : ETJump::renderables) {
       if (r->beforeRender()) {
         r->render();
       }
     }
+
+    ETJump_DrawDrawables();
   }
 
   if (cg.showFireteamMenu) {

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2544,6 +2544,13 @@ extern vmCvar_t etj_checkpointsShadow;
 extern vmCvar_t etj_checkpointsStyle;
 extern vmCvar_t etj_checkpointsCount;
 
+extern vmCvar_t etj_checkpointsPopup;
+extern vmCvar_t etj_checkpointsPopupX;
+extern vmCvar_t etj_checkpointsPopupY;
+extern vmCvar_t etj_checkpointsPopupSize;
+extern vmCvar_t etj_checkpointsPopupShadow;
+extern vmCvar_t etj_checkpointsPopupDuration;
+
 extern vmCvar_t etj_drawMessageTime;
 
 extern vmCvar_t movie_changeFovBasedOnSpeed;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -445,6 +445,13 @@ vmCvar_t etj_checkpointsShadow;
 vmCvar_t etj_checkpointsStyle;
 vmCvar_t etj_checkpointsCount;
 
+vmCvar_t etj_checkpointsPopup;
+vmCvar_t etj_checkpointsPopupX;
+vmCvar_t etj_checkpointsPopupY;
+vmCvar_t etj_checkpointsPopupSize;
+vmCvar_t etj_checkpointsPopupShadow;
+vmCvar_t etj_checkpointsPopupDuration;
+
 vmCvar_t etj_drawMessageTime;
 
 vmCvar_t movie_changeFovBasedOnSpeed;
@@ -966,6 +973,15 @@ cvarTable_t cvarTable[] = {
     {&etj_checkpointsShadow, "etj_checkpointsShadow", "0", CVAR_ARCHIVE},
     {&etj_checkpointsStyle, "etj_checkpointsStyle", "0", CVAR_ARCHIVE},
     {&etj_checkpointsCount, "etj_checkpointsCount", "3", CVAR_ARCHIVE},
+
+    {&etj_checkpointsPopup, "etj_checkpointsPopup", "1", CVAR_ARCHIVE},
+    {&etj_checkpointsPopupX, "etj_checkpointsPopupX", "320", CVAR_ARCHIVE},
+    {&etj_checkpointsPopupY, "etj_checkpointsPopupY", "200", CVAR_ARCHIVE},
+    {&etj_checkpointsPopupSize, "etj_checkpointsPopupSize", "2", CVAR_ARCHIVE},
+    {&etj_checkpointsPopupShadow, "etj_checkpointsPopupShadow", "1",
+     CVAR_ARCHIVE},
+    {&etj_checkpointsPopupDuration, "etj_checkpointsPopupDuration", "1000",
+     CVAR_ARCHIVE},
 
     {&etj_drawMessageTime, "etj_drawMessageTime", "2", CVAR_ARCHIVE},
 

--- a/src/cgame/etj_timerun.cpp
+++ b/src/cgame/etj_timerun.cpp
@@ -65,6 +65,7 @@ void Timerun::onCheckpoint(const TimerunCommands::Checkpoint *cp) {
       cp->checkpointTime;
   _playersTimerunInformation[cp->clientNum].numCheckpointsHit =
       cp->checkpointIndex + 1;
+  _playersTimerunInformation[cp->clientNum].lastCheckpointTimestamp = cg.time;
 }
 
 void Timerun::onStart(const TimerunCommands::Start *start) {

--- a/src/cgame/etj_timerun.h
+++ b/src/cgame/etj_timerun.h
@@ -65,6 +65,7 @@ public:
     int numCheckpointsHit{};
     std::array<int, MAX_TIMERUN_CHECKPOINTS> checkpoints{};
     int nextFreeCheckpointIdx{};
+    int lastCheckpointTimestamp{};
   };
 
   explicit Timerun(int clientNum,

--- a/src/cgame/etj_timerun_view.cpp
+++ b/src/cgame/etj_timerun_view.cpp
@@ -68,18 +68,20 @@ void ETJump::TimerunView::draw() {
     return;
   }
 
-  auto run = currentRun();
-  auto hasTimerun =
-      (cg.demoPlayback && (run->lastRunTimer || run->running)) || cg.hasTimerun;
+  const auto run = currentRun();
+  const int lastRunTimer = run->lastRunTimer;
+  const bool running = run->running;
+  const bool hasTimerun =
+      (cg.demoPlayback && (lastRunTimer || running)) || cg.hasTimerun;
 
   if (!etj_drawRunTimer.integer || !hasTimerun) {
     return;
   }
 
-  auto startTime = run->startTime;
-  auto millis = 0;
-  auto color = &colorDefault;
+  const int startTime = run->startTime;
   const auto font = &cgs.media.limboFont1;
+  const bool autoHide = etj_runTimerAutoHide.integer;
+  vec4_t *color = &colorDefault;
 
   // ensure correct 8ms interval timer when playing
   // specs/demo playback get approximation from cg.time, so timer stays smooth
@@ -89,7 +91,9 @@ void ETJump::TimerunView::draw() {
                           ? cg.predictedPlayerState.commandTime
                           : cg.time;
 
-  if (run->running) {
+  int millis;
+
+  if (running) {
     millis = timeVar - startTime;
   } else {
     millis = run->completionTime;
@@ -101,8 +105,8 @@ void ETJump::TimerunView::draw() {
 
   vec4_t colorTemp;
   const auto range = getTransitionRange(run->previousRecord);
-  const auto style = etj_runTimerShadow.integer ? ITEM_TEXTSTYLE_SHADOWED
-                                                : ITEM_TEXTSTYLE_NORMAL;
+  const int style = etj_runTimerShadow.integer ? ITEM_TEXTSTYLE_SHADOWED
+                                               : ITEM_TEXTSTYLE_NORMAL;
 
   if (run->previousRecord > 0) {
     if (millis > run->previousRecord) {
@@ -110,9 +114,9 @@ void ETJump::TimerunView::draw() {
     }
     // add timer color transition when player gets closer to their pb
     else if (millis + range >= run->previousRecord) {
-      auto start = run->previousRecord - range;
-      auto step = static_cast<float>(millis - start) /
-                  static_cast<float>(run->previousRecord - start);
+      const int start = run->previousRecord - range;
+      const auto step = static_cast<float>(millis - start) /
+                        static_cast<float>(run->previousRecord - start);
 
       ETJump_LerpColors(&colorDefault, &colorFail, &colorTemp, step / 2);
       color = &colorTemp;
@@ -120,32 +124,33 @@ void ETJump::TimerunView::draw() {
   }
 
   // set green color for pb time
-  if (!run->running && millis &&
+  if (!running && millis &&
       (run->previousRecord > millis || run->previousRecord == -1)) {
     color = &colorSuccess;
   }
 
-  auto ms = millis;
-  auto minutes = millis / 60000;
+  const int ms = millis;
+  const int minutes = millis / 60000;
   millis -= minutes * 60000;
-  auto seconds = millis / 1000;
+  const int seconds = millis / 1000;
   millis -= seconds * 1000;
 
-  auto text = ETJump::stringFormat("%02d:%02d.%03d", minutes, seconds, millis);
+  const std::string text =
+      ETJump::stringFormat("%02d:%02d.%03d", minutes, seconds, millis);
+
   auto x = etj_runTimerX.value;
   auto y = etj_runTimerY.value;
-
-  // timer fading/hiding routine
   ETJump_AdjustPosition(&x);
 
-  (*color)[3] = getTimerAlpha(run->running, run->lastRunTimer, timeVar);
+  (*color)[3] = fadeAlpha(running, autoHide, lastRunTimer + fadeHold, fadeTime);
   if ((*color)[3] == 0) {
     return;
   }
 
-  CG_Text_Paint_Centred_Ext(x, y, 0.3, 0.3, *color, text, 0, 0, style, font);
+  CG_Text_Paint_Centred_Ext(x, y, 0.3f, 0.3f, *color, text, 0, 0, style, font);
 
-  if (etj_drawCheckpoints.integer && run->runHasCheckpoints) {
+  if ((etj_drawCheckpoints.integer || etj_checkpointsPopup.integer) &&
+      run->runHasCheckpoints) {
     // only adjust x/y if we're drawing checkpoints detached from runtimer
     if (etj_drawCheckpoints.integer == 2) {
       x = etj_checkpointsX.value;
@@ -155,8 +160,18 @@ void ETJump::TimerunView::draw() {
       // position the times below runtimer
       y += 20;
     }
-    const int currentTime =
-        run->running ? timeVar - run->startTime : run->completionTime;
+
+    const int popupTime =
+        run->lastCheckpointTimestamp + etj_checkpointsPopupDuration.integer;
+    const float popupSize = 0.1f * etj_checkpointsPopupSize.value;
+    const int popupStyle = etj_checkpointsPopupShadow.integer
+                               ? ITEM_TEXTSTYLE_SHADOWED
+                               : ITEM_TEXTSTYLE_NORMAL;
+    const float y2 = etj_checkpointsPopupY.value;
+    float x2 = etj_checkpointsPopupX.value;
+    ETJump_AdjustPosition(&x2);
+
+    const int currentTime = running ? timeVar - startTime : run->completionTime;
     const float textSize = 0.1f * etj_checkpointsSize.value;
     const auto textStyle = etj_checkpointsShadow.integer
                                ? ITEM_TEXTSTYLE_SHADOWED
@@ -169,12 +184,11 @@ void ETJump::TimerunView::draw() {
 
     // do not render checkpoints if we're not running and
     // did not just complete a run
-    if (!run->running && run->completionTime <= 0) {
+    if (!running && run->completionTime <= 0) {
       return;
     }
 
     for (int i = startIndex; i >= 0 && i > endIndex; i--) {
-      vec4_t *checkpointColor = &colorDefault;
       const int checkpointTime = run->checkpoints[i];
       const bool maxCheckpointsHit = i == MAX_TIMERUN_CHECKPOINTS;
 
@@ -209,6 +223,7 @@ void ETJump::TimerunView::draw() {
       }
 
       std::string dir;
+      vec4_t *checkpointColor;
       // if we don't have a next checkpoint set, we can't compare to anything
       // so render checkpoint as white
       if (noRecordCheckpoint || relativeTime == 0 ||
@@ -244,33 +259,50 @@ void ETJump::TimerunView::draw() {
       // follow same fading as runtimer, and if that is 0, we early out
       // before ever reaching this part
       (*checkpointColor)[3] =
-          getTimerAlpha(run->running, run->lastRunTimer, timeVar);
+          fadeAlpha(running, autoHide, lastRunTimer + fadeHold, fadeTime);
 
-      CG_Text_Paint_Centred_Ext(x, y, textSize, textSize, *checkpointColor,
-                                timerStr, 0, 0, textStyle, font);
+      // we must check for cvar here to allow only checkpoint popups to display
+      if (etj_drawCheckpoints.integer) {
+        CG_Text_Paint_Centred_Ext(x, y, textSize, textSize, *checkpointColor,
+                                  timerStr, 0, 0, textStyle, font);
+      }
+
+      if (etj_checkpointsPopup.integer && i == startIndex - 1) {
+        vec4_t cpPopupColor;
+        Vector4Copy(*checkpointColor, cpPopupColor);
+
+        if (popupTime >= cg.time) {
+          CG_Text_Paint_Centred_Ext(x2, y2, popupSize, popupSize, cpPopupColor,
+                                    timerStr, 0, 0, popupStyle, font);
+        } else if (popupTime + popupFadeTime > cg.time) {
+          // we want to always fade here so bypass running/autoHide
+          cpPopupColor[3] = fadeAlpha(false, true, popupTime, popupFadeTime);
+
+          CG_Text_Paint_Centred_Ext(x2, y2, popupSize, popupSize, cpPopupColor,
+                                    timerStr, 0, 0, popupStyle, font);
+        }
+      }
+
       y += static_cast<float>(2 *
                               CG_Text_Height_Ext(timerStr, textSize, 0, font));
     }
   }
 
-  if (run->running) {
-    if (run->previousRecord != -1 && ms > run->previousRecord) {
-      pastRecordAnimation(color, text.c_str(), ms, run->previousRecord);
-    }
+  if (running && run->previousRecord != -1 && ms > run->previousRecord) {
+    pastRecordAnimation(color, text.c_str(), ms, run->previousRecord);
   }
 }
 
-float ETJump::TimerunView::getTimerAlpha(bool running, int lastRunTimer,
-                                         int timeVar) {
-  const int fadeStart = lastRunTimer + fadeHold;
-  const int fadeEnd = fadeStart + fadeOut;
+float ETJump::TimerunView::fadeAlpha(bool running, bool autoHide, int fadeStart,
+                                     int duration) {
+  const int fadeEnd = fadeStart + duration;
+  const int now = cg.time;
 
-  if (!running && etj_runTimerAutoHide.integer) {
-    if (fadeStart < timeVar && fadeEnd > timeVar) {
-      const float step =
-          static_cast<float>(timeVar - fadeStart) / static_cast<float>(fadeOut);
-      return 1.0f - step;
-    } else if (timeVar >= fadeEnd) {
+  if (!running && autoHide) {
+    if (fadeStart < now && fadeEnd > now) {
+      return 1.0f -
+             static_cast<float>(now - fadeStart) / static_cast<float>(duration);
+    } else if (now >= fadeEnd) {
       return 0.0f;
     }
   }
@@ -304,7 +336,7 @@ void ETJump::TimerunView::pastRecordAnimation(vec4_t *color, const char *text,
   const auto scale = 0.3f + 0.25f * step;
 
   const auto originalTextHeight =
-      CG_Text_Height_Ext(text, 0.3, 0, &cgs.media.limboFont1);
+      CG_Text_Height_Ext(text, 0.3f, 0, &cgs.media.limboFont1);
   const auto textHeight =
       static_cast<float>(
           CG_Text_Height_Ext(text, scale, 0, &cgs.media.limboFont1) -

--- a/src/cgame/etj_timerun_view.cpp
+++ b/src/cgame/etj_timerun_view.cpp
@@ -142,7 +142,8 @@ void ETJump::TimerunView::draw() {
   auto y = etj_runTimerY.value;
   ETJump_AdjustPosition(&x);
 
-  (*color)[3] = fadeAlpha(running, autoHide, lastRunTimer + fadeHold, fadeTime);
+  (*color)[3] =
+      getTimerAlpha(running, autoHide, lastRunTimer + fadeHold, fadeTime);
   if ((*color)[3] == 0) {
     return;
   }
@@ -259,7 +260,7 @@ void ETJump::TimerunView::draw() {
       // follow same fading as runtimer, and if that is 0, we early out
       // before ever reaching this part
       (*checkpointColor)[3] =
-          fadeAlpha(running, autoHide, lastRunTimer + fadeHold, fadeTime);
+          getTimerAlpha(running, autoHide, lastRunTimer + fadeHold, fadeTime);
 
       // we must check for cvar here to allow only checkpoint popups to display
       if (etj_drawCheckpoints.integer) {
@@ -276,7 +277,8 @@ void ETJump::TimerunView::draw() {
                                     timerStr, 0, 0, popupStyle, font);
         } else if (popupTime + popupFadeTime > cg.time) {
           // we want to always fade here so bypass running/autoHide
-          cpPopupColor[3] = fadeAlpha(false, true, popupTime, popupFadeTime);
+          cpPopupColor[3] =
+              getTimerAlpha(false, true, popupTime, popupFadeTime);
 
           CG_Text_Paint_Centred_Ext(x2, y2, popupSize, popupSize, cpPopupColor,
                                     timerStr, 0, 0, popupStyle, font);
@@ -293,8 +295,8 @@ void ETJump::TimerunView::draw() {
   }
 }
 
-float ETJump::TimerunView::fadeAlpha(bool running, bool autoHide, int fadeStart,
-                                     int duration) {
+float ETJump::TimerunView::getTimerAlpha(bool running, bool autoHide,
+                                         int fadeStart, int duration) {
   const int fadeEnd = fadeStart + duration;
   const int now = cg.time;
 

--- a/src/cgame/etj_timerun_view.h
+++ b/src/cgame/etj_timerun_view.h
@@ -50,8 +50,8 @@ private:
   static void pastRecordAnimation(vec4_t *color, const char *text,
                                   int timerTime, int record);
 
-  static float fadeAlpha(bool running, bool autoHide, int fadeStart,
-                         int duration);
+  static float getTimerAlpha(bool running, bool autoHide, int fadeStart,
+                             int duration);
 
   vec4_t inactiveTimerColor{};
   std::shared_ptr<Timerun> _timerun;

--- a/src/cgame/etj_timerun_view.h
+++ b/src/cgame/etj_timerun_view.h
@@ -50,8 +50,8 @@ private:
   static void pastRecordAnimation(vec4_t *color, const char *text,
                                   int timerTime, int record);
 
-  // returns the alpha value of runtimer
-  static float getTimerAlpha(bool running, int lastRunTimer, int timeVar);
+  static float fadeAlpha(bool running, bool autoHide, int fadeStart,
+                         int duration);
 
   vec4_t inactiveTimerColor{};
   std::shared_ptr<Timerun> _timerun;
@@ -60,8 +60,10 @@ private:
   vec4_t colorSuccess = {0.627f, 0.941f, 0.349f, 1.0f};
   vec4_t colorFail = {0.976f, 0.262f, 0.262f, 1.0f};
   static const int animationTime = 300;
-  static const int fadeOut = 2000;  // 2s fade out
-  static const int fadeHold = 5000; // 5s pause
+  static const int fadeHold = 5000; // 5s pause before fade starts
+  static const int fadeTime = 2000; // 2s fade
+
+  static const int popupFadeTime = 100;
 
   static bool canSkipDraw();
 };


### PR DESCRIPTION
Adds a popup on screen that shows the checkpoint timer briefly when hitting a checkpoint.

* `etj_checkpointsPopup` - toggle popup
* `etj_checkpointsPopupX/Y` - X/Y position
* `etj_checkpointsPopupSize` - popup size
* `etj_checkpointsPopupShadow` - toggle shadow
* `etj_checkpointsPopupDuration` - how long the popup stays on screen

https://streamable.com/4n3cvm

This also moves timerun view to draw above ETJump renderables (should refactor this in the future and move to IRenderable, it's currently a "drawable" and a sole user of that system) mainly to make this draw above cgaz hud, and fix default value/slider range of `etj_checkpointsY`