### PR TITLE
add mapscript support for trackers

### DIFF
--- a/src/game/etj_progression_tracker.cpp
+++ b/src/game/etj_progression_tracker.cpp
@@ -190,11 +190,11 @@ void ETJump::ProgressionTrackers::useTracker(
       }
     }
 
-    PrintTrackerChanges(activator, oldValues);
+    printTrackerChanges(activator, oldValues);
   }
 }
 
-void ETJump::ProgressionTrackers::PrintTrackerChanges(gentity_t *activator,
+void ETJump::ProgressionTrackers::printTrackerChanges(gentity_t *activator,
                                                       int *oldValues) {
   if (g_debugTrackers.integer <= 0) {
     return;
@@ -204,10 +204,7 @@ void ETJump::ProgressionTrackers::PrintTrackerChanges(gentity_t *activator,
   for (int i = 0; i < MaxProgressionTrackers; i++) {
     if (oldValues[i] != activator->client->sess.progression[i]) {
       const std::string &trackerChangeMsg = stringFormat(
-          "^7Tracker change - "
-          "index: ^3%i "
-          "^7value: ^2%i "
-          "^7from: ^9%i^7\n",
+          "^7Tracker change - index: ^3%i ^7value: ^2%i ^7from: ^9%i^7\n",
           i + 1, activator->client->sess.progression[i], oldValues[i]);
       Printer::SendPopupMessage(clientNum, trackerChangeMsg);
     }

--- a/src/game/etj_progression_tracker.cpp
+++ b/src/game/etj_progression_tracker.cpp
@@ -190,20 +190,26 @@ void ETJump::ProgressionTrackers::useTracker(
       }
     }
 
-    if (g_debugTrackers.integer > 0) {
-      const auto clientNum = ClientNum(activator);
+    PrintTrackerChanges(activator, oldValues);
+  }
+}
 
-      for (int i = 0; i < MaxProgressionTrackers; i++) {
-        if (oldValues[i] != activator->client->sess.progression[i]) {
-          std::string trackerChangeMsg = stringFormat(
-              "^7Tracker change - "
-              "index: ^3%i "
-              "^7value: ^2%i "
-              "^7from: ^9%i^7\n",
-              i + 1, activator->client->sess.progression[i], oldValues[i]);
-          Printer::SendPopupMessage(clientNum, trackerChangeMsg);
-        }
-      }
+void ETJump::ProgressionTrackers::PrintTrackerChanges(gentity_t *activator,
+                                                      int *oldValues) {
+  if (g_debugTrackers.integer <= 0) {
+    return;
+  }
+  const auto clientNum = ClientNum(activator);
+
+  for (int i = 0; i < MaxProgressionTrackers; i++) {
+    if (oldValues[i] != activator->client->sess.progression[i]) {
+      const std::string &trackerChangeMsg = stringFormat(
+          "^7Tracker change - "
+          "index: ^3%i "
+          "^7value: ^2%i "
+          "^7from: ^9%i^7\n",
+          i + 1, activator->client->sess.progression[i], oldValues[i]);
+      Printer::SendPopupMessage(clientNum, trackerChangeMsg);
     }
   }
 }

--- a/src/game/etj_progression_tracker.h
+++ b/src/game/etj_progression_tracker.h
@@ -51,7 +51,7 @@ public:
 
   static const int MaxProgressionTrackers = 50;
   static ETJump::ProgressionTrackers::ProgressionTrackerKeys ParseTrackerKeys();
-  static void PrintTrackerChanges(gentity_t *activator, int *oldValues);
+  static void printTrackerChanges(gentity_t *activator, int *oldValues);
 
   struct ProgressionTracker {
     ProgressionTracker() {

--- a/src/game/etj_progression_tracker.h
+++ b/src/game/etj_progression_tracker.h
@@ -51,6 +51,7 @@ public:
 
   static const int MaxProgressionTrackers = 50;
   static ETJump::ProgressionTrackers::ProgressionTrackerKeys ParseTrackerKeys();
+  static void PrintTrackerChanges(gentity_t *activator, int *oldValues);
 
   struct ProgressionTracker {
     ProgressionTracker() {

--- a/src/game/g_script.cpp
+++ b/src/game/g_script.cpp
@@ -124,6 +124,8 @@ qboolean G_ScriptAction_Create(gentity_t *ent, char *params);
 
 qboolean G_ScriptAction_Announce_Private(gentity_t *ent, char *params);
 
+qboolean G_ScriptAction_Tracker(gentity_t *ent, char *params);
+
 // these are the actions that each event can call
 g_script_stack_action_t gScriptActions[] = {
     {"gotomarker", G_ScriptAction_GotoMarker},
@@ -237,6 +239,7 @@ g_script_stack_action_t gScriptActions[] = {
     {"constructible_duration", G_ScriptAction_ConstructibleDuration},
 
     {"wm_announce_private", G_ScriptAction_Announce_Private},
+    {"tracker", G_ScriptAction_Tracker},
     {nullptr, nullptr}};
 
 qboolean G_Script_EventMatch_StringEqual(g_script_event_t *event,

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -4540,7 +4540,7 @@ qboolean G_ScriptAction_Tracker(gentity_t *ent, char *params) {
 
     if (trackerIndex < 0 || trackerIndex >= MAX_PROGRESSION_TRACKERS) {
       G_Error("G_ScriptAction_Tracker: parsed tracker index (%i) is outside "
-              "range (0 - %i)\n",
+              "range (1 - %i)\n",
               trackerIndex + 1, MAX_PROGRESSION_TRACKERS);
     }
 
@@ -4556,7 +4556,8 @@ qboolean G_ScriptAction_Tracker(gentity_t *ent, char *params) {
   token = COM_ParseExt(&pString, qfalse);
 
   if (!token[0]) {
-    G_Error("G_ScriptAction_Tracker: tracker %s requires a value\n", command);
+    G_Error("G_ScriptAction_Tracker: tracker commands require a value\n",
+            command);
   }
 
   const int trackerValue = Q_atoi(token);
@@ -4594,7 +4595,7 @@ qboolean G_ScriptAction_Tracker(gentity_t *ent, char *params) {
       ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
   }
 
-  ETJump::ProgressionTrackers::PrintTrackerChanges(activator, oldValues);
+  ETJump::ProgressionTrackers::printTrackerChanges(activator, oldValues);
 
   return qtrue;
 }

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -4520,17 +4520,26 @@ qboolean G_ScriptAction_Tracker(gentity_t *ent, char *params) {
 
   token = COM_ParseExt(&pString, qfalse);
   if (!token[0]) {
-    G_Error("G_ScriptAction_Tracker: tracker without an index\n");
+    G_Error("G_ScriptAction_Tracker: tracker without an index/command\n");
   }
 
-  // trackers are 1 indexed in user code
-  const int trackerIndex = Q_atoi(token) - 1;
-  if (trackerIndex < 0 || trackerIndex >= MAX_PROGRESSION_TRACKERS) {
-    G_Error("G_ScriptAction_Tracker: tracker index (%i) is outside range (0 - %i)\n",
-      trackerIndex + 1, MAX_PROGRESSION_TRACKERS);
+  int trackerIndex = 0;
+
+  // if index is omitted, token is the command
+  if (Q_isnumeric(token[0])) {
+    // trackers are 1 indexed in user code
+    trackerIndex = Q_atoi(token) - 1;
+
+    if (trackerIndex < 0 || trackerIndex >= MAX_PROGRESSION_TRACKERS) {
+      G_Error("G_ScriptAction_Tracker: parsed tracker index (%i) is outside "
+              "range (0 - %i)\n",
+              trackerIndex + 1, MAX_PROGRESSION_TRACKERS);
+    }
+
+    // parse next arg as command instead
+    token = COM_ParseExt(&pString, qfalse);
   }
 
-  token = COM_ParseExt(&pString, qfalse);
   if (!token[0]) {
     G_Error("G_ScriptAction_Tracker: tracker without a command\n");
   }

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -10,6 +10,7 @@
 #include "../game/q_shared.h"
 #include "etj_printer.h"
 #include "etj_string_utilities.h"
+#include "etj_progression_tracker.h"
 
 /*
 Contains the code to handle the various commands available with an event script.
@@ -4513,6 +4514,13 @@ qboolean G_ScriptAction_Tracker(gentity_t *ent, char *params) {
 
   const auto progression = activator->client->sess.progression;
 
+  // keep track of old values for debug print
+  int oldValues[MAX_PROGRESSION_TRACKERS];
+
+  if (g_debugTrackers.integer > 0) {
+    memcpy(oldValues, progression, sizeof(oldValues));
+  }
+
   const char *pString, *token;
   char command[MAX_QPATH];
 
@@ -4585,4 +4593,8 @@ qboolean G_ScriptAction_Tracker(gentity_t *ent, char *params) {
     ent->scriptStatus.scriptStackHead =
       ent->scriptEvents[ent->scriptStatus.scriptEventIndex].stack.numItems;
   }
+
+  ETJump::ProgressionTrackers::PrintTrackerChanges(activator, oldValues);
+
+  return qtrue;
 }


### PR DESCRIPTION
syntax: tracker [index (optional)] [command] [value]

available commands:
inc
abort_if_less_than
abort_if_greater_than
abort_if_not_equal
abort_if_equal
bitset
bitreset
abort_if_bitset
abort_if_not_bitset
set

examples:
`tracker inc 1`
`tracker 2 abort_if_equal 2`
`tracker 7 bitset 2`