### PR TITLE
Accelerometer+color coding

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2442,6 +2442,13 @@ extern vmCvar_t etj_maxSpeedDuration;
 extern vmCvar_t etj_speedColorUsesAccel;
 extern vmCvar_t etj_speedAlign;
 
+extern vmCvar_t etj_drawAccel;
+extern vmCvar_t etj_accelX;
+extern vmCvar_t etj_accelY;
+extern vmCvar_t etj_accelSize;
+extern vmCvar_t etj_accelShadow;
+extern vmCvar_t etj_accelAlign;
+
 extern vmCvar_t etj_popupTime;
 extern vmCvar_t etj_popupStayTime;
 extern vmCvar_t etj_popupFadeTime;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -347,6 +347,13 @@ vmCvar_t etj_maxSpeedDuration;
 vmCvar_t etj_speedColorUsesAccel;
 vmCvar_t etj_speedAlign;
 
+vmCvar_t etj_drawAccel;
+vmCvar_t etj_accelX;
+vmCvar_t etj_accelY;
+vmCvar_t etj_accelSize;
+vmCvar_t etj_accelShadow;
+vmCvar_t etj_accelAlign;
+
 vmCvar_t etj_popupTime;
 vmCvar_t etj_popupStayTime;
 vmCvar_t etj_popupFadeTime;
@@ -885,6 +892,12 @@ cvarTable_t cvarTable[] = {
     {&etj_maxSpeedDuration, "etj_maxSpeedDuration", "2000", CVAR_ARCHIVE},
     {&etj_speedColorUsesAccel, "etj_speedColorUsesAccel", "0", CVAR_ARCHIVE},
     {&etj_speedAlign, "etj_speedAlign", "0", CVAR_ARCHIVE},
+
+    {&etj_drawAccel, "etj_drawAccel", "1", CVAR_ARCHIVE},
+    {&etj_accelX, "etj_accelX", "320", CVAR_ARCHIVE},
+    {&etj_accelY, "etj_accelY", "350", CVAR_ARCHIVE},
+    {&etj_accelSize, "etj_accelSize", "3", CVAR_ARCHIVE},
+    {&etj_accelAlign, "etj_accelAlign", "0", CVAR_ARCHIVE},
 
     {&etj_popupTime, "etj_popupTime", "1000", CVAR_ARCHIVE},
     {&etj_popupStayTime, "etj_popupStayTime", "2000", CVAR_ARCHIVE},

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -893,7 +893,7 @@ cvarTable_t cvarTable[] = {
     {&etj_speedColorUsesAccel, "etj_speedColorUsesAccel", "0", CVAR_ARCHIVE},
     {&etj_speedAlign, "etj_speedAlign", "0", CVAR_ARCHIVE},
 
-    {&etj_drawAccel, "etj_drawAccel", "1", CVAR_ARCHIVE},
+    {&etj_drawAccel, "etj_drawAccel", "0", CVAR_ARCHIVE},
     {&etj_accelX, "etj_accelX", "320", CVAR_ARCHIVE},
     {&etj_accelY, "etj_accelY", "350", CVAR_ARCHIVE},
     {&etj_accelSize, "etj_accelSize", "3", CVAR_ARCHIVE},

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -342,9 +342,6 @@ bool CGaz::strafingForwards(const playerState_t &ps, pmove_t *pm) {
 
 float CGaz::getFrameAccel(const playerState_t& ps, pmove_t* pm)
 {
-  // get sprint scale
-  const float scale = PmoveUtils::PM_SprintScale(&ps);
-
   // get usercmd
   const auto ucmdScale =
       static_cast<int8_t>(ps.stats[STAT_USERCMD_BUTTONS] & (BUTTON_WALKING << 8)
@@ -444,9 +441,6 @@ float CGaz::getAltOptAngle(const playerState_t &ps, pmove_t *pm) {
 
   // determine whether strafing "forwards"
   const bool forwards = strafingForwards(ps, pm);
-
-  // get accel defined by physics
-  const float accel = static_cast<float>(ps.speed) * pm->pmext->frametime;
 
   // get variables associated with optimal angle
   const float velAngle = RAD2DEG(std::atan2(ps.velocity[1], ps.velocity[0]));

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -356,12 +356,12 @@ float CGaz::getFrameAccel(const playerState_t& ps, pmove_t* pm)
   }
 
   // get accel defined by physics
-  const float accel = static_cast<float>(ps.speed) * pm->pmext->frametime;
+  float accel = static_cast<float>(ps.speed) * pm->pmext->frametime;
 
   return accel;
 }
 
-float CGaz::getOptAngle(const playerState_t &ps, pmove_t *pm) {
+float CGaz::getOptAngle(const playerState_t &ps, pmove_t *pm, bool alternate) {
   // get player speed
   const float speed = VectorLength2(ps.velocity);
 
@@ -391,7 +391,7 @@ float CGaz::getOptAngle(const playerState_t &ps, pmove_t *pm) {
 
   // get variables associated with optimal angle
   const float velAngle = RAD2DEG(std::atan2(ps.velocity[1], ps.velocity[0]));
-  const float accelAngle = RAD2DEG(std::atan2(-cmd.rightmove, cmd.forwardmove));
+  const float accelAngle = RAD2DEG(std::atan2(alternate ? cmd.rightmove : -cmd.rightmove, cmd.forwardmove));
   float perAngle =
       RAD2DEG(std::acos((ps.speed - getFrameAccel(ps, pm)) / speed * scale));
   if (!forwards) {
@@ -400,68 +400,29 @@ float CGaz::getOptAngle(const playerState_t &ps, pmove_t *pm) {
 
   // shift yaw to optimal angle for all strafe styles
   float opt = yaw;
-  if (cmd.rightmove < 0) {
-    // fullbeat / halfbeat / invert (holding +moveleft)
-    opt -= AngleDelta(yaw + accelAngle, velAngle + perAngle);
-  } else if (cmd.rightmove > 0) {
-    // fullbeat / halfbeat / invert (holding +moveright)
-    opt -= AngleDelta(yaw + accelAngle, velAngle - perAngle);
-  } else if (cmd.forwardmove != 0) {
-    // nobeat
-    opt = velAngle + perAngle;
-  }
 
-  // return minimum angle for which you still gain the highest accel
-  return AngleNormalize180(opt);
-}
-
-float CGaz::getAltOptAngle(const playerState_t &ps, pmove_t *pm) {
-  // get player speed
-  const float speed = VectorLength2(ps.velocity);
-
-  // get sprint scale
-  const float scale = PmoveUtils::PM_SprintScale(&ps);
-
-  // get usercmd
-  const auto ucmdScale =
-      static_cast<int8_t>(ps.stats[STAT_USERCMD_BUTTONS] & (BUTTON_WALKING << 8)
-                              ? CMDSCALE_WALK
-                              : CMDSCALE_DEFAULT);
-  const usercmd_t cmd = PmoveUtils::getUserCmd(ps, ucmdScale);
-
-  // no meaningful value if speed lower than ground speed or no user
-  // input
-  if (speed < static_cast<float>(ps.speed) * scale ||
-      (cmd.forwardmove == 0 && cmd.rightmove == 0)) {
-    return 0;
-  }
-
-  // get player yaw
-  const float &yaw = ps.viewangles[YAW];
-
-  // determine whether strafing "forwards"
-  const bool forwards = strafingForwards(ps, pm);
-
-  // get variables associated with optimal angle
-  const float velAngle = RAD2DEG(std::atan2(ps.velocity[1], ps.velocity[0]));
-  const float accelAngle = RAD2DEG(std::atan2(cmd.rightmove, cmd.forwardmove));
-  float perAngle =
-      RAD2DEG(std::acos((ps.speed - getFrameAccel(ps, pm)) / speed * scale));
-  if (!forwards) {
-    perAngle *= -1;
-  }
-
-  // shift yaw to optimal angle for all strafe styles
-  float opt = yaw;
-  if (cmd.rightmove > 0) {
-    // fullbeat / halfbeat / invert (holding +moveleft)
-    opt -= AngleDelta(yaw + accelAngle, velAngle + perAngle);
-  } else if (cmd.rightmove < 0) {
-    // fullbeat / halfbeat / invert (holding +moveright)
-    opt -= AngleDelta(yaw + accelAngle, velAngle - perAngle);
-  } else if (cmd.forwardmove != 0) {
-    // nobeat
-    opt = velAngle - perAngle;
+  if (alternate) {
+    if (cmd.rightmove > 0) {
+      // fullbeat / halfbeat / invert (holding +moveleft)
+      opt -= AngleDelta(yaw + accelAngle, velAngle + perAngle);
+    } else if (cmd.rightmove < 0) {
+      // fullbeat / halfbeat / invert (holding +moveright)
+      opt -= AngleDelta(yaw + accelAngle, velAngle - perAngle);
+    } else if (cmd.forwardmove != 0) {
+      // nobeat
+      opt = velAngle - perAngle;
+    }
+  } else {
+    if (cmd.rightmove < 0) {
+      // fullbeat / halfbeat / invert (holding +moveleft)
+      opt -= AngleDelta(yaw + accelAngle, velAngle + perAngle);
+    } else if (cmd.rightmove > 0) {
+      // fullbeat / halfbeat / invert (holding +moveright)
+      opt -= AngleDelta(yaw + accelAngle, velAngle - perAngle);
+    } else if (cmd.forwardmove != 0) {
+      // nobeat
+      opt = velAngle + perAngle;
+    }
   }
 
   // return minimum angle for which you still gain the highest accel

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -356,7 +356,7 @@ float CGaz::getFrameAccel(const playerState_t& ps, pmove_t* pm)
   }
 
   // get accel defined by physics
-  float accel = static_cast<float>(ps.speed) * pm->pmext->frametime;
+  const float accel = static_cast<float>(ps.speed) * pm->pmext->frametime;
 
   return accel;
 }

--- a/src/cgame/etj_cgaz.h
+++ b/src/cgame/etj_cgaz.h
@@ -32,6 +32,8 @@ class CGaz : public IRenderable {
 public:
   static bool strafingForwards(const playerState_t &ps, pmove_t *pm);
   static float getOptAngle(const playerState_t &ps, pmove_t *pm);
+  static float getAltOptAngle(const playerState_t &ps, pmove_t *pm);
+  static float getFrameAccel(const playerState_t &ps, pmove_t *pm);
 
   CGaz();
   ~CGaz() override = default;

--- a/src/cgame/etj_cgaz.h
+++ b/src/cgame/etj_cgaz.h
@@ -31,8 +31,7 @@ namespace ETJump {
 class CGaz : public IRenderable {
 public:
   static bool strafingForwards(const playerState_t &ps, pmove_t *pm);
-  static float getOptAngle(const playerState_t &ps, pmove_t *pm);
-  static float getAltOptAngle(const playerState_t &ps, pmove_t *pm);
+  static float getOptAngle(const playerState_t &ps, pmove_t *pm, bool alternate);
   static float getFrameAccel(const playerState_t &ps, pmove_t *pm);
 
   CGaz();

--- a/src/cgame/etj_maxspeed.cpp
+++ b/src/cgame/etj_maxspeed.cpp
@@ -84,7 +84,7 @@ bool ETJump::DisplayMaxSpeed::beforeRender() {
 
 void ETJump::DisplayMaxSpeed::render() const {
 
-  vec4_t color;
+  vec4_t color = {1, 1, 1, 1};
   auto fade = CG_FadeAlpha(_animationStartTime, etj_maxSpeedDuration.integer);
   Vector4Copy(_color, color);
   color[3] *= fade;
@@ -102,7 +102,7 @@ void ETJump::DisplayMaxSpeed::render() const {
       w = CG_Text_Width_Ext(str, size, 0, &cgs.media.limboFont2);
       break;
     default: // center align
-      w = CG_Text_Width_Ext(str, size, 0, &cgs.media.limboFont2) / 2;
+      w = CG_Text_Width_Ext(str, size, 0, &cgs.media.limboFont2) / 2.0f;
       break;
   }
 

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -362,7 +362,7 @@ bool Snaphud::inMainAccelZone(const playerState_t &ps, pmove_t *pm) {
        (cmd.rightmove < 0 || (cmd.forwardmove != 0 && cmd.rightmove == 0)));
 
   // get opt angle
-  float opt = CGaz::getOptAngle(ps, pm);
+  float opt = CGaz::getOptAngle(ps, pm, false);
 
   // update snapzones even if snaphud is not drawn
   vec3_t wishvel;
@@ -445,110 +445,6 @@ bool Snaphud::inMainAccelZone(const playerState_t &ps, pmove_t *pm) {
   return false;
 }
 
-bool Snaphud::shouldSwitch(const playerState_t &ps, pmove_t *pm) {
-  static Snaphud s;
-
-  // get player yaw
-  float yaw = ps.viewangles[YAW];
-
-  // get usercmd
-  const int8_t ucmdScale =
-      ps.stats[STAT_USERCMD_BUTTONS] & (BUTTON_WALKING << 8) ? CMDSCALE_WALK
-                                                             : CMDSCALE_DEFAULT;
-  const usercmd_t cmd = PmoveUtils::getUserCmd(ps, ucmdScale);
-
-  // determine whether strafestyle is "forwards"
-  const bool forwards = CGaz::strafingForwards(ps, pm);
-
-  // determine whether strafing to the right ("moving mouse rightwards")
-  const bool rightStrafe =
-      (forwards && cmd.rightmove > 0) ||
-      (!forwards &&
-       (cmd.rightmove < 0 || (cmd.forwardmove != 0 && cmd.rightmove == 0)));
-
-  // get opt angle
-  float opt = CGaz::getOptAngle(ps, pm);
-
-  // update snapzones even if snaphud is not drawn
-  vec3_t wishvel;
-  const float wishspeed = PmoveUtils::PM_GetWishspeed(
-      wishvel, pm->pmext->scale, cmd, pm->pmext->forward, pm->pmext->right,
-      pm->pmext->up, ps, pm);
-  float speed = wishspeed * pm->pmext->frametime;
-
-  // clamp the max value to match max scaling of target_scale_velocity
-  if (speed > 85) {
-    speed = 85;
-  }
-  if (speed != s.snap.a) {
-    s.snap.a = speed;
-    s.UpdateMaxSnapZones(wishspeed, pm);
-    s.UpdateSnapState();
-  }
-
-  // early out if we have no snapzones yet, this can happen for a brief
-  // moment when swapping teams since we're transitioning from
-  // cg.snap->ps to cg.predictedPlayerstate
-  if (s.snap.zones.size() == 0) {
-    return false;
-  }
-
-  // necessary 45 degrees shift to match snapzones
-  if ((cmd.forwardmove != 0 && cmd.rightmove != 0) ||
-      (cmd.forwardmove == 0 && cmd.rightmove == 0)) {
-    yaw += 45;
-    opt += 45;
-  }
-
-  // snapzones only cover (a bit more than) one fourth of all
-  // viewangles, therefore crop yaw and opt to [0,90)
-  yaw = std::fmod(AngleNormalize360(yaw), 90);
-  opt = std::fmod(AngleNormalize360(opt), 90);
-
-  // get number of snapzones
-  auto snapCount = s.snap.zones.size() - 1;
-
-  // get snapzone index which corresponds to the *next* snapzone
-  // linear search is good enough here as snapCount is always relatively
-  // small
-  unsigned int i = 0;
-  while (i < snapCount && opt >= SHORT2DEG(s.snap.zones[i])) {
-    ++i;
-  }
-
-  // adjust snapzone index for rightStrafe
-  if (rightStrafe) {
-    i = (i == 0 ? snapCount : i - 1);
-  }
-
-  // get the snapzone
-  const float &snap = SHORT2DEG(s.snap.zones[i]);
-  // snap now contains the yaw value corresponding to the start of the
-  // next snapzone, or equivalently the end of the current snapzone
-
-  // return true if yaw is between opt angle and end of the current
-  // snapzone also account for jumps at the boundary (e.g. 100 and 10
-  // both have to be valid)
-  if (rightStrafe) {
-    if (yaw < opt && yaw > snap) {
-      return true;
-    }
-    // this is awkward because can not check for yaw >= 0 since
-    // that is always true
-    if (snap > 90 && (yaw > 90 - std::fmod(snap, 90) || yaw < opt)) {
-      return true;
-    }
-  } else {
-    if (yaw > opt && yaw < snap) {
-      return true;
-    }
-    if (snap > 90 && yaw < std::fmod(snap, 90)) {
-      return true;
-    }
-  }
-
-  return false;
-}
 
 bool Snaphud::canSkipDraw() const {
   if (!etj_drawSnapHUD.integer) {

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -468,7 +468,6 @@ bool Snaphud::shouldSwitch(const playerState_t &ps, pmove_t *pm) {
 
   // get opt angle
   float opt = CGaz::getOptAngle(ps, pm);
-  float altOpt = CGaz::getAltOptAngle(ps, pm);
 
   // update snapzones even if snaphud is not drawn
   vec3_t wishvel;

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -33,7 +33,6 @@ public:
   void render() const override;
   bool beforeRender() override;
   static bool inMainAccelZone(const playerState_t &ps, pmove_t *pm);
-  static bool shouldSwitch(const playerState_t &ps, pmove_t *pm);
 
   Snaphud();
   ~Snaphud(){};

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -33,6 +33,7 @@ public:
   void render() const override;
   bool beforeRender() override;
   static bool inMainAccelZone(const playerState_t &ps, pmove_t *pm);
+  static bool shouldSwitch(const playerState_t &ps, pmove_t *pm);
 
   Snaphud();
   ~Snaphud(){};

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -97,7 +97,7 @@ bool ETJump::DisplaySpeed::beforeRender() {
   _maxSpeed = speed > _maxSpeed ? speed : _maxSpeed;
 
   if (etj_speedColorUsesAccel.integer == 1 ||
-      (etj_speedColorUsesAccel.integer == 2 && speed <= 452 &&
+      (etj_speedColorUsesAccel.integer == 2 && speed <= MAX_GROUNDSTRAFE &&
        ps.groundEntityNum != ENTITYNUM_NONE)) {
     _storedSpeeds.push_back({cg.time, speed});
 
@@ -111,7 +111,7 @@ bool ETJump::DisplaySpeed::beforeRender() {
   }
 
   _lastUpdateTime = frameTime;
-  
+
   _accelx = static_cast<int>(speedx - _lastSpeed[0]);
   _accely = static_cast<int>(speedy - _lastSpeed[1]);
 
@@ -249,7 +249,6 @@ void ETJump::DisplaySpeed::render() const {
   float speedY = etj_speedY.integer;
   ETJump_AdjustPosition(&speedX);
 
-  
   float accelSize = 0.1f * etj_accelSize.value;
   float accelX = etj_accelX.integer;
   float accelY = etj_accelY.integer;
@@ -266,12 +265,12 @@ void ETJump::DisplaySpeed::render() const {
       break;
     case 2: // right align
       speedW = CG_Text_Width_Ext(status.c_str(), speedSize, 0,
-                                  &cgs.media.limboFont2);
+                                 &cgs.media.limboFont2);
       break;
     default: // center align
       speedW = CG_Text_Width_Ext(status.c_str(), speedSize, 0,
-                                  &cgs.media.limboFont2) /
-                2.0f;
+                                 &cgs.media.limboFont2) /
+               2.0f;
       break;
   }
 
@@ -286,12 +285,12 @@ void ETJump::DisplaySpeed::render() const {
       break;
     case 2: // right align
       accelW = CG_Text_Width_Ext(accel_string.c_str(), accelSize, 0,
-                                  &cgs.media.limboFont2);
+                                 &cgs.media.limboFont2);
       break;
     default: // center align
       accelW = CG_Text_Width_Ext(accel_string.c_str(), accelSize, 0,
-                                  &cgs.media.limboFont2) /
-          2.0f;
+                                 &cgs.media.limboFont2) /
+               2.0f;
       break;
   }
 
@@ -307,7 +306,7 @@ void ETJump::DisplaySpeed::render() const {
   const float xyVelocity = VectorLength2(ps->velocity);
 
   if (etj_speedColorUsesAccel.integer == 1 ||
-      (etj_speedColorUsesAccel.integer == 2 && xyVelocity <= 452 &&
+      (etj_speedColorUsesAccel.integer == 2 && xyVelocity <= MAX_GROUNDSTRAFE &&
        ps->groundEntityNum != ENTITYNUM_NONE)) {
     float accel = calcAvgAccel();
     float *accelColor = colorGreen;
@@ -327,16 +326,16 @@ void ETJump::DisplaySpeed::render() const {
     Vector4Copy(_color, color);
   }
 
-  CG_Text_Paint_Ext(speedX - speedW, speedY, speedSize, speedSize, color,
-                    status.c_str(), 0, 0, speedStyle,
-                    &cgs.media.limboFont1);
+  if (etj_drawSpeed2.integer) {
+    CG_Text_Paint_Ext(speedX - speedW, speedY, speedSize, speedSize, color,
+                      status.c_str(), 0, 0, speedStyle, &cgs.media.limboFont1);
+  }
 
   if (etj_drawAccel.integer) {
     CG_Text_Paint_Ext(accelX - accelW, accelY, accelSize, accelSize, color,
                       accel_string.c_str(), 0, 0, accelStyle,
                       &cgs.media.limboFont1);
   }
-
 }
 
 std::string ETJump::DisplaySpeed::getStatus() const {
@@ -377,8 +376,7 @@ bool ETJump::DisplaySpeed::canSkipUpdate(usercmd_t cmd, int frameTime) const {
   // only count this frame if it's relevant to pmove
   // this makes sure that if clients FPS > 125
   // we only count frames at pmove_msec intervals
-  if (!pm->ps || _lastUpdateTime + pm->pmove_msec > frameTime)
-  {
+  if (!pm->ps || _lastUpdateTime + pm->pmove_msec > frameTime) {
     return true;
   }
 

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -243,7 +243,8 @@ void ETJump::DisplaySpeed::render() const {
 
         if (maxAccelx > 0 && _accelx >= 0 || maxAccelx < 0 && _accelx <= 0) {
           frac = std::min(
-              std::max((static_cast<float>(_accelx) / maxAccelx) -
+              std::max(1.0f -
+                           (abs(maxAccelx) - abs(_accelx + maxAccelx) / 2.0f) -
                            (abs(_accely) -
                             abs(std::max(abs(optAccely), abs(altOptAccely)))),
                        0.0f),
@@ -256,7 +257,8 @@ void ETJump::DisplaySpeed::render() const {
 
         if (maxAccely > 0 && _accely >= 0 || maxAccely < 0 && _accely <= 0) {
           frac = std::min(
-              std::max((static_cast<float>(_accely) / maxAccely) -
+              std::max(1.0f -
+                           (abs(maxAccely) - abs(_accely + maxAccely) / 2.0f) -
                            (abs(_accelx) -
                             abs(std::max(abs(optAccelx), abs(altOptAccelx)))),
                        0.0f),

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -226,7 +226,7 @@ void ETJump::DisplaySpeed::calcAccelColor() {
       LerpColor(colorRed, colorGreen, color, frac);
     }
   } else {
-    Vector4Copy(colorRed, color);
+    Vector4Copy(colorWhite, color);
   }
 
   // we want a solid color all the time, no dark tints

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -280,7 +280,7 @@ void ETJump::DisplaySpeed::render() const {
   }
 
   float accelW;
-  switch (etj_speedAlign.integer) {
+  switch (etj_accelAlign.integer) {
     case 1: // left align
       accelW = 0;
       break;

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -115,10 +115,10 @@ bool ETJump::DisplaySpeed::beforeRender() {
 
   const float accelAngle = RAD2DEG(std::atan2(-cmd.rightmove, cmd.forwardmove));
   
-  _accelx = static_cast<int>(std::round(CGaz::getFrameAccel(ps, pm) *
-                cos(DEG2RAD(accelAngle + ps.viewangles[YAW])) * scale));
-  _accely = static_cast<int>(std::round(CGaz::getFrameAccel(ps, pm) *
-                sin(DEG2RAD(accelAngle + ps.viewangles[YAW])) * scale));
+  _accelx = static_cast<int>(speedx - _lastSpeed[0]);
+  _accely = static_cast<int>(speedy - _lastSpeed[1]);
+
+  Vector2Copy(cg.predictedPlayerState.velocity, _lastSpeed);
 
   return true;
 }
@@ -242,9 +242,12 @@ void ETJump::DisplaySpeed::render() const {
         float frac{0};
 
         if (maxAccelx > 0 && _accelx >= 0 || maxAccelx < 0 && _accelx <= 0) {
-          frac = std::min(std::max(static_cast<float>(_accelx) /
-                                       maxAccelx,
-                                   0.0f), 1.0f);
+          frac = std::min(
+              std::max((static_cast<float>(_accelx) / maxAccelx) -
+                           (abs(_accely) -
+                            abs(std::max(abs(optAccely), abs(altOptAccely)))),
+                       0.0f),
+              1.0f);
         }
 
         LerpColor(colorRed, colorGreen, color, frac);
@@ -252,8 +255,12 @@ void ETJump::DisplaySpeed::render() const {
         float frac{0};
 
         if (maxAccely > 0 && _accely >= 0 || maxAccely < 0 && _accely <= 0) {
-          frac = std::min(std::max(
-              static_cast<float>(_accely) / maxAccely, 0.0f), 1.0f);
+          frac = std::min(
+              std::max((static_cast<float>(_accely) / maxAccely) -
+                           (abs(_accelx) -
+                            abs(std::max(abs(optAccelx), abs(altOptAccelx)))),
+                       0.0f),
+              1.0f);
         }
 
         LerpColor(colorRed, colorGreen, color, frac);

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -110,11 +110,6 @@ bool ETJump::DisplaySpeed::beforeRender() {
 
   _lastUpdateTime = frameTime;
   
-  // get sprint scale
-  const float scale = PmoveUtils::PM_SprintScale(&ps);
-
-  const float accelAngle = RAD2DEG(std::atan2(-cmd.rightmove, cmd.forwardmove));
-  
   _accelx = static_cast<int>(speedx - _lastSpeed[0]);
   _accely = static_cast<int>(speedy - _lastSpeed[1]);
 
@@ -241,7 +236,8 @@ void ETJump::DisplaySpeed::render() const {
       if (isMovingx) {
         float frac{0};
 
-        if (maxAccelx > 0 && _accelx >= 0 || maxAccelx < 0 && _accelx <= 0) {
+        if ((maxAccelx > 0 && _accelx >= 0) ||
+            (maxAccelx < 0 && _accelx <= 0)) {
           frac = std::min(
               std::max(1.0f -
                            (abs(maxAccelx) - abs(_accelx + maxAccelx) / 2.0f) -
@@ -255,7 +251,8 @@ void ETJump::DisplaySpeed::render() const {
       } else {
         float frac{0};
 
-        if (maxAccely > 0 && _accely >= 0 || maxAccely < 0 && _accely <= 0) {
+        if ((maxAccely > 0 && _accely >= 0) ||
+            (maxAccely < 0 && _accely <= 0)) {
           frac = std::min(
               std::max(1.0f -
                            (abs(maxAccely) - abs(_accely + maxAccely) / 2.0f) -

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -369,7 +369,8 @@ std::string ETJump::DisplaySpeed::getStatus() const {
 }
 
 bool ETJump::DisplaySpeed::canSkipDraw() const {
-  return !etj_drawSpeed2.integer || ETJump::showingScores();
+  return (!etj_drawSpeed2.integer && !etj_drawAccel.integer) ||
+         ETJump::showingScores();
 }
 
 bool ETJump::DisplaySpeed::canSkipUpdate(usercmd_t cmd, int frameTime) const {

--- a/src/cgame/etj_speed_drawable.h
+++ b/src/cgame/etj_speed_drawable.h
@@ -41,8 +41,10 @@ class DisplaySpeed : public IRenderable {
   vec2_t _lastSpeed{0, 0};
   int _accelx{0}, _accely{0};
   vec4_t _color;
+  vec4_t accelColor;
   pmove_t *pm;
-  bool _shouldDrawShadow{false};
+  bool _shouldDrawSpeedShadow{false};
+  bool _shouldDrawAccelShadow{false};
   int _lastUpdateTime{0};
   static void parseColor(const std::string &color, vec4_t &out);
   void resetMaxSpeed();
@@ -57,6 +59,7 @@ class DisplaySpeed : public IRenderable {
 public:
   DisplaySpeed();
   ~DisplaySpeed();
+  void calcAccelColor();
   void render() const override;
   bool beforeRender() override;
 };

--- a/src/cgame/etj_speed_drawable.h
+++ b/src/cgame/etj_speed_drawable.h
@@ -24,6 +24,7 @@
 
 #pragma once
 #include "etj_irenderable.h"
+#include "etj_pmove_utils.h"
 #include "cg_local.h"
 #include <string>
 #include <list>
@@ -37,14 +38,19 @@ class DisplaySpeed : public IRenderable {
 
   std::list<StoredSpeed> _storedSpeeds;
   float _maxSpeed{0};
+  vec2_t _lastSpeed{0, 0};
+  int _accelx{0}, _accely{0};
   vec4_t _color;
+  pmove_t *pm;
   bool _shouldDrawShadow{false};
+  int _lastUpdateTime{0};
   static void parseColor(const std::string &color, vec4_t &out);
   void resetMaxSpeed();
   void checkShadow();
   void startListeners();
   std::string getStatus() const;
   bool canSkipDraw() const;
+  bool canSkipUpdate(usercmd_t cmd, int frameTime) const;
   void popOldStoredSpeeds();
   float calcAvgAccel() const;
 

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2806,5 +2806,7 @@ enum class CheatCvarFlags {
 }
 
 const int JUMP_VELOCITY = 270;
+// FIXME: this is incorrect when ps.speed is modified
+constexpr int MAX_GROUNDSTRAFE = 452;
 
 #endif // __BG_PUBLIC_H__

--- a/src/game/q_math.cpp
+++ b/src/game/q_math.cpp
@@ -613,6 +613,25 @@ float AngleNormalize180(float angle) {
   return angle;
 }
 
+
+/*
+=================
+AngleNormalize90
+
+returns angle normalized to the range [0 <= angle < 90]
+=================
+*/
+float AngleNormalize90(float angle) {
+  angle = AngleNormalize180(angle);
+  if (angle >= 90.0) {
+    angle -= 180.0;
+  }
+  else if (angle < 0) {
+    angle = 90 + angle;
+  }
+  return angle;
+}
+
 /*
 ================
 AngleNormalize65536


### PR DESCRIPTION
Added acceleration values instead for etj_drawSpeed2, option "10".
Added color coding for speedometer based on current player accel values and optimal accel values: etj_speedColorUsesAccel "2".
Split some cgaz functions to calculate frame acceleration separately.