### PR TITLE
Store timerun state with save slots

### DIFF
--- a/src/game/etj_save_system.h
+++ b/src/game/etj_save_system.h
@@ -45,12 +45,13 @@ public:
   struct SavePosition {
     SavePosition()
         : isValid(false), isLatest(false), origin{0, 0, 0}, vangles{0, 0, 0},
-          stance(SaveStance::Stand) {}
+          stance(SaveStance::Stand), isTimerunSave(false) {}
     bool isValid;
     bool isLatest;
     vec3_t origin;
     vec3_t vangles;
     SaveStance stance;
+    bool isTimerunSave;
   };
 
   struct Client {
@@ -117,6 +118,10 @@ public:
 
   // Resets targets positions
   void resetSavedPositions(gentity_t *ent);
+
+  // invalidates any save slots that are marked as timerun saves
+  // called at the start of a timerun to reset saves from previous run
+  void clearTimerunSaves(gentity_t *ent);
 
   // Saves positions to db on disconnect
   void savePositionsToDatabase(gentity_t *ent);

--- a/src/game/etj_utilities.cpp
+++ b/src/game/etj_utilities.cpp
@@ -100,7 +100,7 @@ void Utilities::startRun(int clientNum) {
 
   if (!(player->client->sess.runSpawnflags &
         static_cast<int>(ETJump::TimerunSpawnflags::NoSave))) {
-    ETJump::saveSystem->resetSavedPositions(player);
+    ETJump::saveSystem->clearTimerunSaves(player);
   }
 
   // If we are debugging, just exit here


### PR DESCRIPTION
Saves are no longer entirely cleared when a timerun starts, we only invalidate any saves that were made while a timerun was active. This allows you to interrupt a timerun by loading to a position that was saved before a timerun was active. For regular save slots (`save/save1/save2`), any slot that is marked as a timerun slot will be invalidated. Backup slots are cleared of any slots that were stored during a timerun, and any remaining valid slots are pushed to the front of the backup queue.

Fixes #1143 