### PR TITLE
Make static coronas client side only

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -4632,6 +4632,13 @@ void CG_DrawMiscGamemodels(void) {
   }
 }
 
+void CG_DrawCoronas() {
+  for (int i = 0; i < cg.numCoronas; i++) {
+    centity_t *corona = &cgs.coronas[i];
+    CG_Corona(corona);
+  }
+}
+
 void SetFov(float fov) {
   char buf[16];
 
@@ -4774,6 +4781,8 @@ void CG_DrawActive(stereoFrame_t stereoView) {
 
   // Gordon
   CG_DrawMiscGamemodels();
+
+  CG_DrawCoronas();
 
   if (!(cg.limboEndCinematicTime > cg.time && cg.showGameView)) {
     for (int i = 0; i < MAX_RENDER_STRINGS; i++) {

--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -1431,7 +1431,7 @@ static void CG_Trap(centity_t *cent) {
 CG_Corona
 ==============
 */
-static void CG_Corona(centity_t *cent) {
+void CG_Corona(centity_t *cent) {
   trace_t tr;
   int r, g, b;
   int dli;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1098,6 +1098,7 @@ typedef struct {
   qboolean mapcoordsValid;
 
   int numMiscGameModels;
+  int numCoronas;
 
   qboolean showCampaignBriefing;
   qboolean showGameView;
@@ -1877,6 +1878,7 @@ typedef struct {
 #define MAX_COMMAND_INFO MAX_CLIENTS
 
 #define MAX_STATIC_GAMEMODELS 1024
+constexpr int MAX_STATIC_CORONAS = 1024;
 
 typedef struct cg_gamemodel_s {
   qhandle_t model;
@@ -2116,6 +2118,7 @@ typedef struct {
   int thirdpersonUpdate;
 
   cg_gamemodel_t miscGameModels[MAX_STATIC_GAMEMODELS];
+  centity_t coronas[MAX_STATIC_CORONAS];
 
   vec2_t ccMenuPos;
   qboolean ccMenuShowing;
@@ -3065,6 +3068,7 @@ void CG_PositionEntityOnTag(refEntity_t *entity, const refEntity_t *parent,
 void CG_PositionRotatedEntityOnTag(refEntity_t *entity,
                                    const refEntity_t *parent,
                                    const char *tagName);
+void CG_Corona(centity_t *cent);
 
 //
 // cg_weapons.c

--- a/src/cgame/cg_spawn.cpp
+++ b/src/cgame/cg_spawn.cpp
@@ -201,8 +201,16 @@ void SP_corona() {
     CG_Error("SP_Corona: MAX_STATIC_CORONAS (%i) exceeded", MAX_STATIC_CORONAS);
   }
 
-  centity_t *corona = &cgs.coronas[cg.numCoronas++];
+  centity_t *corona = &cgs.coronas[cg.numCoronas];
+
+  // this does not need to be the actual entity number,
+  // it just needs to be unique per corona for portal camera drawing
+  // realistically this might break if static and non-static coronas are
+  // in the same portal scene but that is a minor inconvenience
+  // as opposed to the benefit of freeing these from the server
   corona->currentState.number = cg.numCoronas;
+  cg.numCoronas++;
+
   corona->currentState.eType = ET_CORONA;
 
   vec3_t origin{};

--- a/src/cgame/cg_spawn.cpp
+++ b/src/cgame/cg_spawn.cpp
@@ -188,6 +188,45 @@ void SP_misc_gamemodel(void) {
   }
 }
 
+void SP_corona() {
+  char *tmp;
+
+  // server-side coronas
+  if (CG_SpawnString("targetname", "", &tmp) ||
+      CG_SpawnString("spawnflags", "", &tmp)) {
+    return;
+  }
+
+  if (cg.numCoronas >= MAX_STATIC_CORONAS) {
+    CG_Error("SP_Corona: MAX_STATIC_CORONAS (%i) exceeded", MAX_STATIC_CORONAS);
+  }
+
+  centity_t *corona = &cgs.coronas[cg.numCoronas++];
+  corona->currentState.number = cg.numCoronas;
+  corona->currentState.eType = ET_CORONA;
+
+  vec3_t origin{};
+  CG_SpawnVector("origin", "", origin);
+  VectorCopy(origin, corona->lerpOrigin);
+
+  vec3_t color = {1.0f, 1.0f, 1.0f}; // default to white
+
+  // both 'color' and '_color' are valid keys
+  if (!CG_SpawnVector("color", "", color)) {
+    CG_SpawnVector("_color", "", color);
+  }
+
+  VectorScale(color, 255, color);
+
+  corona->currentState.dl_intensity =
+      ((static_cast<int>(color[0])) | (static_cast<int>(color[1]) << 8) |
+       (static_cast<int>(color[2]) << 16));
+
+  float scale;
+  CG_SpawnFloat("scale", "1", &scale);
+  corona->currentState.density = static_cast<int>(scale * 255);
+}
+
 void SP_trigger_objective_info(void) {
   char *temp;
 
@@ -213,6 +252,7 @@ spawn_t spawns[] = {
 
     {"trigger_objective_info", SP_trigger_objective_info},
     {"misc_gamemodel", SP_misc_gamemodel},
+    {"corona", SP_corona},
 };
 
 #define NUMSPAWNS (sizeof(spawns) / sizeof(spawn_t))

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -1442,6 +1442,12 @@ SP_corona
 void SP_corona(gentity_t *ent) {
   float scale;
 
+  // static corona, handle on client side only
+  if (!ent->targetname && !ent->spawnflags) {
+    G_FreeEntity(ent);
+    return;
+  }
+
   ent->s.eType = ET_CORONA;
 
   if (ent->dl_color[0] <= 0 && // if it's black or has no color assigned


### PR DESCRIPTION
Free up coronas that are static from the server so they won't take up entity slots, and handle them client side only.

refs #201 