### PR TITLE
mapscript entity key/value change fixes

### DIFF
--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -4357,7 +4357,7 @@ new ones
 qboolean etpro_ScriptAction_SetValues(gentity_t *ent, char *params) {
   const char *token, *p;
   char key[MAX_TOKEN_CHARS], value[MAX_TOKEN_CHARS];
-  int classchanged = 0;
+  bool classchanged = false;
 
   // rain - reset and fill in the spawnVars info so that spawn
   // functions can use them
@@ -4390,7 +4390,7 @@ qboolean etpro_ScriptAction_SetValues(gentity_t *ent, char *params) {
 
     if (!Q_stricmp(key, "classname")) {
       if (Q_stricmp(value, ent->classname)) {
-        classchanged = 1;
+        classchanged = true;
       }
     }
 
@@ -4417,7 +4417,9 @@ qboolean etpro_ScriptAction_SetValues(gentity_t *ent, char *params) {
 
   // rain - if the classname was changed, call the spawn func again
   if (classchanged) {
+    level.spawning = qtrue;
     G_CallSpawn(ent);
+    level.spawning = qfalse;
     trap_LinkEntity(ent);
   }
 

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -4358,6 +4358,7 @@ qboolean etpro_ScriptAction_SetValues(gentity_t *ent, char *params) {
   const char *token, *p;
   char key[MAX_TOKEN_CHARS], value[MAX_TOKEN_CHARS];
   bool classchanged = false;
+  bool nospawn = false;
 
   // rain - reset and fill in the spawnVars info so that spawn
   // functions can use them
@@ -4388,6 +4389,11 @@ qboolean etpro_ScriptAction_SetValues(gentity_t *ent, char *params) {
                ent->scriptName, GAME_VERSION, ent->scriptName, key, value);
     }
 
+    if (!Q_stricmp(key, "classname_nospawn")) {
+      Q_strncpyz(key, "classname", sizeof(key));
+      nospawn = true;
+    } 
+    
     if (!Q_stricmp(key, "classname")) {
       if (Q_stricmp(value, ent->classname)) {
         classchanged = true;
@@ -4422,9 +4428,12 @@ qboolean etpro_ScriptAction_SetValues(gentity_t *ent, char *params) {
 
   // rain - if the classname was changed, call the spawn func again
   if (classchanged) {
-    level.spawning = qtrue;
-    G_CallSpawn(ent);
-    level.spawning = qfalse;
+    if (!nospawn) {
+      level.spawning = qtrue;
+      G_CallSpawn(ent);
+      level.spawning = qfalse;
+    }
+
     trap_LinkEntity(ent);
   }
 

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -4404,6 +4404,11 @@ qboolean etpro_ScriptAction_SetValues(gentity_t *ent, char *params) {
 
     G_ParseField(key, value, ent);
 
+    if (!Q_stricmp(ent->classname, "trigger_objective_info") && !classchanged) {
+      G_Error("etpro_ScriptAction_SetValues: updating trigger_objective_info "
+              "is not supported\n");
+    }
+
     if (!Q_stricmp(key, "targetname")) {
       // need to hash this ent targetname for setstate script targets...
       ent->targetnamehash =


### PR DESCRIPTION
fix `classname` change crash
disallow updating `trigger_objective_info` from mapscript
allow changing entity type without calling spawn again via `classname_nospawn`