### PR TITLE
Lerp lean angles on spec/demo playback

### DIFF
--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -460,6 +460,8 @@ static void CG_InterpolatePlayerState(qboolean grabAngles) {
     out->velocity[i] = prev->ps.velocity[i] +
                        f * (next->ps.velocity[i] - prev->ps.velocity[i]);
   }
+
+  out->leanf = prev->ps.leanf + f * (next->ps.leanf - prev->ps.leanf);
 }
 
 void CG_AddDirtBulletParticles(vec3_t origin, vec3_t dir, int speed,


### PR DESCRIPTION
Lean angles were never interpolated on demo playback, which caused them to look choppy due to snapshot update rate.