### PR TITLE
Refactor accel meter + fixes

### DIFF
--- a/assets/ui/etjump_settings_3.menu
+++ b/assets/ui/etjump_settings_3.menu
@@ -16,14 +16,18 @@
 #define SUBW_MAX_SPEED_ITEM_Y SUBW_MAX_SPEED_Y + SUBW_HEADER_HEIGHT
 #define SUBW_MAX_SPEED_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 3)
 
-#define SUBW_FIRETEAM_Y SUBW_MAX_SPEED_Y + SUBW_MAX_SPEED_HEIGHT + SUBW_SPACING_Y
-#define SUBW_FIRETEAM_ITEM_Y SUBW_FIRETEAM_Y + SUBW_HEADER_HEIGHT
-#define SUBW_FIRETEAM_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 3)
+#define SUBW_ACCEL_Y SUBW_MAX_SPEED_Y + SUBW_MAX_SPEED_HEIGHT + SUBW_SPACING_Y
+#define SUBW_ACCEL_ITEM_Y SUBW_ACCEL_Y + SUBW_HEADER_HEIGHT
+#define SUBW_ACCEL_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 8)
 
 // Right side menus
 #define SUBW_INDICATORS_Y SUBW_Y
 #define SUBW_INDICATORS_ITEM_Y SUBW_INDICATORS_Y + SUBW_HEADER_HEIGHT
 #define SUBW_INDICATORS_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 23)
+
+#define SUBW_FIRETEAM_Y SUBW_INDICATORS_Y + SUBW_INDICATORS_HEIGHT + SUBW_SPACING_Y
+#define SUBW_FIRETEAM_ITEM_Y SUBW_FIRETEAM_Y + SUBW_HEADER_HEIGHT
+#define SUBW_FIRETEAM_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 3)
 
 #define GROUP_NAME "group_etjump_settings_3"
 
@@ -53,10 +57,10 @@ menuDef {
         CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_SPEED2_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_speedX", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
         SLIDER              (SUBW_ITEM_LEFT_X, SUBW_SPEED2_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Speed meter X:", 0.2, SUBW_ITEM_HEIGHT, etj_speedX 320 0 640 10, "Sets X position of ETJump speed meter\netj_speedX")
         CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_SPEED2_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_speedY", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
-        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_SPEED2_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Speed meter Y:", 0.2, SUBW_ITEM_HEIGHT, etj_speedY 340 0 480 10, "Sets Y position of ETJump speed meter\netj_speedY")
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_SPEED2_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Speed meter Y:", 0.2, SUBW_ITEM_HEIGHT, etj_speedY 320 0 480 10, "Sets Y position of ETJump speed meter\netj_speedY")
         MULTI               (SUBW_ITEM_LEFT_X, SUBW_SPEED2_ITEM_Y + (SUBW_ITEM_SPACING_Y * 4), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Speed meter size:", 0.2, SUBW_ITEM_HEIGHT, "etj_speedSize", cvarFloatList { "Tiny" 1 "Small" 2 "Medium" 3 "Big" 4 }, "Sets size of ETJump speed meter\netj_speedSize")
         MULTI               (SUBW_ITEM_LEFT_X, SUBW_SPEED2_ITEM_Y + (SUBW_ITEM_SPACING_Y * 5), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Speed meter color:", 0.2, SUBW_ITEM_HEIGHT, "etj_speedColor", cvarStrList { "White"; "white"; "Yellow"; "yellow"; "Red"; "red"; "Green"; "green"; "Blue"; "blue"; "Magenta"; "magenta"; "Cyan"; "cyan"; "Orange"; "orange"; "Light Blue"; "0xa0c0ff"; "Medium Blue"; "mdblue"; "Light Red"; "0xffc0a0"; "Medium Red"; "mdred"; "Light Green"; "0xa0ffc0"; "Medium Green"; "mdgreen"; "Dark Green"; "dkgreen"; "Medium Cyan"; "mdcyan"; "Medium Yellow"; "mdyellow"; "Medium Orange"; "mdorange"; "Light Grey"; "ltgrey"; "Medium Grey"; "mdgrey"; "Dark Grey"; "dkgrey"; "Black"; "black" }, "Sets color of ETJump speed meter\netj_speedColor")
-        YESNO               (SUBW_ITEM_LEFT_X, SUBW_SPEED2_ITEM_Y + (SUBW_ITEM_SPACING_Y * 6), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Accel-based color:", 0.2, SUBW_ITEM_HEIGHT, "etj_speedColorUsesAccel", "Color ETJump speed meter based on accel/decel\netj_speedColorUsesAccel")
+        MULTI               (SUBW_ITEM_LEFT_X, SUBW_SPEED2_ITEM_Y + (SUBW_ITEM_SPACING_Y * 6), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Accel-based color:", 0.2, SUBW_ITEM_HEIGHT, "etj_speedColorUsesAccel", cvarFloatList { "Off" 0 "Simple" 1 "Advanced" 2 }, "Color ETJump speed meter based on accel/decel\netj_speedColorUsesAccel")
         YESNO               (SUBW_ITEM_LEFT_X, SUBW_SPEED2_ITEM_Y + (SUBW_ITEM_SPACING_Y * 7), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Speed meter shadow:", 0.2, SUBW_ITEM_HEIGHT, "etj_speedShadow", "Draw shadow on ETJump speed meter\netj_speedShadow")
         MULTI               (SUBW_ITEM_LEFT_X, SUBW_SPEED2_ITEM_Y + (SUBW_ITEM_SPACING_Y * 8), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Speed meter align:", 0.2, SUBW_ITEM_HEIGHT, "etj_speedAlign", cvarFloatList { "Center" 0 "Left" 1 "Right" 2 }, "Sets alignment of ETJump speed meter\netj_speedAlign")
 
@@ -65,18 +69,23 @@ menuDef {
         CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_MAX_SPEED_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_maxSpeedX", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
         SLIDER              (SUBW_ITEM_LEFT_X, SUBW_MAX_SPEED_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Max speed X:", 0.2, SUBW_ITEM_HEIGHT, etj_maxSpeedX 320 0 640 10, "Sets X position of max speed\netj_maxSpeedX")
         CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_MAX_SPEED_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_maxSpeedY", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
-        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_MAX_SPEED_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Max speed Y:", 0.2, SUBW_ITEM_HEIGHT, etj_maxSpeedY 320 0 480 10, "Sets Y position of max speed\netj_maxSpeedY")
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_MAX_SPEED_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Max speed Y:", 0.2, SUBW_ITEM_HEIGHT, etj_maxSpeedY 300 0 480 10, "Sets Y position of max speed\netj_maxSpeedY")
         CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_MAX_SPEED_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_maxSpeedDuration", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
         SLIDER              (SUBW_ITEM_LEFT_X, SUBW_MAX_SPEED_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Max speed duration:", 0.2, SUBW_ITEM_HEIGHT, etj_maxSpeedDuration 2000 0 15000 250, "How long in milliseconds to display max speed\netj_maxSpeedDuration")
 
-    SUBWINDOW(SUBW_RECT_LEFT_X, SUBW_FIRETEAM_Y, SUBW_WIDTH, SUBW_FIRETEAM_HEIGHT, "FIRETEAM")
-        YESNO               (SUBW_ITEM_LEFT_X, SUBW_FIRETEAM_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Fireteam:", 0.2, SUBW_ITEM_HEIGHT, "etj_HUD_fireteam", "Draw fireteam on HUD\netj_HUD_fireteam")
-        CVARFLOATLABEL      (SUBW_ITEM_LEFT_X, SUBW_FIRETEAM_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_fireteamAlpha", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
-        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_FIRETEAM_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Fireteam alpha:", 0.2, SUBW_ITEM_HEIGHT, etj_fireteamAlpha 1 0 1 0.05, "Sets transparency of fireteam\netj_fireteamAlpha")
-        CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_FIRETEAM_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_fireteamPosX", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
-        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_FIRETEAM_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Fireteam X:", 0.2, SUBW_ITEM_HEIGHT, etj_fireteamPosX 0 -640 640 10, "Sets X offset for fireteam\netj_fireteamPosX")
-        CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_FIRETEAM_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_fireteamPosY", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
-        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_FIRETEAM_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Fireteam Y:", 0.2, SUBW_ITEM_HEIGHT, etj_fireteamPosY 0 -480 480 10, "Sets Y offset for fireteam\netj_fireteamPosY")
+    SUBWINDOW(SUBW_RECT_LEFT_X, SUBW_ACCEL_Y, SUBW_WIDTH, SUBW_ACCEL_HEIGHT, "ACCEL")
+        YESNO               (SUBW_ITEM_LEFT_X, SUBW_ACCEL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Draw accel meter:", 0.2, SUBW_ITEM_HEIGHT, "etj_drawAccel", "Draw per-vector acceleration meter\netj_drawAccel")
+        CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_ACCEL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_accelX", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_ACCEL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Accel meter X:", 0.2, SUBW_ITEM_HEIGHT, etj_accelX 320 0 640 10, "Sets X position of acceleration meter\netj_accelX")
+        CVARINTLABEL        (SUBW_ITEM_LEFT_X, SUBW_ACCEL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_accelY", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_ACCEL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Accel meter Y:", 0.2, SUBW_ITEM_HEIGHT, etj_accelY 340 0 480 10, "Sets Y position of acceleration meter\netj_accelY")
+        MULTI               (SUBW_ITEM_LEFT_X, SUBW_ACCEL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Accel meter size:", 0.2, SUBW_ITEM_HEIGHT, "etj_accelSize", cvarFloatList { "Tiny" 1 "Small" 2 "Medium" 3 "Big" 4 }, "Sets size of acceleration meter\netj_accelSize")
+        MULTI               (SUBW_ITEM_LEFT_X, SUBW_ACCEL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 4), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Accel meter color:", 0.2, SUBW_ITEM_HEIGHT, "etj_accelColor", cvarStrList { "White"; "white"; "Yellow"; "yellow"; "Red"; "red"; "Green"; "green"; "Blue"; "blue"; "Magenta"; "magenta"; "Cyan"; "cyan"; "Orange"; "orange"; "Light Blue"; "0xa0c0ff"; "Medium Blue"; "mdblue"; "Light Red"; "0xffc0a0"; "Medium Red"; "mdred"; "Light Green"; "0xa0ffc0"; "Medium Green"; "mdgreen"; "Dark Green"; "dkgreen"; "Medium Cyan"; "mdcyan"; "Medium Yellow"; "mdyellow"; "Medium Orange"; "mdorange"; "Light Grey"; "ltgrey"; "Medium Grey"; "mdgrey"; "Dark Grey"; "dkgrey"; "Black"; "black" }, "Sets color of acceleration meter\netj_accelColor")
+        CVARFLOATLABEL      (SUBW_ITEM_LEFT_X, SUBW_ACCEL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 5), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_accelAlpha", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_LEFT_X, SUBW_ACCEL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 5), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Accel meter alpha:", 0.2, SUBW_ITEM_HEIGHT, etj_accelAlpha 1.0 0 1 0.05, "Sets transparency of acceleration meter\netj_speedAlpha")
+        MULTI               (SUBW_ITEM_LEFT_X, SUBW_ACCEL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 6), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Accel based color:", 0.2, SUBW_ITEM_HEIGHT, "etj_accelColorUsesAccel", cvarFloatList { "Off" 0 "Simple" 1 "Advanced" 2 }, "Color acceleration meter based on accel/decel\netj_accelColorUsesAccel")
+        YESNO               (SUBW_ITEM_LEFT_X, SUBW_ACCEL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 7), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Accel meter shadow:", 0.2, SUBW_ITEM_HEIGHT, "etj_accelShadow", "Draw shadow on acceleration meter\netj_accelShadow")
+        MULTI               (SUBW_ITEM_LEFT_X, SUBW_ACCEL_ITEM_Y + (SUBW_ITEM_SPACING_Y * 8), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Accel meter align:", 0.2, SUBW_ITEM_HEIGHT, "etj_accelAlign", cvarFloatList { "Center" 0 "Left" 1 "Right" 2 }, "Sets alignment of acceleration meter\netj_accelAlign")
 
     SUBWINDOW(SUBW_RECT_RIGHT_X, SUBW_INDICATORS_Y, SUBW_WIDTH, SUBW_INDICATORS_HEIGHT, "INDICATORS")
         MULTI               (SUBW_ITEM_RIGHT_X, SUBW_INDICATORS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Overbounce detector:", 0.2, SUBW_ITEM_HEIGHT, "etj_drawOB", cvarFloatList { "No" 0 "Yes" 1 "Advanced" 2 }, "Draw overbounce detector\netj_drawOB")
@@ -117,6 +126,15 @@ menuDef {
         MULTI               (SUBW_ITEM_RIGHT_X, SUBW_INDICATORS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 21), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "OB watcher size:", 0.2, SUBW_ITEM_HEIGHT, "etj_obWatcherSize", cvarFloatList { "Tiny" 1 "Small" 2 "Medium" 3 "Big" 4 }, "Sets size of overbounce watcher\netj_obWatcherSize")
         MULTI               (SUBW_ITEM_RIGHT_X, SUBW_INDICATORS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 22), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "OB watcher color:", 0.2, SUBW_ITEM_HEIGHT, "etj_obWatcherColor", cvarStrList { "White"; "white"; "Yellow"; "yellow"; "Red"; "red"; "Green"; "green"; "Blue"; "blue"; "Magenta"; "magenta"; "Cyan"; "cyan"; "Orange"; "orange"; "Light Blue"; "0xa0c0ff"; "Medium Blue"; "mdblue"; "Light Red"; "0xffc0a0"; "Medium Red"; "mdred"; "Light Green"; "0xa0ffc0"; "Medium Green"; "mdgreen"; "Dark Green"; "dkgreen"; "Medium Cyan"; "mdcyan"; "Medium Yellow"; "mdyellow"; "Medium Orange"; "mdorange"; "Light Grey"; "ltgrey"; "Medium Grey"; "mdgrey"; "Dark Grey"; "dkgrey"; "Black"; "black" }, "Sets color of overbounce watcher\netj_obWatcherColor")
         EDITFIELD           (SUBW_ITEM_RIGHT_X, SUBW_INDICATORS_ITEM_Y + (SUBW_ITEM_SPACING_Y * 23), SUBW_ITEM_WIDTH, 10, "Extra trace:", 0.2, SUBW_ITEM_HEIGHT, "etj_extraTrace", SUBW_EDITFIELD_MAXCHARS, SUBW_EDITFIELD_MAXPAINTCHARS, "Trace playerclips for various indicators (bitmask)\netj_extraTrace (see /extraTrace command)")
+
+    SUBWINDOW(SUBW_RECT_RIGHT_X, SUBW_FIRETEAM_Y, SUBW_WIDTH, SUBW_FIRETEAM_HEIGHT, "FIRETEAM")
+        YESNO               (SUBW_ITEM_RIGHT_X, SUBW_FIRETEAM_ITEM_Y + (SUBW_ITEM_SPACING_Y * 0), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Fireteam:", 0.2, SUBW_ITEM_HEIGHT, "etj_HUD_fireteam", "Draw fireteam on HUD\netj_HUD_fireteam")
+        CVARFLOATLABEL      (SUBW_ITEM_RIGHT_X, SUBW_FIRETEAM_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_fireteamAlpha", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_FIRETEAM_ITEM_Y + (SUBW_ITEM_SPACING_Y * 1), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Fireteam alpha:", 0.2, SUBW_ITEM_HEIGHT, etj_fireteamAlpha 1 0 1 0.05, "Sets transparency of fireteam\netj_fireteamAlpha")
+        CVARINTLABEL        (SUBW_ITEM_RIGHT_X, SUBW_FIRETEAM_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_fireteamPosX", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_FIRETEAM_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Fireteam X:", 0.2, SUBW_ITEM_HEIGHT, etj_fireteamPosX 0 -640 640 10, "Sets X offset for fireteam\netj_fireteamPosX")
+        CVARINTLABEL        (SUBW_ITEM_RIGHT_X, SUBW_FIRETEAM_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "etj_fireteamPosY", 0.2, ITEM_ALIGN_RIGHT, SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT)
+        SLIDER              (SUBW_ITEM_RIGHT_X, SUBW_FIRETEAM_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_ITEM_HEIGHT, "Fireteam Y:", 0.2, SUBW_ITEM_HEIGHT, etj_fireteamPosY 0 -480 480 10, "Sets Y offset for fireteam\netj_fireteamPosY")
         
         BUTTON              (ETJ_BUTTON_X + (ETJ_BUTTON_SPACING_X * 0), ETJ_BUTTON_Y, ETJ_BUTTON_WIDTH, ETJ_BUTTON_HEIGHT, "BACK", 0.3, ETJ_BUTTON_ITEM_HEIGHT, close etjump_settings_3; open etjump)
         BUTTON              (ETJ_BUTTON_X + (ETJ_BUTTON_SPACING_X * 1), ETJ_BUTTON_Y, ETJ_BUTTON_WIDTH, ETJ_BUTTON_HEIGHT, "TAB 1", 0.3, ETJ_BUTTON_ITEM_HEIGHT, close etjump_settings_3; open etjump_settings_1)

--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(cgame MODULE
 	"cg_view.cpp"
 	"cg_weapons.cpp"
 	"cg_window.cpp"
+	"etj_accel_color.cpp"
+	"etj_accelmeter_drawable.cpp"
 	"etj_areaindicator_drawable.cpp"
 	"etj_autodemo_recorder.cpp"
 	"etj_awaited_command_handler.cpp"

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2450,6 +2450,9 @@ extern vmCvar_t etj_drawAccel;
 extern vmCvar_t etj_accelX;
 extern vmCvar_t etj_accelY;
 extern vmCvar_t etj_accelSize;
+extern vmCvar_t etj_accelColor;
+extern vmCvar_t etj_accelAlpha;
+extern vmCvar_t etj_accelColorUsesAccel;
 extern vmCvar_t etj_accelShadow;
 extern vmCvar_t etj_accelAlign;
 
@@ -4214,6 +4217,7 @@ class PmoveUtils;
 class CvarShadow;
 class ClientRtvHandler;
 class DemoCompatibility;
+class AccelColor;
 
 extern std::shared_ptr<ClientCommandsHandler> serverCommandsHandler;
 extern std::shared_ptr<ClientCommandsHandler> consoleCommandsHandler;
@@ -4227,6 +4231,7 @@ extern std::shared_ptr<EventLoop> eventLoop;
 extern std::shared_ptr<PlayerEventsHandler> playerEventsHandler;
 extern std::shared_ptr<ClientRtvHandler> rtvHandler;
 extern std::shared_ptr<DemoCompatibility> demoCompatibility;
+extern std::shared_ptr<AccelColor> accelColor;
 
 void addRealLoopingSound(const vec3_t origin, const vec3_t velocity,
                          sfxHandle_t sfx, int range, int volume, int soundTime);

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -352,6 +352,9 @@ vmCvar_t etj_drawAccel;
 vmCvar_t etj_accelX;
 vmCvar_t etj_accelY;
 vmCvar_t etj_accelSize;
+vmCvar_t etj_accelColor;
+vmCvar_t etj_accelAlpha;
+vmCvar_t etj_accelColorUsesAccel;
 vmCvar_t etj_accelShadow;
 vmCvar_t etj_accelAlign;
 
@@ -884,22 +887,26 @@ cvarTable_t cvarTable[] = {
     {&etj_drawClock, "etj_drawClock", "1", CVAR_ARCHIVE},
     {&etj_drawSpeed2, "etj_drawSpeed2", "1", CVAR_ARCHIVE},
     {&etj_speedX, "etj_speedX", "320", CVAR_ARCHIVE},
-    {&etj_speedY, "etj_speedY", "340", CVAR_ARCHIVE},
+    {&etj_speedY, "etj_speedY", "320", CVAR_ARCHIVE},
     {&etj_speedSize, "etj_speedSize", "3", CVAR_ARCHIVE},
     {&etj_speedColor, "etj_speedColor", "White", CVAR_ARCHIVE},
     {&etj_speedAlpha, "etj_speedAlpha", "1.0", CVAR_ARCHIVE},
     {&etj_speedShadow, "etj_speedShadow", "0", CVAR_ARCHIVE},
     {&etj_drawMaxSpeed, "etj_drawMaxSpeed", "0", CVAR_ARCHIVE},
     {&etj_maxSpeedX, "etj_maxSpeedX", "320", CVAR_ARCHIVE},
-    {&etj_maxSpeedY, "etj_maxSpeedY", "320", CVAR_ARCHIVE},
+    {&etj_maxSpeedY, "etj_maxSpeedY", "300", CVAR_ARCHIVE},
     {&etj_maxSpeedDuration, "etj_maxSpeedDuration", "2000", CVAR_ARCHIVE},
     {&etj_speedColorUsesAccel, "etj_speedColorUsesAccel", "0", CVAR_ARCHIVE},
     {&etj_speedAlign, "etj_speedAlign", "0", CVAR_ARCHIVE},
 
     {&etj_drawAccel, "etj_drawAccel", "0", CVAR_ARCHIVE},
     {&etj_accelX, "etj_accelX", "320", CVAR_ARCHIVE},
-    {&etj_accelY, "etj_accelY", "350", CVAR_ARCHIVE},
+    {&etj_accelY, "etj_accelY", "340", CVAR_ARCHIVE},
     {&etj_accelSize, "etj_accelSize", "3", CVAR_ARCHIVE},
+    {&etj_accelColor, "etj_accelColor", "white", CVAR_ARCHIVE},
+    {&etj_accelAlpha, "etj_accelAlpha", "1.0", CVAR_ARCHIVE},
+    {&etj_accelColorUsesAccel, "etj_accelColorUsesAccel", "0", CVAR_ARCHIVE},
+    {&etj_accelShadow, "etj_accelShadow", "1", CVAR_ARCHIVE},
     {&etj_accelAlign, "etj_accelAlign", "0", CVAR_ARCHIVE},
 
     {&etj_popupTime, "etj_popupTime", "1000", CVAR_ARCHIVE},

--- a/src/cgame/etj_accel_color.cpp
+++ b/src/cgame/etj_accel_color.cpp
@@ -162,7 +162,7 @@ void AccelColor::calcAccelColor(pmove_t *pm, vec3_t &accel, vec4_t &outColor) {
             std::abs(accel[1]) -
             std::abs(std::max(std::abs(optAccelY), std::abs(altOptAccelY)));
 
-        frac = std::min(std::max(1.0f - absDiffX - absDiffY, 0.0f), 1.0f);
+        frac = Numeric::clamp(0.0f, 1.0f, 1.0f - absDiffX - absDiffY);
       }
     } else {
       if ((maxAccelY > 0 && accel[1] >= 0) ||
@@ -172,7 +172,7 @@ void AccelColor::calcAccelColor(pmove_t *pm, vec3_t &accel, vec4_t &outColor) {
             std::abs(accel[0]) -
             std::abs(std::max(std::abs(optAccelX), std::abs(altOptAccelX)));
 
-        frac = std::min(std::max(1.0f - absDiffY - absDiffX, 0.0f), 1.0f);
+        frac = Numeric::clamp(0.0f, 1.0f, 1.0f - absDiffY - absDiffX);
       }
     }
 

--- a/src/cgame/etj_accel_color.cpp
+++ b/src/cgame/etj_accel_color.cpp
@@ -152,24 +152,31 @@ void AccelColor::calcAccelColor(pmove_t *pm, vec3_t &accel, vec4_t &outColor) {
     // interpolate between red and green based on
     // the average normalized acceleration
     float frac = 0.0f;
+    float absDiffX, absDiffY;
 
     if (isMovingX) {
       if ((maxAccelX > 0 && accel[0] >= 0) ||
           (maxAccelX < 0 && accel[0] <= 0)) {
-        frac = 1.0f -
-               (std::abs(maxAccelX) - std::abs(accel[0] + maxAccelX) * 0.5f) -
-               (std::abs(accel[1]) - std::abs(maxAccelY));
+        absDiffX = std::abs(maxAccelX) - std::abs(accel[0] + maxAccelX) / 2.0f;
+        absDiffY =
+            std::abs(accel[1]) -
+            std::abs(std::max(std::abs(optAccelY), std::abs(altOptAccelY)));
+
+        frac = std::min(std::max(1.0f - absDiffX - absDiffY, 0.0f), 1.0f);
       }
     } else {
       if ((maxAccelY > 0 && accel[1] >= 0) ||
           (maxAccelY < 0 && accel[1] <= 0)) {
-        frac = 1.0f -
-               (std::abs(maxAccelY) - std::abs(accel[1] + maxAccelY) * 0.5f) -
-               (std::abs(accel[0]) - std::abs(maxAccelX));
+        absDiffY = std::abs(maxAccelY) - std::abs(accel[1] + maxAccelY) / 2.0f;
+        absDiffX =
+            std::abs(accel[0]) -
+            std::abs(std::max(std::abs(optAccelX), std::abs(altOptAccelX)));
+
+        frac = std::min(std::max(1.0f - absDiffY - absDiffX, 0.0f), 1.0f);
       }
     }
 
-    LerpColor(colorRed, colorGreen, color, Numeric::clamp(0.0f, 1.0f, frac));
+    LerpColor(colorRed, colorGreen, color, frac);
   } else {
     Vector4Copy(colorWhite, color);
   }

--- a/src/cgame/etj_accel_color.cpp
+++ b/src/cgame/etj_accel_color.cpp
@@ -1,0 +1,222 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_accel_color.h"
+#include "etj_pmove_utils.h"
+#include "etj_cgaz.h"
+#include "../game/etj_numeric_utilities.h"
+
+namespace ETJump {
+void AccelColor::setAccelColor(int &style, float &speed, float &alpha,
+                               pmove_t *pm,
+                               std::list<StoredSpeed> &storedSpeeds,
+                               vec3_t &accel, vec4_t &color) {
+  if (style == Style::Simple ||
+      (style == Style::Advanced &&
+       lowSpeedOnGround(speed, pm->ps->groundEntityNum))) {
+    float avgAccel = calcAvgAccel(storedSpeeds);
+    vec4_t currentAccelColor;
+    Vector4Copy(colorGreen, currentAccelColor);
+
+    if (avgAccel < 0) {
+      Vector4Copy(colorRed, currentAccelColor);
+      avgAccel = -avgAccel;
+    }
+
+    float frac = avgAccel / ACCEL_FOR_SOLID_COLOR;
+    frac = std::min(frac, 1.f);
+
+    LerpColor(colorWhite, currentAccelColor, color, frac);
+  } else if (style == Style::Advanced) {
+    calcAccelColor(pm, accel, color);
+  }
+
+  color[3] *= Numeric::clamp(0.0f, 1.0f, alpha);
+}
+
+void AccelColor::calcAccelColor(pmove_t *pm, vec3_t &accel, vec4_t &outColor) {
+  vec4_t color;
+  const playerState_t &ps = cg.predictedPlayerState;
+  const int8_t ucmdScale = CMDSCALE_DEFAULT;
+  const usercmd_t cmd = PmoveUtils::getUserCmd(ps, ucmdScale);
+
+  float speedX = ps.velocity[0];
+  float speedY = ps.velocity[1];
+
+  const float scale = PmoveUtils::PM_SprintScale(&ps);
+
+  const float accelAngle = RAD2DEG(std::atan2(-cmd.rightmove, cmd.forwardmove));
+  const float accelAngleAlt =
+      RAD2DEG(std::atan2(cmd.rightmove, cmd.forwardmove));
+
+  // max acceleration possible per frame
+  const float frameAccel = CGaz::getFrameAccel(ps, pm);
+  const float gravityAccel =
+      -std::round(static_cast<float>(ps.gravity) * pm->pmext->frametime);
+
+  if (accel[0] != 0.0f || accel[1] != 0.0f) {
+    // get opt angles on both sides of velocity vector
+    const float optAngle = CGaz::getOptAngle(ps, pm, false);
+    const float altOptAngle = CGaz::getOptAngle(ps, pm, true);
+
+    // get accels for opt angle
+    float optAccelX = std::roundf(
+        frameAccel *
+        static_cast<float>(std::cos(DEG2RAD(accelAngle + optAngle)) * scale));
+    float optAccelY = std::roundf(
+        frameAccel *
+        static_cast<float>(std::sin(DEG2RAD(accelAngle + optAngle)) * scale));
+
+    // get accels for alt opt angle
+    float altOptAccelX =
+        std::round(frameAccel *
+                   static_cast<float>(
+                       std::cos(DEG2RAD(accelAngleAlt + altOptAngle)) * scale));
+    float altOptAccelY =
+        std::round(frameAccel *
+                   static_cast<float>(
+                       std::sin(DEG2RAD(accelAngleAlt + altOptAngle)) * scale));
+
+    vec3_t optAccel = {optAccelX, optAccelY, gravityAccel};
+    vec3_t altOptAccel = {altOptAccelX, altOptAccelY, gravityAccel};
+    vec3_t normal = {0, 0, 0};
+
+    VectorCopy(pm->groundTrace.plane.normal, normal);
+
+    if (pm->groundPlane) {
+      PM_ClipVelocity(optAccel, normal, optAccel, OVERCLIP);
+      PM_ClipVelocity(altOptAccel, normal, altOptAccel, OVERCLIP);
+    }
+
+    if ((normal)[0] != 0.0f) {
+      optAccelX = std::roundf(optAccel[0]);
+      altOptAccelX = std::roundf(altOptAccel[0]);
+    }
+
+    if ((normal)[1] != 0.0f) {
+      optAccelX = std::roundf(optAccel[1]);
+      altOptAccelX = std::roundf(altOptAccel[1]);
+    }
+
+    // find max accel possible between opt and altOpt angles
+    float maxAccelX;
+    float maxAccelY;
+    bool isMovingX;
+
+    if (std::abs(speedX) > std::abs(speedY)) {
+      // we're advancing on x-axis
+      isMovingX = true;
+
+      if (std::abs(optAccelX) >= std::abs(altOptAccelX)) {
+        maxAccelX = optAccelX;
+        maxAccelY = optAccelY;
+      } else {
+        maxAccelX = altOptAccelX;
+        maxAccelY = altOptAccelY;
+      }
+    } else {
+      // we're advancing on y-axis
+      isMovingX = false;
+
+      if (std::abs(optAccelY) >= std::abs(altOptAccelY)) {
+        maxAccelX = optAccelX;
+        maxAccelY = optAccelY;
+      } else {
+        maxAccelX = altOptAccelX;
+        maxAccelY = altOptAccelY;
+      }
+    }
+
+    // generate the color based on the average normalized acceleration
+    // interpolate between red and green based on
+    // the average normalized acceleration
+    float frac = 0.0f;
+
+    if (isMovingX) {
+      if ((maxAccelX > 0 && accel[0] >= 0) ||
+          (maxAccelX < 0 && accel[0] <= 0)) {
+        frac = 1.0f -
+               (std::abs(maxAccelX) - std::abs(accel[0] + maxAccelX) * 0.5f) -
+               (std::abs(accel[1]) - std::abs(maxAccelY));
+      }
+    } else {
+      if ((maxAccelY > 0 && accel[1] >= 0) ||
+          (maxAccelY < 0 && accel[1] <= 0)) {
+        frac = 1.0f -
+               (std::abs(maxAccelY) - std::abs(accel[1] + maxAccelY) * 0.5f) -
+               (std::abs(accel[0]) - std::abs(maxAccelX));
+      }
+    }
+
+    LerpColor(colorRed, colorGreen, color, Numeric::clamp(0.0f, 1.0f, frac));
+  } else {
+    Vector4Copy(colorWhite, color);
+  }
+
+  // we want a solid color all the time, no dark tints
+  if (color[0] != 0.0f && color[1] != 0.0f) { // if we have a mix of R & G
+    size_t maxColorIndex = color[0] > color[1] ? 0 : 1;
+    float maxShade = 1.0f; // min value to show per color
+    float coef = maxShade / color[maxColorIndex];
+
+    VectorScale(color, coef, color);
+  }
+
+  Vector4Copy(color, outColor);
+}
+
+float AccelColor::calcAvgAccel(std::list<StoredSpeed> &storedSpeeds) {
+  if (storedSpeeds.size() < 2) { // need 2 speed points to compute acceleration
+    return 0;
+  }
+
+  float totalSpeedDelta = 0;
+  auto iter = storedSpeeds.begin();
+  for (auto prevIter = iter++; iter != storedSpeeds.end(); prevIter = iter++) {
+    totalSpeedDelta += iter->speed - prevIter->speed;
+  }
+
+  const auto timeDeltaMs =
+      static_cast<float>(storedSpeeds.back().time - storedSpeeds.front().time);
+
+  return totalSpeedDelta / (timeDeltaMs / 1000.f);
+}
+
+void AccelColor::popOldStoredSpeeds(std::list<StoredSpeed> &storedSpeeds) {
+  while (!storedSpeeds.empty()) {
+    auto &front = storedSpeeds.front();
+
+    if (cg.time - front.time > ACCEL_COLOR_SMOOTHING_TIME ||
+        cg.time < front.time) {
+      storedSpeeds.pop_front();
+    } else {
+      break;
+    }
+  }
+}
+
+bool AccelColor::lowSpeedOnGround(float speed, int groundEntityNum) {
+  return (speed <= MAX_GROUNDSTRAFE && groundEntityNum != ENTITYNUM_NONE);
+}
+} // namespace ETJump

--- a/src/cgame/etj_accel_color.h
+++ b/src/cgame/etj_accel_color.h
@@ -24,53 +24,33 @@
 
 #pragma once
 
-#include "etj_irenderable.h"
-#include "etj_accel_color.h"
 #include "cg_local.h"
 #include <list>
 
 namespace ETJump {
-class DrawSpeed : public IRenderable {
-  std::list<AccelColor::StoredSpeed> storedSpeeds;
+class AccelColor {
+public:
+  AccelColor() = default;
+  ~AccelColor() = default;
 
-  float maxSpeed{0};
-  float currentSpeed{};
-  std::string speedStr;
-  float y{};
-  float w{};
-  float size{};
-
-  enum Alignment {
-    Left = 1,
-    Right = 2,
+  struct StoredSpeed {
+    int time;
+    float speed;
   };
 
-  vec3_t lastSpeed{};
-  vec3_t accel{};
-  vec4_t speedColor{};
+  enum Style { Simple = 1, Advanced = 2 };
 
-  pmove_t *pm{};
-  int textStyle{};
-  int lastUpdateTime{0};
-  int accelColorStyle{};
+  static void popOldStoredSpeeds(std::list<StoredSpeed> &storedSpeeds);
+  static void setAccelColor(int &style, float &speed, float &alpha, pmove_t *pm,
+                            std::list<StoredSpeed> &storedSpeeds, vec3_t &accel,
+                            vec4_t &color);
+  static bool lowSpeedOnGround(float speed, int groundEntityNum);
 
-  std::string getSpeedString() const;
+private:
+  static constexpr int ACCEL_COLOR_SMOOTHING_TIME = 250;
+  static constexpr float ACCEL_FOR_SOLID_COLOR = 100;
 
-  void resetMaxSpeed();
-  void setTextStyle();
-  void setAccelColorStyle();
-  void setSize();
-
-  void startListeners();
-  static void parseColor(const std::string &color, vec4_t &out);
-  static bool canSkipDraw();
-  bool canSkipUpdate(int frameTime) const;
-
-public:
-  DrawSpeed();
-  ~DrawSpeed() override;
-
-  void render() const override;
-  bool beforeRender() override;
+  static float calcAvgAccel(std::list<StoredSpeed> &storedSpeeds);
+  static void calcAccelColor(pmove_t *pm, vec3_t &accel, vec4_t &outColor);
 };
 } // namespace ETJump

--- a/src/cgame/etj_accelmeter_drawable.cpp
+++ b/src/cgame/etj_accelmeter_drawable.cpp
@@ -1,0 +1,205 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_accelmeter_drawable.h"
+#include "etj_cvar_update_handler.h"
+#include "etj_pmove_utils.h"
+#include "etj_utilities.h"
+#include "../game/etj_string_utilities.h"
+
+namespace ETJump {
+AccelMeter::AccelMeter() {
+  parseColor(etj_accelColor.string, accelColor);
+  setTextStyle();
+  setSize();
+  setAccelColorStyle();
+  startListeners();
+}
+
+void AccelMeter::startListeners() {
+  cvarUpdateHandler->subscribe(&etj_accelColor, [&](const vmCvar_t *cvar) {
+    parseColor(cvar->string, accelColor);
+  });
+
+  cvarUpdateHandler->subscribe(&etj_accelAlpha, [&](const vmCvar_t *cvar) {
+    parseColor(etj_accelColor.string, accelColor);
+  });
+
+  cvarUpdateHandler->subscribe(&etj_accelSize,
+                               [&](const vmCvar_t *cvar) { setSize(); });
+
+  cvarUpdateHandler->subscribe(&etj_accelShadow,
+                               [&](const vmCvar_t *cvar) { setTextStyle(); });
+
+  cvarUpdateHandler->subscribe(
+      &etj_accelColorUsesAccel,
+      [&](const vmCvar_t *cvar) { setAccelColorStyle(); });
+}
+
+void AccelMeter::parseColor(const std::string &color, vec4_t &out) {
+  parseColorString(color, out);
+  out[3] *= etj_accelAlpha.value;
+}
+
+void AccelMeter::setTextStyle() {
+  textStyle =
+      etj_accelShadow.integer ? ITEM_TEXTSTYLE_SHADOWED : ITEM_TEXTSTYLE_NORMAL;
+}
+
+void AccelMeter::setSize() {
+  size = 0.1f * etj_accelSize.value;
+  halfW = static_cast<float>(
+              CG_Text_Width_Ext("-88  -88", size, 0, &cgs.media.limboFont1)) *
+          0.5f;
+}
+
+void AccelMeter::setAccelColorStyle() {
+  if (!etj_accelColorUsesAccel.integer) {
+    parseColor(etj_accelColor.string, accelColor);
+  }
+
+  accelColorStyle = etj_accelColorUsesAccel.integer;
+}
+
+bool AccelMeter::beforeRender() {
+  if (canSkipDraw()) {
+    return false;
+  }
+
+  const playerState_t &ps = cg.predictedPlayerState;
+  const int8_t ucmdScale = CMDSCALE_DEFAULT;
+  const usercmd_t cmd = PmoveUtils::getUserCmd(ps, ucmdScale);
+
+  pm = PmoveUtils::getPmove(cmd);
+
+  // FIXME: this whole update check thing for non-pmove frames should be
+  //  moved to PmoveUtils so it can be done everywhere it needs to be done
+  //  with a single function call
+  const int frameTime = (cg.snap->ps.pm_flags & PMF_FOLLOW || cg.demoPlayback)
+                            ? cg.time
+                            : pm->ps->commandTime;
+
+  if (canSkipUpdate(frameTime)) {
+    return true;
+  }
+
+  lastUpdateTime = frameTime;
+  float currentSpeed = VectorLength2(ps.velocity);
+
+  if (accelColorStyle == AccelColor::Style::Simple ||
+      (accelColorStyle == AccelColor::Style::Advanced &&
+       AccelColor::lowSpeedOnGround(currentSpeed, ps.groundEntityNum))) {
+    storedSpeeds.push_back({cg.time, currentSpeed});
+    AccelColor::popOldStoredSpeeds(storedSpeeds);
+  } else if (!storedSpeeds.empty()) {
+    storedSpeeds.clear();
+  }
+
+  VectorSubtract(ps.velocity, lastSpeed, accel);
+  VectorCopy(ps.velocity, lastSpeed);
+
+  if (pm->ps->pm_type == PM_NOCLIP) {
+    VectorClear(accel);
+
+    if (accelColorStyle) {
+      Vector4Copy(colorWhite, accelColor);
+    } else {
+      parseColor(etj_accelColor.string, accelColor);
+    }
+  } else if (accelColorStyle) {
+    AccelColor::setAccelColor(accelColorStyle, currentSpeed,
+                              etj_accelAlpha.value, pm, storedSpeeds, accel,
+                              accelColor);
+  }
+
+  y = etj_accelY.value;
+
+  accelStr.clear();
+  accelStr.emplace_back(stringFormat("%.0f", accel[0]));
+  accelStr.emplace_back(stringFormat("%.0f", accel[1]));
+
+  return true;
+}
+
+void AccelMeter::render() const {
+  // this happens for a few frames when spawning in a map
+  // because canSkipUpdate exits beforeRender early
+  if (accelStr.empty()) {
+    return;
+  }
+
+  float accelX = etj_accelX.value;
+  ETJump_AdjustPosition(&accelX);
+
+  vec4_t color;
+  Vector4Copy(accelColor, color);
+
+  switch (etj_accelAlign.integer) {
+    case Alignment::Left:
+      CG_Text_Paint_Ext(accelX, y, size, size, color, accelStr[0], 0, 0,
+                        textStyle, &cgs.media.limboFont1);
+      CG_Text_Paint_Ext(accelX + halfW, y, size, size, color, accelStr[1], 0, 0,
+                        textStyle, &cgs.media.limboFont1);
+      break;
+    case Alignment::Right:
+      CG_Text_Paint_RightAligned_Ext(accelX, y, size, size, color, accelStr[0],
+                                     0, 0, textStyle, &cgs.media.limboFont1);
+      CG_Text_Paint_RightAligned_Ext(accelX - halfW, y, size, size, color,
+                                     accelStr[1], 0, 0, textStyle,
+                                     &cgs.media.limboFont1);
+      break;
+    default: // center align
+      CG_Text_Paint_Centred_Ext(accelX - (halfW * 0.5f), y, size, size, color,
+                                accelStr[0], 0, 0, textStyle,
+                                &cgs.media.limboFont1);
+      CG_Text_Paint_Centred_Ext(accelX + (halfW * 0.5f), y, size, size, color,
+                                accelStr[1], 0, 0, textStyle,
+                                &cgs.media.limboFont1);
+      break;
+  }
+}
+
+bool AccelMeter::canSkipUpdate(int frameTime) const {
+  // only count this frame if it's relevant to pmove
+  // this makes sure that if clients FPS > 125
+  // we only count frames at pmove_msec intervals
+  if (!pm->ps || lastUpdateTime + pm->pmove_msec > frameTime) {
+    return true;
+  }
+
+  return false;
+}
+
+bool AccelMeter::canSkipDraw() {
+  if (!etj_drawAccel.integer) {
+    return true;
+  }
+
+  if (showingScores()) {
+    return true;
+  }
+
+  return false;
+}
+} // namespace ETJump

--- a/src/cgame/etj_accelmeter_drawable.cpp
+++ b/src/cgame/etj_accelmeter_drawable.cpp
@@ -35,6 +35,9 @@ AccelMeter::AccelMeter() {
   setSize();
   setAccelColorStyle();
   startListeners();
+
+  accelStr.emplace_back("0");
+  accelStr.emplace_back("0");
 }
 
 void AccelMeter::startListeners() {
@@ -143,12 +146,6 @@ bool AccelMeter::beforeRender() {
 }
 
 void AccelMeter::render() const {
-  // this happens for a few frames when spawning in a map
-  // because canSkipUpdate exits beforeRender early
-  if (accelStr.empty()) {
-    return;
-  }
-
   float accelX = etj_accelX.value;
   ETJump_AdjustPosition(&accelX);
 

--- a/src/cgame/etj_accelmeter_drawable.cpp
+++ b/src/cgame/etj_accelmeter_drawable.cpp
@@ -36,6 +36,8 @@ AccelMeter::AccelMeter() {
   setAccelColorStyle();
   startListeners();
 
+  // add dummy elements here, so we don't try to read an empty vector
+  // at the very beginning of a map when we don't have a valid update yet
   accelStr.emplace_back("0");
   accelStr.emplace_back("0");
 }

--- a/src/cgame/etj_accelmeter_drawable.h
+++ b/src/cgame/etj_accelmeter_drawable.h
@@ -25,52 +25,45 @@
 #pragma once
 
 #include "etj_irenderable.h"
-#include "etj_accel_color.h"
 #include "cg_local.h"
+#include "etj_accel_color.h"
 #include <list>
 
 namespace ETJump {
-class DrawSpeed : public IRenderable {
+class AccelMeter : public IRenderable {
+  int textStyle{};
+  float y{};
+  float wX{};
+  float wY{};
+  float halfW{};
+  float size{};
+  int accelColorStyle{};
+  std::vector<std::string> accelStr;
+
   std::list<AccelColor::StoredSpeed> storedSpeeds;
 
-  float maxSpeed{0};
-  float currentSpeed{};
-  std::string speedStr;
-  float y{};
-  float w{};
-  float size{};
-
-  enum Alignment {
-    Left = 1,
-    Right = 2,
-  };
-
-  vec3_t lastSpeed{};
   vec3_t accel{};
-  vec4_t speedColor{};
+  vec4_t accelColor{};
+  int lastUpdateTime{};
+  vec3_t lastSpeed{};
+
+  enum Alignment { Left = 1, Right = 2 };
+
+  static void parseColor(const std::string &color, vec4_t &out);
+  void setTextStyle();
+  void setSize();
+  void setAccelColorStyle();
+  void startListeners();
+  bool canSkipUpdate(int frameTime) const;
+  static bool canSkipDraw();
 
   pmove_t *pm{};
-  int textStyle{};
-  int lastUpdateTime{0};
-  int accelColorStyle{};
-
-  std::string getSpeedString() const;
-
-  void resetMaxSpeed();
-  void setTextStyle();
-  void setAccelColorStyle();
-  void setSize();
-
-  void startListeners();
-  static void parseColor(const std::string &color, vec4_t &out);
-  static bool canSkipDraw();
-  bool canSkipUpdate(int frameTime) const;
 
 public:
-  DrawSpeed();
-  ~DrawSpeed() override;
+  AccelMeter();
+  ~AccelMeter() override = default;
 
-  void render() const override;
   bool beforeRender() override;
+  void render() const override;
 };
 } // namespace ETJump

--- a/src/cgame/etj_accelmeter_drawable.h
+++ b/src/cgame/etj_accelmeter_drawable.h
@@ -33,8 +33,6 @@ namespace ETJump {
 class AccelMeter : public IRenderable {
   int textStyle{};
   float y{};
-  float wX{};
-  float wY{};
   float halfW{};
   float size{};
   int accelColorStyle{};

--- a/src/cgame/etj_accelmeter_drawable.h
+++ b/src/cgame/etj_accelmeter_drawable.h
@@ -36,7 +36,7 @@ class AccelMeter : public IRenderable {
   float halfW{};
   float size{};
   int accelColorStyle{};
-  std::vector<std::string> accelStr;
+  std::vector<std::string> accelStr{};
 
   std::list<AccelColor::StoredSpeed> storedSpeeds;
 

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -398,10 +398,7 @@ float CGaz::getFrameAccel(const playerState_t &ps, pmove_t *pm) {
     return 0;
   }
 
-  // get accel defined by physics
-  const float accel = static_cast<float>(ps.speed) * pm->pmext->frametime;
-
-  return accel;
+  return static_cast<float>(ps.speed) * pm->pmext->frametime;
 }
 
 float CGaz::getOptAngle(const playerState_t &ps, pmove_t *pm, bool alternate) {

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -59,6 +59,8 @@
 #include "etj_client_rtv_handler.h"
 #include "etj_areaindicator_drawable.h"
 #include "etj_demo_compatibility.h"
+#include "etj_accelmeter_drawable.h"
+#include "etj_accel_color.h"
 
 namespace ETJump {
 std::shared_ptr<ClientCommandsHandler> serverCommandsHandler;
@@ -81,6 +83,7 @@ std::shared_ptr<TrickjumpLines> trickjumpLines;
 std::shared_ptr<ClientRtvHandler> rtvHandler;
 std::shared_ptr<AreaIndicator> areaIndicator;
 std::shared_ptr<DemoCompatibility> demoCompatibility;
+std::shared_ptr<AccelColor> accelColor;
 } // namespace ETJump
 
 static bool isInitialized{false};
@@ -224,6 +227,7 @@ void init() {
   rtvHandler->initialize();
 
   demoCompatibility = std::make_shared<DemoCompatibility>();
+  accelColor = std::make_shared<AccelColor>();
 
   // initialize renderables
   // Overbounce watcher
@@ -233,7 +237,8 @@ void init() {
   // Display max speed from previous load session
   ETJump::renderables.push_back(
       std::make_shared<DisplayMaxSpeed>(ETJump::entityEventsHandler.get()));
-  ETJump::renderables.push_back(std::make_shared<DisplaySpeed>());
+  ETJump::renderables.push_back(std::make_shared<DrawSpeed>());
+  ETJump::renderables.push_back(std::make_shared<AccelMeter>());
   ETJump::renderables.push_back(std::make_shared<StrafeQuality>());
   ETJump::renderables.push_back(
       std::make_shared<JumpSpeeds>(ETJump::entityEventsHandler.get()));

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -26,390 +26,196 @@
 #include "etj_utilities.h"
 #include "etj_cvar_update_handler.h"
 #include "etj_client_commands_handler.h"
-#include "etj_cgaz.h"
-#include "etj_snaphud.h"
-#include <string>
+#include "etj_pmove_utils.h"
 #include "../game/etj_string_utilities.h"
-#include "../game/etj_numeric_utilities.h"
 
-constexpr int ACCEL_COLOR_SMOOTHING_TIME = 250;
-constexpr float ACCEL_FOR_SOLID_COLOR = 100;
+namespace ETJump {
 
-ETJump::DisplaySpeed::DisplaySpeed() {
-  parseColor(etj_speedColor.string, _color);
-  checkShadow();
+DrawSpeed::DrawSpeed() {
+  parseColor(etj_speedColor.string, speedColor);
+  setTextStyle();
+  setAccelColorStyle();
+  setSize();
   startListeners();
 }
 
-ETJump::DisplaySpeed::~DisplaySpeed() {}
+DrawSpeed::~DrawSpeed() {
+  consoleCommandsHandler->unsubscribe("resetmaxspeed");
+}
 
-void ETJump::DisplaySpeed::parseColor(const std::string &color, vec4_t &out) {
+void DrawSpeed::parseColor(const std::string &color, vec4_t &out) {
   parseColorString(color, out);
   out[3] *= etj_speedAlpha.value;
 }
 
-void ETJump::DisplaySpeed::startListeners() {
+void DrawSpeed::startListeners() {
   cvarUpdateHandler->subscribe(&etj_speedColor, [&](const vmCvar_t *cvar) {
-    parseColor(etj_speedColor.string, _color);
+    parseColor(etj_speedColor.string, speedColor);
   });
 
   cvarUpdateHandler->subscribe(&etj_speedAlpha, [&](const vmCvar_t *cvar) {
-    parseColor(etj_speedColor.string, _color);
+    parseColor(etj_speedColor.string, speedColor);
   });
 
+  cvarUpdateHandler->subscribe(&etj_speedSize,
+                               [&](const vmCvar_t *cvar) { setSize(); });
+
   cvarUpdateHandler->subscribe(&etj_speedShadow,
-                               [&](const vmCvar_t *cvar) { checkShadow(); });
+                               [&](const vmCvar_t *cvar) { setTextStyle(); });
+
+  cvarUpdateHandler->subscribe(
+      &etj_speedColorUsesAccel,
+      [&](const vmCvar_t *cvar) { setAccelColorStyle(); });
 
   consoleCommandsHandler->subscribe(
       "resetmaxspeed",
       [&](const std::vector<std::string> &args) { resetMaxSpeed(); });
 }
 
-bool ETJump::DisplaySpeed::beforeRender() {
+bool DrawSpeed::beforeRender() {
   if (canSkipDraw()) {
     return false;
   }
 
   const playerState_t &ps = cg.predictedPlayerState;
-
-  // get usercmd
-  // cmdScale is only checked here to be 0 or !0
-  // so we can just use CMDSCALE_DEFAULT
   const int8_t ucmdScale = CMDSCALE_DEFAULT;
   const usercmd_t cmd = PmoveUtils::getUserCmd(ps, ucmdScale);
 
   pm = PmoveUtils::getPmove(cmd);
+  currentSpeed = VectorLength2(ps.velocity);
 
-  float speedx = cg.predictedPlayerState.velocity[0];
-  float speedy = cg.predictedPlayerState.velocity[1];
-
-  auto speed = std::sqrt(speedx * speedx + speedy * speedy);
-
-  // check if current frame should count towards strafe quality
+  // check if current frame should update speed meter
   // we check for framerate dependency here by comparing current time
   // to last update time, using commandTime for clients for 100%
   // accuracy and cg.time for spectators/demos as an approximation note:
   // this will be wrong for clients running < 125FPS... oh well
-  const auto frameTime = (cg.snap->ps.pm_flags & PMF_FOLLOW || cg.demoPlayback)
-                             ? cg.time
-                             : pm->ps->commandTime;
+  const int frameTime = (cg.snap->ps.pm_flags & PMF_FOLLOW || cg.demoPlayback)
+                            ? cg.time
+                            : pm->ps->commandTime;
 
-  _maxSpeed = speed > _maxSpeed ? speed : _maxSpeed;
-
-  if (etj_speedColorUsesAccel.integer == 1 ||
-      (etj_speedColorUsesAccel.integer == 2 && speed <= MAX_GROUNDSTRAFE &&
-       ps.groundEntityNum != ENTITYNUM_NONE)) {
-    _storedSpeeds.push_back({cg.time, speed});
-
-    popOldStoredSpeeds();
-  } else if (!_storedSpeeds.empty()) {
-    _storedSpeeds.clear();
-  }
-
-  if (canSkipUpdate(cmd, frameTime)) {
+  if (canSkipUpdate(frameTime)) {
     return true;
   }
 
-  _lastUpdateTime = frameTime;
+  lastUpdateTime = frameTime;
+  maxSpeed = currentSpeed > maxSpeed ? currentSpeed : maxSpeed;
 
-  _accelx = static_cast<int>(speedx - _lastSpeed[0]);
-  _accely = static_cast<int>(speedy - _lastSpeed[1]);
+  if (accelColorStyle == AccelColor::Style::Simple ||
+      (accelColorStyle == AccelColor::Style::Advanced &&
+       AccelColor::lowSpeedOnGround(currentSpeed, ps.groundEntityNum))) {
+    storedSpeeds.push_back({cg.time, currentSpeed});
+    AccelColor::popOldStoredSpeeds(storedSpeeds);
+  } else if (!storedSpeeds.empty()) {
+    storedSpeeds.clear();
+  }
 
-  Vector2Copy(cg.predictedPlayerState.velocity, _lastSpeed);
+  VectorSubtract(ps.velocity, lastSpeed, accel);
+  VectorCopy(ps.velocity, lastSpeed);
 
-  if (etj_speedColorUsesAccel.integer == 2 || etj_drawAccel.integer) {
-    calcAccelColor();
+  if (accelColorStyle) {
+    AccelColor::setAccelColor(accelColorStyle, currentSpeed,
+                              etj_speedAlpha.value, pm, storedSpeeds, accel,
+                              speedColor);
+  }
+
+  speedStr = getSpeedString();
+  y = etj_speedY.value;
+
+  // need to calculate this every frame because speed string changes
+  switch (etj_speedAlign.integer) {
+    case Alignment::Left:
+      w = 0;
+      break;
+    case Alignment::Right:
+      w = static_cast<float>(
+          CG_Text_Width_Ext(speedStr, size, 0, &cgs.media.limboFont2));
+      break;
+    default: // center align
+      w = static_cast<float>(
+              CG_Text_Width_Ext(speedStr, size, 0, &cgs.media.limboFont2)) *
+          0.5f;
+      break;
   }
 
   return true;
 }
 
-void ETJump::DisplaySpeed::resetMaxSpeed() {
-  _maxSpeed = 0;
+void DrawSpeed::render() const {
+  float speedX = etj_speedX.value;
+  ETJump_AdjustPosition(&speedX);
+
+  vec4_t color;
+  Vector4Copy(speedColor, color);
+
+  CG_Text_Paint_Ext(speedX - w, y, size, size, color, speedStr, 0, 0, textStyle,
+                    &cgs.media.limboFont1);
+}
+
+void DrawSpeed::resetMaxSpeed() {
+  maxSpeed = 0;
   cg.resetmaxspeed = qtrue; // fix me
 }
 
-void ETJump::DisplaySpeed::checkShadow() {
-  _shouldDrawSpeedShadow = etj_speedShadow.integer > 0 ? true : false;
-  _shouldDrawAccelShadow = etj_accelShadow.integer > 0 ? true : false;
+void DrawSpeed::setTextStyle() {
+  textStyle =
+      etj_speedShadow.integer ? ITEM_TEXTSTYLE_SHADOWED : ITEM_TEXTSTYLE_NORMAL;
 }
 
-void ETJump::DisplaySpeed::calcAccelColor() {
-  vec4_t color;
-
-  float speedx = cg.predictedPlayerState.velocity[0];
-  float speedy = cg.predictedPlayerState.velocity[1];
-
-  const playerState_t ps = cg.predictedPlayerState;
-  const int8_t ucmdScale = CMDSCALE_DEFAULT;
-  const usercmd_t cmd = PmoveUtils::getUserCmd(ps, ucmdScale);
-
-  const float scale = PmoveUtils::PM_SprintScale(&ps);
-
-  const float accelAngle = RAD2DEG(std::atan2(-cmd.rightmove, cmd.forwardmove));
-  const float accelAngleAlt =
-      RAD2DEG(std::atan2(cmd.rightmove, cmd.forwardmove));
-
-  // max acceleration possible per frame
-  const float frameAccel = CGaz::getFrameAccel(ps, pm);
-  if (_accelx || _accely) {
-    // get opt angles on both sides of velocity vector
-    const float optAngle = CGaz::getOptAngle(ps, pm, false);
-    const float altOptAngle = CGaz::getOptAngle(ps, pm, true);
-
-    // get accels for opt angle
-    const int optAccelx = static_cast<int>(
-        std::round(frameAccel * cos(DEG2RAD(accelAngle + optAngle)) * scale));
-    const int optAccely = static_cast<int>(
-        std::round(frameAccel * sin(DEG2RAD(accelAngle + optAngle)) * scale));
-
-    // get accels for alt angle
-    const int altOptAccelx = static_cast<int>(std::round(
-        frameAccel * cos(DEG2RAD(accelAngleAlt + altOptAngle)) * scale));
-    const int altOptAccely = static_cast<int>(std::round(
-        frameAccel * sin(DEG2RAD(accelAngleAlt + altOptAngle)) * scale));
-
-    // find max accel possible between opt and altOpt angles
-    int maxAccelx{0}, maxAccely{0};
-    bool isMovingx = false;
-
-    if (abs(speedx) > abs(speedy)) {
-      // we're advancing on x axis
-      isMovingx = true;
-      if (abs(optAccelx) >= abs(altOptAccelx)) {
-        maxAccelx = optAccelx;
-        maxAccely = optAccely;
-      } else {
-        maxAccelx = altOptAccelx;
-        maxAccely = altOptAccely;
-      }
-    } else {
-      isMovingx = false;
-      // we're advancing on y axis
-      if (abs(optAccely) >= abs(altOptAccely)) {
-        maxAccelx = optAccelx;
-        maxAccely = optAccely;
-      } else {
-        maxAccelx = altOptAccelx;
-        maxAccely = altOptAccely;
-      }
-    }
-
-    // Generate the color based on the average normalized acceleration
-    // Interpolate between red and green based on the average normalized
-    // acceleration
-    if (isMovingx) {
-      float frac{0};
-
-      if ((maxAccelx > 0 && _accelx >= 0) || (maxAccelx < 0 && _accelx <= 0)) {
-        frac = std::min(
-            std::max(1.0f - (abs(maxAccelx) - abs(_accelx + maxAccelx) / 2.0f) -
-                         (abs(_accely) -
-                          abs(std::max(abs(optAccely), abs(altOptAccely)))),
-                     0.0f),
-            1.0f);
-      }
-
-      LerpColor(colorRed, colorGreen, color, frac);
-    } else {
-      float frac{0};
-
-      if ((maxAccely > 0 && _accely >= 0) || (maxAccely < 0 && _accely <= 0)) {
-        frac = std::min(
-            std::max(1.0f - (abs(maxAccely) - abs(_accely + maxAccely) / 2.0f) -
-                         (abs(_accelx) -
-                          abs(std::max(abs(optAccelx), abs(altOptAccelx)))),
-                     0.0f),
-            1.0f);
-      }
-
-      LerpColor(colorRed, colorGreen, color, frac);
-    }
-  } else {
-    Vector4Copy(colorWhite, color);
+void DrawSpeed::setAccelColorStyle() {
+  if (!etj_speedColorUsesAccel.integer) {
+    parseColor(etj_speedColor.string, speedColor);
   }
 
-  // we want a solid color all the time, no dark tints
-  if (color[0] && color[1]) { // if we have a mix of R & G
-    size_t maxColorIndex = color[0] > color[1] ? 0 : 1;
-    float maxShade = 1.0f; // min value to show per color
-    float coef = maxShade / color[maxColorIndex];
-    VectorScale(color, coef, color);
-  }
-
-  // LerpColor adjusts alpha, make sure we still respect etj_speedAlpha
-  color[3] = etj_speedAlpha.value;
-
-  Vector4Copy(color, accelColor);
+  accelColorStyle = etj_speedColorUsesAccel.integer;
 }
 
-void ETJump::DisplaySpeed::render() const {
-  float speedSize = 0.1f * etj_speedSize.value;
-  float speedX = etj_speedX.integer;
-  float speedY = etj_speedY.integer;
-  ETJump_AdjustPosition(&speedX);
+void DrawSpeed::setSize() { size = 0.1f * etj_speedSize.value; }
 
-  float accelSize = 0.1f * etj_accelSize.value;
-  float accelX = etj_accelX.integer;
-  float accelY = etj_accelY.integer;
-  ETJump_AdjustPosition(&accelX);
-
-  auto status = getStatus();
-
-  auto accel_string = stringFormat("%3d %3d", _accelx, _accely);
-
-  float speedW;
-  switch (etj_speedAlign.integer) {
-    case 1: // left align
-      speedW = 0;
-      break;
-    case 2: // right align
-      speedW = CG_Text_Width_Ext(status.c_str(), speedSize, 0,
-                                 &cgs.media.limboFont2);
-      break;
-    default: // center align
-      speedW = CG_Text_Width_Ext(status.c_str(), speedSize, 0,
-                                 &cgs.media.limboFont2) /
-               2.0f;
-      break;
-  }
-
-  if (etj_drawSpeed2.integer == 8) {
-    speedW = 0;
-  }
-
-  float accelW;
-  switch (etj_accelAlign.integer) {
-    case 1: // left align
-      accelW = 0;
-      break;
-    case 2: // right align
-      accelW = CG_Text_Width_Ext(accel_string.c_str(), accelSize, 0,
-                                 &cgs.media.limboFont2);
-      break;
-    default: // center align
-      accelW = CG_Text_Width_Ext(accel_string.c_str(), accelSize, 0,
-                                 &cgs.media.limboFont2) /
-               2.0f;
-      break;
-  }
-
-  int speedStyle =
-      _shouldDrawSpeedShadow ? ITEM_TEXTSTYLE_SHADOWED : ITEM_TEXTSTYLE_NORMAL;
-
-  int accelStyle =
-      _shouldDrawAccelShadow ? ITEM_TEXTSTYLE_SHADOWED : ITEM_TEXTSTYLE_NORMAL;
-
-  vec4_t color = {1, 1, 1, 1};
-
-  playerState_t *ps = &cg.predictedPlayerState;
-  const float xyVelocity = VectorLength2(ps->velocity);
-
-  if (etj_speedColorUsesAccel.integer == 1 ||
-      (etj_speedColorUsesAccel.integer == 2 && xyVelocity <= MAX_GROUNDSTRAFE &&
-       ps->groundEntityNum != ENTITYNUM_NONE)) {
-    float accel = calcAvgAccel();
-    float *accelColor = colorGreen;
-
-    if (accel < 0) {
-      accelColor = colorRed;
-      accel = -accel;
-    }
-
-    float frac = accel / ACCEL_FOR_SOLID_COLOR;
-    frac = std::min(frac, 1.f);
-
-    LerpColor(colorWhite, accelColor, color, frac);
-  } else if (etj_speedColorUsesAccel.integer == 2) {
-    Vector4Copy(accelColor, color);
-  } else {
-    Vector4Copy(_color, color);
-  }
-
-  if (etj_drawSpeed2.integer) {
-    CG_Text_Paint_Ext(speedX - speedW, speedY, speedSize, speedSize, color,
-                      status.c_str(), 0, 0, speedStyle, &cgs.media.limboFont1);
-  }
-
-  if (etj_drawAccel.integer) {
-    CG_Text_Paint_Ext(accelX - accelW, accelY, accelSize, accelSize, color,
-                      accel_string.c_str(), 0, 0, accelStyle,
-                      &cgs.media.limboFont1);
-  }
-}
-
-std::string ETJump::DisplaySpeed::getStatus() const {
-  float speed = sqrt(cg.predictedPlayerState.velocity[0] *
-                         cg.predictedPlayerState.velocity[0] +
-                     cg.predictedPlayerState.velocity[1] *
-                         cg.predictedPlayerState.velocity[1]);
-
+std::string DrawSpeed::getSpeedString() const {
   switch (etj_drawSpeed2.integer) {
     case 2:
-      return stringFormat("%.0f %.0f", speed, _maxSpeed);
+      return stringFormat("%.0f %.0f", currentSpeed, maxSpeed);
     case 3:
-      return stringFormat("%.0f ^z%.0f", speed, _maxSpeed);
+      return stringFormat("%.0f ^z%.0f", currentSpeed, maxSpeed);
     case 4:
-      return stringFormat("%.0f (%.0f)", speed, _maxSpeed);
+      return stringFormat("%.0f (%.0f)", currentSpeed, maxSpeed);
     case 5:
-      return stringFormat("%.0f ^z(%.0f)", speed, _maxSpeed);
+      return stringFormat("%.0f ^z(%.0f)", currentSpeed, maxSpeed);
     case 6:
-      return stringFormat("%.0f ^z[%.0f]", speed, _maxSpeed);
+      return stringFormat("%.0f ^z[%.0f]", currentSpeed, maxSpeed);
     case 7:
-      return stringFormat("%.0f | %.0f", speed, _maxSpeed);
+      return stringFormat("%.0f | %.0f", currentSpeed, maxSpeed);
     case 8:
-      return stringFormat("Speed: %.0f", speed);
+      return stringFormat("Speed: %.0f", currentSpeed);
     // tens
     case 9:
-      return stringFormat("%02i", static_cast<int>(speed) / 10 % 10 * 10);
+      return stringFormat("%02i",
+                          static_cast<int>(currentSpeed) / 10 % 10 * 10);
     default:
-      return stringFormat("%.0f", speed);
+      return stringFormat("%.0f", currentSpeed);
   }
 }
 
-bool ETJump::DisplaySpeed::canSkipDraw() const {
-  return (!etj_drawSpeed2.integer && !etj_drawAccel.integer) ||
-         ETJump::showingScores();
-}
-
-bool ETJump::DisplaySpeed::canSkipUpdate(usercmd_t cmd, int frameTime) const {
+bool DrawSpeed::canSkipUpdate(int frameTime) const {
   // only count this frame if it's relevant to pmove
   // this makes sure that if clients FPS > 125
   // we only count frames at pmove_msec intervals
-  if (!pm->ps || _lastUpdateTime + pm->pmove_msec > frameTime) {
+  if (!pm->ps || lastUpdateTime + pm->pmove_msec > frameTime) {
     return true;
   }
 
   return false;
 }
 
-void ETJump::DisplaySpeed::popOldStoredSpeeds() {
-  do {
-    auto &front = _storedSpeeds.front();
-
-    if (cg.time - front.time > ACCEL_COLOR_SMOOTHING_TIME) { // too old
-      _storedSpeeds.pop_front();
-      continue;
-    } else if (cg.time < front.time) { // we went back in time!
-      _storedSpeeds.pop_front();
-      continue;
-    }
-  } while (false);
-}
-
-float ETJump::DisplaySpeed::calcAvgAccel() const {
-  if (_storedSpeeds.size() < 2) { // need 2 speed points to compute acceleration
-    return 0;
+bool DrawSpeed::canSkipDraw() {
+  if (!etj_drawSpeed2.integer) {
+    return true;
   }
 
-  float totalSpeedDelta = 0;
-  auto iter = _storedSpeeds.begin();
-  for (auto prevIter = iter++; iter != _storedSpeeds.end(); prevIter = iter++) {
-    totalSpeedDelta += iter->speed - prevIter->speed;
+  if (showingScores()) {
+    return true;
   }
 
-  float timeDeltaMs = _storedSpeeds.back().time - _storedSpeeds.front().time;
-  float accel = totalSpeedDelta / (timeDeltaMs / 1000.f);
-
-  return accel;
+  return false;
 }
+} // namespace ETJump


### PR DESCRIPTION
Refactor + fixes to `etj_drawAccel` and advanced accel coloring.

* Refactored `etj_drawspeed2` code
* Moved `etj_drawAccel` and related code out of `etj_speed_drawable.cpp` into `etj_accel_color.cpp/etj_accel_meter_drawable.cpp`
* Fixed `etj_drawAccel` not working if `etj_drawSpeed2` was `0`
* Added `etj_accelColor`, `etj_accelAlpha`, `etj_accelColorUsesAccel` cvars to allow displaying regular colors instead of accel-based colors for accel meter
* Added missing cvar registration for `etj_accelShadow`
* Accel meter now zeroes out when noclipping
* Tweaked `etj_accelAlign` so that the spacing between the readings is consistent
* Added missing menu entries
* Adjusted `etj_speedY`, `etj_maxSpeedY` and `etj_accelY` default values slightly so they won't overlap with run timer

refs #1183 