### PR TITLE
Fix incorrect clientNum in G_RockTheVote_v

### DIFF
--- a/src/game/g_vote.cpp
+++ b/src/game/g_vote.cpp
@@ -492,7 +492,9 @@ int G_RockTheVote_v(gentity_t *ent, unsigned dwVoteIndex, char *arg,
 
     std::vector<std::string> maps{};
     int numMaps;
-    const int clientNum = level.voteInfo.voter_cn;
+    const int clientNum = !level.voteInfo.isAutoRtvVote
+                              ? ClientNum(ent)
+                              : level.voteInfo.voter_cn;
 
     if (arg2[0]) {
       if (!CustomMapTypeExists(arg2)) {


### PR DESCRIPTION
`level.voteInfo.voter_cn` is not set before votecmd check on regular callvotes.

refs #1293 