### PR TITLE
Add shortname options to the command system

### DIFF
--- a/src/game/etj_command_parser.cpp
+++ b/src/game/etj_command_parser.cpp
@@ -35,6 +35,14 @@ ETJump::CommandParser::getOptionOrNull() {
     if (_def.options.count(optionName) > 0) {
       return &_def.options[optionName];
     }
+  } else if (StringUtil::startsWith(*_current, "-")) {
+    const auto optionShortName = (*_current).substr(1);
+
+    for (const auto &op : _def.options) {
+      if (op.second.shortName == optionShortName) {
+        return &_def.options[op.first];
+      }
+    }
   }
 
   return nullptr;
@@ -204,7 +212,7 @@ ETJump::CommandParser::Option ETJump::CommandParser::createDateOption(
 }
 
 void ETJump::CommandParser::expectOption() {
-  if (*_current == "--help") {
+  if (*_current == "--help" || *_current == "-h") {
     _cmd.helpRequested = true;
     return;
   }
@@ -326,4 +334,41 @@ ETJump::CommandParser::Command ETJump::CommandParser::parse() {
         stringFormat("Unknown runtime error: `%s`", e.what()));
     return _cmd;
   }
+}
+std::string ETJump::CommandParser::formatCommandHelpString(
+    const std::string &name, const std::string &shortname,
+    OptionDefinition::Type optionType, const std::string &description,
+    bool required, opt<int> position) {
+  // console line width varies a bit depending on engine and resolution,
+  // but this should be fine for most scenarios
+  const size_t maxLineLen = 120;
+  const size_t flagPad = 23 - shortname.length();
+
+  const std::string &opTypeStr = OptionDefinition::typeToString(optionType);
+  const std::string &positionStr = stringFormat(
+      "%s",
+      position.hasValue() ? stringFormat(" (pos: %d) ", position.value()) : "");
+  const std::string &requiredStr =
+      stringFormat("%s", required ? " [required] " : "");
+
+  const std::string &flagStr =
+      stringFormat("    ^7-%s, --%-*s", shortname, flagPad, name);
+  const std::string &descStr = stringFormat(
+      "^z(%s) ^7%s%s%s", opTypeStr, description, requiredStr, positionStr);
+
+  std::string combinedStr = flagStr + descStr;
+
+  // split from the previous whitespace and indent the new line,
+  // if the description text is too long to fit to console max line width
+  if (sanitize(combinedStr, false).length() > maxLineLen) {
+    const size_t lastWhiteSpace = combinedStr.find_last_of(' ', maxLineLen);
+
+    if (lastWhiteSpace != std::string ::npos) {
+      combinedStr.replace(
+          lastWhiteSpace, 1,
+          '\n' + std::string(sanitize(flagStr, false).length(), ' '));
+    }
+  }
+
+  return combinedStr;
 }

--- a/src/game/etj_command_parser.cpp
+++ b/src/game/etj_command_parser.cpp
@@ -363,7 +363,7 @@ std::string ETJump::CommandParser::formatCommandHelpString(
   if (sanitize(combinedStr, false).length() > maxLineLen) {
     const size_t lastWhiteSpace = combinedStr.find_last_of(' ', maxLineLen);
 
-    if (lastWhiteSpace != std::string ::npos) {
+    if (lastWhiteSpace != std::string::npos) {
       combinedStr.replace(
           lastWhiteSpace, 1,
           '\n' + std::string(sanitize(flagStr, false).length(), ' '));

--- a/src/game/etj_command_parser.h
+++ b/src/game/etj_command_parser.h
@@ -65,6 +65,7 @@ public:
       return "";
     }
 
+    std::string shortName{};
     std::string name{};
     std::string description{};
     Type type{Type::Token};
@@ -72,11 +73,13 @@ public:
     opt<int> position;
 
     static OptionDefinition create(const std::string &name,
+                                   const std::string &shortName,
                                    const std::string &description, Type type,
                                    bool required) {
       auto def = OptionDefinition{};
 
       def.name = name;
+      def.shortName = shortName;
       def.description = description;
       def.type = type;
       def.required = required;
@@ -92,18 +95,10 @@ public:
 
     std::string help() const {
       auto optionsToStrings = Container::map(options, [](const auto &pair) {
-        const auto &optionName = pair.second.name;
-        auto optionType = OptionDefinition::typeToString(pair.second.type);
-        const auto &desc = pair.second.description;
-        auto requiredString = pair.second.required ? " [required] " : "";
-        auto positionString = stringFormat(
-            " (pos: %d) ",
-            pair.second.position.hasValue() ? pair.second.position.value() : 0);
-
-        return stringFormat(
-            "    --%s (%s) %s%s%s", optionName, optionType, desc,
-            requiredString,
-            pair.second.position.hasValue() ? std::move(positionString) : "");
+        return CommandParser::formatCommandHelpString(
+            pair.second.name, pair.second.shortName, pair.second.type,
+            pair.second.description, pair.second.required,
+            pair.second.position);
       });
 
       return stringFormat("Usage: %s\n\n    %s\n\nOptions:\n%s\n", name,
@@ -123,10 +118,13 @@ public:
     }
 
     CommandDefinition &addOption(const std::string &name,
+                                 const std::string &shortName,
                                  const std::string &description,
                                  OptionDefinition::Type type, bool required) {
       auto opt = OptionDefinition{};
+
       opt.name = name;
+      opt.shortName = shortName;
       opt.description = description;
       opt.type = type;
       opt.required = required;
@@ -137,6 +135,7 @@ public:
     }
 
     CommandDefinition &addOption(const std::string &name,
+                                 const std::string &shortName,
                                  const std::string &description,
                                  OptionDefinition::Type type, bool required,
                                  int position) {
@@ -157,7 +156,9 @@ public:
       }
 
       auto opt = OptionDefinition{};
+
       opt.name = name;
+      opt.shortName = shortName;
       opt.description = description;
       opt.type = type;
       opt.required = required;
@@ -232,5 +233,11 @@ private:
   void expectOptionOrExtraArgs();
   void processPositionalArguments();
   void validateCommand();
+
+  static std::string formatCommandHelpString(const std::string &name,
+                                             const std::string &shortname,
+                                             OptionDefinition::Type optionType,
+                                             const std::string &description,
+                                             bool required, opt<int> position);
 };
 } // namespace ETJump

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -180,13 +180,13 @@ bool Rankings(gentity_t *ent, Arguments argv) {
           "overall as the default.\n\n    /rankings --season <season> --page "
           "<page> --page-size <page size>\n\n    Has a shorthand format of:\n  "
           "  /rankings <season>")
-          .addOption("season", "Name of the season to list rankings for",
+          .addOption("season", "s", "Name of the season to list rankings for",
                      ETJump::CommandParser::OptionDefinition::Type::MultiToken,
                      false)
-          .addOption("page", "Which page of rankings to show",
+          .addOption("page", "p", "Which page of rankings to show",
                      ETJump::CommandParser::OptionDefinition::Type::Integer,
                      false)
-          .addOption("page-size", "How many rankings to show per page",
+          .addOption("page-size", "ps", "How many rankings to show per page",
                      ETJump::CommandParser::OptionDefinition::Type::Integer,
                      false),
       &args);
@@ -251,25 +251,25 @@ bool Records(gentity_t *ent, Arguments argv) {
           "--map <map name> --run <run name>\n\n    Has a shorthand format "
           "of:\n    /records <run name>\n    /records <map name> <run name>\n  "
           "  /records <season name> <map name> <run name>")
-          .addOption("season",
+          .addOption("season", "s",
                      "Name of the season to print the records for. Default is "
                      "the overall season.",
                      ETJump::CommandParser::OptionDefinition::Type::MultiToken,
                      false)
-          .addOption("map",
+          .addOption("map", "m",
                      "Name of the map to print the records for. Default is the "
                      "current map.",
                      ETJump::CommandParser::OptionDefinition::Type::MultiToken,
                      false)
           .addOption(
-              "run",
+              "run", "r",
               "Name of the run to print the records for. Default will print "
               "top 3 records for all runs on specified map and your record.",
               ETJump::CommandParser::OptionDefinition::Type::MultiToken, false)
-          .addOption("page", "Which page to display starting at 1",
+          .addOption("page", "p", "Which page to display starting at 1",
                      ETJump::CommandParser::OptionDefinition::Type::Integer,
                      false)
-          .addOption("page-size",
+          .addOption("page-size", "ps",
                      "How many records to show on a single page. Max page size "
                      "is 100 if a run is specified, otherwise 10.",
                      ETJump::CommandParser::OptionDefinition::Type::Integer,
@@ -358,10 +358,10 @@ bool LoadCheckpoints(gentity_t *ent, Arguments argv) {
           "    Has a shorthand format of:\n"
           "    /loadcheckpoints <run name> <rank>\n"
           "    /loadcheckpoints <run name>")
-          .addOption("run", "Name of the run to load the records from.",
+          .addOption("run", "r", "Name of the run to load the records from.",
                      ETJump::CommandParser::OptionDefinition::Type::Token, true,
                      0)
-          .addOption("rank",
+          .addOption("rank", "rk",
                      "Rank to load checkpoints from. Defaults to 1. Value -1 "
                      "clears loaded checkpoints.",
                      ETJump::CommandParser::OptionDefinition::Type::Integer,
@@ -2114,14 +2114,14 @@ bool TimerunAddSeason(gentity_t *ent, Arguments argv) {
       ETJump::CommandParser::CommandDefinition::create(
           "add-season", "Adds a new timerun season\n    !add-season --name "
                         "<name> --start-date <2000-01-01>")
-          .addOption("name", "Name of the season to add",
+          .addOption("name", "n", "Name of the season to add",
                      ETJump::CommandParser::OptionDefinition::Type::MultiToken,
                      true)
-          .addOption("start-date",
+          .addOption("start-date", "sd",
                      "Start date for the timerun season in YYYY-MM-DD format "
                      "(e.g. 2000-01-01)",
                      ETJump::CommandParser::OptionDefinition::Type::Date, true)
-          .addOption("end-date-exclusive",
+          .addOption("end-date-exclusive", "ed",
                      "End date for the timerun season in YYYY-MM-DD format "
                      "(e.g. 2000-01-01)",
                      ETJump::CommandParser::OptionDefinition::Type::Date,
@@ -2169,14 +2169,14 @@ bool TimerunEditSeason(gentity_t *ent, Arguments argv) {
   auto def = std::move(
       ETJump::CommandParser::CommandDefinition::create(
           "edit-season", "Edit an existing timerun season")
-          .addOption("name", "Name of the season to edit",
+          .addOption("name", "n", "Name of the season to edit",
                      ETJump::CommandParser::OptionDefinition::Type::MultiToken,
                      true)
-          .addOption("start-date",
+          .addOption("start-date", "sd",
                      "Start date for the timerun season in YYYY-MM-DD format "
                      "(e.g. 2000-01-01)",
                      ETJump::CommandParser::OptionDefinition::Type::Date, false)
-          .addOption("end-date",
+          .addOption("end-date", "ed",
                      "End date for the timerun season in YYYY-MM-DD format "
                      "(e.g. 2000-01-01)",
                      ETJump::CommandParser::OptionDefinition::Type::Date,
@@ -2215,7 +2215,7 @@ bool TimerunDeleteSeason(gentity_t *ent, Arguments argv) {
       ETJump::CommandParser::CommandDefinition::create(
           "delete-season", "Delete a season. This will delete all the "
                            "records within the season.")
-          .addOption("name", "Exact name of the season to delete",
+          .addOption("name", "n", "Exact name of the season to delete",
                      ETJump::CommandParser::OptionDefinition::Type::MultiToken,
                      true));
 
@@ -2250,14 +2250,14 @@ bool addCustomVote(gentity_t *ent, Arguments argv) {
   const auto def = std::move(
       ETJump::CommandParser::CommandDefinition::create(
           "add-customvote", "Creates a new custom map vote list.")
-          .addOption("name", "Name of the custom vote list",
+          .addOption("name", "n", "Name of the custom vote list",
                      ETJump::CommandParser::OptionDefinition::Type::Token, true)
-          .addOption("full-name", "Full name, displayed in the callvote text.",
-                     ETJump::CommandParser::OptionDefinition::Type::MultiToken,
-                     true)
-          .addOption("maps", "Maps to include in the list, space delimited.",
-                     ETJump::CommandParser::OptionDefinition::Type::MultiToken,
-                     true));
+          .addOption(
+              "full-name", "fn", "Full name, displayed in the callvote text.",
+              ETJump::CommandParser::OptionDefinition::Type::MultiToken, true)
+          .addOption(
+              "maps", "m", "Maps to include in the list, space delimited.",
+              ETJump::CommandParser::OptionDefinition::Type::MultiToken, true));
 
   const auto optCommand =
       ETJump::getOptCommand("add-customvote", clientNum, def, argv);
@@ -2282,7 +2282,7 @@ bool deleteCustomVote(gentity_t *ent, Arguments argv) {
   auto def = std::move(
       ETJump::CommandParser::CommandDefinition::create(
           "delete-customvote", "Deletes a custom map vote list.")
-          .addOption("name", "Name of the list to delete.",
+          .addOption("name", "n", "Name of the list to delete.",
                      ETJump::CommandParser::OptionDefinition::Type::Token,
                      true));
 
@@ -2306,18 +2306,18 @@ bool editCustomVote(gentity_t *ent, Arguments argv) {
   auto def = std::move(
       ETJump::CommandParser::CommandDefinition::create(
           "edit-customvote", "Edits a custom map vote list.")
-          .addOption("list", "Name of the list to edit.",
+          .addOption("list", "l", "Name of the list to edit.",
                      ETJump::CommandParser::OptionDefinition::Type::Token, true)
-          .addOption("name", "Name of the custom vote list.",
+          .addOption("name", "n", "Name of the custom vote list.",
                      ETJump::CommandParser::OptionDefinition::Type::Token,
                      false)
-          .addOption("full-name", "Full name, displayed in the callvote text.",
-                     ETJump::CommandParser::OptionDefinition::Type::MultiToken,
-                     false)
-          .addOption("add-maps", "Maps to add to the list, space delimited.",
-                     ETJump::CommandParser::OptionDefinition::Type::MultiToken,
-                     false)
-          .addOption("remove-maps",
+          .addOption(
+              "full-name", "fn", "Full name, displayed in the callvote text.",
+              ETJump::CommandParser::OptionDefinition::Type::MultiToken, false)
+          .addOption(
+              "add-maps", "am", "Maps to add to the list, space delimited.",
+              ETJump::CommandParser::OptionDefinition::Type::MultiToken, false)
+          .addOption("remove-maps", "rm",
                      "Maps to remove from the list, space delimited.",
                      ETJump::CommandParser::OptionDefinition::Type::MultiToken,
                      false));

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -900,7 +900,7 @@ void ETJump::TimerunV2::printRankings(Timerun::PrintRankingsParams params) {
               _repository->getSeasonsForName(params.season.value(), false);
 
           if (matchingSeasons.empty()) {
-            message = stringFormat("No matching season for name `%s`",
+            message = stringFormat("No matching season for name `%s`\n",
                                    params.season.value());
           } else {
             for (const auto &s : matchingSeasons) {

--- a/tests/command_parser_tests.cpp
+++ b/tests/command_parser_tests.cpp
@@ -43,7 +43,7 @@ TEST_F(CommandParserTests, CommandParser_Returns_CommandWithSingleTokenOption) {
 
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("t", "token", "desc",
+          CreateCommandDefinition().addOption("token", "t",  "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true)
           ,
@@ -58,7 +58,7 @@ TEST_F(CommandParserTests,
                     "stuff"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("t", "token", "desc",
+          CreateCommandDefinition().addOption("token", "t", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true),
           args)
@@ -72,7 +72,7 @@ TEST_F(CommandParserTests,
                     "some", "additional", "stuff"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("t", "token", "desc",
+          CreateCommandDefinition().addOption("token", "t", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true)
           ,
@@ -88,7 +88,7 @@ TEST_F(CommandParserTests, CommandParser_Returns_MultipleCorrectOptions) {
                     "--bar"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("t", "token", "desc",
+          CreateCommandDefinition().addOption("token", "t", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true).addOption(
               "b", "boolean", "desc", CommandParser::OptionDefinition::Type::Boolean,
@@ -107,10 +107,10 @@ TEST_F(CommandParserTests,
                     "--bar"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("t", "token", "desc",
+          CreateCommandDefinition().addOption("token", "t", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true)
-                                   .addOption("b", "boolean", "desc",
+                                   .addOption("boolean", "b", "desc",
                                               CommandParser::OptionDefinition::Type::Boolean,
                                               true),
           args)
@@ -126,11 +126,11 @@ TEST_F(CommandParserTests,
                     "--bar"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("t", "token", "desc",
+          CreateCommandDefinition().addOption("token", "t", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true)
                                    .addOption(
-                                       "b", "boolean", "desc",
+                                       "boolean", "b", "desc",
                                        CommandParser::OptionDefinition::Type::Boolean,
                                        true),
           args)
@@ -144,10 +144,10 @@ TEST_F(CommandParserTests, CommandParser_Returns_CorrectArgs_WithMultiToken) {
                     "param6", "--token", "param7"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("m", "multi", "desc",
+          CreateCommandDefinition().addOption("multi", "m", "desc",
                                               CommandParser::OptionDefinition::Type::MultiToken,
                                               true)
-                                   .addOption("t", "token", "desc",
+                                   .addOption("token", "t", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true),
           args)
@@ -161,10 +161,10 @@ TEST_F(CommandParserTests,
                     "param6", "--token", "param7", "param8"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("m", "multi", "desc",
+          CreateCommandDefinition().addOption("multi", "m", "desc",
                                               CommandParser::OptionDefinition::Type::MultiToken,
                                               true)
-                                   .addOption("t", "token", "desc",
+                                   .addOption("token", "t", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true)
           ,
@@ -180,9 +180,9 @@ TEST_F(CommandParserTests,
   auto cmd =
       CreateCommandParser(
           CreateCommandDefinition()
-          .addOption("m", "multi", "desc",
+          .addOption("multi", "m", "desc",
                      CommandParser::OptionDefinition::Type::MultiToken, true)
-          .addOption("t", "token", "desc",
+          .addOption("token", "t", "desc",
                      CommandParser::OptionDefinition::Type::Token, true),
           args)
       .parse();
@@ -194,7 +194,7 @@ TEST_F(CommandParserTests,
 TEST_F(CommandParserTests, CommandParser_Returns_Error_WhenNoParamForToken) {
   auto args = Args({"--token1"});
   auto cmd = CreateCommandParser(
-          CreateCommandDefinition().addOption("t1", "token1", "desc",
+          CreateCommandDefinition().addOption("token1", "t1", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true)
           ,
@@ -208,7 +208,7 @@ TEST_F(CommandParserTests,
        CommandParser_ReturnsAnError_IfRequiredOptionIsMissing) {
   auto args = CreateDefaultArgs();
   auto def = CreateCommandDefinition().addOption(
-      "o", "opt", "desc", CommandParser::OptionDefinition::Type::Boolean, true);
+      "opt", "o", "desc", CommandParser::OptionDefinition::Type::Boolean, true);
   auto parser = CreateCommandParser(def, args);
   ASSERT_EQ(parser.parse().errors.size(), 1);
 }
@@ -217,7 +217,7 @@ TEST_F(CommandParserTests,
        CommandParser_ConsidersOptionsWithoutDefinitionExtraArgs) {
   auto args = std::vector<std::string>{"--extra-arg"};
   auto def = CreateCommandDefinition().addOption(
-      "o", "opt", "desc", CommandParser::OptionDefinition::Type::Boolean, true);
+      "opt", "o", "desc", CommandParser::OptionDefinition::Type::Boolean, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_EQ(parser.parse().extraArgs[0], "--extra-arg");
@@ -226,7 +226,7 @@ TEST_F(CommandParserTests,
 TEST_F(CommandParserTests, CommandParser_ParsesIntegersCorrectly) {
   auto args = std::vector<std::string>{"--integer", "1"};
   auto def = CreateCommandDefinition().addOption(
-      "i", "integer", "desc", CommandParser::OptionDefinition::Type::Integer, true);
+      "integer", "i", "desc", CommandParser::OptionDefinition::Type::Integer, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_EQ(parser.parse().options["integer"].integer, 1);
@@ -235,7 +235,7 @@ TEST_F(CommandParserTests, CommandParser_ParsesIntegersCorrectly) {
 TEST_F(CommandParserTests, CommandParser_ReturnsError_IfIntegerIsTooLarge) {
   auto args = std::vector<std::string>{"--integer", "999999999999999999999999"};
   auto def = CreateCommandDefinition().addOption(
-      "i", "integer", "desc", CommandParser::OptionDefinition::Type::Integer, true);
+      "integer", "i", "desc", CommandParser::OptionDefinition::Type::Integer, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_TRUE(
@@ -246,7 +246,7 @@ TEST_F(CommandParserTests, CommandParser_ReturnsError_IfIntegerIsTooLarge) {
 TEST_F(CommandParserTests, CommandParser_ReturnsError_IfParamIsNotInteger) {
   auto args = std::vector<std::string>{"--integer", "foobar"};
   auto def = CreateCommandDefinition().addOption(
-      "i", "integer", "desc", CommandParser::OptionDefinition::Type::Integer, true);
+      "integer", "i", "desc", CommandParser::OptionDefinition::Type::Integer, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_TRUE(ETJump::StringUtil::contains(parser.parse().errors[0],
@@ -256,7 +256,7 @@ TEST_F(CommandParserTests, CommandParser_ReturnsError_IfParamIsNotInteger) {
 TEST_F(CommandParserTests, CommandParser_ParsesDecimalsCorrectly) {
   auto args = std::vector<std::string>{"--decimal", "1.23"};
   auto def = CreateCommandDefinition().addOption(
-      "d", "decimal", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
+      "decimal", "d", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_DOUBLE_EQ(parser.parse().options["decimal"].decimal, 1.23);
@@ -265,7 +265,7 @@ TEST_F(CommandParserTests, CommandParser_ParsesDecimalsCorrectly) {
 TEST_F(CommandParserTests, CommandParser_ReturnsError_IfDecimalIsTooLarge) {
   auto args = std::vector<std::string>{"--decimal", "1.79769e+309"};
   auto def = CreateCommandDefinition().addOption(
-      "d", "decimal", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
+      "decimal", "d", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_TRUE(ETJump::StringUtil::contains(parser.parse().errors[0],
@@ -275,7 +275,7 @@ TEST_F(CommandParserTests, CommandParser_ReturnsError_IfDecimalIsTooLarge) {
 TEST_F(CommandParserTests, CommandParser_ReturnsError_IfParamIsNotDecimal) {
   auto args = std::vector<std::string>{"--decimal", "foobar"};
   auto def = CreateCommandDefinition().addOption(
-      "d", "decimal", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
+      "decimal", "d", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_TRUE(ETJump::StringUtil::contains(parser.parse().errors[0],
@@ -285,7 +285,7 @@ TEST_F(CommandParserTests, CommandParser_ReturnsError_IfParamIsNotDecimal) {
 TEST_F(CommandParserTests, CommandParser_ParsesDatesCorrectly) {
   auto args = std::vector<std::string>{"--date", "2023-01-05"};
   auto def = CreateCommandDefinition().addOption(
-      "d", "date", "desc", CommandParser::OptionDefinition::Type::Date, true);
+      "date", "d", "desc", CommandParser::OptionDefinition::Type::Date, true);
   auto parser = CreateCommandParser(def, args);
 
   auto expectedDate = Date{2023, 1, 5};
@@ -295,7 +295,7 @@ TEST_F(CommandParserTests, CommandParser_ParsesDatesCorrectly) {
 TEST_F(CommandParserTests, CommandParser_ReturnsError_IfDateIsNotValid) {
   auto args = std::vector<std::string>{"--date", "foobar"};
   auto def = CreateCommandDefinition().addOption(
-      "d", "date", "desc", CommandParser::OptionDefinition::Type::Date, true);
+      "date", "d", "desc", CommandParser::OptionDefinition::Type::Date, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_TRUE(
@@ -307,9 +307,9 @@ TEST_F(CommandParserTests, CommandParser_HandlesPositionalArgumentsCorrectly) {
   auto args = std::vector<std::string>{"a", "b"};
   auto def =
       CreateCommandDefinition()
-          .addOption("fa", "field-a", "desc",
+          .addOption("field-a", "fa", "desc",
                      CommandParser::OptionDefinition::Type::Token, true, 0)
-          .addOption("fb", "field-b", "desc",
+          .addOption("field-b", "fb", "desc",
                      CommandParser::OptionDefinition::Type::Token, true, 1);
 
   auto parser = CreateCommandParser(def, args);
@@ -322,9 +322,9 @@ TEST_F(CommandParserTests, CommandParser_HandlesPositionalArgumentsCorrectly_IfS
   auto args = std::vector<std::string>{"--field-b", "b", "a"};
   auto def =
       CreateCommandDefinition()
-          .addOption("fa", "field-a", "desc",
+          .addOption("field-a", "fa", "desc",
                      CommandParser::OptionDefinition::Type::Token, true, 0)
-          .addOption("fb", "field-b", "desc",
+          .addOption("field-b", "fb", "desc",
                      CommandParser::OptionDefinition::Type::Token, true, 1);
 
   auto parser = CreateCommandParser(def, args);
@@ -336,7 +336,7 @@ TEST_F(CommandParserTests, CommandParser_HandlesPositionalArgumentsCorrectly_IfS
 TEST_F(CommandParserTests, CommandParser_ShouldNotCrash_IfNoParametersArePassed) {
   auto args = std::vector<std::string>{};
   auto def = CreateCommandDefinition().addOption(
-      "fa", "field-a", "desc", CommandParser::OptionDefinition::Type::Token, false, 0);
+      "field-a", "fa", "desc", CommandParser::OptionDefinition::Type::Token, false, 0);
 
   auto parser = CreateCommandParser(def, args);
 

--- a/tests/command_parser_tests.cpp
+++ b/tests/command_parser_tests.cpp
@@ -91,7 +91,7 @@ TEST_F(CommandParserTests, CommandParser_Returns_MultipleCorrectOptions) {
           CreateCommandDefinition().addOption("token", "t", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true).addOption(
-              "b", "boolean", "desc", CommandParser::OptionDefinition::Type::Boolean,
+              "boolean", "b", "desc", CommandParser::OptionDefinition::Type::Boolean,
               true)
           ,
           args)

--- a/tests/command_parser_tests.cpp
+++ b/tests/command_parser_tests.cpp
@@ -43,7 +43,7 @@ TEST_F(CommandParserTests, CommandParser_Returns_CommandWithSingleTokenOption) {
 
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("token", "desc",
+          CreateCommandDefinition().addOption("t", "token", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true)
           ,
@@ -58,7 +58,7 @@ TEST_F(CommandParserTests,
                     "stuff"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("token", "desc",
+          CreateCommandDefinition().addOption("t", "token", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true),
           args)
@@ -72,7 +72,7 @@ TEST_F(CommandParserTests,
                     "some", "additional", "stuff"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("token", "desc",
+          CreateCommandDefinition().addOption("t", "token", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true)
           ,
@@ -88,10 +88,10 @@ TEST_F(CommandParserTests, CommandParser_Returns_MultipleCorrectOptions) {
                     "--bar"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("token", "desc",
+          CreateCommandDefinition().addOption("t", "token", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true).addOption(
-              "boolean", "desc", CommandParser::OptionDefinition::Type::Boolean,
+              "b", "boolean", "desc", CommandParser::OptionDefinition::Type::Boolean,
               true)
           ,
           args)
@@ -107,10 +107,10 @@ TEST_F(CommandParserTests,
                     "--bar"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("token", "desc",
+          CreateCommandDefinition().addOption("t", "token", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true)
-                                   .addOption("boolean", "desc",
+                                   .addOption("b", "boolean", "desc",
                                               CommandParser::OptionDefinition::Type::Boolean,
                                               true),
           args)
@@ -126,11 +126,11 @@ TEST_F(CommandParserTests,
                     "--bar"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("token", "desc",
+          CreateCommandDefinition().addOption("t", "token", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true)
                                    .addOption(
-                                       "boolean", "desc",
+                                       "b", "boolean", "desc",
                                        CommandParser::OptionDefinition::Type::Boolean,
                                        true),
           args)
@@ -144,10 +144,10 @@ TEST_F(CommandParserTests, CommandParser_Returns_CorrectArgs_WithMultiToken) {
                     "param6", "--token", "param7"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("multi", "desc",
+          CreateCommandDefinition().addOption("m", "multi", "desc",
                                               CommandParser::OptionDefinition::Type::MultiToken,
                                               true)
-                                   .addOption("token", "desc",
+                                   .addOption("t", "token", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true),
           args)
@@ -161,10 +161,10 @@ TEST_F(CommandParserTests,
                     "param6", "--token", "param7", "param8"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("multi", "desc",
+          CreateCommandDefinition().addOption("m", "multi", "desc",
                                               CommandParser::OptionDefinition::Type::MultiToken,
                                               true)
-                                   .addOption("token", "desc",
+                                   .addOption("t", "token", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true)
           ,
@@ -180,9 +180,9 @@ TEST_F(CommandParserTests,
   auto cmd =
       CreateCommandParser(
           CreateCommandDefinition()
-          .addOption("multi", "desc",
+          .addOption("m", "multi", "desc",
                      CommandParser::OptionDefinition::Type::MultiToken, true)
-          .addOption("token", "desc",
+          .addOption("t", "token", "desc",
                      CommandParser::OptionDefinition::Type::Token, true),
           args)
       .parse();
@@ -194,7 +194,7 @@ TEST_F(CommandParserTests,
 TEST_F(CommandParserTests, CommandParser_Returns_Error_WhenNoParamForToken) {
   auto args = Args({"--token1"});
   auto cmd = CreateCommandParser(
-          CreateCommandDefinition().addOption("token1", "desc",
+          CreateCommandDefinition().addOption("t1", "token1", "desc",
                                               CommandParser::OptionDefinition::Type::Token,
                                               true)
           ,
@@ -208,7 +208,7 @@ TEST_F(CommandParserTests,
        CommandParser_ReturnsAnError_IfRequiredOptionIsMissing) {
   auto args = CreateDefaultArgs();
   auto def = CreateCommandDefinition().addOption(
-      "opt", "desc", CommandParser::OptionDefinition::Type::Boolean, true);
+      "o", "opt", "desc", CommandParser::OptionDefinition::Type::Boolean, true);
   auto parser = CreateCommandParser(def, args);
   ASSERT_EQ(parser.parse().errors.size(), 1);
 }
@@ -217,7 +217,7 @@ TEST_F(CommandParserTests,
        CommandParser_ConsidersOptionsWithoutDefinitionExtraArgs) {
   auto args = std::vector<std::string>{"--extra-arg"};
   auto def = CreateCommandDefinition().addOption(
-      "opt", "desc", CommandParser::OptionDefinition::Type::Boolean, true);
+      "o", "opt", "desc", CommandParser::OptionDefinition::Type::Boolean, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_EQ(parser.parse().extraArgs[0], "--extra-arg");
@@ -226,7 +226,7 @@ TEST_F(CommandParserTests,
 TEST_F(CommandParserTests, CommandParser_ParsesIntegersCorrectly) {
   auto args = std::vector<std::string>{"--integer", "1"};
   auto def = CreateCommandDefinition().addOption(
-      "integer", "desc", CommandParser::OptionDefinition::Type::Integer, true);
+      "i", "integer", "desc", CommandParser::OptionDefinition::Type::Integer, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_EQ(parser.parse().options["integer"].integer, 1);
@@ -235,7 +235,7 @@ TEST_F(CommandParserTests, CommandParser_ParsesIntegersCorrectly) {
 TEST_F(CommandParserTests, CommandParser_ReturnsError_IfIntegerIsTooLarge) {
   auto args = std::vector<std::string>{"--integer", "999999999999999999999999"};
   auto def = CreateCommandDefinition().addOption(
-      "integer", "desc", CommandParser::OptionDefinition::Type::Integer, true);
+      "i", "integer", "desc", CommandParser::OptionDefinition::Type::Integer, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_TRUE(
@@ -246,7 +246,7 @@ TEST_F(CommandParserTests, CommandParser_ReturnsError_IfIntegerIsTooLarge) {
 TEST_F(CommandParserTests, CommandParser_ReturnsError_IfParamIsNotInteger) {
   auto args = std::vector<std::string>{"--integer", "foobar"};
   auto def = CreateCommandDefinition().addOption(
-      "integer", "desc", CommandParser::OptionDefinition::Type::Integer, true);
+      "i", "integer", "desc", CommandParser::OptionDefinition::Type::Integer, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_TRUE(ETJump::StringUtil::contains(parser.parse().errors[0],
@@ -256,7 +256,7 @@ TEST_F(CommandParserTests, CommandParser_ReturnsError_IfParamIsNotInteger) {
 TEST_F(CommandParserTests, CommandParser_ParsesDecimalsCorrectly) {
   auto args = std::vector<std::string>{"--decimal", "1.23"};
   auto def = CreateCommandDefinition().addOption(
-      "decimal", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
+      "d", "decimal", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_DOUBLE_EQ(parser.parse().options["decimal"].decimal, 1.23);
@@ -265,7 +265,7 @@ TEST_F(CommandParserTests, CommandParser_ParsesDecimalsCorrectly) {
 TEST_F(CommandParserTests, CommandParser_ReturnsError_IfDecimalIsTooLarge) {
   auto args = std::vector<std::string>{"--decimal", "1.79769e+309"};
   auto def = CreateCommandDefinition().addOption(
-      "decimal", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
+      "d", "decimal", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_TRUE(ETJump::StringUtil::contains(parser.parse().errors[0],
@@ -275,7 +275,7 @@ TEST_F(CommandParserTests, CommandParser_ReturnsError_IfDecimalIsTooLarge) {
 TEST_F(CommandParserTests, CommandParser_ReturnsError_IfParamIsNotDecimal) {
   auto args = std::vector<std::string>{"--decimal", "foobar"};
   auto def = CreateCommandDefinition().addOption(
-      "decimal", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
+      "d", "decimal", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_TRUE(ETJump::StringUtil::contains(parser.parse().errors[0],
@@ -285,7 +285,7 @@ TEST_F(CommandParserTests, CommandParser_ReturnsError_IfParamIsNotDecimal) {
 TEST_F(CommandParserTests, CommandParser_ParsesDatesCorrectly) {
   auto args = std::vector<std::string>{"--date", "2023-01-05"};
   auto def = CreateCommandDefinition().addOption(
-      "date", "desc", CommandParser::OptionDefinition::Type::Date, true);
+      "d", "date", "desc", CommandParser::OptionDefinition::Type::Date, true);
   auto parser = CreateCommandParser(def, args);
 
   auto expectedDate = Date{2023, 1, 5};
@@ -295,7 +295,7 @@ TEST_F(CommandParserTests, CommandParser_ParsesDatesCorrectly) {
 TEST_F(CommandParserTests, CommandParser_ReturnsError_IfDateIsNotValid) {
   auto args = std::vector<std::string>{"--date", "foobar"};
   auto def = CreateCommandDefinition().addOption(
-      "date", "desc", CommandParser::OptionDefinition::Type::Date, true);
+      "d", "date", "desc", CommandParser::OptionDefinition::Type::Date, true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_TRUE(
@@ -307,9 +307,9 @@ TEST_F(CommandParserTests, CommandParser_HandlesPositionalArgumentsCorrectly) {
   auto args = std::vector<std::string>{"a", "b"};
   auto def =
       CreateCommandDefinition()
-          .addOption("field-a", "desc",
+          .addOption("fa", "field-a", "desc",
                      CommandParser::OptionDefinition::Type::Token, true, 0)
-          .addOption("field-b", "desc",
+          .addOption("fb", "field-b", "desc",
                      CommandParser::OptionDefinition::Type::Token, true, 1);
 
   auto parser = CreateCommandParser(def, args);
@@ -322,9 +322,9 @@ TEST_F(CommandParserTests, CommandParser_HandlesPositionalArgumentsCorrectly_IfS
   auto args = std::vector<std::string>{"--field-b", "b", "a"};
   auto def =
       CreateCommandDefinition()
-          .addOption("field-a", "desc",
+          .addOption("fa", "field-a", "desc",
                      CommandParser::OptionDefinition::Type::Token, true, 0)
-          .addOption("field-b", "desc",
+          .addOption("fb", "field-b", "desc",
                      CommandParser::OptionDefinition::Type::Token, true, 1);
 
   auto parser = CreateCommandParser(def, args);
@@ -336,7 +336,7 @@ TEST_F(CommandParserTests, CommandParser_HandlesPositionalArgumentsCorrectly_IfS
 TEST_F(CommandParserTests, CommandParser_ShouldNotCrash_IfNoParametersArePassed) {
   auto args = std::vector<std::string>{};
   auto def = CreateCommandDefinition().addOption(
-      "field-a", "desc", CommandParser::OptionDefinition::Type::Token, false, 0);
+      "fa", "field-a", "desc", CommandParser::OptionDefinition::Type::Token, false, 0);
 
   auto parser = CreateCommandParser(def, args);
 


### PR DESCRIPTION
Each command parameter now has a name (e.g. `--name`) and a shortname (e.g. `-n`). `--help` can also be substituted with `-h`.

Also re-formats the command help prints slightly, the option description is now split to newline manually and indented if it goes over console maximum line length.

![image](https://github.com/etjump/etjump/assets/14221121/101fc750-2816-4303-85dc-478e84673f9b)

![image](https://github.com/etjump/etjump/assets/14221121/7f4f37db-8560-4f31-b251-b574e07abcae)

