### PR TITLE
Limit CGaz + snaphud update rate to 125fps + refactor limiter

### DIFF
--- a/src/cgame/etj_accelmeter_drawable.h
+++ b/src/cgame/etj_accelmeter_drawable.h
@@ -53,7 +53,6 @@ class AccelMeter : public IRenderable {
   void setSize();
   void setAccelColorStyle();
   void startListeners();
-  bool canSkipUpdate(int frameTime) const;
   static bool canSkipDraw();
 
   pmove_t *pm{};

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -230,6 +230,10 @@ bool CGaz::beforeRender() {
     return false;
   }
 
+  if (PmoveUtils::skipUpdate(lastUpdateTime, pm, ps)) {
+    return true;
+  }
+
   // show upmove influence?
   const float scale =
       etj_CGazTrueness.integer & static_cast<int>(CGazTrueness::CGAZ_JUMPCROUCH)

--- a/src/cgame/etj_cgaz.h
+++ b/src/cgame/etj_cgaz.h
@@ -57,6 +57,8 @@ public:
   // next snap in strafe dir, INVALID_SNAP_DIR if not available
   static float drawSnap;
 
+  int lastUpdateTime{};
+
   CGaz();
   ~CGaz() override = default;
 

--- a/src/cgame/etj_pmove_utils.cpp
+++ b/src/cgame/etj_pmove_utils.cpp
@@ -172,4 +172,18 @@ float PmoveUtils::getFrameAccel(const playerState_t &ps, const pmove_t *pm) {
       pm->pmext->up, ps, pm);
   return pm->pmext->accel * wishspeed * pm->pmext->frametime;
 }
+
+bool PmoveUtils::skipUpdate(int &lastUpdateTime, const pmove_t *pm,
+                            const playerState_t *ps) {
+  const int frameTime = (cg.snap->ps.pm_flags & PMF_FOLLOW || cg.demoPlayback)
+                            ? cg.time
+                            : ps->commandTime;
+
+  if (!pm->ps || lastUpdateTime + pm->pmove_msec > frameTime) {
+    return true;
+  }
+
+  lastUpdateTime = frameTime;
+  return false;
+}
 } // namespace ETJump

--- a/src/cgame/etj_pmove_utils.h
+++ b/src/cgame/etj_pmove_utils.h
@@ -54,5 +54,10 @@ public:
 
   // returns total acceleration per frame
   static float getFrameAccel(const playerState_t &ps, const pmove_t *pm);
+
+  // if an update should happen, updates lastUpdateTime to current frametime
+  // and returns false
+  static bool skipUpdate(int &lastUpdateTime, const pmove_t *pm,
+                         const playerState_t *ps);
 };
 } // namespace ETJump

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -215,7 +215,7 @@ void Snaphud::UpdateMaxSnapZones() {
 
   // need to add rounded xy clipped to normal gravity influence to frame accel
   // 11 snap zones for ~78deg slope, 9 zones for 60deg slope, etc.
-  // const int maxSnaphudZonesQ1 = 
+  // const int maxSnaphudZonesQ1 =
   //    static_cast<int>(std::roundf(snap.a + gravityAccelxy) * 2 + 1);
 
   snap.zones.resize(maxSnaphudZonesQ1);
@@ -243,6 +243,10 @@ bool Snaphud::beforeRender() {
   // check this only after we have a valid pmove
   if (pm->pmext->waterlevel > 1 || pm->pmext->ladder) {
     return false;
+  }
+
+  if (PmoveUtils::skipUpdate(lastUpdateTime, pm, ps)) {
+    return true;
   }
 
   // show upmove influence?

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -51,7 +51,7 @@ private:
   bool canSkipDraw() const;
   void InitSnaphud(vec3_t wishvel, int8_t uCmdScale, usercmd_t cmd);
   void UpdateMaxSnapZones();
-  void UpdateSnapState(void);
+  void UpdateSnapState();
   void PrepareDrawables();
   void startListeners();
 
@@ -70,13 +70,14 @@ private:
 
   snaphud_t snap;
 
-  int yaw;
-  vec4_t snaphudColors[4];
-  bool edgesOnly;
-  int edgeThickness;
+  int yaw{};
+  vec4_t snaphudColors[4]{};
+  bool edgesOnly{};
+  int edgeThickness{};
+  int lastUpdateTime{};
 
   playerState_t *ps = &cg.predictedPlayerState;
-  pmove_t *pm;
+  pmove_t *pm{};
 
   struct DrawableSnap {
     int bSnap;
@@ -86,6 +87,6 @@ private:
   };
 
   std::vector<DrawableSnap> drawableSnaps{};
-  bool isCurrentAlt;
+  bool isCurrentAlt{};
 };
 } // namespace ETJump

--- a/src/cgame/etj_speed_drawable.h
+++ b/src/cgame/etj_speed_drawable.h
@@ -66,7 +66,6 @@ class DrawSpeed : public IRenderable {
   void startListeners();
   static void parseColor(const std::string &color, vec4_t &out);
   static bool canSkipDraw();
-  bool canSkipUpdate(int frameTime) const;
 
 public:
   DrawSpeed();

--- a/src/cgame/etj_strafe_quality_drawable.h
+++ b/src/cgame/etj_strafe_quality_drawable.h
@@ -47,7 +47,7 @@ class StrafeQuality : public IRenderable {
   void parseColor();
   void resetStrafeQuality();
   bool canSkipDraw() const;
-  bool canSkipUpdate(usercmd_t cmd, int frameTime);
+  bool canSkipUpdate(usercmd_t cmd);
 
   pmove_t *pm;
 

--- a/src/cgame/etj_upmove_meter_drawable.h
+++ b/src/cgame/etj_upmove_meter_drawable.h
@@ -62,7 +62,7 @@ class UpmoveMeter : public IRenderable {
     mutable vec4_t text_rgba;
   } jump_t;
 
-  jump_t jump_;
+  jump_t jump_{};
 
   int team_;
 
@@ -70,7 +70,8 @@ class UpmoveMeter : public IRenderable {
   static constexpr float graphX_ = 8.0f;
   static constexpr float graphY_ = 8.0f;
 
-  pmove_t *pm;
+  int lastUpdateTime{};
+  pmove_t *pm{};
 
   void startListeners();
   void parseAllColors();


### PR DESCRIPTION
Prevents unnecessary state updates for cgaz and snaphud if there isn't a new pmove frame + refactor the update handler from various drawables to PmoveUtils.

This also fixes flickering yaw angles for `etj_CGaz1DrawSnapZone` due to the yaw angle getting updated at incorrect intervals.