### PR TITLE
Fix demo playback from root of demos folder with ETL on Linux

### DIFF
--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -4286,9 +4286,20 @@ void UI_RunMenuScript(const char **args) {
           // appends demos/ to the beginning of the path
           const auto &front = uiInfo.currentDemoPath.front();
           uiInfo.currentDemoPath.pop_front();
-          auto demoPath =
-              ETJump::StringUtil::join(uiInfo.currentDemoPath, "/") + "/" +
-              uiInfo.demoObjects[uiInfo.demoIndex].name;
+
+          std::string demoPath;
+
+          // only append '/' in front of the name if we're inside a subfolder
+          // otherwise the demo command will be '/demo /demoname.dm_84'
+          // and ET: Legacy will try to open it as an absolute
+          // system file system path and will fail on Linux
+          if (uiInfo.currentDemoPath.empty()) {
+            demoPath = uiInfo.demoObjects[uiInfo.demoIndex].name;
+          } else {
+            demoPath = ETJump::StringUtil::join(uiInfo.currentDemoPath, "/") +
+                       "/" + uiInfo.demoObjects[uiInfo.demoIndex].name;
+          }
+
           uiInfo.currentDemoPath.push_front(front);
           trap_Cmd_ExecuteText(EXEC_APPEND,
                                va("demo \"%s\"\n", demoPath.c_str()));


### PR DESCRIPTION
Do not append `/` in front of the demo file name unless we're trying to playback demo from a subfolder, otherwise ET: Legacy will try to open the demo file with an absolute system filepath, and will fail on Linux.

refs #297