### PR TITLE
Add nowallbug worldspawn key

### DIFF
--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -2108,6 +2108,12 @@ static void PM_GroundTrace(void) {
   PM_TraceAllLegs(&trace, &pm->pmext->proneLegsOffset, pm->ps->origin, point);
   pm->groundTrace = trace;
 
+  if (pm->shared & BG_LEVEL_NO_WALLBUG) {
+    if (trace.allsolid && pm->ps->pm_type != PM_NOCLIP) {
+      VectorClear(pm->ps->velocity);
+    }
+  }
+
   // do something corrective if the trace starts in a solid...
   if (trace.allsolid && !(pm->ps->eFlags & EF_MOUNTEDTANK)) {
     if (!PM_CorrectAllSolid(&trace)) {

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2791,6 +2791,8 @@ const int BG_LEVEL_NO_FALLDAMAGE_FORCE = 1 << 4;
 const int BG_LEVEL_NO_PRONE = 1 << 5;
 // Nodrop is enabled
 const int BG_LEVEL_NO_DROP = 1 << 6;
+// Wallbugging is disabled
+const int BG_LEVEL_NO_WALLBUG = 1 << 7;
 
 namespace ETJump {
 enum class CheatCvarFlags {

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1429,6 +1429,7 @@ typedef struct {
   bool noFallDamage;
   bool noProne;
   bool noDrop;
+  bool noWallbug;
 
   int portalEnabled; // Feen: PGM - Enabled/Disabled by map key
   qboolean portalSurfaces;

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -1110,6 +1110,17 @@ static void initNoDrop() {
   trap_Cvar_Set("shared", va("%d", shared.integer));
   G_Printf("Nodrop is %s.\n", level.noDrop ? "enabled" : "disabled");
 }
+
+static void initNoWallbug() {
+  int value = 0;
+  G_SpawnInt("nowallbug", "0", &value);
+  level.noWallbug = value;
+  level.noWallbug ? shared.integer |= BG_LEVEL_NO_WALLBUG
+                  : shared.integer &= ~BG_LEVEL_NO_WALLBUG;
+
+  trap_Cvar_Set("shared", va("%d", shared.integer));
+  G_Printf("Wallbugging is %s.\n", level.noWallbug ? "disabled" : "enabled");
+}
 } // namespace ETJump
 
 /*QUAKED worldspawn (0 0 0) ? NO_GT_WOLF NO_GT_STOPWATCH NO_GT_CHECKPOINT NO_LMS
@@ -1258,6 +1269,7 @@ void SP_worldspawn(void) {
   ETJump::initNoFallDamage();
   ETJump::initNoProne();
   ETJump::initNoDrop();
+  ETJump::initNoWallbug();
 
   level.mapcoordsValid = qfalse;
   if (G_SpawnVector2D("mapcoordsmins", "-128 128",


### PR DESCRIPTION
Clears player speed if `pm->groundTrace` is `allsolid`, to prevent building up speed while stuck in a wall.