### PR TITLE
Fix teleporter outspeed & sound when no dest is found + refactor spawnflags

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -696,6 +696,15 @@ enum class TriggerMultipleFlags {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+enum TeleporterSpawnflags {
+  None = 0,
+  ResetSpeed = 1 << 0,
+  ConvertSpeed = 1 << 1,
+  RelativePitch = 1 << 2,
+  RelativePitchYaw = 1 << 3,
+  Knockback = 1 << 4
+};
+
 #define MAX_IP_LEN 15
 
 // client data that stays across multiple levels or tournament restarts


### PR DESCRIPTION
`noise` and `outspeed` keys were processed even when teleporter had no destination.

Also refactor spawnflags to use an enum instead of magic numbers.