### PR TITLE
Fix dlights not updating on runtime when spawned via mapscript

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2807,6 +2807,7 @@ void CG_DrawSkyBoxPortal(qboolean fLocalView);
 void CG_Concussive(centity_t *cent);
 
 void CG_Letterbox(float xsize, float ysize, qboolean center);
+void CG_SetupDlightstyles();
 
 //
 // cg_drawtools.c

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -741,7 +741,7 @@ static void CG_ConfigStringModified(void) {
   } else if (num >= CS_PLAYERS && num < CS_PLAYERS + MAX_CLIENTS) {
     CG_NewClientInfo(num - CS_PLAYERS);
   } else if (num >= CS_DLIGHTS && num < CS_DLIGHTS + MAX_DLIGHT_CONFIGSTRINGS) {
-    // FIXME - dlight changes ignored!
+    CG_SetupDlightstyles();
   } else if (num == CS_SHADERSTATE) {
     CG_ShaderStateChanged();
   } else if (num == CS_CHARGETIMES) {


### PR DESCRIPTION
dlight configstring updates were not handled on client if a dlight was spawned via mapscript after initial map load.