### PR TITLE
Token improvements

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -1770,9 +1770,12 @@ bool createToken(gentity_t *ent, Arguments argv) {
     }
   }
 
-  std::array<float, 3> coordinates;
+  std::array<float, 3> coordinates{};
   if (argv->size() < 6) {
     VectorCopy(ent->r.currentOrigin, coordinates);
+    // move closer to ground, but not quite to ground level
+    // to avoid clipping into slopes a bit
+    coordinates[2] += ent->client->ps.mins[2] + 2;
   } else {
     try {
       coordinates[0] = std::stof((*argv)[3]);
@@ -1801,13 +1804,13 @@ bool createToken(gentity_t *ent, Arguments argv) {
     }
   }
 
-  Tokens::Difficulty difficulty;
+  ETJump::Tokens::Difficulty difficulty;
   if ((*argv)[2] == "easy" || ((*argv)[2]) == "e") {
-    difficulty = Tokens::Easy;
+    difficulty = ETJump::Tokens::Easy;
   } else if ((*argv)[2] == "medium" || ((*argv)[2]) == "m") {
-    difficulty = Tokens::Medium;
+    difficulty = ETJump::Tokens::Medium;
   } else if ((*argv)[2] == "hard" || ((*argv)[2]) == "h") {
-    difficulty = Tokens::Hard;
+    difficulty = ETJump::Tokens::Hard;
   } else {
     ChatPrintTo(ent, "^3tokens: ^7difficulty must be either easy (e), medium "
                      "(m) or hard (h)");
@@ -1831,7 +1834,7 @@ bool moveToken(gentity_t *ent) {
     ChatPrintTo(ent, "^3usage: ^7!tokens move can only be used by players.");
     return false;
   }
-  std::array<float, 3> coordinates;
+  std::array<float, 3> coordinates{};
   VectorCopy(ent->r.currentOrigin, coordinates);
 
   auto result = game.tokens->moveNearestToken(coordinates);
@@ -1856,7 +1859,7 @@ bool deleteToken(gentity_t *ent, Arguments argv) {
   }
 
   if (argv->size() == 2) {
-    std::array<float, 3> coordinates;
+    std::array<float, 3> coordinates{};
     VectorCopy(ent->r.currentOrigin, coordinates);
     auto result = game.tokens->deleteNearestToken(coordinates);
     if (!result.first) {
@@ -1870,13 +1873,13 @@ bool deleteToken(gentity_t *ent, Arguments argv) {
   }
 
   if (argv->size() == 4) {
-    Tokens::Difficulty difficulty;
+    ETJump::Tokens::Difficulty difficulty;
     if ((*argv)[2] == "easy" || ((*argv)[2]) == "e") {
-      difficulty = Tokens::Easy;
+      difficulty = ETJump::Tokens::Easy;
     } else if ((*argv)[2] == "medium" || ((*argv)[2]) == "m") {
-      difficulty = Tokens::Medium;
+      difficulty = ETJump::Tokens::Medium;
     } else if ((*argv)[2] == "hard" || ((*argv)[2]) == "h") {
-      difficulty = Tokens::Hard;
+      difficulty = ETJump::Tokens::Hard;
     } else {
       ChatPrintTo(ent, "^3tokens: ^7difficulty must be either easy (e), medium "
                        "(m) or hard (h)");

--- a/src/game/etj_game.h
+++ b/src/game/etj_game.h
@@ -30,6 +30,7 @@
 namespace ETJump {
 class TimerunV2;
 class RockTheVote;
+class Tokens;
 } // namespace ETJump
 
 class Levels;
@@ -38,7 +39,6 @@ class CustomMapVotes;
 class Motd;
 class Timerun;
 class MapStatistics;
-class Tokens;
 
 struct Game {
   Game() {}
@@ -48,7 +48,7 @@ struct Game {
   std::shared_ptr<CustomMapVotes> customMapVotes;
   std::shared_ptr<Motd> motd;
   std::shared_ptr<MapStatistics> mapStatistics;
-  std::shared_ptr<Tokens> tokens;
+  std::shared_ptr<ETJump::Tokens> tokens;
   std::shared_ptr<ETJump::TimerunV2> timerunV2;
   std::shared_ptr<ETJump::RockTheVote> rtv;
 };

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -154,7 +154,7 @@ void OnGameInit() {
   game.customMapVotes =
       std::make_shared<CustomMapVotes>(game.mapStatistics.get());
   game.motd = std::make_shared<Motd>();
-  game.tokens = std::make_shared<Tokens>();
+  game.tokens = std::make_shared<ETJump::Tokens>();
   game.rtv = std::make_shared<ETJump::RockTheVote>();
 
   if (strlen(g_levelConfig.string)) {
@@ -445,30 +445,6 @@ void G_increaseCallvoteCount(const char *mapName) {
 
 void G_increasePassedCount(const char *mapName) {
   game.mapStatistics->increasePassedCount(mapName);
-}
-
-bool allTokensCollected(gentity_t *ent) {
-  auto tokenCounts = game.tokens->getTokenCounts();
-
-  auto easyCount = 0;
-  auto mediumCount = 0;
-  auto hardCount = 0;
-  for (auto i = 0; i < MAX_TOKENS_PER_DIFFICULTY; ++i) {
-    if (ent->client->pers.collectedEasyTokens[i]) {
-      ++easyCount;
-    }
-
-    if (ent->client->pers.collectedMediumTokens[i]) {
-      ++mediumCount;
-    }
-
-    if (ent->client->pers.collectedHardTokens[i]) {
-      ++hardCount;
-    }
-  }
-
-  return tokenCounts[0] == easyCount && tokenCounts[1] == mediumCount &&
-         tokenCounts[2] == hardCount;
 }
 
 namespace ETJump {

--- a/src/game/etj_time_utilities.cpp
+++ b/src/game/etj_time_utilities.cpp
@@ -24,7 +24,6 @@
 
 #include "etj_time_utilities.h"
 #include <chrono>
-#include <time.h>
 #include <ctime>
 
 long long ETJump::getCurrentTimestamp() {

--- a/src/game/etj_tokens.cpp
+++ b/src/game/etj_tokens.cpp
@@ -305,7 +305,7 @@ bool Tokens::allTokensCollected(gentity_t *ent) {
 }
 
 void Tokens::tokenTouch(gentity_t *self, gentity_t *other, trace_t *trace) {
-  if (!other->client) {
+  if (!other->client || other->client->ps.pm_type == PM_NOCLIP) {
     return;
   }
 

--- a/src/game/etj_tokens.h
+++ b/src/game/etj_tokens.h
@@ -22,38 +22,41 @@
  * SOFTWARE.
  */
 
-#ifndef TOKENS_HH
-#define TOKENS_HH
+#pragma once
+
 #include <string>
 #include <array>
 #include "json/json-forwards.h"
 #include <memory>
 
-typedef struct gentity_s gentity_t;
 typedef struct TokenInformation_s TokenInformation;
 
+namespace ETJump {
 class Tokens {
 public:
   enum Difficulty { Easy, Medium, Hard };
 
-  static const int TOKENS_PER_DIFFICULTY = 6;
+  // the entity is drawn as 32x32, but this feels more natural with touching
+  static constexpr float TOKEN_RADIUS = 8.0f;
+
   struct Token {
-    Token();
+    Token()
+        : isActive(false), entity(nullptr), coordinates{0.0f, 0.0f, 0.0f},
+          data(std::make_unique<TokenInformation>()) {}
     std::array<float, 3> coordinates;
     std::string name;
     bool isActive;
     gentity_t *entity;
-    // Because we cannot capture values for the entity think
-    // lambda we must pass the data as a gentity pointer in
-    // gentity Because there is so much data stored storing same
-    // data for every entity would be pretty pointles Only
-    // tokens have the data
+
+    // Because we cannot capture values for the entity think lambda,
+    // we must pass the data as a gentity pointer in gentity.
+    // Because there is so much data stored, storing the same data for
+    // every entity would be pretty pointless.
+    // Only tokens have the data.
     std::unique_ptr<TokenInformation> data;
     Json::Value toJson() const;
     void fromJson(const Json::Value &json);
   };
-  Tokens();
-  ~Tokens();
 
   std::pair<bool, std::string> createToken(Difficulty difficulty,
                                            std::array<float, 3> coordinates);
@@ -63,7 +66,8 @@ public:
     float distance;
     Difficulty difficulty;
   };
-  NearestToken findNearestToken(std::array<float, 3> coordinates);
+
+  static NearestToken findNearestToken(std::array<float, 3> coordinates);
   std::pair<bool, std::string>
   moveNearestToken(std::array<float, 3> coordinates);
   std::pair<bool, std::string>
@@ -71,16 +75,16 @@ public:
   std::pair<bool, std::string> deleteToken(Difficulty difficulty, int index);
 
   bool loadTokens(const std::string &filepath);
-  bool saveTokens(const std::string &filepath);
-  void createEntity(Token &token, Difficulty difficulty);
-  void createEntities();
-  void reset();
-  std::array<int, 3> getTokenCounts() const;
+  static bool saveTokens(const std::string &filepath);
+  static void createEntity(Token &token, Difficulty difficulty);
+  static void tokenTouch(gentity_t *self, gentity_t *other, trace_t *trace);
+  static void createEntities();
+  static void reset();
+  static std::array<int, 3> getTokenCounts();
+
+  static bool allTokensCollected(gentity_t *ent);
 
 private:
   std::string _filepath;
-  std::array<Token, TOKENS_PER_DIFFICULTY> _easyTokens;
-  std::array<Token, TOKENS_PER_DIFFICULTY> _mediumTokens;
-  std::array<Token, TOKENS_PER_DIFFICULTY> _hardTokens;
 };
-#endif
+} // namespace ETJump

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2247,11 +2247,13 @@ void ClientBegin(int clientNum) {
   } else {
     trap_SendServerCommand(clientNum, "hasTimerun 0");
   }
-  for (i = 0; i < MAX_TOKENS_PER_DIFFICULTY; ++i) {
-    ent->client->pers.collectedEasyTokens[i] = qfalse;
-    ent->client->pers.collectedMediumTokens[i] = qfalse;
-    ent->client->pers.collectedHardTokens[i] = qfalse;
+
+  for (i = 0; i < ETJump::MAX_TOKENS_PER_DIFFICULTY; ++i) {
+    ent->client->pers.collectedEasyTokens[i] = false;
+    ent->client->pers.collectedMediumTokens[i] = false;
+    ent->client->pers.collectedHardTokens[i] = false;
   }
+
   ent->client->pers.tokenCollectionStartTime = level.time;
 
   if (!ent->client->sess.receivedTimerunStates) {

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -879,6 +879,8 @@ struct votingInfo_t {
 
   int lastRtvMapVoted; // used for re-votes, the last map number we voted on
 };
+
+static constexpr int MAX_TOKENS_PER_DIFFICULTY = 32;
 } // namespace ETJump
 
 // client data that stays across multiple respawns, but is cleared
@@ -978,10 +980,9 @@ typedef struct {
 
   raceStruct_t race;
 
-#define MAX_TOKENS_PER_DIFFICULTY 6
-  qboolean collectedEasyTokens[MAX_TOKENS_PER_DIFFICULTY];
-  qboolean collectedMediumTokens[MAX_TOKENS_PER_DIFFICULTY];
-  qboolean collectedHardTokens[MAX_TOKENS_PER_DIFFICULTY];
+  bool collectedEasyTokens[ETJump::MAX_TOKENS_PER_DIFFICULTY];
+  bool collectedMediumTokens[ETJump::MAX_TOKENS_PER_DIFFICULTY];
+  bool collectedHardTokens[ETJump::MAX_TOKENS_PER_DIFFICULTY];
   int tokenCollectionStartTime;
 
   int previousSetHealthTime;


### PR DESCRIPTION
* Increase max tokens per difficulty to 32
* Create tokens on ground level instead of player origin
* Fix the token bbox, `r.mins/maxs` were never set so it was a point entity
* Remove think function in favor of touch function, there's no need to keep running think for tokens every 100ms
* Tokens can no longer be collected while noclipping
* General refactor + cleanup