### PR TITLE
Fix rtv state being uninitialized on initial client connect

### DIFF
--- a/src/cgame/etj_client_rtv_handler.cpp
+++ b/src/cgame/etj_client_rtv_handler.cpp
@@ -32,6 +32,17 @@ ClientRtvHandler::ClientRtvHandler() {
   isRtvVote = false;
 }
 
+void ClientRtvHandler::initialize() {
+  setRtvVoteStatus();
+
+  if (!rtvVoteActive()) {
+    return;
+  }
+
+  setRtvConfigStrings(CG_ConfigString(CS_VOTE_YES));
+  countRtvVotes();
+}
+
 void ClientRtvHandler::setRtvConfigStrings(const char *cs) {
   char key[MAX_QPATH]; // these are map names so MAX_QPATH is sufficient
   char value[3];       // can't exceed MAX_CLIENTS + null terminator

--- a/src/cgame/etj_client_rtv_handler.h
+++ b/src/cgame/etj_client_rtv_handler.h
@@ -36,6 +36,8 @@ public:
   ClientRtvHandler();
   ~ClientRtvHandler() = default;
 
+  void initialize();
+
   void setRtvConfigStrings(const char *cs);
   void countRtvVotes();
   int getRtvYesVotes() const;

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -219,6 +219,7 @@ void init() {
   ////////////////////////////////////////////////////////////////
 
   rtvHandler = std::make_shared<ClientRtvHandler>();
+  rtvHandler->initialize();
 
   // initialize renderables
   // Overbounce watcher


### PR DESCRIPTION
If a client connected during or after a failed rtv, the client rtv state would be messed up as it did not have a correct state for rtv status.

refs #1135 