### PR TITLE
Fix being unable activate multiple trigger_multiples at the same time

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -595,6 +595,9 @@ struct gentity_s {
 
   char *targetShaderName;
   char *targetShaderNewName;
+
+  // last activation time of trigger_multiple for each client
+  int triggerActivationTime[MAX_CLIENTS];
 };
 
 // Ridah
@@ -1148,9 +1151,6 @@ struct gclient_s {
   int last8BallTime; // Last level.time client used !8ball.
   int lastVoteTime;
   qboolean cheatDetected;
-
-  // Time when client activated trigger_multiple
-  int multiTriggerActivationTime;
 
   // Time when client activated trigger_push
   int pushTriggerActivationTime;

--- a/src/game/g_trigger.cpp
+++ b/src/game/g_trigger.cpp
@@ -26,7 +26,7 @@ void multi_trigger(gentity_t *ent, gentity_t *activator) {
   }
 
   if (activator && activator->client) {
-    if (activator->client->multiTriggerActivationTime + wait > level.time) {
+    if (ent->triggerActivationTime[ClientNum(activator)] + wait > level.time) {
       return;
     }
   }
@@ -39,7 +39,7 @@ void multi_trigger(gentity_t *ent, gentity_t *activator) {
         ent, "activate",
         activator->client->sess.sessionTeam == TEAM_AXIS ? "axis" : "allies");
 
-    activator->client->multiTriggerActivationTime = level.time;
+    ent->triggerActivationTime[ClientNum(activator)] = level.time;
   } else {
     G_Script_ScriptEvent(ent, "activate", nullptr);
   }


### PR DESCRIPTION
Instead of tracking `trigger_multiple` activation time on client entity, track activation time of each client in the entity itself, to prevent being unable to activate a different `trigger_multiple` entity while still on wait period set by another `trigger_multiple`.

refs #1144 