### PR TITLE
Fix crash in speed drawable + copy paste error in accel color

### DIFF
--- a/src/cgame/etj_accel_color.cpp
+++ b/src/cgame/etj_accel_color.cpp
@@ -98,25 +98,21 @@ void AccelColor::calcAccelColor(pmove_t *pm, vec3_t &accel, vec4_t &outColor) {
                    static_cast<float>(
                        std::sin(DEG2RAD(accelAngleAlt + altOptAngle)) * scale));
 
-    vec3_t optAccel = {optAccelX, optAccelY, gravityAccel};
-    vec3_t altOptAccel = {altOptAccelX, altOptAccelY, gravityAccel};
-    vec3_t normal = {0, 0, 0};
-
-    VectorCopy(pm->groundTrace.plane.normal, normal);
-
     if (pm->groundPlane) {
+      vec3_t optAccel = {optAccelX, optAccelY, gravityAccel};
+      vec3_t altOptAccel = {altOptAccelX, altOptAccelY, gravityAccel};
+      vec3_t normal = {0, 0, 0};
+
+      VectorCopy(pm->groundTrace.plane.normal, normal);
+
       PM_ClipVelocity(optAccel, normal, optAccel, OVERCLIP);
       PM_ClipVelocity(altOptAccel, normal, altOptAccel, OVERCLIP);
-    }
 
-    if ((normal)[0] != 0.0f) {
-      optAccelX = std::roundf(optAccel[0]);
-      altOptAccelX = std::roundf(altOptAccel[0]);
-    }
+      optAccelX = std::round(optAccel[0]);
+      altOptAccelX = std::round(altOptAccel[0]);
 
-    if ((normal)[1] != 0.0f) {
-      optAccelX = std::roundf(optAccel[1]);
-      altOptAccelX = std::roundf(altOptAccel[1]);
+      optAccelY = std::round(optAccel[1]);
+      altOptAccelY = std::round(altOptAccel[1]);
     }
 
     // find max accel possible between opt and altOpt angles

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -84,7 +84,6 @@ bool DrawSpeed::beforeRender() {
   const usercmd_t cmd = PmoveUtils::getUserCmd(*ps, ucmdScale);
 
   pm = PmoveUtils::getPmove(cmd);
-  currentSpeed = VectorLength2(pm->ps->velocity);
 
   // check if current frame should update speed meter
   // we check for framerate dependency here by comparing current time
@@ -99,6 +98,7 @@ bool DrawSpeed::beforeRender() {
     return true;
   }
 
+  currentSpeed = VectorLength2(pm->ps->velocity);
   lastUpdateTime = frameTime;
   maxSpeed = currentSpeed > maxSpeed ? currentSpeed : maxSpeed;
 


### PR DESCRIPTION
* Fix nullptr dereference in `etj_drawspeed2`
* Fix copy/paste error in `calcAccelColor` that assigned Y axis values to X axis variables
* Simplify accel calculations on ground

refs #1183 