### PR TITLE
Fix comment on entitystate number bits

### DIFF
--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -1678,7 +1678,7 @@ typedef enum {
 
 // actual communicated field sizes (msg.c)
 
-// number                  not communicated?
+// number                  10 (GENTITYNUM_BITS)
 // eType                   8
 // eFlags                  24
 // pos.trType              8


### PR DESCRIPTION
Gets communicated as `GENTITYNUM_BITS`.