### PR TITLE
Fix erroneous vote cancel when client 0 disconnects

### DIFF
--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2840,20 +2840,22 @@ void ClientDisconnect(int clientNum) {
 
   // disconnecting does not trigger vote cancel due to team switch in checkVote
   // note: after CalculateRanks so level.numConnectedClients is up-to-date
-  if (level.voteInfo.voter_cn == clientNum) {
-    Printer::BroadcastPopupMessage("^7Vote canceled: caller disconnected.");
-    G_LogPrintf("Vote canceled: %s (caller %s disconnected)\n",
-                level.voteInfo.voteString, ent->client->pers.netname);
-    resetVote();
-    level.voteInfo.voteYes = 0;
-    level.voteInfo.voteNo = level.numConnectedClients;
-  } else if (ent->client->ps.eFlags & EF_VOTED) {
-    if (ent->client->pers.votingInfo.isVotedYes) {
-      level.voteInfo.voteYes--;
-      trap_SetConfigstring(CS_VOTE_YES, va("%i", level.voteInfo.voteYes));
-    } else {
-      level.voteInfo.voteNo--;
-      trap_SetConfigstring(CS_VOTE_NO, va("%i", level.voteInfo.voteNo));
+  if (level.voteInfo.voteTime) {
+    if (level.voteInfo.voter_cn == clientNum) {
+      Printer::BroadcastPopupMessage("^7Vote canceled: caller disconnected.");
+      G_LogPrintf("Vote canceled: %s (caller %s disconnected)\n",
+                  level.voteInfo.voteString, ent->client->pers.netname);
+      resetVote();
+      level.voteInfo.voteYes = 0;
+      level.voteInfo.voteNo = level.numConnectedClients;
+    } else if (ent->client->ps.eFlags & EF_VOTED) {
+      if (ent->client->pers.votingInfo.isVotedYes) {
+        level.voteInfo.voteYes--;
+        trap_SetConfigstring(CS_VOTE_YES, va("%i", level.voteInfo.voteYes));
+      } else {
+        level.voteInfo.voteNo--;
+        trap_SetConfigstring(CS_VOTE_NO, va("%i", level.voteInfo.voteNo));
+      }
     }
   }
 


### PR DESCRIPTION
Handle vote cancel/count stuff only if there's an active vote, as `level.voteInfo.voter_cn` is 0 by default, and voteInfo related stuff isn't necessarily reset after a vote has concluded.

refs #1134 