### PR TITLE
Multiactivator triggers by default + deprecate spawnflags 512 & 2048

### DIFF
--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -343,10 +343,6 @@ void G_TouchTriggers(gentity_t *ent) {
   // trigger_objective_info tracking
   ent->client->touchingTOI = NULL;
 
-  // Zero: reset the bool that keeps track of trigger_multiple,
-  // spawnflags 512 activations
-  ent->client->alreadyActivatedTrigger = qfalse;
-
   // dead clients don't activate triggers!
   if (ent->client->ps.stats[STAT_HEALTH] <= 0) {
     return;

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -676,9 +676,19 @@ enum class DeathrunFlags {
 ///////////////////////////////////////////////////////////////////////////////
 
 enum class TriggerMultipleFlags {
-  // TODO: add the rest
   None = 0,
-  DeathrunOnly = 1 << 10
+  AxisOnly = 1 << 0,
+  AlliesOnly = 1 << 1,
+  NoBots = 1 << 2,
+  BotsOnly = 1 << 3,
+  SoldierOnly = 1 << 4,
+  FieldOpsOnly = 1 << 5,
+  MedicOnly = 1 << 6,
+  EngineerOnly = 1 << 7,
+  CvOpsOnly = 1 << 8,
+  Constant = 1 << 9, // deprecated
+  DeathrunOnly = 1 << 10,
+  MultiActivator = 1 << 11, // deprecated (default behavior now)
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1138,8 +1148,6 @@ struct gclient_s {
   int lastVoteTime;
   qboolean cheatDetected;
 
-  // Whether the client already activated a trigger or not
-  qboolean alreadyActivatedTrigger;
   // Time when client activated trigger_multiple
   int multiTriggerActivationTime;
 
@@ -1225,6 +1233,7 @@ typedef struct {
   int time;         // in msec
   int previousTime; // so movers can back up when blocked
   int frameTime;    // Gordon: time the frame started, for antilag stuff
+  int frameMsec;    // server frame time
 
   int startTime; // level.time the map was started
 

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -3676,8 +3676,7 @@ Advances the non-player objects in the world
 ================
 */
 void G_RunFrame(int levelTime) {
-  int i, msec;
-  //	int			pass = 0;
+  int i;
 
   // if we are waiting for the level to restart, do nothing
   if (level.restarted) {
@@ -3691,8 +3690,7 @@ void G_RunFrame(int levelTime) {
     level.timeDelta = levelTime - level.timeCurrent;
     if ((level.time % 500) == 0) {
       // FIXME: set a PAUSE cs and let the client adjust
-      // their local starttimes
-      //        instead of this spam
+      //  their local start times instead of this spam
       trap_SetConfigstring(CS_LEVEL_START_TIME,
                            va("%i", level.startTime + level.timeDelta));
     }
@@ -3704,11 +3702,10 @@ void G_RunFrame(int levelTime) {
   level.previousTime = level.time;
   level.time = levelTime;
 
-  msec = level.time - level.previousTime;
-  level.frameMsec = msec;
+  level.frameMsec = level.time - level.previousTime;
 
-  level.axisBombCounter -= msec;
-  level.alliedBombCounter -= msec;
+  level.axisBombCounter -= level.frameMsec;
+  level.alliedBombCounter -= level.frameMsec;
 
   if (level.axisBombCounter < 0) {
     level.axisBombCounter = 0;
@@ -3748,7 +3745,7 @@ uebrgpiebrpgibqeripgubeqrpigubqifejbgipegbrtibgurepqgbn%i", level.time)
 
   // go through all allocated objects
   for (i = 0; i < level.num_entities; i++) {
-    G_RunEntity(&g_entities[i], msec);
+    G_RunEntity(&g_entities[i], level.frameMsec);
   }
 
   for (i = 0; i < level.numConnectedClients; i++) {

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -3705,6 +3705,7 @@ void G_RunFrame(int levelTime) {
   level.time = levelTime;
 
   msec = level.time - level.previousTime;
+  level.frameMsec = msec;
 
   level.axisBombCounter -= msec;
   level.alliedBombCounter -= msec;


### PR DESCRIPTION
Make the `spawnflags 2048` of `trigger_multiple` the default behavior, and deprecate both `spawnflags 512 (constant)` and `2048 (multiactivator)`. Backwards compatibility is handled by setting wait to one server frame on old 512 triggers.