### PR TITLE
Add info print before chat replay + disable on demo playback

### DIFF
--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -628,7 +628,7 @@ void runFrameEnd() {
     cg.shadowCvarsSet = true;
   }
 
-  if (cg.clientFrame >= 10 && !cg.chatReplayReceived) {
+  if (!cg.demoPlayback && cg.clientFrame >= 10 && !cg.chatReplayReceived) {
     trap_SendConsoleCommand("getchatreplay");
     cg.chatReplayReceived = true;
   }

--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -61,6 +61,17 @@ void ChatReplay::sendChatMessages(gentity_t *ent) {
     return;
   }
 
+  // shouldn't ever happen but just in case,
+  // so we don't print out the info when there's no messages
+  if (chatReplayBuffer.empty()) {
+    return;
+  }
+
+  const int clientNum = ClientNum(ent);
+
+  Printer::SendChatMessage(clientNum,
+                           "^gServer: replaying latest chat messages:");
+
   for (const auto &msg : chatReplayBuffer) {
     // skip messages from ignored clients
     if (COM_BitCheck(ent->client->sess.ignoreClients, msg.clientNum)) {
@@ -68,7 +79,7 @@ void ChatReplay::sendChatMessages(gentity_t *ent) {
     }
 
     const std::string &message = parseChatMessage(msg);
-    trap_SendServerCommand(ClientNum(ent), message.c_str());
+    trap_SendServerCommand(clientNum, message.c_str());
   }
 }
 


### PR DESCRIPTION
Indicate that these messages are from chat replay.

Also disable on demo playback since qagame module isn't loaded anyway, and any chat replay would be local messages instead of the once actually on the server.

refs #1335 