### PR TITLE
Fix OB detector not getting correct shared value on demo playback

### DIFF
--- a/src/cgame/etj_overbounce_shared.cpp
+++ b/src/cgame/etj_overbounce_shared.cpp
@@ -69,7 +69,7 @@ bool Overbounce::isOverbounce(float zVel, float startHeight, float endHeight,
 }
 
 bool Overbounce::surfaceAllowsOverbounce(trace_t *trace) {
-  if (cg_pmove.shared & BG_LEVEL_NO_OVERBOUNCE) {
+  if (cgs.shared & BG_LEVEL_NO_OVERBOUNCE) {
     return ((trace->surfaceFlags & SURF_OVERBOUNCE) != 0);
   } else {
     return (trace->surfaceFlags & SURF_OVERBOUNCE) == 0;


### PR DESCRIPTION
`cg_pmove.shared` is always 0 on demo playback, whereas `cgs.shared` has the correct value.