### PR TITLE
Fix client-side FPS dependencies

### DIFF
--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -44,7 +44,7 @@ typedef struct particle_s {
   int shaderAnim;
   int roll;
 
-  int accumroll;
+  float accumroll;
 
 } cparticle_t;
 
@@ -429,7 +429,7 @@ void CG_AddParticleToScene(cparticle_t *p, vec3_t org, float alpha) {
       vec3_t temp;
 
       vectoangles(rforward, temp);
-      p->accumroll += p->roll;
+      p->accumroll += p->roll * cg.frametime / 8.0f;
       temp[ROLL] += p->accumroll * 0.1;
       //			temp[ROLL] += p->roll *
       // 0.1;

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -369,7 +369,7 @@ void CG_KickAngles(void) {
   float idealCenterSpeed, kickChange;
   int i, frametime, t;
   float ft;
-#define STEP 20
+  constexpr int STEP = 3;
   char buf[32]; // NERVE - SMF
 
   // this code is frametime-dependant, so split it up into small chunks

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -3386,18 +3386,20 @@ void PM_CoolWeapons(void) {
     // if you have the weapon
     if (COM_BitCheck(pm->ps->weapons, wp)) {
       // and it's hot
-      if (pm->ps->weapHeat[wp]) {
+      if (pm->pmext->weapHeat[wp] != 0) {
         if (pm->skill[SK_HEAVY_WEAPONS] >= 2 &&
             pm->ps->stats[STAT_PLAYER_CLASS] == PC_SOLDIER) {
-          pm->ps->weapHeat[wp] -=
-              ((float)GetAmmoTableData(wp)->coolRate * 2.f * pml.frametime);
+          pm->pmext->weapHeat[wp] -=
+              static_cast<float>(GetAmmoTableData(wp)->coolRate) * 2.f *
+              pml.frametime;
         } else {
-          pm->ps->weapHeat[wp] -=
-              ((float)GetAmmoTableData(wp)->coolRate * pml.frametime);
+          pm->pmext->weapHeat[wp] -=
+              static_cast<float>(GetAmmoTableData(wp)->coolRate) *
+              pml.frametime;
         }
 
-        if (pm->ps->weapHeat[wp] < 0) {
-          pm->ps->weapHeat[wp] = 0;
+        if (pm->pmext->weapHeat[wp] < 0) {
+          pm->pmext->weapHeat[wp] = 0;
         }
       }
     }
@@ -3409,25 +3411,24 @@ void PM_CoolWeapons(void) {
     if (pm->ps->persistant[PERS_HWEAPON_USE] ||
         pm->ps->eFlags & EF_MOUNTEDTANK) {
       // rain - floor to prevent 8-bit wrap
-      pm->ps->curWeapHeat = floor(
-          (((float)pm->ps->weapHeat[WP_DUMMY_MG42] / MAX_MG42_HEAT)) * 255.0f);
+      pm->ps->curWeapHeat =
+          std::floor(((static_cast<float>(pm->pmext->weapHeat[WP_DUMMY_MG42]) /
+                       MAX_MG42_HEAT)) *
+                     255.0f);
     } else {
       // rain - #172 - don't divide by 0
       maxHeat = GetAmmoTableData(pm->ps->weapon)->maxHeat;
 
       // rain - floor to prevent 8-bit wrap
       if (maxHeat != 0) {
-        pm->ps->curWeapHeat =
-            floor((((float)pm->ps->weapHeat[pm->ps->weapon] / (float)maxHeat)) *
-                  255.0f);
+        pm->ps->curWeapHeat = std::floor(
+            ((static_cast<float>(pm->pmext->weapHeat[pm->ps->weapon]) /
+              static_cast<float>(maxHeat))) *
+            255.0f);
       } else {
         pm->ps->curWeapHeat = 0;
       }
     }
-
-    //		if(pm->ps->weapHeat[pm->ps->weapon])
-    //			Com_Printf("pm heat: %d, %d\n",
-    // pm->ps->weapHeat[pm->ps->weapon], pm->ps->curWeapHeat);
   }
 }
 
@@ -3754,17 +3755,18 @@ static void PM_Weapon(void) {
       // how it's wanted ( bleugh ) no cooldown on weaps
       // while using mg42, but need to update heat on
       // mg42 itself
-      if (pm->ps->weapHeat[WP_DUMMY_MG42]) {
-        pm->ps->weapHeat[WP_DUMMY_MG42] -= (300.f * pml.frametime);
+      if (pm->pmext->weapHeat[WP_DUMMY_MG42] != 9) {
+        pm->pmext->weapHeat[WP_DUMMY_MG42] -= (300.f * pml.frametime);
 
-        if (pm->ps->weapHeat[WP_DUMMY_MG42] < 0) {
-          pm->ps->weapHeat[WP_DUMMY_MG42] = 0;
+        if (pm->pmext->weapHeat[WP_DUMMY_MG42] < 0) {
+          pm->pmext->weapHeat[WP_DUMMY_MG42] = 0;
         }
 
         // rain - floor() to prevent 8-bit wrap
-        pm->ps->curWeapHeat =
-            floor((((float)pm->ps->weapHeat[WP_DUMMY_MG42] / MAX_MG42_HEAT)) *
-                  255.0f);
+        pm->ps->curWeapHeat = std::floor(
+            ((static_cast<float>(pm->pmext->weapHeat[WP_DUMMY_MG42]) /
+              MAX_MG42_HEAT)) *
+            255.0f);
       }
 
       if (pm->ps->weaponTime > 0) {
@@ -3781,9 +3783,9 @@ static void PM_Weapon(void) {
 
       if (pm->cmd.buttons & BUTTON_ATTACK) {
         if (PM_IsSinglePlayerGame()) {
-          pm->ps->weapHeat[WP_DUMMY_MG42] += MG42_RATE_OF_FIRE_SP;
+          pm->pmext->weapHeat[WP_DUMMY_MG42] += MG42_RATE_OF_FIRE_SP;
         } else {
-          pm->ps->weapHeat[WP_DUMMY_MG42] += MG42_RATE_OF_FIRE_MP;
+          pm->pmext->weapHeat[WP_DUMMY_MG42] += MG42_RATE_OF_FIRE_MP;
         }
 
         PM_AddEvent(EV_FIRE_WEAPON_MG42);
@@ -3799,7 +3801,7 @@ static void PM_Weapon(void) {
         pm->ps->viewlocked = 2; // this enable screen jitter when
                                 // firing
 
-        if (pm->ps->weapHeat[WP_DUMMY_MG42] >= MAX_MG42_HEAT) {
+        if (pm->pmext->weapHeat[WP_DUMMY_MG42] >= MAX_MG42_HEAT) {
           pm->ps->weaponTime = MAX_MG42_HEAT; // cap heat
                                               // to max
           PM_AddEvent(EV_WEAP_OVERHEAT);
@@ -3842,16 +3844,18 @@ static void PM_Weapon(void) {
     // it's wanted ( bleugh ) no cooldown on weaps while using
     // mg42, but need to update heat
     // on mg42 itself
-    if (pm->ps->weapHeat[WP_DUMMY_MG42]) {
-      pm->ps->weapHeat[WP_DUMMY_MG42] -= (300.f * pml.frametime);
+    if (pm->pmext->weapHeat[WP_DUMMY_MG42] != 0) {
+      pm->pmext->weapHeat[WP_DUMMY_MG42] -= (300.f * pml.frametime);
 
-      if (pm->ps->weapHeat[WP_DUMMY_MG42] < 0) {
-        pm->ps->weapHeat[WP_DUMMY_MG42] = 0;
+      if (pm->pmext->weapHeat[WP_DUMMY_MG42] < 0) {
+        pm->pmext->weapHeat[WP_DUMMY_MG42] = 0;
       }
 
       // rain - floor() to prevent 8-bit wrap
-      pm->ps->curWeapHeat = floor(
-          (((float)pm->ps->weapHeat[WP_DUMMY_MG42] / MAX_MG42_HEAT)) * 255.0f);
+      pm->ps->curWeapHeat =
+          std::floor(((static_cast<float>(pm->pmext->weapHeat[WP_DUMMY_MG42]) /
+                       MAX_MG42_HEAT)) *
+                     255.0f);
     }
 
     if (pm->ps->weaponTime > 0) {
@@ -3867,7 +3871,7 @@ static void PM_Weapon(void) {
     }
 
     if (pm->cmd.buttons & BUTTON_ATTACK) {
-      pm->ps->weapHeat[WP_DUMMY_MG42] += MG42_RATE_OF_FIRE_MP;
+      pm->pmext->weapHeat[WP_DUMMY_MG42] += MG42_RATE_OF_FIRE_MP;
 
       PM_AddEvent(EV_FIRE_WEAPON_MOUNTEDMG42);
 
@@ -3878,7 +3882,7 @@ static void PM_Weapon(void) {
       // pm->ps->viewlocked = 2;		// this
       // enable screen jitter when firing
 
-      if (pm->ps->weapHeat[WP_DUMMY_MG42] >= MAX_MG42_HEAT) {
+      if (pm->pmext->weapHeat[WP_DUMMY_MG42] >= MAX_MG42_HEAT) {
         pm->ps->weaponTime = MAX_MG42_HEAT; // cap heat to max
         PM_AddEvent(EV_WEAP_OVERHEAT);
         pm->ps->weaponTime = 2000; // force "heat recovery
@@ -4705,7 +4709,7 @@ static void PM_Weapon(void) {
 
   // add weapon heat
   if (GetAmmoTableData(pm->ps->weapon)->maxHeat) {
-    pm->ps->weapHeat[pm->ps->weapon] +=
+    pm->pmext->weapHeat[pm->ps->weapon] +=
         GetAmmoTableData(pm->ps->weapon)->nextShotTime;
   }
 
@@ -5049,11 +5053,11 @@ static void PM_Weapon(void) {
 
   // the weapon can overheat, and it's hot
   if (GetAmmoTableData(pm->ps->weapon)->maxHeat &&
-      pm->ps->weapHeat[pm->ps->weapon]) {
+      (pm->pmext->weapHeat[pm->ps->weapon] != 0)) {
     // it is overheating
-    if (pm->ps->weapHeat[pm->ps->weapon] >=
+    if (pm->pmext->weapHeat[pm->ps->weapon] >=
         GetAmmoTableData(pm->ps->weapon)->maxHeat) {
-      pm->ps->weapHeat[pm->ps->weapon] =
+      pm->pmext->weapHeat[pm->ps->weapon] =
           GetAmmoTableData(pm->ps->weapon)->maxHeat; // cap heat to max
       PM_AddEvent(EV_WEAP_OVERHEAT);
       //			PM_StartWeaponAnim(WEAP_IDLE1);

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -1724,7 +1724,7 @@ static void PM_DeadMove(void) {
   // extra friction
 
   forward = VectorLength(pm->ps->velocity);
-  forward -= 20;
+  forward -= 2500 * pml.frametime;
   if (forward <= 0) {
     VectorClear(pm->ps->velocity);
   } else {

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -623,6 +623,7 @@ typedef struct {
   int adrenalineTime;
 
   float weapHeat[MAX_WEAPONS]; // weapon heat, used to be in ps
+  float bobCycle;              // for fps-independent bobCycle
 } pmoveExt_t; // data used both in client and server - store it here
               // instead of playerstate to prevent different engine versions of
               // playerstate between XP and MP

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -621,6 +621,8 @@ typedef struct {
 
   // timestamp adrenaline should expire at
   int adrenalineTime;
+
+  float weapHeat[MAX_WEAPONS]; // weapon heat, used to be in ps
 } pmoveExt_t; // data used both in client and server - store it here
               // instead of playerstate to prevent different engine versions of
               // playerstate between XP and MP

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -568,7 +568,7 @@ typedef struct {
   int silencedSideArm; // Gordon: Keep track of whether the luger/colt
                        // is silenced "in holster", prolly want to do
                        // this for the kar98 etc too
-  int sprintTime;
+  float sprintTime;
 
   int airleft;
 
@@ -847,7 +847,6 @@ constexpr int EF_PLAYER_UNUSED5 = EF_PATH_LINK;       // used only on entities
 constexpr int EF_PLAYER_UNUSED6 = EF_SPARE0;          // used only on entities
 // clang-format on
 
-
 #define BG_PlayerMounted(eFlags)                                               \
   ((eFlags & EF_MG42_ACTIVE) || (eFlags & EF_MOUNTEDTANK) ||                   \
    (eFlags & EF_AAGUN_ACTIVE))
@@ -861,10 +860,10 @@ typedef enum {
 
   // (SA) for Wolf
   PW_INVULNERABLE,
-  PW_FIRE,      //----(SA)
+  PW_FIRE,          //----(SA)
   PW_PUSHERPREDICT, // used for pusher prediction, was PW_ELECTRIC
-  PW_BREATHER,  //----(SA)
-  PW_NOFATIGUE, //----(SA)
+  PW_BREATHER,      //----(SA)
+  PW_NOFATIGUE,     //----(SA)
 
   PW_REDFLAG,
   PW_BLUEFLAG,

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -3517,7 +3517,8 @@ qboolean Do_Activate_f(gentity_t *ent, gentity_t *traceEnt) {
       Q_strncpyz(ent->tagName, "tag_player", MAX_QPATH);
       ent->backupWeaponTime = ent->client->ps.weaponTime;
       ent->client->ps.weaponTime = traceEnt->backupWeaponTime;
-      ent->client->ps.weapHeat[WP_DUMMY_MG42] = traceEnt->mg42weapHeat;
+      ent->client->pmext.weapHeat[WP_DUMMY_MG42] =
+          static_cast<float>(traceEnt->mg42weapHeat);
 
       ent->tankLink = traceEnt;
       traceEnt->tankLink = ent;
@@ -3557,7 +3558,8 @@ qboolean Do_Activate_f(gentity_t *ent, gentity_t *traceEnt) {
 
       ent->backupWeaponTime = ent->client->ps.weaponTime;
       ent->client->ps.weaponTime = traceEnt->backupWeaponTime;
-      ent->client->ps.weapHeat[WP_DUMMY_MG42] = traceEnt->mg42weapHeat;
+      ent->client->pmext.weapHeat[WP_DUMMY_MG42] =
+          static_cast<float>(traceEnt->mg42weapHeat);
 
       G_UseTargets(traceEnt,
                    ent); //----(SA)	added for Mike so
@@ -3648,7 +3650,8 @@ void G_LeaveTank(gentity_t *ent, qboolean position) {
     TeleportPlayer(ent, pos, ent->client->ps.viewangles);
   }
 
-  tank->mg42weapHeat = ent->client->ps.weapHeat[WP_DUMMY_MG42];
+  tank->mg42weapHeat =
+      static_cast<int>(ent->client->pmext.weapHeat[WP_DUMMY_MG42]);
   tank->backupWeaponTime = ent->client->ps.weaponTime;
   ent->client->ps.weaponTime = ent->backupWeaponTime;
 
@@ -3705,7 +3708,8 @@ void Cmd_Activate_f(gentity_t *ent) {
       for (i = 0; i < level.num_entities; i++) {
         if (g_entities[i].s.eType == ET_MG42_BARREL &&
             g_entities[i].r.ownerNum == ent->s.number) {
-          g_entities[i].mg42weapHeat = ent->client->ps.weapHeat[WP_DUMMY_MG42];
+          g_entities[i].mg42weapHeat =
+              static_cast<int>(ent->client->pmext.weapHeat[WP_DUMMY_MG42]);
           g_entities[i].backupWeaponTime = ent->client->ps.weaponTime;
           break;
         }

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -2175,7 +2175,8 @@ void mg42_think(gentity_t *self) {
 
   // heat handling
   if (owner->client) {
-    self->mg42weapHeat = owner->client->ps.weapHeat[WP_DUMMY_MG42];
+    self->mg42weapHeat =
+        static_cast<int>(owner->client->pmext.weapHeat[WP_DUMMY_MG42]);
   }
 
   // overheated mg42 smokes
@@ -2285,7 +2286,8 @@ void mg42_stopusing(gentity_t *self) {
     // owner->client->ps.gunfx = 0;
 
     // owner->client->ps.weapHeat[WP_DUMMY_MG42] = 0;
-    self->mg42weapHeat = owner->client->ps.weapHeat[WP_DUMMY_MG42];
+    self->mg42weapHeat =
+        static_cast<int>(owner->client->pmext.weapHeat[WP_DUMMY_MG42]);
     self->backupWeaponTime = owner->client->ps.weaponTime;
     owner->client->ps.weaponTime = owner->backupWeaponTime;
 
@@ -2368,7 +2370,8 @@ void mg42_use(gentity_t *ent, gentity_t *other, gentity_t *activator) {
     owner->client->ps.viewlocked = 0; // let them look around
     owner->active = qfalse;
     // owner->client->ps.gunfx = 0;
-    other->client->ps.weapHeat[WP_DUMMY_MG42] = ent->mg42weapHeat;
+    other->client->pmext.weapHeat[WP_DUMMY_MG42] =
+        static_cast<float>(ent->mg42weapHeat);
     ent->backupWeaponTime = owner->client->ps.weaponTime;
     owner->backupWeaponTime = owner->client->ps.weaponTime;
   }

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -1437,6 +1437,8 @@ typedef struct playerState_s {
   // transmission "weapstatus" value.
 
   // ETJump: unused, we track this in pmext instead
+  // this doesn't get communicated though, weapHeat is communicated
+  // by storing currently held weapon's heat to curWeapHeat
   int weapHeat[MAX_WEAPONS]; // some weapons can overheat.  this tracks
                              // (server-side) how hot each weapon
                              // currently is.

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -545,8 +545,8 @@ extern vec4_t g_color_table[32];
    ishex(*((p) + 3)) && ishex(*((p) + 4)) && ishex(*((p) + 5)))
 #define Q_HexColorStringHasAlpha(p) (ishex(*((p) + 6)) && ishex(*((p) + 7)))
 
-#define DEG2RAD(a) (((a)*M_PI) / 180.0F)
-#define RAD2DEG(a) (((a)*180.0f) / M_PI)
+#define DEG2RAD(a) (((a) * M_PI) / 180.0F)
+#define RAD2DEG(a) (((a) * 180.0f) / M_PI)
 #define RAD2SHORT(a) ((a) * (32768.f / (float)M_PI))
 #define SHORT2RAD(a) ((a) * ((float)M_PI / 32768.f))
 #define SHORT2DEG(a) (((a) / 32768.f) * 180.0f)
@@ -1076,7 +1076,7 @@ typedef enum {
 */
 #define ANIM_BITS 10
 
-#define ANGLE2SHORT(x) ((int)((x)*65536 / 360) & 65535)
+#define ANGLE2SHORT(x) ((int)((x) * 65536 / 360) & 65535)
 #define SHORT2ANGLE(x) ((x) * (360.0 / 65536))
 
 #define SNAPFLAG_RATE_DELAYED 1
@@ -1435,6 +1435,8 @@ typedef struct playerState_s {
   // however, they (appear to) change at different rates and I can't
   // currently see how to optimize this to one server->client
   // transmission "weapstatus" value.
+
+  // ETJump: unused, we track this in pmext instead
   int weapHeat[MAX_WEAPONS]; // some weapons can overheat.  this tracks
                              // (server-side) how hot each weapon
                              // currently is.


### PR DESCRIPTION
Ported over from ET: Legacy.

### Pmove related fixes

**These weren't really issues to begin with as they only affected `pmove_fixed 0` gameplay**

* weapon recoil is now always equal to ~125fps
* stamina recharge is now consistent on any fps
* weapon overheating is now equal to 125fps
* bobcycle + footsteps are now equal to 125fps
* PM_DeadMove is now equal to 125fps

### Visual fixes

* screenshakes from explosions are now normalized to 125fps
* kickangles (screenshake from shooting) is now normalized to 333fps
* particle effect rotation (cg_wolfparticles) is now normalized to 125fps

refs #894 