### PR TITLE
Make etj_CGaz1DrawSnapZone respect etj_CGazTrueness

### DIFF
--- a/src/cgame/etj_accel_color.cpp
+++ b/src/cgame/etj_accel_color.cpp
@@ -69,7 +69,7 @@ void AccelColor::calcAccelColor(const pmove_t *pm, const playerState_t *ps,
       RAD2DEG(std::atan2(cmd.rightmove, cmd.forwardmove));
 
   // max acceleration possible per frame
-  const float frameAccel = PmoveUtils::getFrameAccel(*ps, pm);
+  const float frameAccel = PmoveUtils::getFrameAccel(*ps, pm, true);
   const float gravityAccel =
       -std::round(static_cast<float>(ps->gravity) * pm->pmext->frametime);
 

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -141,7 +141,10 @@ float CGaz::UpdateDrawSnap(const playerState_t *ps, pmove_t *pm) {
     return Snaphud::INVALID_SNAP_DIR;
   }
 
-  const Snaphud::CurrentSnap cs = Snaphud::getCurrentSnap(*ps, pm);
+  const Snaphud::CurrentSnap cs = Snaphud::getCurrentSnap(
+      *ps, pm,
+      etj_CGazTrueness.integer &
+          static_cast<int>(CGazTrueness::CGAZ_JUMPCROUCH));
 
   if (cs.snap == Snaphud::INVALID_SNAP_DIR) {
     return Snaphud::INVALID_SNAP_DIR;

--- a/src/cgame/etj_pmove_utils.cpp
+++ b/src/cgame/etj_pmove_utils.cpp
@@ -154,7 +154,8 @@ void PmoveUtils::PM_UpdateWishvel(vec3_t wishvel, usercmd_t cmd, vec3_t forward,
   }
 }
 
-float PmoveUtils::getFrameAccel(const playerState_t &ps, const pmove_t *pm) {
+float PmoveUtils::getFrameAccel(const playerState_t &ps, const pmove_t *pm,
+                                const bool upmoveTrueness) {
   const auto ucmdScale =
       static_cast<int8_t>(ps.stats[STAT_USERCMD_BUTTONS] & (BUTTON_WALKING << 8)
                               ? CMDSCALE_WALK
@@ -167,9 +168,11 @@ float PmoveUtils::getFrameAccel(const playerState_t &ps, const pmove_t *pm) {
   }
 
   vec3_t wishvel;
-  const float wishspeed = PmoveUtils::PM_GetWishspeed(
-      wishvel, pm->pmext->scale, cmd, pm->pmext->forward, pm->pmext->right,
-      pm->pmext->up, ps, pm);
+  const float scale = upmoveTrueness ? pm->pmext->scale : pm->pmext->scaleAlt;
+  const float wishspeed =
+      PmoveUtils::PM_GetWishspeed(wishvel, scale, cmd, pm->pmext->forward,
+                                  pm->pmext->right, pm->pmext->up, ps, pm);
+
   return pm->pmext->accel * wishspeed * pm->pmext->frametime;
 }
 

--- a/src/cgame/etj_pmove_utils.h
+++ b/src/cgame/etj_pmove_utils.h
@@ -53,7 +53,7 @@ public:
                                const playerState_t &ps);
 
   // returns total acceleration per frame
-  static float getFrameAccel(const playerState_t &ps, const pmove_t *pm);
+  static float getFrameAccel(const playerState_t &ps, const pmove_t *pm, bool upmoveTrueness);
 
   // if an update should happen, updates lastUpdateTime to current frametime
   // and returns false

--- a/src/cgame/etj_pmove_utils.h
+++ b/src/cgame/etj_pmove_utils.h
@@ -53,7 +53,8 @@ public:
                                const playerState_t &ps);
 
   // returns total acceleration per frame
-  static float getFrameAccel(const playerState_t &ps, const pmove_t *pm, bool upmoveTrueness);
+  static float getFrameAccel(const playerState_t &ps, const pmove_t *pm,
+                             bool upmoveTrueness);
 
   // if an update should happen, updates lastUpdateTime to current frametime
   // and returns false

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -349,7 +349,8 @@ void Snaphud::render() const {
 }
 
 Snaphud::CurrentSnap Snaphud::getCurrentSnap(const playerState_t &ps,
-                                             pmove_t *pm) {
+                                             pmove_t *pm,
+                                             const bool upmoveTrueness) {
   static Snaphud s;
   CurrentSnap cs{};
 
@@ -374,7 +375,7 @@ Snaphud::CurrentSnap Snaphud::getCurrentSnap(const playerState_t &ps,
   // get opt angle
   float opt = CGaz::getOptAngle(ps, pm, false);
 
-  float frameAccel = PmoveUtils::getFrameAccel(ps, pm);
+  float frameAccel = PmoveUtils::getFrameAccel(ps, pm, upmoveTrueness);
 
   // clamp the max value to match max scaling of target_scale_velocity
   if (frameAccel > 85) {
@@ -435,7 +436,7 @@ Snaphud::CurrentSnap Snaphud::getCurrentSnap(const playerState_t &ps,
 }
 
 bool Snaphud::inMainAccelZone(const playerState_t &ps, pmove_t *pm) {
-  const Snaphud::CurrentSnap cs = getCurrentSnap(ps, pm);
+  const Snaphud::CurrentSnap cs = getCurrentSnap(ps, pm, true);
 
   if (cs.snap == INVALID_SNAP_DIR) {
     return false;

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -41,7 +41,8 @@ public:
 
   void render() const override;
   bool beforeRender() override;
-  static CurrentSnap getCurrentSnap(const playerState_t &ps, pmove_t *pm);
+  static CurrentSnap getCurrentSnap(const playerState_t &ps, pmove_t *pm,
+                                    bool upmoveTrueness);
   static bool inMainAccelZone(const playerState_t &ps, pmove_t *pm);
 
   Snaphud();


### PR DESCRIPTION
`getFrameAccel` can now return accel that ignores upmove influence.

refs #1175 