### PR TITLE
Add warning messages about missing misc_gamemodels/server models

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -874,8 +874,10 @@ cvarTable_t cvarTable[] = {
     {&etj_CGaz2FixedSpeed, "etj_CGaz2FixedSpeed", "0", CVAR_ARCHIVE},
     {&etj_CGaz2NoVelocityDir, "etj_CGaz2NoVelocityDir", "0", CVAR_ARCHIVE},
     {&etj_CGaz1DrawSnapZone, "etj_CGaz1DrawSnapZone", "0", CVAR_ARCHIVE},
-    {&etj_CGaz2WishDirFixedSpeed, "etj_CGaz2WishDirFixedSpeed", "0", CVAR_ARCHIVE},
-    {&etj_CGaz2WishDirUniformLength, "etj_CGaz2WishDirUniformLength", "0", CVAR_ARCHIVE},
+    {&etj_CGaz2WishDirFixedSpeed, "etj_CGaz2WishDirFixedSpeed", "0",
+     CVAR_ARCHIVE},
+    {&etj_CGaz2WishDirUniformLength, "etj_CGaz2WishDirUniformLength", "0",
+     CVAR_ARCHIVE},
 
     {&cl_yawspeed, "cl_yawspeed", "0", CVAR_ARCHIVE},
     {&cl_freelook, "cl_freelook", "1", CVAR_ARCHIVE},
@@ -2881,6 +2883,11 @@ static void CG_RegisterGraphics(void) {
       break;
     }
     cgs.gameModels[i] = trap_R_RegisterModel(modelName);
+
+    if (!cgs.gameModels[i]) {
+      CG_Printf(S_COLOR_YELLOW "WARNING: failed to register server model %s\n",
+                modelName);
+    }
   }
 
   for (i = 1; i < MAX_MODELS; i++) {

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -704,6 +704,11 @@ static void CG_ConfigStringModified(void) {
     CG_ParseGlobalFog();
   } else if (num >= CS_MODELS && num < CS_MODELS + MAX_MODELS) {
     cgs.gameModels[num - CS_MODELS] = trap_R_RegisterModel(str);
+
+    if (!cgs.gameModels[num - CS_MODELS]) {
+      CG_Printf(S_COLOR_YELLOW "WARNING: failed to register server model %s\n",
+                str);
+    }
   } else if (num >= CS_SOUNDS && num < CS_SOUNDS + MAX_SOUNDS) {
     if (str[0] != '*') // player specific sounds don't register here
     {                  // Ridah, register sound scripts seperately

--- a/src/cgame/cg_spawn.cpp
+++ b/src/cgame/cg_spawn.cpp
@@ -185,6 +185,8 @@ void SP_misc_gamemodel(void) {
     gamemodel->radius = RadiusFromBounds(mins, maxs);
   } else {
     gamemodel->radius = 0;
+    CG_Printf(S_COLOR_YELLOW "WARNING: failed to register misc_gamemodel %s\n",
+              model);
   }
 }
 


### PR DESCRIPTION
This mainly aids mappers in making sure that every required model that needs to displayed on runtime is included in the map pk3.

![image](https://github.com/etjump/etjump/assets/14221121/259a1b51-4158-4839-aa93-c8b0e2d3ed8c)
