### PR TITLE
Don't start timeruns if client toggled pmove_fixed before

### DIFF
--- a/src/game/etj_timerun_entities.cpp
+++ b/src/game/etj_timerun_entities.cpp
@@ -153,12 +153,24 @@ bool TimerunEntity::canStartTimerun(gentity_t *self, gentity_t *activator,
           "^3WARNING: ^7Timerun was not started. Invalid playerstate!");
       return false;
     }
+
     if (client->noclipThisLife) {
       Printer::SendCenterMessage(*clientNum,
                                  "^3WARNING: ^7Timerun was not started. Noclip "
                                  "activated this life, ^3/kill ^7required!");
       return false;
     }
+
+    if (client->pmoveOffThisLife &&
+        (!self->spawnflags ||
+         self->spawnflags &
+             static_cast<int>(TimerunSpawnflags::ResetNoPmove))) {
+      Printer::SendCenterMessage(
+          *clientNum, "^3WARNING: ^7Timerun was not started. ^3pmove_fixed 0 "
+                      "^7set this life, ^3/kill ^7required!");
+      return false;
+    }
+
     if (*speed > self->velocityUpperLimit) {
       Printer::SendCenterMessage(
           *clientNum, stringFormat("^3WARNING: ^7Timerun was not started. Too "
@@ -166,6 +178,7 @@ bool TimerunEntity::canStartTimerun(gentity_t *self, gentity_t *activator,
                                    *speed, self->velocityUpperLimit));
       return false;
     }
+
     if (client->ps.viewangles[ROLL] != 0) {
       Printer::SendCenterMessage(
           *clientNum, stringFormat("^3WARNING: ^7Timerun was not started. "

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -988,6 +988,8 @@ void ClientThink_real(gentity_t *ent) {
     ucmd->serverTime =
         ((ucmd->serverTime + pmove_msec.integer - 1) / pmove_msec.integer) *
         pmove_msec.integer;
+  } else {
+    client->pmoveOffThisLife = true;
   }
 
   msec = ucmd->serverTime - client->ps.commandTime;

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1016,6 +1016,7 @@ struct gclient_s {
 
   qboolean noclip;
   bool noclipThisLife;
+  bool pmoveOffThisLife;
 
   int lastCmdTime; // level.time of last usercmd_t, for EF_CONNECTION
                    // we can't just use pers.lastCommand.time, because


### PR DESCRIPTION
Similar to `noclip`, prevent timeruns from starting if `pmove_fixed 0` was set before the run started, unless the run does not force `pmove_fixed 1` to begin with.