### PR TITLE
Fix server-side fps dependencies

### DIFF
--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -423,10 +423,11 @@ void CopyToBodyQue(gentity_t *ent) {
   BODY_CLASS(body) = ent->client->sess.playerType;
   BODY_CHARACTER(body) = ent->client->pers.characterIndex;
   BODY_VALUE(body) = 0;
+  body->s.time = level.time;
 
   body->s.time2 = 0;
 
-  body->activator = NULL;
+  body->activator = nullptr;
 
   body->nextthink = level.time + BODY_TIME(ent->client->sess.sessionTeam);
 

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -3387,7 +3387,8 @@ qboolean Do_Activate2_f(gentity_t *ent, gentity_t *traceEnt) {
     if (!ent->client->ps.powerups[PW_BLUEFLAG] &&
         !ent->client->ps.powerups[PW_REDFLAG]) {
       if (traceEnt->s.eType == ET_CORPSE) {
-        if (BODY_TEAM(traceEnt) < 4 &&
+        if (level.time - traceEnt->s.time >= DEFAULT_SV_FRAMETIME &&
+            BODY_TEAM(traceEnt) < 4 &&
             BODY_TEAM(traceEnt) != ent->client->sess.sessionTeam) {
           found = qtrue;
 
@@ -3395,17 +3396,6 @@ qboolean Do_Activate2_f(gentity_t *ent, gentity_t *traceEnt) {
 
             traceEnt->nextthink =
                 traceEnt->timestamp + BODY_TIME(BODY_TEAM(traceEnt));
-
-            //						BG_AnimScriptEvent(
-            //&ent->client->ps,
-            // ent->client->pers.character->animModelInfo,
-            // ANIM_ET_PICKUPGRENADE,
-            // qfalse, qtrue );
-            // ent->client->ps.pm_flags
-            // |=
-            // PMF_TIME_LOCKPLAYER;
-            //						ent->client->ps.pm_time
-            //= 2100;
 
             ent->client->ps.powerups[PW_OPS_DISGUISED] = 1;
             ent->client->ps.powerups[PW_OPS_CLASS_1] = BODY_CLASS(traceEnt) & 1;
@@ -3438,6 +3428,7 @@ qboolean Do_Activate2_f(gentity_t *ent, gentity_t *traceEnt) {
             ClientUserinfoChanged(ent->s.clientNum);
           } else {
             BODY_VALUE(traceEnt) += 5;
+            traceEnt->s.time = level.time;
           }
         }
       }

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -257,6 +257,9 @@ typedef struct TokenInformation_s TokenInformation;
 constexpr int MAX_TIMERUNS = 20;
 constexpr int MAX_TIMERUN_NAME_LENGTH = 64;
 
+// default sv_fps 20 frametime for framerate independent server timings
+constexpr int DEFAULT_SV_FRAMETIME = 50;
+
 //====================================================================
 
 #define MAX_NETNAME 36

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1176,6 +1176,8 @@ struct gclient_s {
 
   // true if name change was issues by someone using !rename command on us
   bool forceRename;
+
+  int lastRevivePushTime;
 };
 
 typedef struct {

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1989,6 +1989,7 @@ extern vmCvar_t g_banIPs;
 extern vmCvar_t g_filterBan;
 extern vmCvar_t g_smoothClients;
 extern vmCvar_t pmove_msec;
+extern vmCvar_t sv_fps;
 
 // Rafael
 extern vmCvar_t g_scriptName; // name of script file to run (instead of default

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1679,7 +1679,7 @@ qboolean G_HasDroppedItem(gentity_t *ent, int modType);
 void G_RunFlamechunk(gentity_t *ent);
 
 //----(SA) removed unused q3a weapon firing
-gentity_t *fire_flamechunk(gentity_t *self, vec3_t start, vec3_t dir);
+gentity_t *fire_flamechunk(gentity_t *self, const vec3_t start, vec3_t dir);
 
 gentity_t *fire_grenade(gentity_t *self, const vec3_t start,
                         const vec3_t aimdir, int grenadeWPID);

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -1534,6 +1534,14 @@ qboolean G_ScriptAction_Wait(gentity_t *ent, char *params) {
     }
     max = Q_atoi(token);
 
+    // get as close as possible to sv_fps 20 intervals for compatibility
+    if (sv_fps.integer > 20) {
+      min = min + DEFAULT_SV_FRAMETIME - (min & DEFAULT_SV_FRAMETIME) -
+            level.frameTime;
+      max = max + DEFAULT_SV_FRAMETIME - (max & DEFAULT_SV_FRAMETIME) -
+            level.frameTime;
+    }
+
     if (ent->scriptStatus.scriptStackChangeTime + min > level.time) {
       return qfalse;
     }
@@ -1546,6 +1554,13 @@ qboolean G_ScriptAction_Wait(gentity_t *ent, char *params) {
   }
 
   duration = Q_atoi(token);
+
+  // get as close as possible to sv_fps 20 intervals for compatibility
+  if (sv_fps.integer > 20) {
+    duration = duration + DEFAULT_SV_FRAMETIME -
+               (duration % DEFAULT_SV_FRAMETIME) - level.frameTime;
+  }
+
   return (ent->scriptStatus.scriptStackChangeTime + duration < level.time)
              ? qtrue
              : qfalse;

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -1536,9 +1536,9 @@ qboolean G_ScriptAction_Wait(gentity_t *ent, char *params) {
 
     // get as close as possible to sv_fps 20 intervals for compatibility
     if (sv_fps.integer > 20) {
-      min = min + DEFAULT_SV_FRAMETIME - (min & DEFAULT_SV_FRAMETIME) -
+      min = min + DEFAULT_SV_FRAMETIME - (min % DEFAULT_SV_FRAMETIME) -
             level.frameTime;
-      max = max + DEFAULT_SV_FRAMETIME - (max & DEFAULT_SV_FRAMETIME) -
+      max = max + DEFAULT_SV_FRAMETIME - (max % DEFAULT_SV_FRAMETIME) -
             level.frameTime;
     }
 


### PR DESCRIPTION
Fixes to various things affected by increasing `sv_fps > 20`.

* `wait` key in mapscripts is emulating `sv_fps 20` behavior
* Disguise stealing is normalized to `sv_fps 20`
* Flamethrower flamechunks movement per frame normalized to `sv_fps 20`
* `WolfRevivePushEnt` push frequence normalized to `sv_fps 20`

There are still a few smaller things that are affected by high `sv_fps`, but these are the most important ones for our potential use case.

refs #894 