### PR TITLE
Fix portalgun getting removed incorrectly with target_init

### DIFF
--- a/src/game/etj_target_init.h
+++ b/src/game/etj_target_init.h
@@ -39,8 +39,6 @@ private:
     RemoveStartingWeapons = 128
   };
 
-  static constexpr int NUM_KEPT_WEAPONS = 7;
-
   static void use(gentity_t *self, gentity_t *other, gentity_t *activator);
 
 public:

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -13,6 +13,7 @@
 #include "etj_string_utilities.h"
 #include "etj_timerun_entities.h"
 #include "etj_missilepad.h"
+#include "etj_target_init.h"
 
 qboolean G_SpawnStringExt(const char *key, const char *defaultString,
                           char **out, const char *file, int line) {
@@ -729,7 +730,7 @@ spawn_t spawns[] = {
     {"target_deathrun_checkpoint", SP_target_deathrun_checkpoint},
     {"target_displaytjl", SP_target_tjldisplay},
     {"target_cleartjl", SP_target_tjlclear},
-    {"target_init", SP_target_init},
+    {"target_init", ETJump::TargetInit::spawn},
     {"func_missilepad", ETJump::Missilepad::spawn},
     {nullptr, nullptr},
 };


### PR DESCRIPTION
The spawnflags which removed weapons from the player (`KeepWeapons` & `RemoveStartingWeapons`) were not respecting `KeepPortalgun` spawnflag.

fixes #1273 