### PR TITLE
Send teaminfo updates to both teams

### DIFF
--- a/src/game/g_team.cpp
+++ b/src/game/g_team.cpp
@@ -936,9 +936,9 @@ void TeamplayInfoMessage(team_t team) {
   bufferedData = team == TEAM_AXIS ? level.tinfoAxis : level.tinfoAllies;
 
   tinfo = va("tinfo %i%s", cnt, string);
-  if (!Q_stricmp(bufferedData,
-                 tinfo)) // Gordon: no change so just return
-  {
+
+  // Gordon: no change so just return
+  if (!Q_stricmp(bufferedData, tinfo)) {
     return;
   }
 
@@ -946,11 +946,12 @@ void TeamplayInfoMessage(team_t team) {
 
   for (i = 0; i < level.numConnectedClients; i++) {
     player = g_entities + level.sortedClients[i];
-    if (player->inuse && player->client->sess.sessionTeam == team) {
-      if (player->client->pers.connected == CON_CONNECTED) {
-        trap_SendServerCommand(player - g_entities, tinfo);
-      }
+
+    if (!player->inuse || player->client->pers.connected != CON_CONNECTED) {
+      continue;
     }
+
+    trap_SendServerCommand(ClientNum(player), tinfo);
   }
 }
 


### PR DESCRIPTION
Since our fireteams are shared between all teams, this ensures that players on Axis get the health info of players on Allies and vice versa. ~~This was actually already the case if a player had swapped teams once before, but this makes sure that it's always communicated, even if no team swaps ever occur.~~ No it was not, it would just not update the health at all and keep the last known value.

fixes #1305 