### PR TITLE
Cleanup dynamic shader cleanup calls

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -2086,8 +2086,6 @@ static void CG_RegisterSounds(void) {
 
 //===================================================================================
 
-static std::vector<std::string> dynamicallyLoadedShaders;
-
 /*
 =================
 CG_RegisterGraphics
@@ -2391,7 +2389,6 @@ static void CG_RegisterGraphics(void) {
                 "rgbGen identity",
             }});
         trap_R_LoadDynamicShader(shaderName, shader.c_str());
-        dynamicallyLoadedShaders.push_back(shaderName);
 
         cgs.media.commandCentreAutomapShader[i] =
             trap_R_RegisterShaderNoMip(shaderName);
@@ -4071,10 +4068,8 @@ void CG_Shutdown(void) {
   ETJump::shutdown();
 
   // unload dynamically loaded shaders
-  for (const auto &shaderName : dynamicallyLoadedShaders) {
-    trap_R_LoadDynamicShader(shaderName.c_str(), nullptr);
-  }
-  dynamicallyLoadedShaders.clear();
+  // single call will clear all dynamic shaders
+  trap_R_LoadDynamicShader(nullptr, nullptr);
 
   Shutdown_Display();
 }

--- a/src/cgame/etj_console_alpha.cpp
+++ b/src/cgame/etj_console_alpha.cpp
@@ -92,8 +92,5 @@ std::string ConsoleAlphaHandler::createSolidBackground() {
 }
 
 ConsoleAlphaHandler::~ConsoleAlphaHandler() {
-  // unload dynamic shader, so if you do `vid_restart` you won't
-  // accidently load it twice
-  trap_R_LoadDynamicShader(shaderName, nullptr);
   trap_R_RemapShader("console-16bit", "console-16bit", "0");
 }

--- a/src/cgame/etj_draw_leaves_handler.cpp
+++ b/src/cgame/etj_draw_leaves_handler.cpp
@@ -60,7 +60,4 @@ void DrawLeavesHandler::turnOffLeaves() {
   }
 }
 
-DrawLeavesHandler::~DrawLeavesHandler() {
-  trap_R_LoadDynamicShader(shaderName, nullptr);
-  turnOnLeaves();
-}
+DrawLeavesHandler::~DrawLeavesHandler() { turnOnLeaves(); }


### PR DESCRIPTION
Sending nullptr for both shadername and shadertext will clear up all dynamic shaders, there's no need to keep track of them on cgame side.

refs #159, #800 