### PR TITLE
Fix backups breaking on initial save to a slot + cleanup save code

### DIFF
--- a/src/game/etj_save_system.cpp
+++ b/src/game/etj_save_system.cpp
@@ -27,47 +27,43 @@
 #include "etj_session.h"
 #include <iostream>
 
-ETJump::SaveSystem::Client::Client() {
-  alliesBackupPositions.clear();
-  axisBackupPositions.clear();
-
+namespace ETJump {
+SaveSystem::Client::Client() {
   for (int i = 0; i < MAX_SAVED_POSITIONS; i++) {
-    alliesSavedPositions[i].isValid = false;
-    alliesSavedPositions[i].isLatest = false;
-    axisSavedPositions[i].isValid = false;
-    axisSavedPositions[i].isLatest = false;
+    alliesSaves[i].isValid = false;
+    alliesSaves[i].isLatest = false;
+    axisSaves[i].isValid = false;
+    axisSaves[i].isLatest = false;
   }
+
+  alliesBackups.clear();
+  axisBackups.clear();
 
   for (int i = 0; i < MAX_BACKUP_POSITIONS; i++) {
-    alliesBackupPositions.push_back(SavePosition());
-    alliesBackupPositions[i].isValid = false;
-
-    axisBackupPositions.push_back(SavePosition());
-    axisBackupPositions[i].isValid = false;
+    alliesBackups.emplace_back();
+    axisBackups.emplace_back();
   }
 
-  alliesLastLoadPosition.isValid = false;
-  axisLastLoadPosition.isValid = false;
+  alliesLastLoadPos.isValid = false;
+  axisLastLoadPos.isValid = false;
 }
 
-ETJump::SaveSystem::DisconnectedClient::DisconnectedClient() {
+SaveSystem::DisconnectedClient::DisconnectedClient() {
   for (int i = 0; i < MAX_SAVED_POSITIONS; i++) {
-    alliesSavedPositions[i].isValid = false;
-    alliesSavedPositions[i].isLatest = false;
-    axisSavedPositions[i].isValid = false;
-    axisSavedPositions[i].isLatest = false;
-    progression = 0;
+    alliesSaves[i].isValid = false;
+    alliesSaves[i].isLatest = false;
+    axisSaves[i].isValid = false;
+    axisSaves[i].isLatest = false;
   }
 
-  alliesLastLoadPosition.isValid = false;
-  axisLastLoadPosition.isValid = false;
+  alliesLastLoadPos.isValid = false;
+  axisLastLoadPos.isValid = false;
+  progression = 0;
+  saveLimit = 0;
 }
-
-// Zero: required for saving saves to db
-std::string UserDatabase_Guid(gentity_t *ent);
 
 // Saves current position
-void ETJump::SaveSystem::save(gentity_t *ent) {
+void SaveSystem::save(gentity_t *ent) {
   auto *client = ent->client;
   const int clientNum = ClientNum(ent);
 
@@ -91,8 +87,7 @@ void ETJump::SaveSystem::save(gentity_t *ent) {
                                static_cast<int>(SaveLoadRestrictions::Move)) {
     // comparing to zero vector
     if (!VectorCompare(client->ps.velocity, vec3_origin)) {
-      CPTo(ent, "^3Save ^7is disabled while moving on "
-                "this map.");
+      CPTo(ent, "^3Save ^7is disabled while moving on this map.");
       return;
     }
   }
@@ -105,8 +100,9 @@ void ETJump::SaveSystem::save(gentity_t *ent) {
     return;
   }
 
-  auto argv = GetArgs();
-  auto position = 0;
+  const auto argv = GetArgs();
+  int position = 0;
+
   if (argv->size() > 1) {
     ToInt((*argv)[1], position);
 
@@ -146,15 +142,13 @@ void ETJump::SaveSystem::save(gentity_t *ent) {
 
   if (!g_cheats.integer) {
     if (level.noSave) {
-      if ((!trace.fraction) != 1.0f) {
-        CPTo(ent, "^7You can not ^3save "
-                  "^7inside this area.");
+      if (trace.fraction == 1.0f) {
+        CPTo(ent, "^7You can not ^3save ^7inside this area.");
         return;
       }
     } else {
       if (trace.fraction != 1.0f) {
-        CPTo(ent, "^7You can not ^3save "
-                  "^7inside this area.");
+        CPTo(ent, "^7You can not ^3save ^7inside this area.");
         return;
       }
     }
@@ -195,28 +189,27 @@ void ETJump::SaveSystem::save(gentity_t *ent) {
   }
 
   const auto teamSaves = client->sess.sessionTeam == TEAM_ALLIES
-                             ? _clients[clientNum].alliesSavedPositions
-                             : _clients[clientNum].axisSavedPositions;
+                             ? _clients[clientNum].alliesSaves
+                             : _clients[clientNum].axisSaves;
   SavePosition *pos = teamSaves + position;
 
   if (pos->isLatest) {
     saveBackupPosition(ent, pos);
   } else {
-    const int slot = getLatestSaveSlot(client);
+    const int latestSlot = getLatestSaveSlot(client);
 
-    if (slot != -1) {
-      saveBackupPosition(ent, teamSaves + slot);
+    if (latestSlot != -1) {
+      saveBackupPosition(ent, teamSaves + latestSlot);
     }
   }
 
   resetLatestSaveSlot(ent);
   storePosition(client, pos);
-
   sendClientCommands(ent, position);
 }
 
 // Loads position
-void ETJump::SaveSystem::load(gentity_t *ent) {
+void SaveSystem::load(gentity_t *ent) {
   auto *client = ent->client;
 
   if (!client) {
@@ -247,8 +240,9 @@ void ETJump::SaveSystem::load(gentity_t *ent) {
     return;
   }
 
-  auto argv = GetArgs();
-  auto slot = 0;
+  const auto argv = GetArgs();
+  int slot = 0;
+
   if (argv->size() > 1) {
     ToInt((*argv)[1], slot);
 
@@ -270,21 +264,25 @@ void ETJump::SaveSystem::load(gentity_t *ent) {
     return;
   }
 
-  auto validSave = getValidTeamSaveForSlot(ent, client->sess.sessionTeam, slot);
-  if (validSave) {
+  const auto pos = getValidTeamSaveForSlot(ent, client->sess.sessionTeam, slot);
+
+  if (pos) {
     saveLastLoadPos(ent); // store position for unload command
-    restoreStanceFromSave(ent, validSave);
+    restoreStanceFromSave(ent, pos);
+
     if (!g_cheats.integer && client->sess.timerunActive &&
         client->sess.runSpawnflags &
             static_cast<int>(ETJump::TimerunSpawnflags::NoSave)) {
       InterruptRun(ent);
     }
+
     // allow fast respawn + load if we got gibbed to skip death sequence
     if (ent->client->ps.stats[STAT_HEALTH] <= GIB_HEALTH) {
       ent->client->ps.pm_flags &= ~PMF_LIMBO;
       ClientSpawn(ent, qfalse);
     }
-    teleportPlayer(ent, validSave);
+
+    teleportPlayer(ent, pos);
   } else {
     CPTo(ent, "^7Use ^3save ^7first.");
   }
@@ -292,7 +290,7 @@ void ETJump::SaveSystem::load(gentity_t *ent) {
 
 // Saves position, does not check for anything. Used for target_save
 void ETJump::SaveSystem::forceSave(gentity_t *location, gentity_t *ent) {
-  SavePosition *pos = nullptr;
+  SavePosition *pos;
   auto *client = ent->client;
   const int clientNum = ClientNum(ent);
 
@@ -301,9 +299,9 @@ void ETJump::SaveSystem::forceSave(gentity_t *location, gentity_t *ent) {
   }
 
   if (client->sess.sessionTeam == TEAM_ALLIES) {
-    pos = &_clients[clientNum].alliesSavedPositions[0];
+    pos = &_clients[clientNum].alliesSaves[0];
   } else if (client->sess.sessionTeam == TEAM_AXIS) {
-    pos = &_clients[clientNum].axisSavedPositions[0];
+    pos = &_clients[clientNum].axisSaves[0];
   } else {
     return;
   }
@@ -311,10 +309,10 @@ void ETJump::SaveSystem::forceSave(gentity_t *location, gentity_t *ent) {
   if (pos->isLatest) {
     saveBackupPosition(ent, pos);
   } else {
-    const int slot = getLatestSaveSlot(client);
+    const int latestSlot = getLatestSaveSlot(client);
 
-    if (slot != -1) {
-      saveBackupPosition(ent, pos + slot);
+    if (latestSlot != -1) {
+      saveBackupPosition(ent, pos + latestSlot);
     }
   }
 
@@ -324,16 +322,20 @@ void ETJump::SaveSystem::forceSave(gentity_t *location, gentity_t *ent) {
   VectorCopy(location->s.angles, pos->vangles);
   pos->isValid = true;
   pos->isLatest = true;
-  pos->stance = client->ps.eFlags & EF_CROUCHING ? Crouch
-                : client->ps.eFlags & EF_PRONE   ? Prone
-                                                 : Stand;
 
-  trap_SendServerCommand(ent - g_entities, "savePrint");
+  if (client->ps.eFlags & EF_PRONE) {
+    pos->stance = Prone;
+  } else {
+    pos->stance = client->ps.eFlags & EF_CROUCHING ? Crouch : Stand;
+  }
+
+  trap_SendServerCommand(clientNum, "savePrint");
 }
 
 // Loads backup position
-void ETJump::SaveSystem::loadBackupPosition(gentity_t *ent) {
+void SaveSystem::loadBackupPosition(gentity_t *ent) {
   auto *client = ent->client;
+  const int clientNum = ClientNum(ent);
 
   if (!client) {
     return;
@@ -370,8 +372,9 @@ void ETJump::SaveSystem::loadBackupPosition(gentity_t *ent) {
     return;
   }
 
-  auto argv = GetArgs();
-  auto slot = 0;
+  const auto argv = GetArgs();
+  int slot = 0;
+
   if (argv->size() > 1) {
     ToInt(argv->at(1), slot);
 
@@ -390,20 +393,23 @@ void ETJump::SaveSystem::loadBackupPosition(gentity_t *ent) {
     return;
   }
 
-  SavePosition *pos = nullptr;
+  SavePosition *pos;
+
   if (client->sess.sessionTeam == TEAM_ALLIES) {
-    pos = &_clients[ClientNum(ent)].alliesBackupPositions[slot];
+    pos = &_clients[clientNum].alliesBackups[slot];
   } else {
-    pos = &_clients[ClientNum(ent)].axisBackupPositions[slot];
+    pos = &_clients[clientNum].axisBackups[slot];
   }
 
   if (pos->isValid) {
     restoreStanceFromSave(ent, pos);
+
     if (client->sess.timerunActive &&
         client->sess.runSpawnflags &
             static_cast<int>(ETJump::TimerunSpawnflags::NoSave)) {
       InterruptRun(ent);
     }
+
     teleportPlayer(ent, pos);
   } else {
     CPTo(ent, "^7Use ^3save ^7first.");
@@ -412,8 +418,8 @@ void ETJump::SaveSystem::loadBackupPosition(gentity_t *ent) {
 
 // Undo last load command and teleport to last position client loaded from
 // Position validation is done here
-void ETJump::SaveSystem::unload(gentity_t *ent) {
-  auto *client = ent->client;
+void SaveSystem::unload(gentity_t *ent) {
+  const auto *client = ent->client;
 
   if (!client) {
     return;
@@ -453,33 +459,30 @@ void ETJump::SaveSystem::unload(gentity_t *ent) {
     return;
   }
 
-  auto validPos = getValidTeamUnloadPos(ent, client->sess.sessionTeam);
+  const auto pos = getValidTeamUnloadPos(ent, client->sess.sessionTeam);
 
-  if (validPos) {
+  if (pos) {
     if (!g_cheats.integer) {
-      // check for nosave areas only if we have valid
-      // pos
+      // check for nosave areas only if we have valid pos
       trace_t trace;
-      trap_TraceCapsule(&trace, validPos->origin, ent->r.mins, ent->r.maxs,
-                        validPos->origin, ent->s.number, CONTENTS_NOSAVE);
+      trap_TraceCapsule(&trace, pos->origin, ent->r.mins, ent->r.maxs,
+                        pos->origin, ent->s.number, CONTENTS_NOSAVE);
 
       if (level.noSave) {
-        if ((!trace.fraction) != 1.0f) {
-          CPTo(ent, "^7You can not ^3unload "
-                    "^7to this area.");
+        if (trace.fraction == 1.0f) {
+          CPTo(ent, "^7You can not ^3unload ^7to this area.");
           return;
         }
       } else {
         if (trace.fraction != 1.0f) {
-          CPTo(ent, "^7You can not ^3unload "
-                    "^7to this area.");
+          CPTo(ent, "^7You can not ^3unload ^7to this area.");
           return;
         }
       }
     }
 
-    restoreStanceFromSave(ent, validPos);
-    teleportPlayer(ent, validPos);
+    restoreStanceFromSave(ent, pos);
+    teleportPlayer(ent, pos);
   } else {
     CPTo(ent, "^7Use ^3load ^7first.");
   }
@@ -489,14 +492,15 @@ void ETJump::SaveSystem::unload(gentity_t *ent) {
 // position validation is done later. This is to prevent unexpected behavior
 // where the last load position is not a valid position, and client is
 // teleported to a position that was valid before that.
-void ETJump::SaveSystem::saveLastLoadPos(gentity_t *ent) {
-  SavePosition *pos = nullptr;
+void SaveSystem::saveLastLoadPos(gentity_t *ent) {
+  SavePosition *pos;
   auto *client = ent->client;
+  const int clientNum = ClientNum(ent);
 
   if (client->sess.sessionTeam == TEAM_ALLIES) {
-    pos = &_clients[ClientNum(ent)].alliesLastLoadPosition;
+    pos = &_clients[clientNum].alliesLastLoadPos;
   } else if (client->sess.sessionTeam == TEAM_AXIS) {
-    pos = &_clients[ClientNum(ent)].axisLastLoadPosition;
+    pos = &_clients[clientNum].axisLastLoadPos;
   } else {
     return;
   }
@@ -504,77 +508,71 @@ void ETJump::SaveSystem::saveLastLoadPos(gentity_t *ent) {
   storePosition(client, pos);
 }
 
-void ETJump::SaveSystem::reset() {
-  for (int clientIndex = 0; clientIndex < level.numConnectedClients;
-       clientIndex++) {
-    int clientNum = level.sortedClients[clientIndex];
-    // TODO: reset saved positions here
-    resetSavedPositions(g_entities + clientNum);
+void SaveSystem::reset() {
+  for (int i = 0; i < level.numConnectedClients; i++) {
+    resetSavedPositions(g_entities + level.sortedClients[i]);
   }
 
   _savedPositions.clear();
 }
 
 // Used to reset positions on map change/restart
-void ETJump::SaveSystem::resetSavedPositions(gentity_t *ent) {
-  int clientNum = ClientNum(ent);
-  for (int saveIndex = 0; saveIndex < MAX_SAVED_POSITIONS; saveIndex++) {
-    _clients[clientNum].alliesSavedPositions[saveIndex].isValid = false;
-    _clients[clientNum].alliesSavedPositions[saveIndex].isLatest = false;
-    _clients[clientNum].axisSavedPositions[saveIndex].isValid = false;
-    _clients[clientNum].axisSavedPositions[saveIndex].isLatest = false;
+void SaveSystem::resetSavedPositions(gentity_t *ent) {
+  const int clientNum = ClientNum(ent);
+  for (int i = 0; i < MAX_SAVED_POSITIONS; i++) {
+    _clients[clientNum].alliesSaves[i].isValid = false;
+    _clients[clientNum].alliesSaves[i].isLatest = false;
+    _clients[clientNum].axisSaves[i].isValid = false;
+    _clients[clientNum].axisSaves[i].isLatest = false;
   }
 
-  for (int backupIndex = 0; backupIndex < MAX_BACKUP_POSITIONS; backupIndex++) {
-    _clients[clientNum].alliesBackupPositions[backupIndex].isValid = false;
-    _clients[clientNum].axisBackupPositions[backupIndex].isValid = false;
+  for (int i = 0; i < MAX_BACKUP_POSITIONS; i++) {
+    _clients[clientNum].alliesBackups[i].isValid = false;
+    _clients[clientNum].axisBackups[i].isValid = false;
   }
 
   _clients[clientNum].quickDeployPositions[TEAM_ALLIES].isValid = false;
   _clients[clientNum].quickDeployPositions[TEAM_AXIS].isValid = false;
 
-  _clients[clientNum].alliesLastLoadPosition.isValid = false;
-  _clients[clientNum].axisLastLoadPosition.isValid = false;
+  _clients[clientNum].alliesLastLoadPos.isValid = false;
+  _clients[clientNum].axisLastLoadPos.isValid = false;
 }
 
 // Called on client disconnect. Saves saves for future sessions
-void ETJump::SaveSystem::savePositionsToDatabase(gentity_t *ent) {
-
+void SaveSystem::savePositionsToDatabase(gentity_t *ent) {
   if (!ent->client) {
     return;
   }
 
-  std::string guid = _session->Guid(ent);
-
+  const std::string guid = _session->Guid(ent);
+  const int clientNum = ClientNum(ent);
   DisconnectedClient client;
 
   for (int i = 0; i < MAX_SAVED_POSITIONS; i++) {
     // Allied
-    VectorCopy(_clients[ClientNum(ent)].alliesSavedPositions[i].origin,
-               client.alliesSavedPositions[i].origin);
-    VectorCopy(_clients[ClientNum(ent)].alliesSavedPositions[i].vangles,
-               client.alliesSavedPositions[i].vangles);
-    client.alliesSavedPositions[i].isValid =
-        _clients[ClientNum(ent)].alliesSavedPositions[i].isValid;
-    client.alliesSavedPositions[i].isLatest =
-        _clients[ClientNum(ent)].alliesSavedPositions[i].isLatest;
+    VectorCopy(_clients[clientNum].alliesSaves[i].origin,
+               client.alliesSaves[i].origin);
+    VectorCopy(_clients[clientNum].alliesSaves[i].vangles,
+               client.alliesSaves[i].vangles);
+
+    client.alliesSaves[i].isValid = _clients[clientNum].alliesSaves[i].isValid;
+    client.alliesSaves[i].isLatest =
+        _clients[clientNum].alliesSaves[i].isLatest;
     // Axis
-    VectorCopy(_clients[ClientNum(ent)].axisSavedPositions[i].origin,
-               client.axisSavedPositions[i].origin);
-    VectorCopy(_clients[ClientNum(ent)].axisSavedPositions[i].vangles,
-               client.axisSavedPositions[i].vangles);
-    client.axisSavedPositions[i].isValid =
-        _clients[ClientNum(ent)].axisSavedPositions[i].isValid;
-    client.axisSavedPositions[i].isLatest =
-        _clients[ClientNum(ent)].axisSavedPositions[i].isLatest;
+    VectorCopy(_clients[clientNum].axisSaves[i].origin,
+               client.axisSaves[i].origin);
+    VectorCopy(_clients[clientNum].axisSaves[i].vangles,
+               client.axisSaves[i].vangles);
+
+    client.axisSaves[i].isValid = _clients[clientNum].axisSaves[i].isValid;
+    client.axisSaves[i].isLatest = _clients[clientNum].axisSaves[i].isLatest;
   }
 
   client.progression = ent->client->sess.clientMapProgression;
   client.saveLimit = ent->client->sess.saveLimit;
   ent->client->sess.loadPreviousSavedPositions = qfalse;
 
-  std::map<std::string, DisconnectedClient>::iterator it =
-      _savedPositions.find(guid);
+  const auto it = _savedPositions.find(guid);
 
   if (it != _savedPositions.end()) {
     it->second = client;
@@ -584,8 +582,7 @@ void ETJump::SaveSystem::savePositionsToDatabase(gentity_t *ent) {
 }
 
 // Called on client connect. Loads saves from previous session
-void ETJump::SaveSystem::loadPositionsFromDatabase(gentity_t *ent) {
-
+void SaveSystem::loadPositionsFromDatabase(gentity_t *ent) {
   if (!ent->client) {
     return;
   }
@@ -594,41 +591,41 @@ void ETJump::SaveSystem::loadPositionsFromDatabase(gentity_t *ent) {
     return;
   }
 
-  std::string guid = _session->Guid(ent);
-
-  std::map<std::string, DisconnectedClient>::iterator it =
-      _savedPositions.find(guid);
+  const std::string guid = _session->Guid(ent);
+  const int clientNum = ClientNum(ent);
+  const auto it = _savedPositions.find(guid);
 
   if (it != _savedPositions.end()) {
-
-    unsigned validPositionsCount = 0;
+    uint8_t validPositionsCount = 0;
 
     for (int i = 0; i < MAX_SAVED_POSITIONS; i++) {
       // Allied
-      VectorCopy(it->second.alliesSavedPositions[i].origin,
-                 _clients[ClientNum(ent)].alliesSavedPositions[i].origin);
-      VectorCopy(it->second.alliesSavedPositions[i].vangles,
-                 _clients[ClientNum(ent)].alliesSavedPositions[i].vangles);
-      _clients[ClientNum(ent)].alliesSavedPositions[i].isValid =
-          it->second.alliesSavedPositions[i].isValid;
-      _clients[ClientNum(ent)].alliesSavedPositions[i].isLatest =
-          it->second.alliesSavedPositions[i].isLatest;
+      VectorCopy(it->second.alliesSaves[i].origin,
+                 _clients[clientNum].alliesSaves[i].origin);
+      VectorCopy(it->second.alliesSaves[i].vangles,
+                 _clients[clientNum].alliesSaves[i].vangles);
 
-      if (it->second.alliesSavedPositions[i].isValid) {
+      _clients[clientNum].alliesSaves[i].isValid =
+          it->second.alliesSaves[i].isValid;
+      _clients[clientNum].alliesSaves[i].isLatest =
+          it->second.alliesSaves[i].isLatest;
+
+      if (it->second.alliesSaves[i].isValid) {
         ++validPositionsCount;
       }
 
       // Axis
-      VectorCopy(it->second.axisSavedPositions[i].origin,
-                 _clients[ClientNum(ent)].axisSavedPositions[i].origin);
-      VectorCopy(it->second.axisSavedPositions[i].vangles,
-                 _clients[ClientNum(ent)].axisSavedPositions[i].vangles);
-      _clients[ClientNum(ent)].axisSavedPositions[i].isValid =
-          it->second.axisSavedPositions[i].isValid;
-      _clients[ClientNum(ent)].axisSavedPositions[i].isLatest =
-          it->second.axisSavedPositions[i].isLatest;
+      VectorCopy(it->second.axisSaves[i].origin,
+                 _clients[clientNum].axisSaves[i].origin);
+      VectorCopy(it->second.axisSaves[i].vangles,
+                 _clients[clientNum].axisSaves[i].vangles);
 
-      if (it->second.axisSavedPositions[i].isValid) {
+      _clients[clientNum].axisSaves[i].isValid =
+          it->second.axisSaves[i].isValid;
+      _clients[clientNum].axisSaves[i].isLatest =
+          it->second.axisSaves[i].isLatest;
+
+      if (it->second.axisSaves[i].isValid) {
         ++validPositionsCount;
       }
     }
@@ -636,35 +633,27 @@ void ETJump::SaveSystem::loadPositionsFromDatabase(gentity_t *ent) {
     ent->client->sess.loadPreviousSavedPositions = qfalse;
     ent->client->sess.clientMapProgression = it->second.progression;
     ent->client->sess.saveLimit = it->second.saveLimit;
+
     if (validPositionsCount) {
-      ChatPrintTo(ent, "^<ETJump: ^7loaded saved positions "
-                       "from previous session.");
+      ChatPrintTo(ent,
+                  "^gETJump: ^7loaded saved positions from previous session.");
     }
   }
 }
 
-void ETJump::SaveSystem::storeTeamQuickDeployPosition(gentity_t *ent,
-                                                      team_t team) {
-  auto lastValidSave = getValidTeamSaveForSlot(ent, team, 0);
+void SaveSystem::storeTeamQuickDeployPosition(gentity_t *ent, team_t team) {
+  const auto lastValidSave = getValidTeamSaveForSlot(ent, team, 0);
+
   if (lastValidSave) {
-    auto client = &_clients[ClientNum(ent)];
+    const auto client = &_clients[ClientNum(ent)];
     auto autoSave = &(client->quickDeployPositions[team]);
     *autoSave = *lastValidSave;
   }
 }
 
-void ETJump::SaveSystem::loadTeamQuickDeployPosition(gentity_t *ent,
-                                                     team_t team) {
-  auto validSave = getValidTeamQuickDeploySave(ent, team);
-  if (validSave) {
-    restoreStanceFromSave(ent, validSave);
-    teleportPlayer(ent, validSave);
-  }
-}
+void SaveSystem::loadOnceTeamQuickDeployPosition(gentity_t *ent, team_t team) {
+  const auto validSave = getValidTeamQuickDeploySave(ent, team);
 
-void ETJump::SaveSystem::loadOnceTeamQuickDeployPosition(gentity_t *ent,
-                                                         team_t team) {
-  auto validSave = getValidTeamQuickDeploySave(ent, team);
   if (validSave) {
     restoreStanceFromSave(ent, validSave);
     teleportPlayer(ent, validSave);
@@ -672,9 +661,8 @@ void ETJump::SaveSystem::loadOnceTeamQuickDeployPosition(gentity_t *ent,
   }
 }
 
-ETJump::SaveSystem::SavePosition *
-ETJump::SaveSystem::getValidTeamSaveForSlot(gentity_t *ent, team_t team,
-                                            int slot) {
+SaveSystem::SavePosition *
+SaveSystem::getValidTeamSaveForSlot(gentity_t *ent, team_t team, int slot) {
   if (!ent || !ent->client) {
     return nullptr;
   }
@@ -683,12 +671,13 @@ ETJump::SaveSystem::getValidTeamSaveForSlot(gentity_t *ent, team_t team,
     return nullptr;
   }
 
-  auto client = &_clients[ClientNum(ent)];
-  SavePosition *pos = nullptr;
+  const auto client = &_clients[ClientNum(ent)];
+  SavePosition *pos;
+
   if (team == TEAM_ALLIES) {
-    pos = &client->alliesSavedPositions[slot];
+    pos = &client->alliesSaves[slot];
   } else {
-    pos = &client->axisSavedPositions[slot];
+    pos = &client->axisSaves[slot];
   }
 
   if (!pos->isValid) {
@@ -698,8 +687,8 @@ ETJump::SaveSystem::getValidTeamSaveForSlot(gentity_t *ent, team_t team,
   return pos;
 }
 
-ETJump::SaveSystem::SavePosition *
-ETJump::SaveSystem::getValidTeamUnloadPos(gentity_t *ent, team_t team) {
+SaveSystem::SavePosition *SaveSystem::getValidTeamUnloadPos(gentity_t *ent,
+                                                            team_t team) {
   if (!ent || !ent->client) {
     return nullptr;
   }
@@ -708,12 +697,13 @@ ETJump::SaveSystem::getValidTeamUnloadPos(gentity_t *ent, team_t team) {
     return nullptr;
   }
 
-  auto client = &_clients[ClientNum(ent)];
-  SavePosition *pos = nullptr;
+  const auto client = &_clients[ClientNum(ent)];
+  SavePosition *pos;
+
   if (team == TEAM_ALLIES) {
-    pos = &client->alliesLastLoadPosition;
+    pos = &client->alliesLastLoadPos;
   } else {
-    pos = &client->axisLastLoadPosition;
+    pos = &client->axisLastLoadPos;
   }
 
   if (!pos->isValid) {
@@ -723,8 +713,8 @@ ETJump::SaveSystem::getValidTeamUnloadPos(gentity_t *ent, team_t team) {
   return pos;
 }
 
-ETJump::SaveSystem::SavePosition *
-ETJump::SaveSystem::getValidTeamQuickDeploySave(gentity_t *ent, team_t team) {
+SaveSystem::SavePosition *
+SaveSystem::getValidTeamQuickDeploySave(gentity_t *ent, team_t team) {
   if (!ent || !ent->client) {
     return nullptr;
   }
@@ -733,8 +723,8 @@ ETJump::SaveSystem::getValidTeamQuickDeploySave(gentity_t *ent, team_t team) {
     return nullptr;
   }
 
-  auto client = &_clients[ClientNum(ent)];
-  auto pos = &client->quickDeployPositions[team];
+  const auto client = &_clients[ClientNum(ent)];
+  const auto pos = &client->quickDeployPositions[team];
 
   if (!pos->isValid) {
     return nullptr;
@@ -743,13 +733,13 @@ ETJump::SaveSystem::getValidTeamQuickDeploySave(gentity_t *ent, team_t team) {
   return pos;
 }
 
-void ETJump::SaveSystem::restoreStanceFromSave(gentity_t *ent,
-                                               SavePosition *pos) {
+void SaveSystem::restoreStanceFromSave(gentity_t *ent, SavePosition *pos) {
   if (!ent || !ent->client) {
     return;
   }
 
   auto client = ent->client;
+
   if (pos->stance == Crouch) {
     client->ps.eFlags &= ~EF_PRONE;
     client->ps.eFlags &= ~EF_PRONE_MOVING;
@@ -765,31 +755,34 @@ void ETJump::SaveSystem::restoreStanceFromSave(gentity_t *ent,
 }
 
 // Saves backup position
-void ETJump::SaveSystem::saveBackupPosition(gentity_t *ent, SavePosition *pos) {
-
+void SaveSystem::saveBackupPosition(gentity_t *ent, SavePosition *pos) {
   if (!ent->client) {
     return;
   }
 
   if (ent->client->sess.timerunActive &&
       ent->client->sess.runSpawnflags &
-          static_cast<int>(ETJump::TimerunSpawnflags::NoBackups)) {
+          static_cast<int>(TimerunSpawnflags::NoBackups)) {
     return;
   }
 
+  const int clientNum = ClientNum(ent);
   SavePosition backup;
+
   VectorCopy(pos->origin, backup.origin);
   VectorCopy(pos->vangles, backup.vangles);
+
   backup.isValid = pos->isValid;
   backup.isLatest = pos->isLatest;
   backup.stance = pos->stance;
+
   // Can never be spectator as this would not be called
   if (ent->client->sess.sessionTeam == TEAM_ALLIES) {
-    _clients[ClientNum(ent)].alliesBackupPositions.pop_back();
-    _clients[ClientNum(ent)].alliesBackupPositions.push_front(backup);
+    _clients[clientNum].alliesBackups.pop_back();
+    _clients[clientNum].alliesBackups.push_front(backup);
   } else {
-    _clients[ClientNum(ent)].axisBackupPositions.pop_back();
-    _clients[ClientNum(ent)].axisBackupPositions.push_front(backup);
+    _clients[clientNum].axisBackups.pop_back();
+    _clients[clientNum].axisBackups.push_front(backup);
   }
 }
 
@@ -799,20 +792,18 @@ void ETJump::SaveSystem::storePosition(gclient_s *client, SavePosition *pos) {
   pos->isValid = true;
   pos->isLatest = true;
 
-  if (client->ps.eFlags & EF_CROUCHING) {
-    pos->stance = Crouch;
-  } else if (client->ps.eFlags & EF_PRONE) {
+  if (client->ps.eFlags & EF_PRONE) {
     pos->stance = Prone;
   } else {
-    pos->stance = Stand;
+    pos->stance = client->ps.eFlags & EF_CROUCHING ? Crouch : Stand;
   }
 }
 
-int ETJump::SaveSystem::getLatestSaveSlot(gclient_s *client) {
+int SaveSystem::getLatestSaveSlot(gclient_s *client) {
   const int clientNum = ClientNum(client);
   const auto teamSaves = client->sess.sessionTeam == TEAM_ALLIES
-                             ? _clients[clientNum].alliesSavedPositions
-                             : _clients[clientNum].axisSavedPositions;
+                             ? _clients[clientNum].alliesSaves
+                             : _clients[clientNum].axisSaves;
   int slot = -1;
 
   for (int i = 0; i < MAX_SAVED_POSITIONS; i++) {
@@ -825,19 +816,19 @@ int ETJump::SaveSystem::getLatestSaveSlot(gclient_s *client) {
   return slot;
 }
 
-void ETJump::SaveSystem::resetLatestSaveSlot(gentity_t *ent) {
+void SaveSystem::resetLatestSaveSlot(gentity_t *ent) {
   const int clientNum = ClientNum(ent);
   const auto teamSaves = ent->client->sess.sessionTeam == TEAM_ALLIES
-                             ? _clients[clientNum].alliesSavedPositions
-                             : _clients[clientNum].axisSavedPositions;
+                             ? _clients[clientNum].alliesSaves
+                             : _clients[clientNum].axisSaves;
 
   for (int i = 0; i < MAX_SAVED_POSITIONS; i++) {
     teamSaves[i].isLatest = false;
   }
 }
 
-void ETJump::SaveSystem::sendClientCommands(gentity_t *ent, int position) {
-  auto self = ClientNum(ent);
+void SaveSystem::sendClientCommands(gentity_t *ent, int position) {
+  const int self = ClientNum(ent);
   int target;
   std::string saveMsg = va("savePrint %d\n", position);
 
@@ -859,11 +850,11 @@ void ETJump::SaveSystem::sendClientCommands(gentity_t *ent, int position) {
   }
 }
 
-void ETJump::SaveSystem::teleportPlayer(gentity_t *ent, SavePosition *pos) {
+void SaveSystem::teleportPlayer(gentity_t *ent, SavePosition *pos) {
   auto *client = ent->client;
   client->ps.eFlags ^= EF_TELEPORT_BIT;
-  G_AddEvent(ent, EV_LOAD_TELEPORT, 0);
 
+  G_AddEvent(ent, EV_LOAD_TELEPORT, 0);
   G_SetOrigin(ent, pos->origin);
   VectorClear(client->ps.velocity);
 
@@ -873,10 +864,4 @@ void ETJump::SaveSystem::teleportPlayer(gentity_t *ent, SavePosition *pos) {
 
   client->ps.pm_time = 1; // Crashland + instant load bug fix.
 }
-
-ETJump::SaveSystem::SaveSystem(const std::shared_ptr<Session> session)
-    : _session(session)
-//: guidInterface_(guidInterface)
-{}
-
-ETJump::SaveSystem::~SaveSystem() {}
+} // namespace ETJump

--- a/src/game/etj_save_system.h
+++ b/src/game/etj_save_system.h
@@ -22,15 +22,7 @@
  * SOFTWARE.
  */
 
-#ifndef G_SAVE_H
-#define G_SAVE_H
-
-#ifdef min
-  #undef min
-#endif
-#ifdef max
-  #undef max
-#endif
+#pragma once
 
 #include <map>
 #include <string>
@@ -38,14 +30,12 @@
 
 #include "etj_local.h"
 
-class Session;
-
 namespace ETJump {
 class SaveSystem {
 public:
-  SaveSystem(const std::shared_ptr<Session> session);
-  /*SaveSystem( IGuid *guidInterface );*/
-  ~SaveSystem();
+  explicit SaveSystem(const std::shared_ptr<Session> &session)
+      : _session(session) {}
+  ~SaveSystem() = default;
 
   static const int MAX_SAVED_POSITIONS = 3;
   static const int MAX_BACKUP_POSITIONS = 3;
@@ -66,13 +56,13 @@ public:
   struct Client {
     Client();
 
-    SavePosition alliesSavedPositions[MAX_SAVED_POSITIONS];
-    std::deque<SavePosition> alliesBackupPositions;
-    SavePosition alliesLastLoadPosition;
+    SavePosition alliesSaves[MAX_SAVED_POSITIONS];
+    std::deque<SavePosition> alliesBackups;
+    SavePosition alliesLastLoadPos;
 
-    SavePosition axisSavedPositions[MAX_SAVED_POSITIONS];
-    std::deque<SavePosition> axisBackupPositions;
-    SavePosition axisLastLoadPosition;
+    SavePosition axisSaves[MAX_SAVED_POSITIONS];
+    std::deque<SavePosition> axisBackups;
+    SavePosition axisLastLoadPos;
 
     // contains a couple of extra positions for TEAM_SPEC and
     // TEAM_FREE, but simplifies the accessing code
@@ -83,13 +73,13 @@ public:
     DisconnectedClient();
 
     // Allies saved positions at the time of disconnect
-    SavePosition alliesSavedPositions[MAX_SAVED_POSITIONS];
+    SavePosition alliesSaves[MAX_SAVED_POSITIONS];
     // Axis saved positions at the time of disconnect
-    SavePosition axisSavedPositions[MAX_SAVED_POSITIONS];
+    SavePosition axisSaves[MAX_SAVED_POSITIONS];
 
     // Last load positions
-    SavePosition axisLastLoadPosition;
-    SavePosition alliesLastLoadPosition;
+    SavePosition axisLastLoadPos;
+    SavePosition alliesLastLoadPos;
 
     // So called "map ident"
     int progression;
@@ -135,7 +125,6 @@ public:
   void loadPositionsFromDatabase(gentity_t *ent);
 
   void storeTeamQuickDeployPosition(gentity_t *ent, team_t team);
-  void loadTeamQuickDeployPosition(gentity_t *ent, team_t team);
   void loadOnceTeamQuickDeployPosition(gentity_t *ent, team_t team);
 
 private:
@@ -143,13 +132,13 @@ private:
   void saveBackupPosition(gentity_t *ent, SavePosition *pos);
 
   // copies player positional info to target position
-  void storePosition(gclient_s *client, SavePosition *pos);
+  static void storePosition(gclient_s *client, SavePosition *pos);
 
   // returns the latest save slot number that client used in their current team
   // -1 if no slots found (no saved positions in current team)
   int getLatestSaveSlot(gclient_s *client);
 
-  // marks all save slots as not latest, called before storing a new save pos
+  // marks all save slots as 'not latest', called before storing a new save pos
   // this does not touch backup positions as we don't care about them
   // since 'isLatest' check is only done to save slots, not backup slots
   void resetLatestSaveSlot(gentity_t *ent);
@@ -159,15 +148,14 @@ private:
 
   SavePosition *getValidTeamQuickDeploySave(gentity_t *ent, team_t team);
 
-  void restoreStanceFromSave(gentity_t *ent, SavePosition *pos);
+  static void restoreStanceFromSave(gentity_t *ent, SavePosition *pos);
 
   SavePosition *getValidTeamSaveForSlot(gentity_t *ent, team_t team, int slot);
 
   SavePosition *getValidTeamUnloadPos(gentity_t *ent, team_t team);
 
-  // Commands that are sent to client when they succesfully save
-  // position
-  void sendClientCommands(gentity_t *ent, int position);
+  // Commands that are sent to client when they successfully save a position
+  static void sendClientCommands(gentity_t *ent, int position);
 
   // All clients' save related data
   Client _clients[MAX_CLIENTS];
@@ -177,8 +165,5 @@ private:
 
   // Interface to get player guid
   const std::shared_ptr<Session> _session;
-  /*IGuid *guidInterface_;*/
 };
 } // namespace ETJump
-
-#endif

--- a/src/game/etj_save_system.h
+++ b/src/game/etj_save_system.h
@@ -54,9 +54,10 @@ public:
 
   struct SavePosition {
     SavePosition()
-        : isValid(false), origin{0, 0, 0}, vangles{0, 0, 0},
+        : isValid(false), isLatest(false), origin{0, 0, 0}, vangles{0, 0, 0},
           stance(SaveStance::Stand) {}
     bool isValid;
+    bool isLatest;
     vec3_t origin;
     vec3_t vangles;
     SaveStance stance;
@@ -143,6 +144,15 @@ private:
 
   // copies player positional info to target position
   void storePosition(gclient_s *client, SavePosition *pos);
+
+  // returns the latest save slot number that client used in their current team
+  // -1 if no slots found (no saved positions in current team)
+  int getLatestSaveSlot(gclient_s *client);
+
+  // marks all save slots as not latest, called before storing a new save pos
+  // this does not touch backup positions as we don't care about them
+  // since 'isLatest' check is only done to save slots, not backup slots
+  void resetLatestSaveSlot(gentity_t *ent);
 
   // Teleports player to the saved position
   static void teleportPlayer(gentity_t *ent, SavePosition *pos);


### PR DESCRIPTION
Fixes backup slots breaking when a client save to a save slot for the first time. `save` was trying to backup the previous save in the slot that the client used (`save/save1/save2`) but if there was no previous save in the slot, an invalid slot would be backed up.

Save system now keeps track of which slot client saved to last time, and backup is created from the previous slot client saved into, before current `save` command. This will sometimes lead to scenarios where there's a duplicate slot in `backup` as there is in one of the save slots. For example, if a client does `save` followed by `save1` when there are no prior saves, `load` and `backup` will now contain the same save slot, but this is a better solution (and still logical as backups are supposed to be slot-agnostic) than storing an invalid position.