### PR TITLE
Fix div by 0 in G_RunEntity on first server frame

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1244,8 +1244,7 @@ typedef struct {
   int framenum;
   int time;         // in msec
   int previousTime; // so movers can back up when blocked
-  int frameTime;    // Gordon: time the frame started, for antilag stuff
-  int frameMsec;    // server frame time
+  int frameTime;    // server frame time
 
   int startTime; // level.time the map was started
 

--- a/src/game/g_trigger.cpp
+++ b/src/game/g_trigger.cpp
@@ -22,7 +22,7 @@ void multi_trigger(gentity_t *ent, gentity_t *activator) {
 
   // old constant triggers: set wait to server frame time for spawnflags 512
   if (ent->spawnflags & static_cast<int>(TriggerMultipleFlags::Constant)) {
-    wait = level.frameMsec;
+    wait = level.frameTime;
   }
 
   if (activator && activator->client) {


### PR DESCRIPTION
Do not rely on level.time to set server frame time, instead grab it directly from `sv_fps` value.