### PR TITLE
Fix portal reset sound playing for incorrect clients

### DIFF
--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1585,6 +1585,7 @@ void target_remove_portals_use(gentity_t *self, gentity_t *other,
                              EV_GENERAL_CLIENT_SOUND_VOLUME, self->noise_index);
 
       noiseEnt->s.onFireStart = self->s.onFireStart;
+      noiseEnt->s.teamNum = ClientNum(activator);
     }
 
     if (!(self->spawnflags & SF_REMOVE_PORTALS_NO_TEXT)) {


### PR DESCRIPTION
s.teamNum was never set so it only worked correctly for clientNum 0.

fixes #1283 
refs #1129 