### PR TITLE
Fix multiline tooltip vertical spacing

### DIFF
--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -4032,7 +4032,6 @@ void Item_Text_DrawAutoWrapped(itemDef_t *item, const char *textPtr,
   fontInfo_t *font = DC->getActiveFont();
   float lineWidth = 0;
   float lineHeight = 0;
-  constexpr float DEFAULT_LINEHEIGHT = 11.0f;
 
   newLinePtr = nullptr;
 

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -246,6 +246,8 @@ typedef struct modelDef_s {
 
 #define UI_MAX_TEXT_LINES 64
 
+constexpr float DEFAULT_LINEHEIGHT = 11.0f;
+
 typedef struct itemDef_s {
   Window window;      // common positional, border, style, layout info
   rectDef_t textRect; // rectangle the text ( if any ) consumes
@@ -255,7 +257,7 @@ typedef struct itemDef_s {
   int textalignment; // ( optional ) alignment for text within rect
                      // based on text width
   float textalignx;  // ( optional ) text alignment x coord
-  float textaligny;  // ( optional ) text alignment x coord
+  float textaligny;  // ( optional ) text alignment y coord
   float textscale;   // scale percentage from 72pts
   int font;          // (SA)
   int textStyle;     // ( optional ) style, normal and shadowed are it for


### PR DESCRIPTION
Not perfect but it somewhat works, ideally `Multiline_Text_Height` would need to take in pointer to the `itemDef_t` so we could get the actual `textaligny` value, same issue is the cause for horizontal misalignment too and why the spacing for that was hardcoded to work somewhat ok.

fixes #1285 