### PR TITLE
Fix chat mentions breaking chat coloring

### DIFF
--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -972,14 +972,16 @@ void setPlayerOffset(gentity_t *ent) {
     dst[i] += Numeric::clamp(value, -MaxAxisOffset, MaxAxisOffset);
   }
 
-  // check if there is a non-noclippable content between our position and current target
+  // check if there is a non-noclippable content between our position and
+  // current target
   trace_t trace;
   trap_TraceCapsule(&trace, ent->client->ps.origin, ent->client->ps.mins,
-                  ent->client->ps.maxs, dst, ent->client->ps.clientNum,
-                  CONTENTS_NONOCLIP);
+                    ent->client->ps.maxs, dst, ent->client->ps.clientNum,
+                    CONTENTS_NONOCLIP);
 
   if (level.noNoclip == (trace.fraction == 1.0f)) {
-    Printer::SendConsoleMessage(clientNum, "^7You cannot ^3setoffset ^7to this area.\n");
+    Printer::SendConsoleMessage(clientNum,
+                                "^7You cannot ^3setoffset ^7to this area.\n");
     return;
   }
 
@@ -2136,7 +2138,7 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
   escapedName = EscapeString(name);
 
   if (g_chatOptions.integer & CHAT_OPTIONS_INTERPOLATE_NAME_TAGS) {
-    printText = interpolateNametags(text);
+    printText = interpolateNametags(text, color);
   }
 
   if (target) {

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2879,7 +2879,7 @@ void C_ChatPrintTo(gentity_t *target, const char *msg);
 void C_ConsolePrintAll(const char *msg);
 void C_ConsolePrintTo(gentity_t *target, const char *msg);
 const char *EscapeString(const char *in);
-const char *interpolateNametags(const char *text);
+const char *interpolateNametags(const char *text, const int color);
 const char *findAndReplaceNametags(const char *text, const char *name);
 
 // Returns clientnum from ent

--- a/src/game/g_utilities.cpp
+++ b/src/game/g_utilities.cpp
@@ -619,7 +619,7 @@ std::vector<int> getMatchingIds(const std::string &name) {
   return pidsVector;
 }
 
-std::string interpolateNametags(std::string input) {
+std::string interpolateNametags(std::string input, const int color) {
   std::string interpolated;
   std::vector<std::string> split = ETJump::StringUtil::split(input, "@");
 
@@ -627,17 +627,22 @@ std::string interpolateNametags(std::string input) {
     return input;
   }
 
-  auto i = 1;
-  auto len = 0;
-  for (len = split.size(); i < len; i += 2) {
+  int i = 1;
+  int len;
+  std::string colorCode = "^";
+  colorCode += static_cast<char>(color);
+
+  for (len = static_cast<int>(split.size()); i < len; i += 2) {
     interpolated += split[i - 1];
 
-    if (split[i].length() == 0) {
+    if (split[i].empty()) {
       interpolated += "@";
     } else {
       auto names = getNames(getMatchingIds(split[i]));
-      if (names.size() > 0) {
-        interpolated += "^7" + ETJump::StringUtil::join(names, "^2, ^7") + "^2";
+      if (!names.empty()) {
+        const std::string &splitStr = colorCode + ", ^7";
+        interpolated +=
+            "^7" + ETJump::StringUtil::join(names, splitStr) + colorCode;
       } else {
         interpolated += "@" + split[i] + "@";
       }
@@ -650,10 +655,10 @@ std::string interpolateNametags(std::string input) {
   return interpolated;
 }
 
-const char *interpolateNametags(const char *text) {
+const char *interpolateNametags(const char *text, const int color) {
   static char buf[MAX_SAY_TEXT] = "\0";
 
-  auto interpolated = interpolateNametags(std::string(text));
+  auto interpolated = interpolateNametags(std::string(text), color);
 
   Q_strncpyz(buf, interpolated.c_str(), sizeof(buf));
   return buf;


### PR DESCRIPTION
All mentions transformed the rest of the chat to global chat color, regardless if the chat was global, team or fireteam chat.

Fixes #1193 