### PR TITLE
add func_portaltarget

### DIFF
--- a/src/game/g_mover.cpp
+++ b/src/game/g_mover.cpp
@@ -3816,6 +3816,17 @@ void SP_func_door_rotating(gentity_t *ent) {
   trap_LinkEntity(ent);
 }
 
+void SP_func_portaltarget(gentity_t* ent) {
+  trap_SetBrushModel(ent, ent->model);
+  
+  ent->moverState = MOVER_POS1;
+  ent->r.svFlags &= SVF_IGNOREBMODELEXTENTS;
+  ent->s.eType = ET_MOVER;
+
+  VectorCopy(ent->s.origin, ent->s.pos.trBase);
+  VectorCopy(ent->s.origin, ent->r.currentOrigin);
+}
+
 /*
 ===============================================================================
 

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -229,6 +229,7 @@ void SP_func_brushmodel(gentity_t *ent);
 void SP_misc_constructiblemarker(gentity_t *ent);
 void SP_target_explosion(gentity_t *ent);
 void SP_misc_landmine(gentity_t *ent);
+void SP_func_portaltarget(gentity_t *ent);
 
 void SP_trigger_always(gentity_t *ent);
 void SP_trigger_multiple(gentity_t *ent);
@@ -512,6 +513,8 @@ spawn_t spawns[] = {
     {"func_timer", SP_func_timer}, // rename trigger_timer?
 
     {"func_invisible_user", SP_func_invisible_user},
+
+    {"func_portaltarget", SP_func_portaltarget},
 
     // Triggers are brush objects that cause an effect when contacted
     // by a living player, usually involving firing targets.

--- a/src/game/g_weapon.cpp
+++ b/src/game/g_weapon.cpp
@@ -3626,7 +3626,8 @@ void Weapon_Portal_Fire(gentity_t *ent, int portalNumber) {
 
   vectoangles(tr.plane.normal, t_portalAngles);
 
-  if (tr.entityNum < MAX_GENTITIES &&
+  if (tr.entityNum != ENTITYNUM_WORLD &&
+      tr.entityNum < MAX_GENTITIES &&
       !Q_stricmp(g_entities[tr.entityNum].classname, "func_portaltarget")) {
 
     gentity_t *brushEnt = &g_entities[tr.entityNum];

--- a/src/game/g_weapon.cpp
+++ b/src/game/g_weapon.cpp
@@ -3578,6 +3578,7 @@ void Weapon_Portal_Fire(gentity_t *ent, int portalNumber) {
   vec3_t trace_start; // Actual trace start
   vec3_t trace_end;   // trace end point
   trace_t tr;         // trace results..
+  vec3_t tr_end;      // trace end adjusted for possible func_portaltarget
 
   // BBox info
   vec3_t t_portalAngles; // Could be used for all angles conversions...
@@ -3623,10 +3624,35 @@ void Weapon_Portal_Fire(gentity_t *ent, int portalNumber) {
     return;
   }
 
-  // Go ahead and calc new endpos just in case....
-  VectorMA(tr.endpos, 5, tr.plane.normal,
-           t_endpos); // Changed from 32..
   vectoangles(tr.plane.normal, t_portalAngles);
+
+  if (tr.entityNum < MAX_GENTITIES &&
+      !Q_stricmp(g_entities[tr.entityNum].classname, "func_portaltarget")) {
+
+    gentity_t *brushEnt = &g_entities[tr.entityNum];
+
+    vec3_t be_position; // brush ent position
+    vec3_t delta; // delta between brushent position and trace end
+    vec3_t normalScaled; // plane normal scaled by dotproduct of delta and itself
+
+    // use explicit origin if set, center of brush model otherwise
+    if (!VectorCompare(brushEnt->r.currentOrigin, vec3_origin)) {
+      VectorCopy(brushEnt->r.currentOrigin, be_position);
+    } else {
+      be_position[0] = (brushEnt->r.absmax[0] + brushEnt->r.absmin[0]) / 2;
+      be_position[1] = (brushEnt->r.absmax[1] + brushEnt->r.absmin[1]) / 2;
+      be_position[2] = (brushEnt->r.absmax[2] + brushEnt->r.absmin[2]) / 2;
+    }
+
+    VectorSubtract(be_position, tr.endpos, delta);
+    const float dotProduct = DotProduct(delta, tr.plane.normal);
+    VectorScale(tr.plane.normal, dotProduct, normalScaled);
+    VectorSubtract(be_position, normalScaled, tr_end);
+  } else {
+    VectorCopy(tr.endpos, tr_end);
+  }
+
+  VectorMA(tr_end, 5, tr.plane.normal, t_endpos);
 
   // check that portals aren't overlapping..
   if ((ent->portalBlue) || (ent->portalRed)) {
@@ -3635,7 +3661,7 @@ void Weapon_Portal_Fire(gentity_t *ent, int portalNumber) {
 
       if (Distance(t_portalAngles, ent->portalRed->s.angles) <
               MIN_ANGLES_DIFF &&
-          Distance(tr.endpos, ent->portalRed->s.origin) < MIN_PORTALS_DIST) {
+          Distance(tr_end, ent->portalRed->s.origin) < MIN_PORTALS_DIST) {
         return;
       }
 
@@ -3643,7 +3669,7 @@ void Weapon_Portal_Fire(gentity_t *ent, int portalNumber) {
 
       if (Distance(t_portalAngles, ent->portalBlue->s.angles) <
               MIN_ANGLES_DIFF &&
-          Distance(tr.endpos, ent->portalBlue->s.origin) < MIN_PORTALS_DIST) {
+          Distance(tr_end, ent->portalBlue->s.origin) < MIN_PORTALS_DIST) {
         return;
       }
     }
@@ -3668,8 +3694,8 @@ void Weapon_Portal_Fire(gentity_t *ent, int portalNumber) {
   portalNumber == 1 ? VectorCopy(blueTrail, tent->s.angles)
                     : VectorCopy(redTrail, tent->s.angles);
 
-  SnapVectorTowards(tr.endpos, start);
-  VectorCopy(tr.endpos, tent->s.origin2);
+  SnapVectorTowards(tr_end, start);
+  VectorCopy(tr_end, tent->s.origin2);
   tent->s.otherEntityNum2 = ent->s.number;
   // END - Rail
 


### PR DESCRIPTION
like func_static, stands there doing nothing. portals that would spawn on this brush always spawn in the center of the bmodel, or using explicit origin brush if set. requires surfaceparm/worldspawn combination for portal surfaces, just like any other brush.