### PR TITLE
Fix nonoclip trace always using standing mins/maxs

### DIFF
--- a/src/game/etj_utilities.cpp
+++ b/src/game/etj_utilities.cpp
@@ -164,17 +164,17 @@ void Utilities::RemovePlayerWeapons(int clientNum) {
 
 bool Utilities::inNoNoclipArea(gentity_t *ent) {
   trace_t trace;
-  trap_TraceCapsule(&trace, ent->client->ps.origin, ent->client->ps.mins,
-                    ent->client->ps.maxs, ent->client->ps.origin,
-                    ent->client->ps.clientNum, CONTENTS_NONOCLIP);
+  trap_TraceCapsule(&trace, ent->client->ps.origin, ent->r.mins, ent->r.maxs,
+                    ent->client->ps.origin, ent->client->ps.clientNum,
+                    CONTENTS_NONOCLIP);
 
   // if we're touching a no-noclip area, do another trace for solids
   // so that we don't get instantly stuck in a wall, unable to noclip
   // if we fly to a no-noclip area through a wall
   if (level.noNoclip) {
     if (trace.fraction == 1.0f) {
-      trap_TraceCapsule(&trace, ent->client->ps.origin, ent->client->ps.mins,
-                        ent->client->ps.maxs, ent->client->ps.origin,
+      trap_TraceCapsule(&trace, ent->client->ps.origin, ent->r.mins,
+                        ent->r.maxs, ent->client->ps.origin,
                         ent->client->ps.clientNum, CONTENTS_SOLID);
 
       if (!trace.allsolid) {
@@ -183,8 +183,8 @@ bool Utilities::inNoNoclipArea(gentity_t *ent) {
     }
   } else {
     if (trace.fraction != 1.0f) {
-      trap_TraceCapsule(&trace, ent->client->ps.origin, ent->client->ps.mins,
-                        ent->client->ps.maxs, ent->client->ps.origin,
+      trap_TraceCapsule(&trace, ent->client->ps.origin, ent->r.mins,
+                        ent->r.maxs, ent->client->ps.origin,
                         ent->client->ps.clientNum, CONTENTS_SOLID);
 
       if (!trace.allsolid) {


### PR DESCRIPTION
This caused client being able to noclip inside nonoclip zones, if they were crouched/prone and had no room to stand, as the trace would return allsolid, which would allow noclip to prevent wallstuck.

refs #1157 