### PR TITLE
Don't start timeruns if setoffset was used after respawn

### DIFF
--- a/src/game/etj_timerun_entities.cpp
+++ b/src/game/etj_timerun_entities.cpp
@@ -155,9 +155,16 @@ bool TimerunEntity::canStartTimerun(gentity_t *self, gentity_t *activator,
     }
 
     if (client->noclipThisLife) {
-      Printer::SendCenterMessage(*clientNum,
-                                 "^3WARNING: ^7Timerun was not started. Noclip "
-                                 "activated this life, ^3/kill ^7required!");
+      Printer::SendCenterMessage(
+          *clientNum, "^3WARNING: ^7Timerun was not started. ^3noclip "
+                      "^7activated this life, ^3/kill ^7required!");
+      return false;
+    }
+
+    if (client->setoffsetThisLife) {
+      Printer::SendCenterMessage(
+          *clientNum, "^3WARNING: ^7Timerun was not started. ^3setoffset "
+                      "^7activated this life, ^3/kill ^7required!");
       return false;
     }
 

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -969,6 +969,7 @@ void setPlayerOffset(gentity_t *ent) {
   VectorCopy(ent->client->ps.viewangles, angles);
 
   decreaseNoclipCount(ent, "setoffset");
+  ent->client->noclipThisLife = true;
 
   for (auto i = 0; i < 3; i++) {
     trap_Argv(i + 1, buffer, sizeof buffer);

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -969,7 +969,7 @@ void setPlayerOffset(gentity_t *ent) {
   VectorCopy(ent->client->ps.viewangles, angles);
 
   decreaseNoclipCount(ent, "setoffset");
-  ent->client->noclipThisLife = true;
+  ent->client->setoffsetThisLife = true;
 
   for (auto i = 0; i < 3; i++) {
     trap_Argv(i + 1, buffer, sizeof buffer);

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1019,6 +1019,7 @@ struct gclient_s {
 
   qboolean noclip;
   bool noclipThisLife;
+  bool setoffsetThisLife;
   bool pmoveOffThisLife;
 
   int lastCmdTime; // level.time of last usercmd_t, for EF_CONNECTION


### PR DESCRIPTION
This follows same restrictions as noclip so it makes sense to restrict it too.