### PR TITLE
Fix setoffset not bypassing nonoclip restrictions in devmap

### DIFF
--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -979,7 +979,7 @@ void setPlayerOffset(gentity_t *ent) {
                     ent->client->ps.maxs, dst, ent->client->ps.clientNum,
                     CONTENTS_NONOCLIP);
 
-  if (level.noNoclip == (trace.fraction == 1.0f)) {
+  if (!g_cheats.integer && level.noNoclip == (trace.fraction == 1.0f)) {
     Printer::SendConsoleMessage(clientNum,
                                 "^7You cannot ^3setoffset ^7to this area.\n");
     return;


### PR DESCRIPTION
Going through nonoclip volumes was not possible.

fixes #1282 
refs #1192 