### PR TITLE
Fix crash when cooked grenade was removed by init or starttimer

### DIFF
--- a/src/game/etj_target_init.cpp
+++ b/src/game/etj_target_init.cpp
@@ -131,6 +131,8 @@ void TargetInit::use(gentity_t *self, gentity_t *other, gentity_t *activator) {
         activator->client->ps.weapon = WP_KNIFE;
       }
     }
+
+    activator->client->ps.grenadeTimeLeft = 0;
   }
 }
 } // namespace ETJump

--- a/src/game/etj_utilities.cpp
+++ b/src/game/etj_utilities.cpp
@@ -154,11 +154,14 @@ static char *BuildOSPath(const char *file) {
 
 void Utilities::RemovePlayerWeapons(int clientNum) {
   auto *cl = (g_entities + clientNum)->client;
-  for (auto i = 0; i < WP_NUM_WEAPONS; i++) {
+
+  for (int i = 0; i < WP_NUM_WEAPONS; i++) {
     if (BG_WeaponDisallowedInTimeruns(i)) {
       COM_BitClear(cl->ps.weapons, i);
     }
   }
+
+  cl->ps.grenadeTimeLeft = 0;
 }
 
 bool Utilities::inNoNoclipArea(gentity_t *ent) {


### PR DESCRIPTION
`ps.grenadeTimeLeft` wasn't reset when a client started a timerun or activated `target_init` with `REMOVE_STARTING_WEAPONS`, causing a crash with invalid grenade weapon ID when dying as it would try to drop a non-existent grenade.