### PR TITLE
Fix incorrect g_ghostplayers value check in WolfRevivePushEnt

### DIFF
--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1693,7 +1693,7 @@ extern vec3_t playerMins, playerMaxs;
 
 void WolfRevivePushEnt(gentity_t *self, gentity_t *other) {
 
-  if (!g_ghostPlayers.integer || g_ghostPlayers.integer == 2) {
+  if (!g_ghostPlayers.integer || g_ghostPlayers.integer >= 2) {
 
     vec3_t dir, push;
 


### PR DESCRIPTION
When a map has `noghost` set and `g_ghostplayers` is set to `1`, the value gets set to `3` instead of `2`, therefore the check needs to be `>= 2`. `InitGhosting` is responsible for making sure `g_ghostplayers` is never set to other values than 0 or 1 on map start, so there are no special cases where this would be incorrect with some weird value > 2.