### PR TITLE
Improve autortv prints and behavior

### DIFF
--- a/src/game/etj_rtv.cpp
+++ b/src/game/etj_rtv.cpp
@@ -157,6 +157,10 @@ void RockTheVote::callAutoRtv() {
 
   Q_strncpyz(voteArg, "rtv", sizeof(voteArg));
 
+  // must be set before G_voteCmdCheck, otherwise auto rtv won't get called
+  // if vote_allow_rtv is set to 0
+  level.voteInfo.isAutoRtvVote = true;
+
   if ((i = G_voteCmdCheck(nullptr, voteArg, nullptr)) != G_OK) {
     if (i == G_NOTFOUND) {
       G_LogPrintf(
@@ -168,6 +172,7 @@ void RockTheVote::callAutoRtv() {
     // if we fail here, it's because we don't have enough maps,
     // so push back auto rtv timer so that we don't flood the logs
     autoRtvStartTime = level.time;
+    level.voteInfo.isAutoRtvVote = false; // reset in case vote cmd fails
     return;
   }
 
@@ -179,7 +184,6 @@ void RockTheVote::callAutoRtv() {
   level.voteInfo.voteTime = level.time;
   level.voteInfo.voter_cn = -1;
   level.voteInfo.voter_team = TEAM_FREE;
-  level.voteInfo.isAutoRtvVote = true;
 
   autoRtvStartTime = level.time; // reset cooldown in case this vote fails
   anyonePlayedSinceLastVote = false;

--- a/src/game/etj_rtv.h
+++ b/src/game/etj_rtv.h
@@ -32,8 +32,6 @@ class RockTheVote {
   bool isRtvVote;
   // holds the map names and their vote counts for rtv
   std::vector<std::pair<std::string, int>> rtvMaps;
-
-  int autoRtvStartTime;
   bool anyonePlayedSinceLastVote;
   bool twoMinWarningGiven;
 
@@ -60,5 +58,7 @@ public:
 
   // upper cap of autoRtv interval, 24h
   static const int AUTORTV_MAX_TIME = 24 * 60;
+
+  int autoRtvStartTime;
 };
 } // namespace ETJump


### PR DESCRIPTION
* Auto RTV can no longer be voted off if it's already off
* Adjusting auto RTV time will now display the actual minutes until next vote, instead of simply the interval it was voted to be
  * Time until next vote won't be displayed if voting to such low value that the vote gets called immediately
* Auto RTV no longer gets blocked if rtv voting is disabled with `vote_allow_rtv 0`

refs #1135 