### PR TITLE
Round jump speeds instead of truncating

### DIFF
--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -866,7 +866,8 @@ static qboolean PM_CheckJump(void) {
   }
 
   // store horizontal speed for CHS 55
-  pm->ps->persistant[PERS_JUMP_SPEED] = VectorLength2(pm->ps->velocity);
+  pm->ps->persistant[PERS_JUMP_SPEED] =
+      static_cast<int>(std::round(VectorLength2(pm->ps->velocity)));
 
   return qtrue;
 }


### PR DESCRIPTION
All other speed displays use rounding, jump speeds was the only one using truncated speed.

Fixes #948 