### PR TITLE
Add chat replay functionality

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1264,6 +1264,7 @@ typedef struct {
   char deformText[MAX_RENDER_STRINGS][MAX_RENDER_STRING_LENGTH];
 
   bool shadowCvarsSet;
+  bool chatReplayReceived;
 
   // portalgun auto-binding
   bool portalgunBindingsAdjusted;

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -628,6 +628,11 @@ void runFrameEnd() {
     cg.shadowCvarsSet = true;
   }
 
+  if (cg.clientFrame >= 10 && !cg.chatReplayReceived) {
+    trap_SendConsoleCommand("getchatreplay");
+    cg.chatReplayReceived = true;
+  }
+
   if (etj_autoPortalBinds.integer) {
     if (cg.weaponSelect == WP_PORTAL_GUN && !cg.portalgunBindingsAdjusted) {
       cgDC.getKeysForBinding("weapalt", &cg.weapAltB1, &cg.weapAltB2);

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(qagame MODULE
 	"q_shared.cpp"
 	"etj_async_operation.cpp"
 	"etj_banner_system.cpp"
+	"etj_chat_replay.cpp"
 	"etj_command_parser.cpp"
 	"etj_command_variables.cpp"
 	"etj_commands.cpp"

--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -82,7 +82,7 @@ void ChatReplay::readChatsFromFile() {
   Json::Value root;
 
   if (!JsonUtils::readFile(chatReplayFile, root)) {
-    logger.error("Couldn't open chat replay file '%s' for reading.",
+    logger.error("Could not open chat replay file '%s' for reading.",
                  chatReplayFile);
     return;
   }

--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "g_local.h"
+#include "etj_chat_replay.h"
+
+namespace ETJump {
+ChatReplay::ChatReplay() { chatReplayBuffer.clear(); }
+
+void ChatReplay::storeChatmessage(int clientNum, const std::string &name,
+                                  const std::string &message, bool localize,
+                                  bool encoded) {
+  ChatMessage msg{};
+
+  msg.clientNum = clientNum;
+  msg.name = name;
+  msg.localize = localize;
+  msg.encoded = encoded;
+  msg.message = message;
+
+  chatReplayBuffer.emplace_back(msg);
+
+  if (chatReplayBuffer.size() > MAX_CHAT_REPLAY_BUFFER) {
+    chatReplayBuffer.pop_front();
+  }
+}
+
+void ChatReplay::sendChatMessages(gentity_t *ent) {
+  if (chatReplayBuffer.empty()) {
+    return;
+  }
+
+  for (const auto &msg : chatReplayBuffer) {
+    // skip messages from ignored clients
+    if (COM_BitCheck(ent->client->sess.ignoreClients, msg.clientNum)) {
+      continue;
+    }
+
+    const char *cmd = msg.encoded ? "enc_chat" : "chat";
+    trap_SendServerCommand(ClientNum(ent),
+                           va("%s \"%s%c%c%s\" %i %i", cmd, msg.name.c_str(),
+                              Q_COLOR_ESCAPE, COLOR_GREEN, msg.message.c_str(),
+                              msg.clientNum, msg.localize));
+  }
+}
+} // namespace ETJump

--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -112,7 +112,7 @@ void ChatReplay::writeChatsToFile() {
     root.append(chat);
   }
 
-  if (!ETJump::JsonUtils::writeFile(chatReplayFile, root)) {
+  if (!JsonUtils::writeFile(chatReplayFile, root)) {
     logger.error("Could not open chat replay file '%s' for writing.",
                  chatReplayFile);
   }

--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -29,7 +29,7 @@
 #include "etj_log.h"
 
 namespace ETJump {
-Log logger("chatreplay");
+Log ChatReplay::logger = Log("chat-replay");
 
 ChatReplay::ChatReplay() {
   chatReplayBuffer.clear();

--- a/src/game/etj_chat_replay.h
+++ b/src/game/etj_chat_replay.h
@@ -41,6 +41,10 @@ class ChatReplay {
 
   std::list<ChatMessage> chatReplayBuffer;
 
+  static std::string parseChatMessage(const ChatMessage &msg);
+  void readChatsFromFile();
+  void writeChatsToFile();
+
 public:
   ChatReplay();
   ~ChatReplay();
@@ -50,11 +54,5 @@ public:
                         bool encoded);
 
   void sendChatMessages(gentity_t *ent);
-
-  static std::string parseChatMessage(const ChatMessage &msg);
-
-  void readChatsFromFile();
-
-  void writeChatsToFile();
 };
 } // namespace ETJump

--- a/src/game/etj_chat_replay.h
+++ b/src/game/etj_chat_replay.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <list>
+#include "etj_log.h"
 
 namespace ETJump {
 class ChatReplay {
@@ -35,6 +36,8 @@ class ChatReplay {
     bool localize;
     bool encoded;
   };
+
+  static Log logger;
 
   static constexpr int MAX_CHAT_REPLAY_BUFFER = 10;
   const std::string chatReplayFile = "chatreplay.json";

--- a/src/game/etj_chat_replay.h
+++ b/src/game/etj_chat_replay.h
@@ -24,32 +24,30 @@
 
 #pragma once
 
-#include <memory>
+#include <list>
 
 namespace ETJump {
-class TimerunV2;
-class RockTheVote;
-class ChatReplay;
-} // namespace ETJump
+class ChatReplay {
+  struct ChatMessage {
+    int clientNum;
+    std::string name;
+    std::string message;
+    std::string location;
+    bool localize;
+    bool encoded;
+  };
 
-class Levels;
-class Commands;
-class CustomMapVotes;
-class Motd;
-class Timerun;
-class MapStatistics;
-class Tokens;
+  static constexpr int MAX_CHAT_REPLAY_BUFFER = 10;
 
-struct Game {
-  Game() {}
+  std::list<ChatMessage> chatReplayBuffer;
 
-  std::shared_ptr<Levels> levels;
-  std::shared_ptr<Commands> commands;
-  std::shared_ptr<CustomMapVotes> customMapVotes;
-  std::shared_ptr<Motd> motd;
-  std::shared_ptr<MapStatistics> mapStatistics;
-  std::shared_ptr<Tokens> tokens;
-  std::shared_ptr<ETJump::TimerunV2> timerunV2;
-  std::shared_ptr<ETJump::RockTheVote> rtv;
-  std::shared_ptr<ETJump::ChatReplay> chatReplay;
+public:
+  ChatReplay();
+  ~ChatReplay() = default;
+
+  void storeChatmessage(int clientNum, const std::string &name,
+                        const std::string &message, bool localize,
+                        bool encoded);
+  void sendChatMessages(gentity_t *ent);
 };
+} // namespace ETJump

--- a/src/game/etj_chat_replay.h
+++ b/src/game/etj_chat_replay.h
@@ -32,22 +32,29 @@ class ChatReplay {
     int clientNum;
     std::string name;
     std::string message;
-    std::string location;
     bool localize;
     bool encoded;
   };
 
   static constexpr int MAX_CHAT_REPLAY_BUFFER = 10;
+  const std::string chatReplayFile = "chatreplay.json";
 
   std::list<ChatMessage> chatReplayBuffer;
 
 public:
   ChatReplay();
-  ~ChatReplay() = default;
+  ~ChatReplay();
 
-  void storeChatmessage(int clientNum, const std::string &name,
+  void storeChatMessage(int clientNum, const std::string &name,
                         const std::string &message, bool localize,
                         bool encoded);
+
   void sendChatMessages(gentity_t *ent);
+
+  static std::string parseChatMessage(const ChatMessage &msg);
+
+  void readChatsFromFile();
+
+  void writeChatsToFile();
 };
 } // namespace ETJump

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -38,6 +38,7 @@
 #include "etj_string_utilities.h"
 #include "etj_printer.h"
 #include "etj_timerun_v2.h"
+#include "etj_chat_replay.h"
 
 typedef std::function<bool(gentity_t *ent, Arguments argv)> Command;
 typedef std::pair<std::function<bool(gentity_t *ent, Arguments argv)>, char>
@@ -379,6 +380,11 @@ bool LoadCheckpoints(gentity_t *ent, Arguments argv) {
   game.timerunV2->loadCheckpoints(ClientNum(ent), level.rawmapname, runName,
                                   rank);
 
+  return true;
+}
+
+bool GetChatReplay(gentity_t *ent, Arguments argv) {
+  game.chatReplay->sendChatMessages(ent);
   return true;
 }
 } // namespace ClientCommands
@@ -2484,6 +2490,7 @@ Commands::Commands() {
   commands_["load-checkpoints"] = ClientCommands::LoadCheckpoints;
   commands_["rankings"] = ClientCommands::Rankings;
   commands_["seasons"] = ClientCommands::ListSeasons;
+  commands_["getchatreplay"] = ClientCommands::GetChatReplay;
 }
 
 bool Commands::ClientCommand(gentity_t *ent, const std::string &commandStr) {

--- a/src/game/etj_json_utilities.cpp
+++ b/src/game/etj_json_utilities.cpp
@@ -27,6 +27,8 @@
 #include "utilities.hpp"
 
 namespace ETJump {
+Log JsonUtils::logger = Log("JSON-utils");
+
 bool JsonUtils::writeFile(const std::string &file, const Json::Value &root) {
   Json::StyledWriter writer;
   const std::string &output = writer.write(root);
@@ -51,7 +53,13 @@ bool JsonUtils::readFile(const std::string &file, Json::Value &root) {
   }
 
   Json::CharReaderBuilder readerBuilder;
-  Json::parseFromStream(readerBuilder, fIn, &root, nullptr);
+  std::string errors;
+
+  if (!Json::parseFromStream(readerBuilder, fIn, &root, &errors)) {
+    logger.error("Failed to parse JSON file '%s': %s", file, errors);
+    return false;
+  }
+
   fIn.close();
   return true;
 }

--- a/src/game/etj_json_utilities.h
+++ b/src/game/etj_json_utilities.h
@@ -25,9 +25,12 @@
 #pragma once
 
 #include "json/json.h"
+#include "etj_log.h"
 
 namespace ETJump {
 class JsonUtils {
+  static Log logger;
+
 public:
   // returns true on successful read
   static bool readFile(const std::string &file, Json::Value &root);

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -236,6 +236,7 @@ void OnGameShutdown() {
   game.tokens = nullptr;
   game.timerunV2 = nullptr;
   game.rtv = nullptr;
+  game.chatReplay = nullptr;
   ETJump::Log::processMessages();
 }
 

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -39,6 +39,7 @@
 #include "etj_timerun_repository.h"
 #include "etj_timerun_v2.h"
 #include "etj_rtv.h"
+#include "etj_chat_replay.h"
 
 Game game;
 
@@ -156,6 +157,7 @@ void OnGameInit() {
   game.motd = std::make_shared<Motd>();
   game.tokens = std::make_shared<Tokens>();
   game.rtv = std::make_shared<ETJump::RockTheVote>();
+  game.chatReplay = std::make_shared<ETJump::ChatReplay>();
 
   if (strlen(g_levelConfig.string)) {
     if (!game.levels->ReadFromConfig()) {

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -1,7 +1,6 @@
 #include "g_local.h"
 #include <vector>
 #include <regex>
-#include "etj_result_set_formatter.h"
 #include "utilities.hpp"
 #include "etj_printer.h"
 #include "etj_operation_result.h"
@@ -11,6 +10,7 @@
 #include "etj_numeric_utilities.h"
 #include "etj_rtv.h"
 #include "etj_utilities.h"
+#include "etj_chat_replay.h"
 
 namespace ETJump {
 enum class VotingTypes {
@@ -2107,6 +2107,11 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
 
   if (g_chatOptions.integer & CHAT_OPTIONS_INTERPOLATE_NAME_TAGS) {
     printText = interpolateNametags(text, color);
+  }
+
+  if (mode == SAY_ALL) {
+    game.chatReplay->storeChatmessage(clientNum, escapedName, printText,
+                                      localize, encoded);
   }
 
   if (target) {

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -2110,7 +2110,7 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
   }
 
   if (mode == SAY_ALL) {
-    game.chatReplay->storeChatmessage(clientNum, escapedName, printText,
+    game.chatReplay->storeChatMessage(clientNum, escapedName, printText,
                                       localize, encoded);
   }
 


### PR DESCRIPTION
Replays up to 10 last global chat messages to client when they connect to a server, or perform a `vid_restart`.

Few limitations:
* Chat timestamps are lost as they are generated on demand client side, and I'd rather not transmit them and start to perform timezone conversions
* Chat team flag might be wrong, as it's parsed on demand on client side, so if a message was sent as Allies, and the replay is performed after the player has swapped to Axis, it will show the Axis flag in chat instead

refs #349 