### PR TITLE
Fix client side corona count not resetting on map restarts

### DIFF
--- a/src/cgame/cg_spawn.cpp
+++ b/src/cgame/cg_spawn.cpp
@@ -510,6 +510,7 @@ void CG_ParseEntitiesFromString(void) {
   cg.spawning = qtrue;
   cg.numSpawnVars = 0;
   cg.numMiscGameModels = 0;
+  cg.numCoronas = 0;
 
   // the worldspawn is not an actual entity, but it still
   // has a "spawn" function to perform any global setup


### PR DESCRIPTION
map_restart does not null cg_t so the count needs to be reset manually on spawn.

refs #1201 