### PR TITLE
Fix out of bounds access on CG_GetTag

### DIFF
--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -2533,6 +2533,10 @@ qboolean CG_GetTag(int clientNum, char *tagname, orientation_t *orientation) {
   vec3_t org;
   int i;
 
+  if (clientNum < 0 || clientNum >= MAX_CLIENTS) {
+    return qfalse;
+  }
+
   ci = &cgs.clientinfo[clientNum];
 
   if (cg.snap && clientNum == cg.snap->ps.clientNum &&


### PR DESCRIPTION
`G_PositionEntityOnTag` will call `trap_GetTag`with a clientNum of -1, which will cause out of bound access here. This has been fixed in ETL/ETe on server side (SV_GetTag returns false if clientNum is out of bounds), so this behavior is exclusive to 2.60b.