### PR TITLE
Add basic demo compatibility checker + fix client-only coronas on old demos

### DIFF
--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(cgame MODULE
 	"etj_cvar_master_drawer.cpp"
 	"etj_cvar_shadow.cpp"
 	"etj_cvar_update_handler.cpp"
+	"etj_demo_compatibility.cpp"
 	"etj_demo_recorder.cpp"
 	"etj_draw_leaves_handler.cpp"
 	"etj_drawable.cpp"

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -10,6 +10,7 @@
 #include "../game/etj_numeric_utilities.h"
 #include "../game/etj_string_utilities.h"
 #include "etj_client_rtv_handler.h"
+#include "etj_demo_compatibility.h"
 
 #define STATUSBARHEIGHT 452
 char *BindingFromName(const char *cvar);
@@ -4633,6 +4634,10 @@ void CG_DrawMiscGamemodels(void) {
 }
 
 void CG_DrawCoronas() {
+  if (cg.demoPlayback && !ETJump::demoCompatibility->isCompatible("3.1.2")) {
+    return;
+  }
+
   for (int i = 0; i < cg.numCoronas; i++) {
     centity_t *corona = &cgs.coronas[i];
     CG_Corona(corona);

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -4634,7 +4634,10 @@ void CG_DrawMiscGamemodels(void) {
 }
 
 void CG_DrawCoronas() {
-  if (cg.demoPlayback && !ETJump::demoCompatibility->isCompatible("3.1.2")) {
+  static bool clientSideCoronas =
+      ETJump::demoCompatibility->isCompatible("3.1.2");
+
+  if (cg.demoPlayback && !clientSideCoronas) {
     return;
   }
 

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -4635,7 +4635,7 @@ void CG_DrawMiscGamemodels(void) {
 
 void CG_DrawCoronas() {
   static bool clientSideCoronas =
-      ETJump::demoCompatibility->isCompatible("3.1.2");
+      ETJump::demoCompatibility->isCompatible({3, 1, 2});
 
   if (cg.demoPlayback && !clientSideCoronas) {
     return;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4205,6 +4205,7 @@ class PlayerEventsHandler;
 class PmoveUtils;
 class CvarShadow;
 class ClientRtvHandler;
+class DemoCompatibility;
 
 extern std::shared_ptr<ClientCommandsHandler> serverCommandsHandler;
 extern std::shared_ptr<ClientCommandsHandler> consoleCommandsHandler;
@@ -4217,6 +4218,7 @@ extern std::shared_ptr<AutoDemoRecorder> autoDemoRecorder;
 extern std::shared_ptr<EventLoop> eventLoop;
 extern std::shared_ptr<PlayerEventsHandler> playerEventsHandler;
 extern std::shared_ptr<ClientRtvHandler> rtvHandler;
+extern std::shared_ptr<DemoCompatibility> demoCompatibility;
 
 void addRealLoopingSound(const vec3_t origin, const vec3_t velocity,
                          sfxHandle_t sfx, int range, int volume, int soundTime);

--- a/src/cgame/etj_demo_compatibility.cpp
+++ b/src/cgame/etj_demo_compatibility.cpp
@@ -29,7 +29,11 @@
 #include "../game/etj_string_utilities.h"
 
 namespace ETJump {
-DemoCompatibility::DemoCompatibility() { parseDemoVersion(); }
+DemoCompatibility::DemoCompatibility() {
+  if (cg.demoPlayback) {
+    parseDemoVersion();
+  }
+}
 
 void DemoCompatibility::parseDemoVersion() {
   const char *serverInfoCS = CG_ConfigString(CS_SERVERINFO);

--- a/src/cgame/etj_demo_compatibility.cpp
+++ b/src/cgame/etj_demo_compatibility.cpp
@@ -81,10 +81,7 @@ void DemoCompatibility::fillVersionInfo(Version *version,
   version->patch = std::stoi(splits[2].substr(0, 1));
 }
 
-bool DemoCompatibility::isCompatible(const std::string &minimumVersion) const {
-  Version minimum;
-  fillVersionInfo(&minimum, minimumVersion, ".");
-
+bool DemoCompatibility::isCompatible(Version minimum) const {
   // parsing failed
   if (!minimum.major && !minimum.minor && !minimum.patch) {
     return false;

--- a/src/cgame/etj_demo_compatibility.cpp
+++ b/src/cgame/etj_demo_compatibility.cpp
@@ -82,11 +82,6 @@ void DemoCompatibility::fillVersionInfo(Version *version,
 }
 
 bool DemoCompatibility::isCompatible(Version minimum) const {
-  // parsing failed
-  if (!minimum.major && !minimum.minor && !minimum.patch) {
-    return false;
-  }
-
   if (demoVersion.major != minimum.major) {
     return demoVersion.major > minimum.major;
   }

--- a/src/cgame/etj_demo_compatibility.cpp
+++ b/src/cgame/etj_demo_compatibility.cpp
@@ -1,0 +1,103 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <string>
+
+#include "etj_demo_compatibility.h"
+#include "cg_local.h"
+#include "../game/etj_string_utilities.h"
+
+namespace ETJump {
+DemoCompatibility::DemoCompatibility() { parseDemoVersion(); }
+
+void DemoCompatibility::parseDemoVersion() {
+  const char *serverInfoCS = CG_ConfigString(CS_SERVERINFO);
+  std::string versionStr = Info_ValueForKey(serverInfoCS, "mod_version");
+
+  // mod_version is present from '2.0.3 Alpha' onwards
+  // if not present, look for sv_referencedPakNames as a fallback
+  if (!versionStr.empty()) {
+    fillVersionInfo(&demoVersion, versionStr, ".");
+  } else {
+    const char *sysInfoCS = CG_ConfigString(CS_SYSTEMINFO);
+    const char *pakNames = Info_ValueForKey(sysInfoCS, "sv_referencedPakNames");
+    versionStr = std::strchr(pakNames, '/'); // etjump/...
+
+    size_t idx = std::string::npos;
+
+    for (size_t i = 0; i < versionStr.length(); i++) {
+      if (Q_isnumeric(versionStr[i])) {
+        idx = i;
+        break;
+      }
+    }
+
+    // parsing failed, bail
+    if (idx == std::string::npos) {
+      return;
+    }
+
+    versionStr.erase(0, idx);
+
+    // pre 2.4.0 used '_' in pk3 name as delimiter
+    fillVersionInfo(&demoVersion, versionStr, "_");
+  }
+}
+
+void DemoCompatibility::fillVersionInfo(Version *version,
+                                        const std::string &versionStr,
+                                        const std::string &delimiter) {
+  const auto splits = StringUtil::split(versionStr, delimiter);
+
+  // bail if we have some weird version without at least 3 digits
+  if (splits.size() < 3) {
+    CG_Printf("^3WARNING: could not parse version compatibility info!\n");
+    return;
+  }
+
+  version->major = std::stoi(splits[0].substr(0, 1));
+  version->minor = std::stoi(splits[1].substr(0, 1));
+  version->patch = std::stoi(splits[2].substr(0, 1));
+}
+
+bool DemoCompatibility::isCompatible(const std::string &minimumVersion) const {
+  Version minimum;
+  fillVersionInfo(&minimum, minimumVersion, ".");
+
+  // parsing failed
+  if (!minimum.major && !minimum.minor && !minimum.patch) {
+    return false;
+  }
+
+  if (demoVersion.major != minimum.major) {
+    return demoVersion.major > minimum.major;
+  }
+
+  if (demoVersion.minor != minimum.minor) {
+    return demoVersion.minor > minimum.minor;
+  }
+
+  return demoVersion.patch >= minimum.patch;
+}
+} // namespace ETJump

--- a/src/cgame/etj_demo_compatibility.h
+++ b/src/cgame/etj_demo_compatibility.h
@@ -26,23 +26,23 @@
 
 namespace ETJump {
 class DemoCompatibility {
-public:
   struct Version {
     int major;
     int minor;
     int patch;
   };
-  DemoCompatibility();
-  ~DemoCompatibility() = default;
 
-  // returns true if the demo version is newer or same as minimumVersion
-  bool isCompatible(Version minimum) const;
-
-private:
   void parseDemoVersion();
   static void fillVersionInfo(Version *version, const std::string &versionStr,
                               const std::string &delimiter);
 
   Version demoVersion{};
+
+public:
+  DemoCompatibility();
+  ~DemoCompatibility() = default;
+
+  // returns true if the demo version is newer or same as minimumVersion
+  bool isCompatible(Version minimum) const;
 };
 } // namespace ETJump

--- a/src/cgame/etj_demo_compatibility.h
+++ b/src/cgame/etj_demo_compatibility.h
@@ -26,24 +26,23 @@
 
 namespace ETJump {
 class DemoCompatibility {
+public:
   struct Version {
-    Version() : major(0), minor(0), patch(0) {}
     int major;
     int minor;
     int patch;
   };
-
-  void parseDemoVersion();
-  static void fillVersionInfo(Version *version, const std::string &versionStr,
-                              const std::string &delimiter);
-
-  Version demoVersion;
-
-public:
   DemoCompatibility();
   ~DemoCompatibility() = default;
 
   // returns true if the demo version is newer or same as minimumVersion
-  bool isCompatible(const std::string &minimumVersion) const;
+  bool isCompatible(Version minimum) const;
+
+private:
+  void parseDemoVersion();
+  static void fillVersionInfo(Version *version, const std::string &versionStr,
+                              const std::string &delimiter);
+
+  Version demoVersion{};
 };
 } // namespace ETJump

--- a/src/cgame/etj_demo_compatibility.h
+++ b/src/cgame/etj_demo_compatibility.h
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+namespace ETJump {
+class DemoCompatibility {
+  struct Version {
+    Version() : major(0), minor(0), patch(0) {}
+    int major;
+    int minor;
+    int patch;
+  };
+
+  void parseDemoVersion();
+  static void fillVersionInfo(Version *version, const std::string &versionStr,
+                              const std::string &delimiter);
+
+  Version demoVersion;
+
+public:
+  DemoCompatibility();
+  ~DemoCompatibility() = default;
+
+  // returns true if the demo version is newer or same as minimumVersion
+  bool isCompatible(const std::string &minimumVersion) const;
+};
+} // namespace ETJump

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -58,6 +58,7 @@
 #include "etj_rtv_drawable.h"
 #include "etj_client_rtv_handler.h"
 #include "etj_areaindicator_drawable.h"
+#include "etj_demo_compatibility.h"
 
 namespace ETJump {
 std::shared_ptr<ClientCommandsHandler> serverCommandsHandler;
@@ -79,6 +80,7 @@ std::shared_ptr<TimerunView> timerunView;
 std::shared_ptr<TrickjumpLines> trickjumpLines;
 std::shared_ptr<ClientRtvHandler> rtvHandler;
 std::shared_ptr<AreaIndicator> areaIndicator;
+std::shared_ptr<DemoCompatibility> demoCompatibility;
 } // namespace ETJump
 
 static bool isInitialized{false};
@@ -220,6 +222,8 @@ void init() {
 
   rtvHandler = std::make_shared<ClientRtvHandler>();
   rtvHandler->initialize();
+
+  demoCompatibility = std::make_shared<DemoCompatibility>();
 
   // initialize renderables
   // Overbounce watcher


### PR DESCRIPTION
Adds a basic demo playback compatibility checker. Currently supports parsing only `MAJOR.MINOR.PATCH` version, so some old versions we had (e.g. `-RC3`) will not be differentiated from the stable release. Also does not support git versions.