### PR TITLE
Add custom vote editing via admin commands

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -1487,6 +1487,7 @@ void CG_InitConsoleCommands() {
   trap_AddCommand("help");
   trap_AddCommand("race");
   trap_AddCommand("listinfo");
+  trap_AddCommand("customvotes");
   trap_AddCommand("records");
   trap_AddCommand("times");
   trap_AddCommand("ranks");
@@ -1531,4 +1532,8 @@ void CG_InitConsoleCommands() {
   trap_AddCommand("enc_say");
   trap_AddCommand("enc_say_team");
   trap_AddCommand("enc_say_buddy");
+
+  trap_AddCommand("generateCustomvotes");
+  trap_AddCommand("readCustomvotes");
+  trap_AddCommand("generateMotd");
 }

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(qagame MODULE
 	"etj_file.cpp"
 	"etj_filesystem.cpp"
 	"etj_inactivity_timer.cpp"
+	"etj_json_utilities.cpp"
 	"etj_levels.cpp"
 	"etj_log.cpp"
 	"etj_main.cpp"

--- a/src/game/etj_custom_map_votes.cpp
+++ b/src/game/etj_custom_map_votes.cpp
@@ -22,13 +22,14 @@
  * SOFTWARE.
  */
 
+#include <fstream>
+#include <algorithm>
+
 #include "etj_custom_map_votes.h"
 #include "etj_map_statistics.h"
 #include "etj_string_utilities.h"
-#include <fstream>
 #include "utilities.hpp"
-#include "json/json.h"
-#include <algorithm>
+#include "etj_printer.h"
 
 CustomMapVotes::CustomMapVotes(MapStatistics *mapStats) : _mapStats(mapStats) {}
 
@@ -167,6 +168,208 @@ void CustomMapVotes::GenerateVotesFile() {
   Load();
 }
 
+void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
+                                       const std::string &fullName,
+                                       const std::string &maps) {
+  const std::string &customVotesFile = g_customMapVotesFile.string;
+  Json::Value root;
+
+  // read and append to existing file if present
+  if (readCustomvoteFile(customVotesFile, root)) {
+
+    // make sure we don't already have a list with this name
+    for (const auto &lists : customMapVotes_) {
+      if (name == lists.type) {
+        Printer::SendChatMessage(clientNum,
+                                 "^3add-customvote: ^7operation failed, check "
+                                 "console for more information.");
+        Printer::SendConsoleMessage(
+            clientNum,
+            ETJump::stringFormat("^3add-customvote: ^7a list with the name "
+                                 "^3'%s' ^7already exists.\n",
+                                 name));
+        return;
+      }
+    }
+  }
+
+  Json::Value vote;
+  vote["name"] = name;
+  vote["callvote_text"] = fullName;
+  vote["maps"] = Json::arrayValue;
+
+  const auto mapList = ETJump::StringUtil::split(maps, " ");
+
+  for (const auto &map : mapList) {
+    vote["maps"].append(map);
+  }
+
+  root.append(vote);
+
+  if (!writeCustomvoteFile(customVotesFile, root)) {
+    Printer::SendChatMessage(clientNum, "^3add-customvote: ^7operation failed, "
+                                        "check console for more information.");
+    Printer::SendConsoleMessage(
+        clientNum, ETJump::stringFormat("^3add-customvote: ^7couldn't open the "
+                                        "file ^3'%s' ^7for writing.\n",
+                                        customVotesFile));
+    return;
+  }
+
+  Load();
+  Printer::SendChatMessage(
+      clientNum, ETJump::stringFormat("^3add-customvote: ^7successfully added "
+                                      "a new custom vote list ^3'%s'",
+                                      name));
+}
+
+void CustomMapVotes::deleteCustomvoteList(int clientNum,
+                                          const std::string &name) {
+  const std::string &customVotesFile = g_customMapVotesFile.string;
+  Json::Value root;
+
+  if (!readCustomvoteFile(customVotesFile, root)) {
+    Printer::SendChatMessage(clientNum,
+                             "^3delete-customvote: ^7operation failed, check "
+                             "console for more information.");
+    Printer::SendConsoleMessage(
+        clientNum, ETJump::stringFormat("^3delete-customvote: ^7couldn't open "
+                                        "the file ^3'%s' ^7for reading.\n",
+                                        customVotesFile));
+    return;
+  }
+
+  bool found = false;
+
+  for (Json::ArrayIndex i = 0; i < root.size(); i++) {
+    if (root[i]["name"].asString() == name) {
+      Json::Value removed;
+      root.removeIndex(i, &removed);
+      found = true;
+      break;
+    }
+  }
+
+  if (!found) {
+    Printer::SendChatMessage(
+        clientNum, ETJump::stringFormat("^3delete-customvote: ^7a list with "
+                                        "the name ^3'%s' ^7was not found.\n",
+                                        name));
+    return;
+  }
+
+  if (!writeCustomvoteFile(customVotesFile, root)) {
+    Printer::SendChatMessage(clientNum,
+                             "^3delete-customvote: ^7operation failed, check "
+                             "console for more information.");
+    Printer::SendConsoleMessage(
+        clientNum, ETJump::stringFormat("^3delete-customvote: ^7couldn't open "
+                                        "the file ^3'%s' ^7for writing.\n",
+                                        customVotesFile));
+    return;
+  }
+
+  Load();
+  Printer::SendChatMessage(
+      clientNum,
+      ETJump::stringFormat(
+          "^3delete-customvote: ^7successfully deleted custom vote list ^3'%s'",
+          name));
+}
+
+void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
+                                        const std::string &name,
+                                        const std::string &fullName,
+                                        const std::string &addMaps,
+                                        const std::string &removeMaps) {
+  const std::string &customVotesFile = g_customMapVotesFile.string;
+  Json::Value root;
+
+  if (!readCustomvoteFile(customVotesFile, root)) {
+    Printer::SendChatMessage(clientNum,
+                             "^3edit-customvote: ^7operation failed, check "
+                             "console for more information.");
+    Printer::SendConsoleMessage(
+        clientNum, ETJump::stringFormat("^3edit-customvote: ^7couldn't open "
+                                        "the file ^3'%s' ^7for reading.\n",
+                                        customVotesFile));
+    return;
+  }
+
+  bool found = false;
+
+  for (auto &object : root) {
+    if (object["name"].asString() == list) {
+      if (!name.empty()) {
+        for (const auto &key : object) {
+          if (key == object["name"].asString()) {
+            object["name"] = name;
+          }
+        }
+      }
+
+      if (!fullName.empty()) {
+        for (const auto &key : object) {
+          if (key == object["callvote_text"].asString()) {
+            object["callvote_text"] = fullName;
+          }
+        }
+      }
+
+      if (!addMaps.empty()) {
+        const auto mapList = ETJump::StringUtil::split(addMaps, " ");
+
+        for (const auto &map : mapList) {
+          object["maps"].append(map);
+        }
+      }
+
+      if (!removeMaps.empty()) {
+        const auto mapList = ETJump::StringUtil::split(removeMaps, " ");
+
+        for (const auto &map : mapList) {
+          for (Json::ArrayIndex i = 0; i < object["maps"].size(); i++) {
+            if (object["maps"][i].asString() == map) {
+              Json::Value removed;
+              object["maps"].removeIndex(i, &removed);
+              break;
+            }
+          }
+        }
+      }
+
+      found = true;
+      break;
+    }
+  }
+
+  if (!found) {
+    Printer::SendChatMessage(
+        clientNum, ETJump::stringFormat("^3edit-customvote: ^7a list with the "
+                                        "name ^3'%s' ^7was not found.\n",
+                                        list));
+    return;
+  }
+
+  if (!writeCustomvoteFile(customVotesFile, root)) {
+    Printer::SendChatMessage(clientNum,
+                             "^3edit-customvote: ^7operation failed, check "
+                             "console for more information.");
+    Printer::SendConsoleMessage(
+        clientNum, ETJump::stringFormat("^3edit-customvote: ^7couldn't open "
+                                        "the file ^3'%s' ^7for writing.\n",
+                                        customVotesFile));
+    return;
+  }
+
+  Load();
+  Printer::SendChatMessage(
+      clientNum,
+      ETJump::stringFormat(
+          "^3edit-customvote: ^7successfully edited custom vote list ^3'%s'",
+          list));
+}
+
 std::string CustomMapVotes::ListInfo(const std::string &type) {
   std::string buffer;
 
@@ -242,4 +445,35 @@ std::string const CustomMapVotes::RandomMap(std::string const &type) {
 bool CustomMapVotes::isValidMap(const std::string &mapName) {
   return G_MapExists(mapName.c_str()) && mapName != level.rawmapname &&
          !MapStatistics::isBlockedMap(mapName);
+}
+
+bool CustomMapVotes::writeCustomvoteFile(const std::string &file,
+                                         const Json::Value &root) {
+  Json::StyledWriter writer;
+  const std::string &output = writer.write(root);
+  std::ofstream fOut(GetPath(file));
+
+  if (!fOut) {
+    fOut.close();
+    return false;
+  }
+
+  fOut << output;
+  fOut.close();
+  return true;
+}
+
+bool CustomMapVotes::readCustomvoteFile(const std::string &file,
+                                        Json::Value &root) {
+  std::ifstream fIn(GetPath(file));
+
+  if (!fIn) {
+    fIn.close();
+    return false;
+  }
+
+  Json::CharReaderBuilder readerBuilder;
+  Json::parseFromStream(readerBuilder, fIn, &root, nullptr);
+  fIn.close();
+  return true;
 }

--- a/src/game/etj_custom_map_votes.cpp
+++ b/src/game/etj_custom_map_votes.cpp
@@ -30,6 +30,7 @@
 #include "etj_string_utilities.h"
 #include "utilities.hpp"
 #include "etj_printer.h"
+#include "etj_json_utilities.h"
 
 CustomMapVotes::CustomMapVotes(MapStatistics *mapStats) : _mapStats(mapStats) {}
 
@@ -175,7 +176,7 @@ void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
   Json::Value root;
 
   // read and append to existing file if present
-  if (readCustomvoteFile(customVotesFile, root)) {
+  if (ETJump::JsonUtils::readFile(customVotesFile, root)) {
 
     // make sure we don't already have a list with this name
     for (const auto &lists : customMapVotes_) {
@@ -206,7 +207,7 @@ void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
 
   root.append(vote);
 
-  if (!writeCustomvoteFile(customVotesFile, root)) {
+  if (!ETJump::JsonUtils::writeFile(customVotesFile, root)) {
     Printer::SendChatMessage(clientNum, "^3add-customvote: ^7operation failed, "
                                         "check console for more information.");
     Printer::SendConsoleMessage(
@@ -228,7 +229,7 @@ void CustomMapVotes::deleteCustomvoteList(int clientNum,
   const std::string &customVotesFile = g_customMapVotesFile.string;
   Json::Value root;
 
-  if (!readCustomvoteFile(customVotesFile, root)) {
+  if (!ETJump::JsonUtils::readFile(customVotesFile, root)) {
     Printer::SendChatMessage(clientNum,
                              "^3delete-customvote: ^7operation failed, check "
                              "console for more information.");
@@ -258,7 +259,7 @@ void CustomMapVotes::deleteCustomvoteList(int clientNum,
     return;
   }
 
-  if (!writeCustomvoteFile(customVotesFile, root)) {
+  if (!ETJump::JsonUtils::writeFile(customVotesFile, root)) {
     Printer::SendChatMessage(clientNum,
                              "^3delete-customvote: ^7operation failed, check "
                              "console for more information.");
@@ -285,7 +286,7 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
   const std::string &customVotesFile = g_customMapVotesFile.string;
   Json::Value root;
 
-  if (!readCustomvoteFile(customVotesFile, root)) {
+  if (!ETJump::JsonUtils::readFile(customVotesFile, root)) {
     Printer::SendChatMessage(clientNum,
                              "^3edit-customvote: ^7operation failed, check "
                              "console for more information.");
@@ -351,7 +352,7 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
     return;
   }
 
-  if (!writeCustomvoteFile(customVotesFile, root)) {
+  if (!ETJump::JsonUtils::writeFile(customVotesFile, root)) {
     Printer::SendChatMessage(clientNum,
                              "^3edit-customvote: ^7operation failed, check "
                              "console for more information.");
@@ -445,35 +446,4 @@ std::string const CustomMapVotes::RandomMap(std::string const &type) {
 bool CustomMapVotes::isValidMap(const std::string &mapName) {
   return G_MapExists(mapName.c_str()) && mapName != level.rawmapname &&
          !MapStatistics::isBlockedMap(mapName);
-}
-
-bool CustomMapVotes::writeCustomvoteFile(const std::string &file,
-                                         const Json::Value &root) {
-  Json::StyledWriter writer;
-  const std::string &output = writer.write(root);
-  std::ofstream fOut(GetPath(file));
-
-  if (!fOut) {
-    fOut.close();
-    return false;
-  }
-
-  fOut << output;
-  fOut.close();
-  return true;
-}
-
-bool CustomMapVotes::readCustomvoteFile(const std::string &file,
-                                        Json::Value &root) {
-  std::ifstream fIn(GetPath(file));
-
-  if (!fIn) {
-    fIn.close();
-    return false;
-  }
-
-  Json::CharReaderBuilder readerBuilder;
-  Json::parseFromStream(readerBuilder, fIn, &root, nullptr);
-  fIn.close();
-  return true;
 }

--- a/src/game/etj_custom_map_votes.h
+++ b/src/game/etj_custom_map_votes.h
@@ -22,11 +22,11 @@
  * SOFTWARE.
  */
 
-#ifndef CUSTOM_MAP_VOTES_HH
-#define CUSTOM_MAP_VOTES_HH
+#pragma once
 
 #include <vector>
 #include <string>
+#include "json/json.h"
 
 class MapStatistics;
 
@@ -57,10 +57,21 @@ public:
   std::string ListInfo(const std::string &name);
   void GenerateVotesFile();
 
+  void addCustomvoteList(int clientNum, const std::string &name,
+                         const std::string &fullName, const std::string &maps);
+  void deleteCustomvoteList(int clientNum, const std::string &name);
+
+  void editCustomvoteList(int clientNum, const std::string &list,
+                          const std::string &name, const std::string &fullName,
+                          const std::string &addMaps,
+                          const std::string &removeMaps);
+
 private:
+  static bool readCustomvoteFile(const std::string &file, Json::Value &root);
+  static bool writeCustomvoteFile(const std::string &file,
+                                  const Json::Value &root);
+
   std::vector<MapType> customMapVotes_;
   const std::vector<std::string> *_currentMapsOnServer;
   MapStatistics *_mapStats;
 };
-
-#endif

--- a/src/game/etj_custom_map_votes.h
+++ b/src/game/etj_custom_map_votes.h
@@ -26,7 +26,6 @@
 
 #include <vector>
 #include <string>
-#include "json/json.h"
 
 class MapStatistics;
 
@@ -67,10 +66,6 @@ public:
                           const std::string &removeMaps);
 
 private:
-  static bool readCustomvoteFile(const std::string &file, Json::Value &root);
-  static bool writeCustomvoteFile(const std::string &file,
-                                  const Json::Value &root);
-
   std::vector<MapType> customMapVotes_;
   const std::vector<std::string> *_currentMapsOnServer;
   MapStatistics *_mapStats;

--- a/src/game/etj_json_utilities.cpp
+++ b/src/game/etj_json_utilities.cpp
@@ -1,0 +1,58 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <fstream>
+#include "etj_json_utilities.h"
+#include "utilities.hpp"
+
+namespace ETJump {
+bool JsonUtils::writeFile(const std::string &file, const Json::Value &root) {
+  Json::StyledWriter writer;
+  const std::string &output = writer.write(root);
+  std::ofstream fOut(GetPath(file));
+
+  if (!fOut) {
+    fOut.close();
+    return false;
+  }
+
+  fOut << output;
+  fOut.close();
+  return true;
+}
+
+bool JsonUtils::readFile(const std::string &file, Json::Value &root) {
+  std::ifstream fIn(GetPath(file));
+
+  if (!fIn) {
+    fIn.close();
+    return false;
+  }
+
+  Json::CharReaderBuilder readerBuilder;
+  Json::parseFromStream(readerBuilder, fIn, &root, nullptr);
+  fIn.close();
+  return true;
+}
+} // namespace ETJump

--- a/src/game/etj_json_utilities.h
+++ b/src/game/etj_json_utilities.h
@@ -1,0 +1,38 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "json/json.h"
+
+namespace ETJump {
+class JsonUtils {
+public:
+  // returns true on successful read
+  static bool readFile(const std::string &file, Json::Value &root);
+
+  // returns true on successful write
+  static bool writeFile(const std::string &file, const Json::Value &root);
+};
+} // namespace ETJump

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -298,6 +298,11 @@ qboolean OnConsoleCommand() {
     return qtrue;
   }
 
+  if (command == "readcustomvotes") {
+    game.customMapVotes->Load();
+    return qtrue;
+  }
+
   if (command == "logstate") {
     LogServerState();
     return qtrue;


### PR DESCRIPTION
Adds admin commands to edit customvotes on the server.

* `!add-customvote` - adds a new custom vote list
  * Parameters (all required):
    * `--name [name]` - name of the list
    * `--full-name [callvote_text]` - full name displayed in callvote
    * `--maps [map list]` - maps to include in the list, space delimited
  * If no custom vote file is present, will create a new one
* `!delete-customvote` - deletes a custom vote list
  * Parameters (all required)
    * `--name [name]` - name of the list to delete
* `!edit-customvote` - edits an existing custom vote list
  * Parameters:
    * `--list [name]` - custom vote list to edit (required)
    * `--name [newname]` - sets new name for the list (optional)
    * `--full-name [callvote_text]` - sets new full name for the list (optional)
    * `--add-maps [maps to add]` - adds maps to the list, space delimited (optional)
    * `--remove-maps [maps to remove]` -  removes maps from the list, space delimited (optional)

Command access is provided with admin flag `c`.

Additional changes:
* `customvotes` alias for `listinfo` command
* Add missing autocomplete for `generateCustomvotes` and `generateMotd`
* New command `readCustomvotes` to reload custom vote file