### PR TITLE
add grenade support for target_give

### DIFF
--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -1873,6 +1873,9 @@ weapon_t BG_WeaponForMOD(int MOD);
 qboolean BG_WeaponInWolfMP(int weapon);
 qboolean BG_PlayerTouchesItem(playerState_t *ps, entityState_t *item,
                               int atTime);
+int BG_GrenadesForClass(int cls, int *skills);
+weapon_t BG_GrenadeTypeForTeam(team_t team);
+
 qboolean BG_PlayerSeesItem(playerState_t *ps, entityState_t *item, int atTime);
 qboolean BG_CheckMagicAmmo(const playerState_t *ps, int *skill, int teamNum);
 qboolean BG_AddMagicAmmo(playerState_t *ps, int *skill, int teamNum,


### PR DESCRIPTION
weapon_grenadelauncher and weapon_grenadepineapple, for axis and allies respectively.

can be used through target_give or directly

nades, unlike other weapons, respect the max ammo limitations of each class. use "count" key on entity to add multiple nades at once