### PR TITLE
Fix potential nullptr dereference in demo compat checker

### DIFF
--- a/src/cgame/etj_demo_compatibility.cpp
+++ b/src/cgame/etj_demo_compatibility.cpp
@@ -46,8 +46,13 @@ void DemoCompatibility::parseDemoVersion() {
   } else {
     const char *sysInfoCS = CG_ConfigString(CS_SYSTEMINFO);
     const char *pakNames = Info_ValueForKey(sysInfoCS, "sv_referencedPakNames");
-    versionStr = std::strchr(pakNames, '/'); // etjump/...
 
+    // sanity check, shouldn't happen
+    if (pakNames == nullptr) {
+      return;
+    }
+
+    versionStr = std::strchr(pakNames, '/'); // etjump/...
     size_t idx = std::string::npos;
 
     for (size_t i = 0; i < versionStr.length(); i++) {


### PR DESCRIPTION
Shouldn't ever happen as `sv_referencedPakNames` should always be in `CS_SYSTEMINFO`, but just in case.

refs #1210 