### PR TITLE
Fix rtv with no args + !rtv [list] command

### DIFF
--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -2846,7 +2846,13 @@ static void CG_ServerCommand(void) {
 
   // for !rtv admin command
   if (!Q_stricmp(cmd, "callvote")) {
-    trap_SendConsoleCommand(va("%s %s", cmd, arguments[0].c_str()));
+    std::string command = va("%s %s", cmd, arguments[0].c_str());
+
+    if (arguments.size() > 1) {
+      command += " " + arguments[1];
+    }
+
+    trap_SendConsoleCommand(command.c_str());
     return;
   }
 

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -2220,7 +2220,13 @@ bool TimerunDeleteSeason(gentity_t *ent, Arguments argv) {
 }
 
 bool RockTheVote(gentity_t *ent, Arguments argv) {
-  trap_SendServerCommand(ClientNum(ent), "callvote rtv");
+  std::string cmd = "callvote rtv";
+
+  if (argv->size() > 1) {
+    cmd += " " + argv->at(1);
+  }
+
+  trap_SendServerCommand(ClientNum(ent), cmd.c_str());
   return true;
 }
 

--- a/src/game/g_vote.cpp
+++ b/src/game/g_vote.cpp
@@ -494,7 +494,7 @@ int G_RockTheVote_v(gentity_t *ent, unsigned dwVoteIndex, char *arg,
     int numMaps;
     const int clientNum = ClientNum(ent);
 
-    if (arg2) {
+    if (arg2[0]) {
       if (!CustomMapTypeExists(arg2)) {
         Printer::SendPopupMessage(
             clientNum,
@@ -539,7 +539,7 @@ int G_RockTheVote_v(gentity_t *ent, unsigned dwVoteIndex, char *arg,
         Printer::SendPopupMessage(
             clientNum, stringFormat("Sorry, calling [lof]^3%s^7[lon] with less "
                                     "than 3 maps on %s is not possible.",
-                                    arg, arg2 ? "a list" : "the server"));
+                                    arg, arg2[0] ? "a list" : "the server"));
       }
       return G_INVALID;
     }
@@ -559,7 +559,7 @@ int G_RockTheVote_v(gentity_t *ent, unsigned dwVoteIndex, char *arg,
     } else {
       while (uniqueMaps.size() <= maxMaps) {
         // neither of these functions ever return the current map
-        const char *map = arg2 ? GetRandomMapByType(arg2) : GetRandomMap();
+        const char *map = arg2[0] ? GetRandomMapByType(arg2) : GetRandomMap();
         uniqueMaps.insert(map);
       }
     }


### PR DESCRIPTION
`arg2` is always a valid pointer so checking for that alone doesn't work. Also forgot to handle `!rtv` command completely.

refs #1215 