### PR TITLE
Fix numericfield item not reading maxchars

### DIFF
--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -5944,7 +5944,8 @@ void Item_ValidateTypeData(itemDef_t *item) {
              item->type == ITEM_TYPE_SLIDER || item->type == ITEM_TYPE_TEXT) {
     item->typeData = UI_Alloc(sizeof(editFieldDef_t));
     memset(item->typeData, 0, sizeof(editFieldDef_t));
-    if (item->type == ITEM_TYPE_EDITFIELD) {
+    if (item->type == ITEM_TYPE_EDITFIELD ||
+        item->type == ITEM_TYPE_NUMERICFIELD) {
       if (!((editFieldDef_t *)item->typeData)->maxPaintChars) {
         ((editFieldDef_t *)item->typeData)->maxPaintChars = MAX_EDITFIELD;
       }


### PR DESCRIPTION
This messed up keyhandling for home/end as the key handler wasn't aware of how many characters the field supported, so it could not calculate cursor position correctly.