### PR TITLE
Add lagometer shader + alpha cvars

### DIFF
--- a/assets/scripts/trickjump.shader
+++ b/assets/scripts/trickjump.shader
@@ -907,3 +907,15 @@ gfx/2d/up
 		rgbGen vertex
 	}
 }
+
+gfx/2d/lagometer
+{
+	noPicMip
+	noMipMaps
+	nocompress
+	{
+		map gfx/2d/lag.tga
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen vertex
+	}
+}

--- a/assets/ui/etjump_settings_hud1_chat.menu
+++ b/assets/ui/etjump_settings_hud1_chat.menu
@@ -6,7 +6,7 @@
 #define MENU_NAME "etjump_settings_hud1_chat"
 #define GROUP_NAME "group_etjump_settings_hud1"
 
-#define NUM_SUBMENUS 12
+#define NUM_SUBMENUS 13
 #define SIDEBAR_BTN_Y (SIDEBAR_Y + (SIDEBAR_H * 0.5) - (((NUM_SUBMENUS * SIDEBAR_BTN_H) + (MAIN_ELEMENT_MARGIN * (NUM_SUBMENUS - 1))) * 0.5))
 
 menuDef {
@@ -48,8 +48,9 @@ menuDef {
     SIDEBUTTON          (8, "POPUPS", close MENU_NAME; open etjump_settings_hud1_popups)
     SIDEBUTTON          (9, "FIRETEAM", close MENU_NAME; open etjump_settings_hud1_fireteam)
     SIDEBUTTON          (10, "SPECTATOR INFO", close MENU_NAME; open etjump_settings_hud1_specinfo)
-    SIDEBUTTON          (11, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
-    SIDEBUTTON          (12, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
+    SIDEBUTTON          (11, "LAGOMETER", close MENU_NAME; open etjump_settings_hud1_lagometer)
+    SIDEBUTTON          (12, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
+    SIDEBUTTON          (13, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "CHAT")
 

--- a/assets/ui/etjump_settings_hud1_crosshair.menu
+++ b/assets/ui/etjump_settings_hud1_crosshair.menu
@@ -6,7 +6,7 @@
 #define MENU_NAME "etjump_settings_hud1_crosshair"
 #define GROUP_NAME "group_etjump_settings_hud1"
 
-#define NUM_SUBMENUS 12
+#define NUM_SUBMENUS 13
 #define NUM_SETTINGS 12 // required for bottom-up settings drawing
 #define SIDEBAR_BTN_Y (SIDEBAR_Y + (SIDEBAR_H * 0.5) - (((NUM_SUBMENUS * SIDEBAR_BTN_H) + (MAIN_ELEMENT_MARGIN * (NUM_SUBMENUS - 1))) * 0.5))
 
@@ -49,8 +49,9 @@ menuDef {
     SIDEBUTTON          (8, "POPUPS", close MENU_NAME; open etjump_settings_hud1_popups)
     SIDEBUTTON          (9, "FIRETEAM", close MENU_NAME; open etjump_settings_hud1_fireteam)
     SIDEBUTTON          (10, "SPECTATOR INFO", close MENU_NAME; open etjump_settings_hud1_specinfo)
-    SIDEBUTTON          (11, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
-    SIDEBUTTON          (12, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
+    SIDEBUTTON          (11, "LAGOMETER", close MENU_NAME; open etjump_settings_hud1_lagometer)
+    SIDEBUTTON          (12, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
+    SIDEBUTTON          (13, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "CROSSHAIR")
 

--- a/assets/ui/etjump_settings_hud1_fireteam.menu
+++ b/assets/ui/etjump_settings_hud1_fireteam.menu
@@ -6,7 +6,7 @@
 #define MENU_NAME "etjump_settings_hud1_fireteam"
 #define GROUP_NAME "group_etjump_settings_hud1"
 
-#define NUM_SUBMENUS 12
+#define NUM_SUBMENUS 13
 #define SIDEBAR_BTN_Y (SIDEBAR_Y + (SIDEBAR_H * 0.5) - (((NUM_SUBMENUS * SIDEBAR_BTN_H) + (MAIN_ELEMENT_MARGIN * (NUM_SUBMENUS - 1))) * 0.5))
 
 menuDef {
@@ -48,8 +48,9 @@ menuDef {
     SIDEBUTTON          (8, "POPUPS", close MENU_NAME; open etjump_settings_hud1_popups)
     SIDEBUTTON_ACTIVE   (9, "FIRETEAM", close MENU_NAME; open MENU_NAME)
     SIDEBUTTON          (10, "SPECTATOR INFO", close MENU_NAME; open etjump_settings_hud1_specinfo)
-    SIDEBUTTON          (11, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
-    SIDEBUTTON          (12, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
+    SIDEBUTTON          (11, "LAGOMETER", close MENU_NAME; open etjump_settings_hud1_lagometer)
+    SIDEBUTTON          (12, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
+    SIDEBUTTON          (13, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "FIRETEAM")
 

--- a/assets/ui/etjump_settings_hud1_indicators.menu
+++ b/assets/ui/etjump_settings_hud1_indicators.menu
@@ -6,7 +6,7 @@
 #define MENU_NAME "etjump_settings_hud1_indicators"
 #define GROUP_NAME "group_etjump_settings_hud1"
 
-#define NUM_SUBMENUS 12
+#define NUM_SUBMENUS 13
 #define SIDEBAR_BTN_Y (SIDEBAR_Y + (SIDEBAR_H * 0.5) - (((NUM_SUBMENUS * SIDEBAR_BTN_H) + (MAIN_ELEMENT_MARGIN * (NUM_SUBMENUS - 1))) * 0.5))
 
 menuDef {
@@ -48,8 +48,9 @@ menuDef {
     SIDEBUTTON          (8, "POPUPS", close MENU_NAME; open etjump_settings_hud1_popups)
     SIDEBUTTON          (9, "FIRETEAM", close MENU_NAME; open etjump_settings_hud1_fireteam)
     SIDEBUTTON          (10, "SPECTATOR INFO", close MENU_NAME; open etjump_settings_hud1_specinfo)
-    SIDEBUTTON          (11, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
-    SIDEBUTTON          (12, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
+    SIDEBUTTON          (11, "LAGOMETER", close MENU_NAME; open etjump_settings_hud1_lagometer)
+    SIDEBUTTON          (12, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
+    SIDEBUTTON          (13, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "INDICATORS")
     

--- a/assets/ui/etjump_settings_hud1_keys.menu
+++ b/assets/ui/etjump_settings_hud1_keys.menu
@@ -6,7 +6,7 @@
 #define MENU_NAME "etjump_settings_hud1_keys"
 #define GROUP_NAME "group_etjump_settings_hud1"
 
-#define NUM_SUBMENUS 12
+#define NUM_SUBMENUS 13
 #define SIDEBAR_BTN_Y (SIDEBAR_Y + (SIDEBAR_H * 0.5) - (((NUM_SUBMENUS * SIDEBAR_BTN_H) + (MAIN_ELEMENT_MARGIN * (NUM_SUBMENUS - 1))) * 0.5))
 
 menuDef {
@@ -48,8 +48,9 @@ menuDef {
     SIDEBUTTON          (8, "POPUPS", close MENU_NAME; open etjump_settings_hud1_popups)
     SIDEBUTTON          (9, "FIRETEAM", close MENU_NAME; open etjump_settings_hud1_fireteam)
     SIDEBUTTON          (10, "SPECTATOR INFO", close MENU_NAME; open etjump_settings_hud1_specinfo)
-    SIDEBUTTON          (11, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
-    SIDEBUTTON          (12, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
+    SIDEBUTTON          (11, "LAGOMETER", close MENU_NAME; open etjump_settings_hud1_lagometer)
+    SIDEBUTTON          (12, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
+    SIDEBUTTON          (13, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "KEYS")
 

--- a/assets/ui/etjump_settings_hud1_lagometer.menu
+++ b/assets/ui/etjump_settings_hud1_lagometer.menu
@@ -3,7 +3,7 @@
 #include "ui/menumacros.h"
 #include "ui/menumacros_ext.h"
 
-#define MENU_NAME "etjump_settings_hud1_scoreboard"
+#define MENU_NAME "etjump_settings_hud1_lagometer"
 #define GROUP_NAME "group_etjump_settings_hud1"
 
 #define NUM_SUBMENUS 13
@@ -39,7 +39,7 @@ menuDef {
     WINDOW_BLANK(SIDEBAR_X, SIDEBAR_Y, SIDEBAR_W, SIDEBAR_H)
 
     SIDEBUTTON          (1, "CROSSHAIR", close MENU_NAME; open etjump_settings_hud1_crosshair)
-    SIDEBUTTON          (2, "KEYS", close MENU_NAME; open etjump_settings_hud1_keys)
+    SIDEBUTTON_         (2, "KEYS", close MENU_NAME; open MENU_NAME)
     SIDEBUTTON          (3, "SPEED 1", close MENU_NAME; open etjump_settings_hud1_speed1)
     SIDEBUTTON          (4, "SPEED 2", close MENU_NAME; open etjump_settings_hud1_speed2)
     SIDEBUTTON          (5, "MAX SPEED", close MENU_NAME; open etjump_settings_hud1_maxspeed)
@@ -48,14 +48,21 @@ menuDef {
     SIDEBUTTON          (8, "POPUPS", close MENU_NAME; open etjump_settings_hud1_popups)
     SIDEBUTTON          (9, "FIRETEAM", close MENU_NAME; open etjump_settings_hud1_fireteam)
     SIDEBUTTON          (10, "SPECTATOR INFO", close MENU_NAME; open etjump_settings_hud1_specinfo)
-    SIDEBUTTON          (11, "LAGOMETER", close MENU_NAME; open etjump_settings_hud1_lagometer)
-    SIDEBUTTON_ACTIVE   (12, "SCOREBOARD", close MENU_NAME; open MENU_NAME)
+    SIDEBUTTON_ACTIVE   (11, "LAGOMETER", close MENU_NAME; open etjump_settings_hud1_lagometer)
+    SIDEBUTTON          (12, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
     SIDEBUTTON          (13, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
 
-    SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "SCOREBOARD")
+    SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "KEYS")
 
-        MULTI               (SETTINGS_ITEM_POS(1), "Alternative scoreboard:", 0.2, SETTINGS_ITEM_H, "etj_altScoreboard", cvarFloatList { "No" 0 "ETJump 1" 1 "ETJump 2" 2 "ETJump 3" 3 }, "Displays alternative scoreboard\netj_altScoreboard")
-        YESNO               (SETTINGS_ITEM_POS(2), "Draw idle indicator:", 0.2, SETTINGS_ITEM_H, "etj_drawScoreboardInactivity", "Draw idle indicator on inactive clients\netj_drawScoreboardInactivity")
+        MULTI               (SETTINGS_ITEM_POS(1), "Draw lagometer:", 0.2, SETTINGS_ITEM_H, "cg_lagometer", cvarFloatList { "No" 0 "Online only" 1 "Always" 2 }, "Draw lagometer on HUD\ncg_lagometer")
+        CVARINTLABEL        (SETTINGS_ITEM_POS(2), "etj_lagometerX", 0.2, ITEM_ALIGN_RIGHT, SLIDER_LABEL_X, SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(2), "Lagometer X:", 0.2, SETTINGS_ITEM_H, etj_lagometerX 0 -640 640 10, "Sets X offset for lagometer\netj_lagometerX")
+        CVARINTLABEL        (SETTINGS_ITEM_POS(3), "etj_lagometerY", 0.2, ITEM_ALIGN_RIGHT, SLIDER_LABEL_X, SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(3), "Lagometer Y:", 0.2, SETTINGS_ITEM_H, etj_lagometerY 0 -480 480 10, "Sets Y offset for lagometer\netj_lagometerY")
+        YESNO               (SETTINGS_ITEM_POS(4), "Lagometer shader:", 0.2, SETTINGS_ITEM_H, "etj_lagometerShader", "Use shader for lagometer instead of solid color\netj_lagometerAlpha")
+        CVARFLOATLABEL      (SETTINGS_ITEM_POS(5), "etj_lagometerAlpha", 0.2, ITEM_ALIGN_RIGHT, SLIDER_LABEL_X, SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(5), "Lagometer alpha:", 0.2, SETTINGS_ITEM_H, etj_lagometerAlpha 1 0 1 0.05, "Sets transparency of lagometer background\netj_lagometerAlpha")
+        YESNO               (SETTINGS_ITEM_POS(6), "Draw connection issues:", 0.2, SETTINGS_ITEM_H, "etj_drawConnectionIssues", "Draw connection interrupted message with high ping\netj_drawConnectionIssues")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/assets/ui/etjump_settings_hud1_lagometer.menu
+++ b/assets/ui/etjump_settings_hud1_lagometer.menu
@@ -39,7 +39,7 @@ menuDef {
     WINDOW_BLANK(SIDEBAR_X, SIDEBAR_Y, SIDEBAR_W, SIDEBAR_H)
 
     SIDEBUTTON          (1, "CROSSHAIR", close MENU_NAME; open etjump_settings_hud1_crosshair)
-    SIDEBUTTON_         (2, "KEYS", close MENU_NAME; open MENU_NAME)
+    SIDEBUTTON          (2, "KEYS", close MENU_NAME; open MENU_NAME)
     SIDEBUTTON          (3, "SPEED 1", close MENU_NAME; open etjump_settings_hud1_speed1)
     SIDEBUTTON          (4, "SPEED 2", close MENU_NAME; open etjump_settings_hud1_speed2)
     SIDEBUTTON          (5, "MAX SPEED", close MENU_NAME; open etjump_settings_hud1_maxspeed)
@@ -52,7 +52,7 @@ menuDef {
     SIDEBUTTON          (12, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
     SIDEBUTTON          (13, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
 
-    SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "KEYS")
+    SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "LAGOMETER")
 
         MULTI               (SETTINGS_ITEM_POS(1), "Draw lagometer:", 0.2, SETTINGS_ITEM_H, "cg_lagometer", cvarFloatList { "No" 0 "Online only" 1 "Always" 2 }, "Draw lagometer on HUD\ncg_lagometer")
         CVARINTLABEL        (SETTINGS_ITEM_POS(2), "etj_lagometerX", 0.2, ITEM_ALIGN_RIGHT, SLIDER_LABEL_X, SETTINGS_ITEM_H)

--- a/assets/ui/etjump_settings_hud1_maxspeed.menu
+++ b/assets/ui/etjump_settings_hud1_maxspeed.menu
@@ -6,7 +6,7 @@
 #define MENU_NAME "etjump_settings_hud1_maxspeed"
 #define GROUP_NAME "group_etjump_settings_hud1"
 
-#define NUM_SUBMENUS 12
+#define NUM_SUBMENUS 13
 #define SIDEBAR_BTN_Y (SIDEBAR_Y + (SIDEBAR_H * 0.5) - (((NUM_SUBMENUS * SIDEBAR_BTN_H) + (MAIN_ELEMENT_MARGIN * (NUM_SUBMENUS - 1))) * 0.5))
 
 menuDef {
@@ -48,8 +48,9 @@ menuDef {
     SIDEBUTTON          (8, "POPUPS", close MENU_NAME; open etjump_settings_hud1_popups)
     SIDEBUTTON          (9, "FIRETEAM", close MENU_NAME; open etjump_settings_hud1_fireteam)
     SIDEBUTTON          (10, "SPECTATOR INFO", close MENU_NAME; open etjump_settings_hud1_specinfo)
-    SIDEBUTTON          (11, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
-    SIDEBUTTON          (12, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
+    SIDEBUTTON          (11, "LAGOMETER", close MENU_NAME; open etjump_settings_hud1_lagometer)
+    SIDEBUTTON          (12, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
+    SIDEBUTTON          (13, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "MAX SPEED")
     

--- a/assets/ui/etjump_settings_hud1_misc.menu
+++ b/assets/ui/etjump_settings_hud1_misc.menu
@@ -6,7 +6,7 @@
 #define MENU_NAME "etjump_settings_hud1_misc"
 #define GROUP_NAME "group_etjump_settings_hud1"
 
-#define NUM_SUBMENUS 12
+#define NUM_SUBMENUS 13
 #define SIDEBAR_BTN_Y (SIDEBAR_Y + (SIDEBAR_H * 0.5) - (((NUM_SUBMENUS * SIDEBAR_BTN_H) + (MAIN_ELEMENT_MARGIN * (NUM_SUBMENUS - 1))) * 0.5))
 
 menuDef {
@@ -48,8 +48,9 @@ menuDef {
     SIDEBUTTON          (8, "POPUPS", close MENU_NAME; open etjump_settings_hud1_popups)
     SIDEBUTTON          (9, "FIRETEAM", close MENU_NAME; open etjump_settings_hud1_fireteam)
     SIDEBUTTON          (10, "SPECTATOR INFO", close MENU_NAME; open etjump_settings_hud1_specinfo)
-    SIDEBUTTON          (11, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
-    SIDEBUTTON_ACTIVE   (12, "MISC", close MENU_NAME; open MENU_NAME)
+    SIDEBUTTON          (11, "LAGOMETER", close MENU_NAME; open etjump_settings_hud1_lagometer)
+    SIDEBUTTON          (12, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
+    SIDEBUTTON_ACTIVE   (13, "MISC", close MENU_NAME; open MENU_NAME)
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "MISCELLANEOUS")
 
@@ -64,17 +65,11 @@ menuDef {
         YESNO               (SETTINGS_ITEM_POS(8), "Draw health:", 0.2, SETTINGS_ITEM_H, "etj_HUD_playerHealth", "Draw health on HUD\netj_HUD_playerHealth")
         YESNO               (SETTINGS_ITEM_POS(9), "Draw weapon icon:", 0.2, SETTINGS_ITEM_H, "etj_HUD_weaponIcon", "Draw weapon icon on HUD\netj_HUD_weaponIcon")
         YESNO               (SETTINGS_ITEM_POS(10), "Draw XP info:", 0.2, SETTINGS_ITEM_H, "etj_HUD_xpInfo", "Draw XP info on HUD\netj_HUD_xpInfo")
-        MULTI               (SETTINGS_ITEM_POS(11), "Draw lagometer:", 0.2, SETTINGS_ITEM_H, "cg_lagometer", cvarFloatList { "No" 0 "Online only" 1 "Always" 2 }, "Draw lagometer on HUD\ncg_lagometer")
-        CVARINTLABEL        (SETTINGS_ITEM_POS(12), "etj_lagometerX", 0.2, ITEM_ALIGN_RIGHT, SLIDER_LABEL_X, SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS(12), "Lagometer X:", 0.2, SETTINGS_ITEM_H, etj_lagometerX 0 -640 640 10, "Sets X offset for lagometer\netj_lagometerX")
-        CVARINTLABEL        (SETTINGS_ITEM_POS(13), "etj_lagometerY", 0.2, ITEM_ALIGN_RIGHT, SLIDER_LABEL_X, SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS(13), "Lagometer Y:", 0.2, SETTINGS_ITEM_H, etj_lagometerY 0 -480 480 10, "Sets Y offset for lagometer\netj_lagometerY")
-        YESNO               (SETTINGS_ITEM_POS(14), "Draw connection issues:", 0.2, SETTINGS_ITEM_H, "etj_drawConnectionIssues", "Draw connection interrupted message with high ping\netj_drawConnectionIssues")
-        MULTI               (SETTINGS_ITEM_POS(15), "HUD projection:", 0.2, SETTINGS_ITEM_H, "etj_projection", cvarFloatList { "Rectilinear" 0 "Cylindrical" 1 "Panini" 2 }, "Sets projection type of CGaz 1 and snaphud\netj_projection")
-        YESNO               (SETTINGS_ITEM_POS(16), "Draw banners:", 0.2, SETTINGS_ITEM_H, "etj_drawBanners", "Draw banner prints on HUD\netj_drawBanners")
-        EDITFIELD_EXT       (SETTINGS_EF_POS(17), "Save message:", 0.2, SETTINGS_ITEM_H, "etj_saveMsg", SETTINGS_EF_MAXCHARS, SETTINGS_EF_MAXPAINTCHARS, "Message to print when saving position\netj_saveMsg")
-        CVARFLOATLABEL      (SETTINGS_ITEM_POS(18), "etj_expandedMapAlpha", 0.2, ITEM_ALIGN_RIGHT, SLIDER_LABEL_X, SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS(18), "Expanded map alpha:", 0.2, SETTINGS_ITEM_H, etj_expandedMapAlpha 0.7 0 1 0.05, "Sets transparency of expanded map\netj_expandedMapAlpha")
+        MULTI               (SETTINGS_ITEM_POS(11), "HUD projection:", 0.2, SETTINGS_ITEM_H, "etj_projection", cvarFloatList { "Rectilinear" 0 "Cylindrical" 1 "Panini" 2 }, "Sets projection type of CGaz 1 and snaphud\netj_projection")
+        YESNO               (SETTINGS_ITEM_POS(12), "Draw banners:", 0.2, SETTINGS_ITEM_H, "etj_drawBanners", "Draw banner prints on HUD\netj_drawBanners")
+        EDITFIELD_EXT       (SETTINGS_EF_POS(13), "Save message:", 0.2, SETTINGS_ITEM_H, "etj_saveMsg", SETTINGS_EF_MAXCHARS, SETTINGS_EF_MAXPAINTCHARS, "Message to print when saving position\netj_saveMsg")
+        CVARFLOATLABEL      (SETTINGS_ITEM_POS(14), "etj_expandedMapAlpha", 0.2, ITEM_ALIGN_RIGHT, SLIDER_LABEL_X, SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(14), "Expanded map alpha:", 0.2, SETTINGS_ITEM_H, etj_expandedMapAlpha 0.7 0 1 0.05, "Sets transparency of expanded map\netj_expandedMapAlpha")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/assets/ui/etjump_settings_hud1_popups.menu
+++ b/assets/ui/etjump_settings_hud1_popups.menu
@@ -6,7 +6,7 @@
 #define MENU_NAME "etjump_settings_hud1_popups"
 #define GROUP_NAME "group_etjump_settings_hud1"
 
-#define NUM_SUBMENUS 12
+#define NUM_SUBMENUS 13
 #define SIDEBAR_BTN_Y (SIDEBAR_Y + (SIDEBAR_H * 0.5) - (((NUM_SUBMENUS * SIDEBAR_BTN_H) + (MAIN_ELEMENT_MARGIN * (NUM_SUBMENUS - 1))) * 0.5))
 
 menuDef {
@@ -48,8 +48,9 @@ menuDef {
     SIDEBUTTON_ACTIVE   (8, "POPUPS", close MENU_NAME; open MENU_NAME)
     SIDEBUTTON          (9, "FIRETEAM", close MENU_NAME; open etjump_settings_hud1_fireteam)
     SIDEBUTTON          (10, "SPECTATOR INFO", close MENU_NAME; open etjump_settings_hud1_specinfo)
-    SIDEBUTTON          (11, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
-    SIDEBUTTON          (12, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
+    SIDEBUTTON          (11, "LAGOMETER", close MENU_NAME; open etjump_settings_hud1_lagometer)
+    SIDEBUTTON          (12, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
+    SIDEBUTTON          (13, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "POPUPS")
 

--- a/assets/ui/etjump_settings_hud1_specinfo.menu
+++ b/assets/ui/etjump_settings_hud1_specinfo.menu
@@ -6,7 +6,7 @@
 #define MENU_NAME "etjump_settings_hud1_specinfo"
 #define GROUP_NAME "group_etjump_settings_hud1"
 
-#define NUM_SUBMENUS 12
+#define NUM_SUBMENUS 13
 #define SIDEBAR_BTN_Y (SIDEBAR_Y + (SIDEBAR_H * 0.5) - (((NUM_SUBMENUS * SIDEBAR_BTN_H) + (MAIN_ELEMENT_MARGIN * (NUM_SUBMENUS - 1))) * 0.5))
 
 menuDef {
@@ -48,8 +48,9 @@ menuDef {
     SIDEBUTTON          (8, "POPUPS", close MENU_NAME; open etjump_settings_hud1_popups)
     SIDEBUTTON          (9, "FIRETEAM", close MENU_NAME; open etjump_settings_hud1_fireteam)
     SIDEBUTTON_ACTIVE   (10, "SPECTATOR INFO", close MENU_NAME; open MENU_NAME)
-    SIDEBUTTON          (11, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
-    SIDEBUTTON          (12, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
+    SIDEBUTTON          (11, "LAGOMETER", close MENU_NAME; open etjump_settings_hud1_lagometer)
+    SIDEBUTTON          (12, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
+    SIDEBUTTON          (13, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "SPECTATOR INFO")
     

--- a/assets/ui/etjump_settings_hud1_speed1.menu
+++ b/assets/ui/etjump_settings_hud1_speed1.menu
@@ -6,7 +6,7 @@
 #define MENU_NAME "etjump_settings_hud1_speed1"
 #define GROUP_NAME "group_etjump_settings_hud1"
 
-#define NUM_SUBMENUS 12
+#define NUM_SUBMENUS 13
 #define SIDEBAR_BTN_Y (SIDEBAR_Y + (SIDEBAR_H * 0.5) - (((NUM_SUBMENUS * SIDEBAR_BTN_H) + (MAIN_ELEMENT_MARGIN * (NUM_SUBMENUS - 1))) * 0.5))
 
 menuDef {
@@ -48,8 +48,9 @@ menuDef {
     SIDEBUTTON          (8, "POPUPS", close MENU_NAME; open etjump_settings_hud1_popups)
     SIDEBUTTON          (9, "FIRETEAM", close MENU_NAME; open etjump_settings_hud1_fireteam)
     SIDEBUTTON          (10, "SPECTATOR INFO", close MENU_NAME; open etjump_settings_hud1_specinfo)
-    SIDEBUTTON          (11, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
-    SIDEBUTTON          (12, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
+    SIDEBUTTON          (11, "LAGOMETER", close MENU_NAME; open etjump_settings_hud1_lagometer)
+    SIDEBUTTON          (12, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
+    SIDEBUTTON          (13, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "SPEED 1")
 

--- a/assets/ui/etjump_settings_hud1_speed2.menu
+++ b/assets/ui/etjump_settings_hud1_speed2.menu
@@ -6,7 +6,7 @@
 #define MENU_NAME "etjump_settings_hud1_speed2"
 #define GROUP_NAME "group_etjump_settings_hud1"
 
-#define NUM_SUBMENUS 12
+#define NUM_SUBMENUS 13
 #define SIDEBAR_BTN_Y (SIDEBAR_Y + (SIDEBAR_H * 0.5) - (((NUM_SUBMENUS * SIDEBAR_BTN_H) + (MAIN_ELEMENT_MARGIN * (NUM_SUBMENUS - 1))) * 0.5))
 
 menuDef {
@@ -48,8 +48,9 @@ menuDef {
     SIDEBUTTON          (8, "POPUPS", close MENU_NAME; open etjump_settings_hud1_popups)
     SIDEBUTTON          (9, "FIRETEAM", close MENU_NAME; open etjump_settings_hud1_fireteam)
     SIDEBUTTON          (10, "SPECTATOR INFO", close MENU_NAME; open etjump_settings_hud1_specinfo)
-    SIDEBUTTON          (11, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
-    SIDEBUTTON          (12, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
+    SIDEBUTTON          (11, "LAGOMETER", close MENU_NAME; open etjump_settings_hud1_lagometer)
+    SIDEBUTTON          (12, "SCOREBOARD", close MENU_NAME; open etjump_settings_hud1_scoreboard)
+    SIDEBUTTON          (13, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "SPEED 2")
     

--- a/assets/ui/menus.txt
+++ b/assets/ui/menus.txt
@@ -93,6 +93,7 @@
 	loadMenu { "ui/etjump_settings_hud1_popups.menu" }
 	loadMenu { "ui/etjump_settings_hud1_fireteam.menu" }
 	loadMenu { "ui/etjump_settings_hud1_specinfo.menu" }
+	loadMenu { "ui/etjump_settings_hud1_lagometer.menu" }
 	loadMenu { "ui/etjump_settings_hud1_scoreboard.menu" }
 	loadMenu { "ui/etjump_settings_hud1_misc.menu" }
 

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -784,8 +784,24 @@ static void CG_DrawLagometer() {
   x = SCREEN_WIDTH - 48 + ETJump_AdjustPosition(etj_lagometerX.value);
   y = 480 - 200 + etj_lagometerY.value;
 
-  trap_R_SetColor(nullptr);
-  CG_DrawPic(x, y, 48, 48, cgs.media.lagometerShader);
+  const float alpha = Numeric::clamp(etj_lagometerAlpha.value, 0.0f, 1.0f);
+
+  if (etj_lagometerShader.integer) {
+    vec4_t mainColor;
+    Vector4Copy(colorWhite, mainColor);
+    mainColor[3] *= alpha;
+
+    ETJump::drawPic(x, y, 48, 48, cgs.media.lagometerShader, mainColor);
+  } else {
+    vec4_t borderColor = {0.5f, 0.5f, 0.5f, 0.5f};
+    vec4_t backgroundColor = {0.16f, 0.2f, 0.17f, 0.8f};
+
+    borderColor[3] *= alpha;
+    backgroundColor[3] *= alpha;
+
+    CG_FillRect(x, y, 48, 48, backgroundColor);
+    CG_DrawRect_FixedBorder(x, y, 48, 48, 1, borderColor);
+  }
 
   ax = x;
   ay = y;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2667,6 +2667,8 @@ extern vmCvar_t etj_onRunStart;
 extern vmCvar_t etj_onRunEnd;
 extern vmCvar_t etj_lagometerX;
 extern vmCvar_t etj_lagometerY;
+extern vmCvar_t etj_lagometerShader;
+extern vmCvar_t etj_lagometerAlpha;
 extern vmCvar_t etj_spectatorVote;
 extern vmCvar_t etj_extraTrace;
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -565,6 +565,8 @@ vmCvar_t etj_onRunStart;
 vmCvar_t etj_onRunEnd;
 vmCvar_t etj_lagometerX;
 vmCvar_t etj_lagometerY;
+vmCvar_t etj_lagometerShader;
+vmCvar_t etj_lagometerAlpha;
 vmCvar_t etj_spectatorVote;
 vmCvar_t etj_extraTrace;
 
@@ -1118,6 +1120,8 @@ cvarTable_t cvarTable[] = {
     {&etj_onRunEnd, "etj_onRunEnd", "", CVAR_ARCHIVE},
     {&etj_lagometerX, "etj_lagometerX", "0", CVAR_ARCHIVE},
     {&etj_lagometerY, "etj_lagometerY", "0", CVAR_ARCHIVE},
+    {&etj_lagometerShader, "etj_lagometerShader", "1", CVAR_ARCHIVE},
+    {&etj_lagometerAlpha, "etj_lagometerAlpha", "1.0", CVAR_ARCHIVE},
     {&etj_spectatorVote, "", "0", 0},
     {&etj_extraTrace, "etj_extraTrace", "0", CVAR_ARCHIVE},
     // Autodemo
@@ -2217,7 +2221,7 @@ static void CG_RegisterGraphics(void) {
   cgs.media.smokePuffRageProShader = trap_R_RegisterShader("smokePuffRagePro");
   cgs.media.shotgunSmokePuffShader = trap_R_RegisterShader("shotgunSmokePuff");
   cgs.media.bloodTrailShader = trap_R_RegisterShader("bloodTrail");
-  cgs.media.lagometerShader = trap_R_RegisterShader("lagometer");
+  cgs.media.lagometerShader = trap_R_RegisterShader("gfx/2d/lagometer");
   cgs.media.reticleShaderSimple =
       trap_R_RegisterShader("gfx/misc/reticlesimple");
   cgs.media.binocShaderSimple = trap_R_RegisterShader("gfx/misc/binocsimple");


### PR DESCRIPTION
Allows adjusting the background alpha of lagometer and turning off the shader used for it in favor of a solid color.

* `etj_lagometerShader 1/0`
* `etj_lagometerAlpha 0.0 - 1.0`

![image](https://github.com/etjump/etjump/assets/14221121/fa9cd6d2-1c19-4162-b1c7-52af5d918f6c)![image](https://github.com/etjump/etjump/assets/14221121/55109798-d2b7-4f6a-b8fc-f1fbe8d3e396)![image](https://github.com/etjump/etjump/assets/14221121/6a7cfd47-c06d-4b23-addf-98768469d47c)

