### PR TITLE
Fix autoswitch not working when running out of ammo on some weapons

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -2003,15 +2003,14 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       if (es->number == cg.snap->ps.clientNum &&
           ((cg_noAmmoAutoSwitch.integer > 0 &&
             !CG_WeaponSelectable(cg.weaponSelect)) ||
-           (cg_autoswitch.integer == AutoSwitchFlags::Enabled &&
-            (es->weapon == WP_MORTAR_SET || es->weapon == WP_MOBILE_MG42_SET ||
-             es->weapon == WP_GRENADE_LAUNCHER ||
-             es->weapon == WP_GRENADE_PINEAPPLE || es->weapon == WP_DYNAMITE ||
-             es->weapon == WP_SMOKE_MARKER || es->weapon == WP_PANZERFAUST ||
-             es->weapon == WP_ARTY || es->weapon == WP_LANDMINE ||
-             es->weapon == WP_SATCHEL || es->weapon == WP_SATCHEL_DET ||
-             es->weapon == WP_TRIPMINE || es->weapon == WP_SMOKE_BOMB ||
-             es->weapon == WP_AMMO || es->weapon == WP_MEDKIT)))) {
+           es->weapon == WP_MORTAR_SET || es->weapon == WP_MOBILE_MG42_SET ||
+           es->weapon == WP_GRENADE_LAUNCHER ||
+           es->weapon == WP_GRENADE_PINEAPPLE || es->weapon == WP_DYNAMITE ||
+           es->weapon == WP_SMOKE_MARKER || es->weapon == WP_PANZERFAUST ||
+           es->weapon == WP_ARTY || es->weapon == WP_LANDMINE ||
+           es->weapon == WP_SATCHEL || es->weapon == WP_SATCHEL_DET ||
+           es->weapon == WP_TRIPMINE || es->weapon == WP_SMOKE_BOMB ||
+           es->weapon == WP_AMMO || es->weapon == WP_MEDKIT)) {
         CG_OutOfAmmoChange(event == EV_WEAPONSWITCHED ? qfalse : qtrue);
       }
       break;

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -4741,6 +4741,23 @@ void CG_OutOfAmmoChange(qboolean allowforceswitch) {
     }
   }
 
+  // When we drop a weapon by picking up a new one, we end up here.
+  // This is because EV_NOAMMO event gets added since we lose our primary
+  // weapon (there is no ammo left) so the game thinks we might want to switch.
+  // This happens if 'cg_noAmmoAutoSwitch' is enabled, and we have no ammo
+  // in our equipped weapon, which is fine, EXCEPT the game also forces this
+  // behavior for certain other weapons, e.g. grenades (see EV_NOAMMO
+  // event handling). This makes sense, as you don't want to end up with 0
+  // grenades in hand after throwing out the last one. This means that if we
+  // are not holding our primary weapon while picking up a new one, and we are
+  // also holding one of the weapons defined in the event handling, we are
+  // forced to switch to the newly picked up weapon. We don't want that,
+  // it's stupid, so if the currently selected weapon is still valid,
+  // exit out here before we are forced into a weapon switch.
+  if (CG_WeaponSelectable(cg.weaponSelect)) {
+    return;
+  }
+
   //
   // more complicated selection
   //


### PR DESCRIPTION
Autoswitch was not working for certain weapons when running out of ammo unless `cg_autoswitch` was set to `1`, see the comment added into `CG_OutOfAmmoChange`.

refs #1266 