### PR TITLE
Fix freecam key out of bound access

### DIFF
--- a/src/cgame/cg_info.cpp
+++ b/src/cgame/cg_info.cpp
@@ -109,6 +109,12 @@ void CG_ShowHelp_Off(int *status) {
 void CG_DemoClick(int key, qboolean down) {
   int milli = trap_Milliseconds();
 
+  if (key & K_CHAR_FLAG) {
+    return;
+  }
+
+  key &= ~K_CHAR_FLAG;
+
   // Avoid active console keypress issues
   if (!down && !cgs.fKeyPressed[key]) {
     return;


### PR DESCRIPTION
Keycodes need to be masked out with K_CHAR_FLAG to not overrun the array.

fixes #1004 