### PR TITLE
Fix CGaz2 velocity direction flickering on spec/demo playback

### DIFF
--- a/src/cgame/etj_pmove_utils.cpp
+++ b/src/cgame/etj_pmove_utils.cpp
@@ -186,7 +186,10 @@ bool PmoveUtils::skipUpdate(int &lastUpdateTime, const pmove_t *pm,
     return true;
   }
 
-  lastUpdateTime = frameTime;
+  // ensure lastUpdateTime is always aligned to pmove_msec interval
+  // even if cg.time does not exactly align to it correctly to prevent
+  // uneven update rates across various drawables that utilize this
+  lastUpdateTime = frameTime - (frameTime % pm->pmove_msec);
   return false;
 }
 } // namespace ETJump


### PR DESCRIPTION
Due to CGaz state being shared and used by `getOptAngle` as a result of #1271, `drawVel` was sometimes getting updated out of sync with cgaz drawing due to inaccuracy of `cg.time`, especially on framerates which can't be divided by `pmove_msec` directly. `PmoveUtils::skipUpdate` will now always return a timestamp that perfectly aligns to `pmove_msec` value, ensuring that updates always happen in sync between drawables that utilize this, ensuring the all math is done on the same values.