### PR TITLE
Fix rename issues

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -1574,6 +1574,20 @@ bool Rename(gentity_t *ent, Arguments argv) {
     return false;
   }
 
+  if (ent) {
+    if (IsTargetHigherLevel(ent, target, true)) {
+      if (ent != target) {
+        Printer::SendChatMessage(
+            ClientNum(ent), "^3rename: ^7you cannot rename a fellow admin.");
+        return false;
+      }
+    }
+
+    if (ent != target) {
+      target->client->forceRename = true;
+    }
+  }
+
   char userinfo[MAX_INFO_STRING] = "\0";
   int cn = ClientNum(target);
   trap_GetUserinfo(cn, userinfo, sizeof(userinfo));

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -1692,6 +1692,12 @@ static void ClientCleanName(const char *in, char *out, int outSize) {
 void G_NameChanged(gentity_t *ent) {
   gclient_t *client = ent->client;
 
+  // don't take away name change limits if an admin renamed us
+  if (client->forceRename) {
+    client->forceRename = false;
+    return;
+  }
+
   if (level.time >
       client->sess.lastNameChangeTime + (g_nameChangeInterval.integer) * 1000) {
     client->sess.nameChangeCount = 0;

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1161,6 +1161,9 @@ struct gclient_s {
 
   // Amount of portalgun portals shot since last reset
   int numPortals;
+
+  // true if name change was issues by someone using !rename command on us
+  bool forceRename;
 };
 
 typedef struct {


### PR DESCRIPTION
* `!rename` no longer works on admins that are same level/higher than you
* `!rename` no longer reduces name change limit (unless used on yourself)

fixes #1158 