### PR TITLE
Disable fast floating point math

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -29,9 +29,10 @@ function(create_compiler_opts target)
 		-Wno-unused-parameter
 		-Wno-missing-field-initializers
 		$<$<CONFIG:Release>:
-			-flto=auto			# link time optimizations
-			-O3					# max optimization
-			-ffast-math>		# fast floating point math
+			-flto=auto				# link time optimizations
+			-O3						# max optimization
+			-fno-math-errno			# disable math function errors
+			-fno-trapping-math>		# disable user visible traps
 		$<$<CONFIG:Debug>:
 			-Og					# supress optimizations
 			-g3					# generate debug info
@@ -53,9 +54,10 @@ function(create_compiler_opts target)
 		-Wno-unused-parameter
 		-Wno-missing-field-initializers
 		$<$<CONFIG:Release>:
-			-O3					# max optimization
-			-flto				# link time optimizations
-			-ffast-math>		# fast floating point math
+			-O3						# max optimization
+			-flto					# link time optimizations
+			-fno-math-errno			# disable math function errors
+			-fno-trapping-math>		# disable user visible traps
 		$<$<CONFIG:Debug>:
 			-Og					# supress optimizations
 			-g3					# generate debug info
@@ -81,7 +83,7 @@ function(create_compiler_opts target)
 			# /GL                # full exe/dll optimization
 			/Gy                # generate useful information for optimizer
 			/Ob2               # let compiler inline freely
-			/fp:fast>          # fast floating point math
+			/fp:strict>        # disable user facing math trapping (implies /fp:except)
 		$<$<CONFIG:Debug>:
 			/Ob0               # no inlining
 			/Od                # no optimizations

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -83,7 +83,8 @@ function(create_compiler_opts target)
 			# /GL                # full exe/dll optimization
 			/Gy                # generate useful information for optimizer
 			/Ob2               # let compiler inline freely
-			/fp:strict>        # disable user facing math trapping (implies /fp:except)
+			/fp:strict         # disable user facing math trapping
+			/fp:except->       # disable floating point exceptions
 		$<$<CONFIG:Debug>:
 			/Ob0               # no inlining
 			/Od                # no optimizations


### PR DESCRIPTION
Disable fast floating point math from release mode compile options, and instead just disable user-facing math trapping and floating point exception handling. This means we also now support NaN.

This fixes a flickering issue with `etj_CGaz1DrawSnapZone` which was caused by a fp math error in `AnglesToRange`. Need to test this a bit more still as there might be some other affected things now that we allow NaN.