### PR TITLE
Fix client votingInfo & autoRtv status not resetting

### DIFF
--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -2780,7 +2780,7 @@ void Cmd_Vote_f(gentity_t *ent) {
     level.voteInfo.voteCanceled = qtrue;
     level.voteInfo.voteNo = level.numConnectedClients;
     level.voteInfo.voteYes = 0;
-    game.rtv->setRtvStatus(false);
+
     Printer::BroadcastPopupMessage("^7Vote canceled by caller.");
   };
 

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -3015,7 +3015,14 @@ void resetVote() {
   level.voteInfo.voteTime = 0;
   level.voteInfo.forcePass = qfalse;
   level.voteInfo.voteCanceled = qfalse;
+  level.voteInfo.isAutoRtvVote = false;
   game.rtv->setRtvStatus(false);
+
+  for (int i = 0; i < level.numConnectedClients; i++) {
+    gentity_t *client = g_entities + level.sortedClients[i];
+    memset(&client->client->pers.votingInfo, 0, sizeof(ETJump::votingInfo_t));
+  }
+
   trap_SetConfigstring(CS_VOTE_TIME, "");
 }
 


### PR DESCRIPTION
`client->pers.votingInfo` was never reset if a vote failed or got canceled, which caused all sorts of issues. For example you could not re-vote anymore if you had used all 3 re-vote attempts on a previous vote. This also messed up `lastRtvMapVoted` variable which would in some scenarios cause unwanted reduction of a vote count from a map during RTV vote. This seems to have always been broken, but with RTV testing this became more apparent.

Also fix for autoRtv status not resetting if autoRtv fails.

`game.rtv->setRtvStatus(false);` in the `cancelVote` lambda was redundant as `resetVote` would be called next server frame, which also sets it to false.

refs #1135 