### PR TITLE
cgaz2 line length improvements

### DIFF
--- a/assets/ui/etjump_settings_hud2_cgaz.menu
+++ b/assets/ui/etjump_settings_hud2_cgaz.menu
@@ -67,9 +67,12 @@ menuDef {
         MULTI               (SETTINGS_ITEM_POS(12), "CGaz trueness:", 0.2, SETTINGS_ITEM_H, "etj_CGazTrueness", cvarFloatList { "Off" 0 "Upmove" 1 "Groundzones" 2 "Upmove + Groundzones" 3 }, "Sets trueness of CGaz\netj_CGazTrueness")
         YESNO               (SETTINGS_ITEM_POS(13), "CGaz over Snaphud:", 0.2, SETTINGS_ITEM_H, "etj_CGazOnTop", "Draw CGaz on top of snaphud (vid_restart required)\netj_CGazOnTop")
         CVARINTLABEL        (SETTINGS_ITEM_POS(14), "etj_CGaz2FixedSpeed", 0.2, ITEM_ALIGN_RIGHT, SLIDER_LABEL_X, SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS(14), "CGaz fixed speed:", 0.2, SETTINGS_ITEM_H, etj_CGaz2FixedSpeed 0 0 1200 50, "Fixed speed value to use for drawing CGaz 2 instead of real speed, 0 to disable\netj_CGaz2FixedSpeed")
+        SLIDER              (SETTINGS_ITEM_POS(14), "CGaz fixed speed:", 0.2, SETTINGS_ITEM_H, etj_CGaz2FixedSpeed 0 0 6500 50, "Fixed speed value to use for drawing CGaz 2 instead of real speed, 0 to disable\netj_CGaz2FixedSpeed")
         MULTI               (SETTINGS_ITEM_POS(15), "Hide velocity direction:", 0.2, SETTINGS_ITEM_H, "etj_CGaz2NoVelocityDir", cvarFloatList { "No" 0 "Always" 1 "When over wishspeed" 2 }, "Hide velocity direction line on CGaz2\netj_CGaz2NoVelocityDir")
         YESNO               (SETTINGS_ITEM_POS(16), "Draw snap zone:", 0.2, SETTINGS_ITEM_H, "etj_CGaz1DrawSnapZone", "Extend minimum angle drawing to the end of current snap zone (CGaz 1 only)\netj_CGaz1DrawSnapZone")
+        YESNO               (SETTINGS_ITEM_POS(17), "Uniform wishdir length:", 0.2, SETTINGS_ITEM_H, "etj_CGaz2WishDirUniformLength", "Use uniform length for wishdir line drawing (CGaz 2 only)\netj_CGaz2WishDirUniformLength")
+        CVARINTLABEL        (SETTINGS_ITEM_POS(18), "etj_CGaz2WishDirFixedSpeed", 0.2, ITEM_ALIGN_RIGHT, SLIDER_LABEL_X, SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(18), "CGaz fixed wishdir speed:", 0.2, SETTINGS_ITEM_H, etj_CGaz2WishDirFixedSpeed 0 0 6500 50, "Fixed speed value to use for drawing CGaz 2 wishdir, 0 to use default\netj_CGaz2WishDirFixedSpeed")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -164,21 +164,19 @@ void DrawLine(float x1, float y1, float x2, float y2, float w, float h,
     return;
   }
 
-  const auto scrw = SCREEN_WIDTH;
-  const auto scrh = SCREEN_HEIGHT;
+  const auto scrw = static_cast<float>(SCREEN_WIDTH);
+  const auto scrh = static_cast<float>(SCREEN_HEIGHT);
 
   trap_R_SetColor(color);
 
   // Use a single DrawPic for horizontal or vertical lines
   if (x1 == x2) {
     x1 = Numeric::clamp(x1, 0, scrw);
-    x2 = Numeric::clamp(x2, 0, scrw);
 
     CG_DrawPic(x1, std::min(y1, y2), w, std::abs(y1 - y2),
                cgs.media.whiteShader);
   } else if (y1 == y2) {
     y1 = Numeric::clamp(y1, 0, scrh);
-    y2 = Numeric::clamp(y2, 0, scrh);
 
     CG_DrawPic(std::min(x1, x2), y1, std::abs(x1 - x2), h,
                cgs.media.whiteShader);
@@ -345,7 +343,8 @@ void CG_FilledBar(float x, float y, float w, float h, float *startColor,
                   int flags) {
   // colorAtPos is the lerped color if necessary
   vec4_t backgroundcolor = {1, 1, 1, 0.25f}, colorAtPos;
-  int indent = (flags & FilledBarFlags::BAR_BORDER_SMALL) ? BAR_BORDERSIZE_SMALL : BAR_BORDERSIZE;
+  int indent = (flags & FilledBarFlags::BAR_BORDER_SMALL) ? BAR_BORDERSIZE_SMALL
+                                                          : BAR_BORDERSIZE;
 
   if (frac > 1) {
     frac = 1.f;

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -1,6 +1,7 @@
 // cg_drawtools.c -- helper functions called by cg_draw, cg_scoreboard, cg_info,
 // etc
 #include "cg_local.h"
+#include "../game/etj_numeric_utilities.h"
 
 /*
 ================
@@ -163,22 +164,34 @@ void DrawLine(float x1, float y1, float x2, float y2, float w, float h,
     return;
   }
 
+  const auto scrw = SCREEN_WIDTH;
+  const auto scrh = SCREEN_HEIGHT;
+
   trap_R_SetColor(color);
 
   // Use a single DrawPic for horizontal or vertical lines
   if (x1 == x2) {
-    CG_DrawPic(x1, y1 < y2 ? y1 : y2, w, std::abs(y1 - y2),
+    x1 = Numeric::clamp(x1, 0, scrw);
+    x2 = Numeric::clamp(x2, 0, scrw);
+
+    CG_DrawPic(x1, std::min(y1, y2), w, std::abs(y1 - y2),
                cgs.media.whiteShader);
   } else if (y1 == y2) {
-    CG_DrawPic(x1 < x2 ? x1 : x2, y1, std::abs(x1 - x2), h,
+    y1 = Numeric::clamp(y1, 0, scrh);
+    y2 = Numeric::clamp(y2, 0, scrh);
+
+    CG_DrawPic(std::min(x1, x2), y1, std::abs(x1 - x2), h,
                cgs.media.whiteShader);
   } else {
     len = (x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1);
     len = std::sqrt(len);
     stepX = (x2 - x1) / len;
     stepY = (y2 - y1) / len;
+
     while (i < len) {
-      CG_DrawPic(x1, y1, w, h, cgs.media.whiteShader);
+      if (x1 >= 0 && x1 <= scrw && y1 >= 0 && y1 <= scrh) {
+        CG_DrawPic(x1, y1, w, h, cgs.media.whiteShader);
+      }
       x1 += stepX;
       y1 += stepY;
       i++;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2410,6 +2410,8 @@ extern vmCvar_t etj_CGazOnTop;
 extern vmCvar_t etj_CGaz2FixedSpeed;
 extern vmCvar_t etj_CGaz2NoVelocityDir;
 extern vmCvar_t etj_CGaz1DrawSnapZone;
+extern vmCvar_t etj_CGaz2WishDirFixedSpeed;
+extern vmCvar_t etj_CGaz2WishDirUniformLength;
 
 extern vmCvar_t etj_drawOB;
 // Aciz: movable drawOB

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -309,6 +309,8 @@ vmCvar_t etj_CGazOnTop;
 vmCvar_t etj_CGaz2FixedSpeed;
 vmCvar_t etj_CGaz2NoVelocityDir;
 vmCvar_t etj_CGaz1DrawSnapZone;
+vmCvar_t etj_CGaz2WishDirFixedSpeed;
+vmCvar_t etj_CGaz2WishDirUniformLength;
 
 vmCvar_t etj_drawOB;
 // Aciz: movable drawOB
@@ -872,6 +874,8 @@ cvarTable_t cvarTable[] = {
     {&etj_CGaz2FixedSpeed, "etj_CGaz2FixedSpeed", "0", CVAR_ARCHIVE},
     {&etj_CGaz2NoVelocityDir, "etj_CGaz2NoVelocityDir", "0", CVAR_ARCHIVE},
     {&etj_CGaz1DrawSnapZone, "etj_CGaz1DrawSnapZone", "0", CVAR_ARCHIVE},
+    {&etj_CGaz2WishDirFixedSpeed, "etj_CGaz2WishDirFixedSpeed", "0", CVAR_ARCHIVE},
+    {&etj_CGaz2WishDirUniformLength, "etj_CGaz2WishDirUniformLength", "0", CVAR_ARCHIVE},
 
     {&cl_yawspeed, "cl_yawspeed", "0", CVAR_ARCHIVE},
     {&cl_freelook, "cl_freelook", "1", CVAR_ARCHIVE},

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -330,7 +330,7 @@ void CGaz::render() const {
 
       if (etj_CGaz2WishDirFixedSpeed.value > 0) {
         // scale to get same lengths as minline fixed speed
-        constexpr float wishDirScale = 2.0f * 5.0f * 127.0f;
+        constexpr float wishDirScale = 2.0f * 5.0f * CMDSCALE_DEFAULT;
         mult = etj_CGaz2WishDirFixedSpeed.value / wishDirScale;
       }
 
@@ -365,7 +365,7 @@ void CGaz::render() const {
 
       if (!drawSides && etj_CGaz2FixedSpeed.value > 0) {
         // prevent comically long velocity direction lines on fixed speeds
-        dirSize = std::min(127.0f, dirSize);
+        dirSize = std::min(static_cast<float>(CMDSCALE_DEFAULT), dirSize);
       }
 
       DrawLine(scx, scy, scx + dirSize * std::sin(drawVel),

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -340,8 +340,15 @@ void CGaz::render() const {
 
     if (!etj_CGaz2NoVelocityDir.integer ||
         (!drawSides && etj_CGaz2NoVelocityDir.integer == 2)) {
-      DrawLine(scx, scy, scx + velSize * std::sin(drawVel),
-               scy - velSize * std::cos(drawVel), CGaz2Colors[0]);
+      float dirSize = velSize;
+
+      if (!drawSides && etj_CGaz2FixedSpeed.value > 0) {
+        // prevent comically long velocity direction lines on fixed speeds
+        dirSize = std::min(128.0f, dirSize);
+      }
+
+      DrawLine(scx, scy, scx + dirSize * std::sin(drawVel),
+               scy - dirSize * std::cos(drawVel), CGaz2Colors[0]);
     }
 
     if (drawSides) {

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -336,8 +336,8 @@ void CGaz::render() const {
 
       if (etj_CGaz2WishDirUniformLength.integer && cmd.rightmove &&
           cmd.forwardmove) {
-        constexpr float isqrt2 = 0.70710678118;
-        mult *= isqrt2;
+        static const float sqrt2 = std::sqrtf(2.0f);
+        mult /= sqrt2;
       }
 
       DrawLine(scx, scy, scx + mult * static_cast<float>(cmd.rightmove),

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -323,8 +323,27 @@ void CGaz::render() const {
       ETJump_EnableWidthScale(false);
       scx -= SCREEN_OFFSET_X;
     }
-    DrawLine(scx, scy, scx + static_cast<float>(cmd.rightmove),
-             scy - static_cast<float>(cmd.forwardmove), CGaz2Colors[1]);
+
+    // draw movement keys direction
+    if (cmd.rightmove || cmd.forwardmove) {
+      float mult = 1.0f;
+
+      if (etj_CGaz2WishDirFixedSpeed.value > 0) {
+        // scale to get same lengths as minline fixed speed
+        constexpr float wishDirScale = 2.0f * 5.0f * 127.0f;
+        mult = etj_CGaz2WishDirFixedSpeed.value / wishDirScale;
+      }
+
+      if (etj_CGaz2WishDirUniformLength.integer && cmd.rightmove &&
+          cmd.forwardmove) {
+        constexpr float isqrt2 = 0.70710678118;
+        mult *= isqrt2;
+      }
+
+      DrawLine(scx, scy, scx + mult * static_cast<float>(cmd.rightmove),
+               scy - mult * static_cast<float>(cmd.forwardmove),
+               CGaz2Colors[1]);
+    }
 
     // When under wishspeed velocity, most accel happens when
     // you move straight towards your current velocity, so skip

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -336,7 +336,7 @@ void CGaz::render() const {
 
       if (etj_CGaz2WishDirUniformLength.integer && cmd.rightmove &&
           cmd.forwardmove) {
-        static const float sqrt2 = std::sqrtf(2.0f);
+        static const float sqrt2 = std::sqrt(2.0f);
         mult /= sqrt2;
       }
 

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -331,11 +331,13 @@ void CGaz::render() const {
     // drawing the "wings" on the sides
     const bool drawSides = state.vf > state.wishspeed;
 
-    auto velSize =
-        etj_CGaz2FixedSpeed.value > 0 ? etj_CGaz2FixedSpeed.value : state.vf;
-    velSize /= 5;
-    if (velSize > SCREEN_HEIGHT * 0.5f) {
-      velSize = SCREEN_HEIGHT * 0.5f;
+    // minline length, either fixed or from current speed
+    float velSize;
+
+    if (etj_CGaz2FixedSpeed.value > 0) {
+      velSize = etj_CGaz2FixedSpeed.value / 5.0f;
+    } else {
+      velSize = std::min(state.vf / 5.0f, SCREEN_HEIGHT / 2.0f);
     }
 
     if (!etj_CGaz2NoVelocityDir.integer ||
@@ -344,7 +346,7 @@ void CGaz::render() const {
 
       if (!drawSides && etj_CGaz2FixedSpeed.value > 0) {
         // prevent comically long velocity direction lines on fixed speeds
-        dirSize = std::min(128.0f, dirSize);
+        dirSize = std::min(127.0f, dirSize);
       }
 
       DrawLine(scx, scy, scx + dirSize * std::sin(drawVel),


### PR DESCRIPTION
closes #1292

- fix super long velocity dir on high fixed speeds with no velocity dir
- remove cap from CGaz2 minline fixed speed length
- `etj_CGaz2WishDirUniformLength` to fix wish dir line being 41% too long when strafing diagonally
- `etj_CGaz2WishDirFixedSpeed` to allow customizing wish dir line length