### PR TITLE
Always interrupt timeruns when client goes to spec

### DIFF
--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -1719,7 +1719,8 @@ void Cmd_Team_f(gentity_t *ent) {
     G_SetClientWeapons(ent, w, w2, qtrue);
   }
 
-  if (!ent->client->sess.runSpawnflags ||
+  if (ent->client->sess.sessionTeam == TEAM_SPECTATOR ||
+      !ent->client->sess.runSpawnflags ||
       ent->client->sess.runSpawnflags &
           static_cast<int>(ETJump::TimerunSpawnflags::ResetTeamChange)) {
     InterruptRun(ent);


### PR DESCRIPTION
Even for timeruns that do not reset on team change, it doesn't make much sense to keep them running if client switches to spec.