### PR TITLE
Fix double footsteps on cushion + etj_fixedCushionSteps prediction

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -1536,16 +1536,18 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
     if (!etj_fixedCushionSteps.integer) {
       event = EV_FOOTSTEP;
     }
-  } else if (event == EV_UPHILLSTEP && !etj_uphillSteps.integer) {
-    return;
   }
 
   switch (event) {
     //
     // movement generated events
     //
-    case EV_FOOTSTEP:
     case EV_UPHILLSTEP:
+      if (!etj_uphillSteps.integer) {
+        break;
+      }
+      // fall through
+    case EV_FOOTSTEP:
       DEBUGNAME("EV_FOOTSTEP");
       if (es->eventParm != FOOTSTEP_TOTAL && cg_footsteps.integer) {
         if (es->eventParm) {

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -1403,8 +1403,7 @@ void PM_CheckPortal(void) {
 
   VectorMA(pm->ps->origin, TRACE_PORTAL_DIST, straightdown, spot);
   pm->trace(&trace, newOrigin /*pm->ps->origin*/, pm->ps->mins, pm->ps->maxs,
-            spot, pm->ps->clientNum,
-            (CONTENTS_TRIGGER | CONTENTS_SOLID));
+            spot, pm->ps->clientNum, (CONTENTS_TRIGGER | CONTENTS_SOLID));
   // trap_Trace( &trace, pm->ps->origin, pm->mins, pm->maxs, spot,
   // pm->ps->clientNum, CONTENTS_TRIGGER );
 
@@ -1867,6 +1866,11 @@ static void PM_CheckFallDamage(const float delta) {
   }
 }
 
+static void PM_AddCushionFootstep(const float &delta) {
+  PM_AddEventExt(delta > 7 ? EV_CUSHIONFALLSTEP : EV_FOOTSTEP,
+                 PM_FootstepForSurface());
+}
+
 /*
 =================
 PM_CrashLand
@@ -1936,27 +1940,22 @@ static void PM_CrashLand(void) {
 
   // End PGM Test
 
-  static const auto PM_AddCushionFootstep = [&delta]() {
-    PM_AddEventExt(delta > 7 ? EV_CUSHIONFALLSTEP : EV_FOOTSTEP,
-                   PM_FootstepForSurface());
-  };
-
   // Aciz: moved fall damage and stepsound handling into
   // PM_CheckFallDamage to avoid very messy code when checking whether
   // nofalldamage is enabled/disabled.
   if (pm->shared & BG_LEVEL_NO_FALLDAMAGE_FORCE) {
-    PM_AddCushionFootstep();
+    PM_AddCushionFootstep(delta);
   } else if (pm->shared & BG_LEVEL_NO_FALLDAMAGE) {
     if (pm->groundTrace.surfaceFlags & SURF_NODAMAGE) {
       PM_CheckFallDamage(delta);
     } else {
-      PM_AddCushionFootstep();
+      PM_AddCushionFootstep(delta);
     }
   } else {
     if (!(pm->groundTrace.surfaceFlags & SURF_NODAMAGE)) {
       PM_CheckFallDamage(delta);
     } else {
-      PM_AddCushionFootstep();
+      PM_AddCushionFootstep(delta);
     }
   }
 


### PR DESCRIPTION
For some reason, having the footstep function as a lambda would break `delta` value on server side pmove, which caused double stepsounds to play as client and server sent different events. This also caused prediction to be borked when `etj_fixedCushionSteps` was enabled.

Also don't early out from `CG_EntityEvent` for uphill steps as that breaks footstep counter.

refs #1136 