### PR TITLE
Bump client-only corona version check

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -4635,7 +4635,7 @@ void CG_DrawMiscGamemodels(void) {
 
 void CG_DrawCoronas() {
   static bool clientSideCoronas =
-      ETJump::demoCompatibility->isCompatible({3, 1, 2});
+      ETJump::demoCompatibility->isCompatible({3, 2, 0});
 
   if (cg.demoPlayback && !clientSideCoronas) {
     return;


### PR DESCRIPTION
Next version will be 3.2.0 rather than 3.1.2 as this release ended up being larger than I anticipated

refs #1210 