### PR TITLE
Add comments indicating killpath for trap_Error calls

### DIFF
--- a/src/cgame/cg_syscalls.cpp
+++ b/src/cgame/cg_syscalls.cpp
@@ -35,6 +35,7 @@ void trap_PumpEventLoop(void) {
 
 void trap_Print(const char *fmt) { SystemCall(CG_PRINT, fmt); }
 
+// coverity[+kill]
 void trap_Error(const char *fmt) { SystemCall(CG_ERROR, fmt); }
 
 int trap_Milliseconds(void) { return SystemCall(CG_MILLISECONDS); }
@@ -478,7 +479,7 @@ void trap_GetGameState(gameState_t *gamestate) {
 }
 
 #ifdef _DEBUG
-  //#define FAKELAG
+  // #define FAKELAG
   #ifdef FAKELAG
     #define MAX_SNAPSHOT_BACKUP 256
     #define MAX_SNAPSHOT_MASK (MAX_SNAPSHOT_BACKUP - 1)

--- a/src/game/g_syscalls.cpp
+++ b/src/game/g_syscalls.cpp
@@ -31,6 +31,7 @@ inline int PASSFLOAT(const float &f) noexcept {
 
 void trap_Printf(const char *fmt) { SystemCall(G_PRINT, fmt); }
 
+// coverity[+kill]
 void trap_Error(const char *fmt) { SystemCall(G_ERROR, fmt); }
 
 int trap_Milliseconds(void) { return SystemCall(G_MILLISECONDS); }
@@ -237,7 +238,7 @@ sfxHandle_t trap_RegisterSound(const char *sample, qboolean compressed) {
 }
 
 #ifdef DEBUG
-  //#define FAKELAG
+  // #define FAKELAG
   #ifdef FAKELAG
     #define MAX_USERCMD_BACKUP 256
     #define MAX_USERCMD_MASK (MAX_USERCMD_BACKUP - 1)

--- a/src/ui/ui_syscalls.cpp
+++ b/src/ui/ui_syscalls.cpp
@@ -30,6 +30,7 @@ inline int PASSFLOAT(const float &f) noexcept {
 
 void trap_Print(const char *string) { SystemCall(UI_PRINT, string); }
 
+// coverity[+kill]
 void trap_Error(const char *string) { SystemCall(UI_ERROR, string); }
 
 int trap_Milliseconds(void) { return SystemCall(UI_MILLISECONDS); }


### PR DESCRIPTION
Coverity scan can only model external code, so we can't simply add CG/G_Error etc overrides with a modeling file.