### PR TITLE
Fix limbopanel button mouseovers on widescreen

### DIFF
--- a/src/cgame/cg_limbopanel.cpp
+++ b/src/cgame/cg_limbopanel.cpp
@@ -1207,31 +1207,31 @@ void CG_LimboPanel_ClassBar_Draw(panel_button_t *button) {
   char buffer[64];
   float w;
 
-  if (BG_CursorInRect(&medalPic0.rect)) {
+  if (BG_CursorInRectWide(&medalPic0.rect)) {
     text = skillNames[0];
-  } else if (BG_CursorInRect(&medalPic1.rect)) {
+  } else if (BG_CursorInRectWide(&medalPic1.rect)) {
     text = skillNames[1];
-  } else if (BG_CursorInRect(&medalPic2.rect)) {
+  } else if (BG_CursorInRectWide(&medalPic2.rect)) {
     text = skillNames[2];
-  } else if (BG_CursorInRect(&medalPic3.rect)) {
+  } else if (BG_CursorInRectWide(&medalPic3.rect)) {
     text = skillNames[3];
-  } else if (BG_CursorInRect(&medalPic4.rect)) {
+  } else if (BG_CursorInRectWide(&medalPic4.rect)) {
     text = skillNames[4];
-  } else if (BG_CursorInRect(&medalPic5.rect)) {
+  } else if (BG_CursorInRectWide(&medalPic5.rect)) {
     text = skillNames[5];
-  } else if (BG_CursorInRect(&medalPic6.rect)) {
+  } else if (BG_CursorInRectWide(&medalPic6.rect)) {
     text = skillNames[6];
   } else if (CG_LimboPanel_GetTeam() == TEAM_SPECTATOR) {
     text = "JOIN A TEAM";
-  } else if (BG_CursorInRect(&classButton0.rect)) {
+  } else if (BG_CursorInRectWide(&classButton0.rect)) {
     text = BG_ClassnameForNumber(0);
-  } else if (BG_CursorInRect(&classButton1.rect)) {
+  } else if (BG_CursorInRectWide(&classButton1.rect)) {
     text = BG_ClassnameForNumber(1);
-  } else if (BG_CursorInRect(&classButton2.rect)) {
+  } else if (BG_CursorInRectWide(&classButton2.rect)) {
     text = BG_ClassnameForNumber(2);
-  } else if (BG_CursorInRect(&classButton3.rect)) {
+  } else if (BG_CursorInRectWide(&classButton3.rect)) {
     text = BG_ClassnameForNumber(3);
-  } else if (BG_CursorInRect(&classButton4.rect)) {
+  } else if (BG_CursorInRectWide(&classButton4.rect)) {
     text = BG_ClassnameForNumber(4);
   }
 
@@ -1516,8 +1516,8 @@ void CG_LimboPanel_RenderLight(panel_button_t *button) {
     button->data[3] = button->data[3] ^ 1;
     //			if( button->data[3] ) {
     //				button->data[2] = cg.time + rand() %
-    // 200; 			} else { 				button->data[2] = cg.time +
-    // rand() % 1000;
+    // 200; 			} else {
+    // button->data[2] = cg.time + rand() % 1000;
     //			}
     //		}
 

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -7968,6 +7968,15 @@ qboolean BG_CursorInRect(rectDef_t *rect) {
                               DC->cursory);
 }
 
+// applies SCREEN_OFFSET_X to rect->x to compare cursor position
+// with widescreen corrected rect->x, used when you have to compare
+// widescreen corrected panel with the original rect
+qboolean BG_CursorInRectWide(rectDef_t *rect) {
+  return BG_RectContainsPoint(rect->x + SCREEN_OFFSET_X, rect->y, rect->w,
+                              rect->h, static_cast<float>(DC->cursorx),
+                              static_cast<float>(DC->cursory));
+}
+
 void BG_PanelButton_RenderEdit(panel_button_t *button) {
   qboolean useCvar = button->data[0] ? qfalse : qtrue;
   int offset = -1;

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -662,6 +662,7 @@ panel_button_t *BG_PanelButtons_GetFocusButton(void);
 qboolean BG_RectContainsPoint(float x, float y, float w, float h, float px,
                               float py);
 qboolean BG_CursorInRect(rectDef_t *rect);
+qboolean BG_CursorInRectWide(rectDef_t *rect);
 
 void BG_FitTextToWidth_Ext(char *instr, float scale, float w, int size,
                            fontInfo_t *font);


### PR DESCRIPTION
`CG_LimboPanel_ClassBar_Draw` compared cursor position to the original rectDef, which doesn't contain widescreen corrected coordinates obviously. Rather than having to get the correct button address from the panel buttons vector, this adds a convenience function `BG_CursorInRectWide` to get widescreen corrected results by passing the original rect in.

fixes #1087 