### PR TITLE
etj_CGazDrawSnapZone

### DIFF
--- a/assets/ui/etjump_settings_2.menu
+++ b/assets/ui/etjump_settings_2.menu
@@ -19,7 +19,7 @@
 // Right side menus
 #define SUBW_CGAZ_Y SUBW_Y
 #define SUBW_CGAZ_ITEM_Y SUBW_CGAZ_Y + SUBW_HEADER_HEIGHT
-#define SUBW_CGAZ_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 14)
+#define SUBW_CGAZ_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 15)
 
 #define SUBW_POPUPS_Y SUBW_CGAZ_Y + SUBW_CGAZ_HEIGHT + SUBW_SPACING_Y
 #define SUBW_POPUPS_ITEM_Y SUBW_POPUPS_Y + SUBW_HEADER_HEIGHT
@@ -105,6 +105,7 @@ menuDef {
         CVARINTLABEL        (SUBW_ITEM_RIGHT_X, SUBW_CGAZ_ITEM_Y + (SUBW_ITEM_SPACING_Y * 13), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_CGaz2FixedSpeed", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
         SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_CGAZ_ITEM_Y + (SUBW_ITEM_SPACING_Y * 13), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "CGaz fixed speed:", 0.2, SUBW_ITEM_HEIGHT, etj_CGaz2FixedSpeed 0 0 1200 50, "Fixed speed value to use for drawing CGaz 2 instead of real speed\netj_CGaz2FixedSpeed")
         YESNO               (SUBW_ITEM_RIGHT_X, SUBW_CGAZ_ITEM_Y + (SUBW_ITEM_SPACING_Y * 14), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Hide velocity dir:", 0.2, SUBW_ITEM_HEIGHT, "etj_CGaz2NoVelocityDir", "Hide velocity direction line on CGaz2\netj_CGaz2NoVelocityDir")
+        YESNO               (SUBW_ITEM_RIGHT_X, SUBW_CGAZ_ITEM_Y + (SUBW_ITEM_SPACING_Y * 15), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Draw snap zone:", 0.2, SUBW_ITEM_HEIGHT, "etj_CGazDrawSnapZone", "Extend minimum angle drawing to the end of current snap zone (CGaz 1 only)\netj_CGazDrawSnapZone")
 
     SUBWINDOW(SUBW_RECT_RIGHT_X, SUBW_POPUPS_Y, SUBW_WIDTH, SUBW_POPUPS_HEIGHT, "POPUPS")
         MULTI               (SUBW_ITEM_RIGHT_X, SUBW_POPUPS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Draw popups:", 0.2, SUBW_ITEM_HEIGHT, "etj_HUD_popup", cvarFloatList { "No" 0 "Left" 1 "Right" 2 }, "Draw popups on HUD\netj_HUD_popup")

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2406,7 +2406,7 @@ extern vmCvar_t etj_CGazTrueness;
 extern vmCvar_t etj_CGazOnTop;
 extern vmCvar_t etj_CGaz2FixedSpeed;
 extern vmCvar_t etj_CGaz2NoVelocityDir;
-extern vmCvar_t etj_CGazDrawAccelZone;
+extern vmCvar_t etj_CGazDrawSnapZone;
 
 extern vmCvar_t etj_drawOB;
 // Aciz: movable drawOB

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2406,6 +2406,7 @@ extern vmCvar_t etj_CGazTrueness;
 extern vmCvar_t etj_CGazOnTop;
 extern vmCvar_t etj_CGaz2FixedSpeed;
 extern vmCvar_t etj_CGaz2NoVelocityDir;
+extern vmCvar_t etj_CGazDrawAccelZone;
 
 extern vmCvar_t etj_drawOB;
 // Aciz: movable drawOB

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -308,6 +308,7 @@ vmCvar_t etj_CGazTrueness;
 vmCvar_t etj_CGazOnTop;
 vmCvar_t etj_CGaz2FixedSpeed;
 vmCvar_t etj_CGaz2NoVelocityDir;
+vmCvar_t etj_CGazDrawAccelZone;
 
 vmCvar_t etj_drawOB;
 // Aciz: movable drawOB
@@ -857,6 +858,7 @@ cvarTable_t cvarTable[] = {
     {&etj_CGazOnTop, "etj_CGazOnTop", "0", CVAR_ARCHIVE | CVAR_LATCH},
     {&etj_CGaz2FixedSpeed, "etj_CGaz2FixedSpeed", "0", CVAR_ARCHIVE},
     {&etj_CGaz2NoVelocityDir, "etj_CGaz2NoVelocityDir", "0", CVAR_ARCHIVE},
+    {&etj_CGazDrawAccelZone, "etj_CGazDrawAccelZone", "0", CVAR_ARCHIVE},
 
     {&cl_yawspeed, "cl_yawspeed", "0", CVAR_ARCHIVE},
     {&cl_freelook, "cl_freelook", "1", CVAR_ARCHIVE},

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -308,7 +308,7 @@ vmCvar_t etj_CGazTrueness;
 vmCvar_t etj_CGazOnTop;
 vmCvar_t etj_CGaz2FixedSpeed;
 vmCvar_t etj_CGaz2NoVelocityDir;
-vmCvar_t etj_CGazDrawAccelZone;
+vmCvar_t etj_CGazDrawSnapZone;
 
 vmCvar_t etj_drawOB;
 // Aciz: movable drawOB
@@ -858,7 +858,7 @@ cvarTable_t cvarTable[] = {
     {&etj_CGazOnTop, "etj_CGazOnTop", "0", CVAR_ARCHIVE | CVAR_LATCH},
     {&etj_CGaz2FixedSpeed, "etj_CGaz2FixedSpeed", "0", CVAR_ARCHIVE},
     {&etj_CGaz2NoVelocityDir, "etj_CGaz2NoVelocityDir", "0", CVAR_ARCHIVE},
-    {&etj_CGazDrawAccelZone, "etj_CGazDrawAccelZone", "0", CVAR_ARCHIVE},
+    {&etj_CGazDrawSnapZone, "etj_CGazDrawSnapZone", "0", CVAR_ARCHIVE},
 
     {&cl_yawspeed, "cl_yawspeed", "0", CVAR_ARCHIVE},
     {&cl_freelook, "cl_freelook", "1", CVAR_ARCHIVE},

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -128,7 +128,7 @@ float CGaz::UpdateDrawSnap() {
     return NAN;
   }
 
-  Snaphud::CurrentSnap cs = Snaphud::getCurrentSnap(*ps, pm);
+  const Snaphud::CurrentSnap cs = Snaphud::getCurrentSnap(*ps, pm);
 
   if (std::isnan(cs.snap)) {
     return NAN;

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -123,8 +123,10 @@ void CGaz::UpdateDraw(float wishspeed, float accel) {
 }
 
 float CGaz::UpdateDrawSnap() {
-  // don't highligh snapzone on very low velocities
-  if (!etj_CGazDrawSnapZone.integer || state.vf < state.wishspeed) {
+  // don't highlight snapzone on very low velocities,
+  // or if drawing isn't requested
+  if (!etj_CGazDrawSnapZone.integer || !(etj_drawCGaz.integer & 1) ||
+      state.vf < state.wishspeed) {
     return NAN;
   }
 
@@ -137,15 +139,16 @@ float CGaz::UpdateDrawSnap() {
   float snap = cs.snap;
 
   // edge case, solution from snaphud code
-  if (cs.rightStrafe && snap > 90) {
-    snap = 90 - std::fmod(snap, 90);
+  if (cs.rightStrafe && snap > 90.0f) {
+    snap = 90.0f - std::fmod(snap, 90.0f);
   }
 
   // snaps are in absolute angles, calculate it relative to yaw
-  const float viewOffset = AngleNormalize180(cs.yaw - RAD2DEG(yaw));
+  const float viewOffset =
+      AngleNormalize180(cs.yaw - static_cast<float>(RAD2DEG(yaw)));
 
   float snapInCgazAngles =
-      std::fmod(!cs.rightStrafe ? snap - viewOffset : viewOffset - snap, 90);
+      std::fmod(!cs.rightStrafe ? snap - viewOffset : viewOffset - snap, 90.0f);
 
   if (snapInCgazAngles < 0.0f) {
     snapInCgazAngles += 90.0f;

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -258,15 +258,20 @@ void CGaz::render() const {
       fov = Numeric::clamp(etj_CGazFov.value, 1, 179);
     }
 
-    const auto zone1 = drawMin;
+    const float zone1 = drawMin;
 
-    const auto zone2 = std::isnan(drawSnap) ? drawOpt
-                       : drawSnap < drawMin ? drawMaxCos
-                                            : drawSnap;
-    // if snap < min angle, the accel zone fills the whole snapzone
+    float zone2 = drawOpt;
 
-    const auto zone3 = std::max(zone2, drawMaxCos);
-    const auto zone4 = drawMax == 0 || drawMax == (float)M_PI || drawMax >= zone3 ? drawMax : zone3;
+    if (!std::isnan(drawSnap)) {
+      // if snap < min angle, the accel zone fills the whole snapzone
+      zone2 = drawSnap < drawMin ? drawMaxCos : drawSnap;
+    }
+
+    const float zone3 = std::max(zone2, drawMaxCos);
+
+    const float zone4 =
+        drawMax == 0 || drawMax == (float)M_PI || drawMax >= zone3 ? drawMax
+                                                                   : zone3;
 
     // No accel zone
     CG_FillAngleYaw(-zone1, +zone1, yaw, y, h, fov, CGaz1Colors[0]);

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -128,7 +128,6 @@ float CGaz::UpdateDrawSnap() {
     return NAN;
   }
 
-  const usercmd_t cmd = PmoveUtils::getUserCmd(*ps, CMDSCALE_DEFAULT);
   Snaphud::CurrentSnap cs = Snaphud::getCurrentSnap(*ps, pm);
 
   if (std::isnan(cs.snap)) {
@@ -142,9 +141,9 @@ float CGaz::UpdateDrawSnap() {
     snap = 90 - std::fmod(snap, 90);
   }
 
+  // snaps are in absolute angles, calculate it relative to yaw
   const float viewOffset = AngleNormalize180(cs.yaw - RAD2DEG(yaw));
 
-  // convert grid based snap angle to cgaz's velocity vector based
   float snapInCgazAngles =
       std::fmod(!cs.rightStrafe ? snap - viewOffset : viewOffset - snap, 90);
 

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -124,7 +124,7 @@ void CGaz::UpdateDraw(float wishspeed, float accel) {
 
 float CGaz::UpdateDrawSnap() {
   // don't highligh snapzone on very low velocities
-  if (!etj_CGazDrawAccelZone.integer || state.vf < state.wishspeed) {
+  if (!etj_CGazDrawSnapZone.integer || state.vf < state.wishspeed) {
     return NAN;
   }
 

--- a/src/cgame/etj_cgaz.h
+++ b/src/cgame/etj_cgaz.h
@@ -61,6 +61,7 @@ private:
   float drawOpt{};
   float drawMaxCos{};
   float drawMax{};
+  float drawSnap{}; // NaN if disabled or not applicable
   float drawVel{};
   float yaw{};
   vec4_t CGaz1Colors[4]{};
@@ -73,8 +74,9 @@ private:
   void UpdateDraw(float wishspeed, float accel);
   static float UpdateDrawMin(state_t const *state);
   static float UpdateDrawOpt(state_t const *state);
-  static float UpdateDrawMaxCos(state_t const *state, float d_opt);
-  static float UpdateDrawMax(state_t const *state, float d_max_cos);
+  static float UpdateDrawMaxCos(state_t const *state);
+  static float UpdateDrawMax(state_t const *state);
+  float UpdateDrawSnap();
   void startListeners();
 
   playerState_t *ps = &cg.predictedPlayerState;

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -432,15 +432,15 @@ Snaphud::CurrentSnap Snaphud::getCurrentSnap(const playerState_t &ps,
 }
 
 bool Snaphud::inMainAccelZone(const playerState_t &ps, pmove_t *pm) {
-  auto cs = getCurrentSnap(ps, pm);
+  const Snaphud::CurrentSnap cs = getCurrentSnap(ps, pm);
 
   if (std::isnan(cs.snap)) {
     return false;
   }
 
-  auto yaw = cs.yaw;
-  auto opt = cs.opt;
-  auto snap = cs.snap;
+  const float yaw = cs.yaw;
+  const float opt = cs.opt;
+  const float snap = cs.snap;
 
   // return true if yaw is between opt angle and end of the current
   // snapzone also account for jumps at the boundary (e.g. 100 and 10

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -31,10 +31,10 @@ namespace ETJump {
 class Snaphud : public IRenderable {
 public:
   struct CurrentSnap {
-    float snap;
-    float yaw;
-    float opt;
-    bool rightStrafe;
+    float snap; // next snap in strafe dir, NaN if snap can't be fetched
+    float yaw; // view yaw
+    float opt; // optimal angle
+    bool rightStrafe; // whether turning right
   };
 
   void render() const override;

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -30,8 +30,16 @@
 namespace ETJump {
 class Snaphud : public IRenderable {
 public:
+  struct CurrentSnap {
+    float snap;
+    float yaw;
+    float opt;
+    bool rightStrafe;
+  };
+
   void render() const override;
   bool beforeRender() override;
+  static CurrentSnap getCurrentSnap(const playerState_t &ps, pmove_t *pm);
   static bool inMainAccelZone(const playerState_t &ps, pmove_t *pm);
 
   Snaphud();


### PR DESCRIPTION
cvar to highlight current snapzone in cgaz1 instead of the small accel zone (light green by default)

![image](https://github.com/etjump/etjump/assets/68028366/4470ea25-5d59-4184-935a-11e1eeb6443b)
