### PR TITLE
Fix unnecessary auto rtv 2min warning prints

### DIFF
--- a/src/game/etj_rtv.cpp
+++ b/src/game/etj_rtv.cpp
@@ -36,7 +36,6 @@ RockTheVote::RockTheVote() {
   isRtvVote = false;
   autoRtvStartTime = level.startTime;
   anyonePlayedSinceLastVote = false;
-  twoMinWarningGiven = false;
 }
 
 std::vector<std::string> RockTheVote::getMostVotedMaps() {
@@ -140,11 +139,14 @@ bool RockTheVote::checkAutoRtv() {
   const int autoRtvMsec = g_autoRtv.integer * 1000 * 60;
   const int autoRtvCooldown = autoRtvStartTime + autoRtvMsec;
 
-  if (!twoMinWarningGiven && level.time > autoRtvCooldown - (1000 * 60 * 2) &&
+  // checks for exactly 2 minutes until vote, this should be fine as long as
+  // server doesn't randomly lag or something and skip a frame, but this
+  // isn't really critical anyway and is the simplest way to solve this getting
+  // printed when adjusting auto rtv time so that it gets instantly called
+  if (level.time == autoRtvCooldown - (1000 * 60 * 2) &&
       g_autoRtv.integer >= 2) {
     Printer::BroadcastChatMessage(
         "^gServer: automatic Rock The Vote will be called in ^32 ^gminutes.");
-    twoMinWarningGiven = true;
     return false;
   }
 
@@ -187,7 +189,6 @@ void RockTheVote::callAutoRtv() {
 
   autoRtvStartTime = level.time; // reset cooldown in case this vote fails
   anyonePlayedSinceLastVote = false;
-  twoMinWarningGiven = false;
   isRtvVote = true;
 
   std::string voteMsg = stringFormat("Server called an automatic %s.\n",

--- a/src/game/etj_rtv.h
+++ b/src/game/etj_rtv.h
@@ -33,7 +33,6 @@ class RockTheVote {
   // holds the map names and their vote counts for rtv
   std::vector<std::pair<std::string, int>> rtvMaps;
   bool anyonePlayedSinceLastVote;
-  bool twoMinWarningGiven;
 
 public:
   RockTheVote();


### PR DESCRIPTION
If we're adjusting the time to be lower so that we have less than 2 minutes until next vote, we don't need to print this warning as the vote pass message will tell us that, and this value was hardcoded anyway to it would be wrong in some scenarios (e.g. when adjusted such that autortv would get called instantly)

refs #1135 