### PR TITLE
Fix UI crash in host menu with 500+ maps

### DIFF
--- a/src/ui/ui_gameinfo.cpp
+++ b/src/ui/ui_gameinfo.cpp
@@ -191,7 +191,7 @@ UI_LoadArenas
 void UI_LoadArenas() {
   int numdirs;
   char filename[128];
-  char dirlist[16000];
+  char dirlist[16384];
   char *dirptr;
   int i;
   int dirlen;
@@ -200,13 +200,21 @@ void UI_LoadArenas() {
   uiInfo.mapCount = 0;
 
   // get all arenas from .arena files
-  numdirs = trap_FS_GetFileList("scripts", ".arena", dirlist, 12000);
+  numdirs = trap_FS_GetFileList("scripts", ".arena", dirlist, sizeof(dirlist));
   dirptr = dirlist;
   for (i = 0; i < numdirs; i++, dirptr += dirlen + 1) {
     dirlen = static_cast<int>(strlen(dirptr));
     Q_strncpyz(filename, "scripts/", sizeof(filename));
     Q_strcat(filename, sizeof(filename), dirptr);
     UI_LoadArenasFromFile(filename);
+  }
+
+  // cap here rather than in the parser, so we get proper map counts
+  if (uiInfo.mapCount >= MAX_MAPS) {
+    Com_Printf(S_COLOR_YELLOW "WARNING: reached maximum maps for UI display "
+                              "(%i > %i), not all maps are displayed.\n",
+               uiInfo.mapCount, MAX_MAPS - 1);
+    uiInfo.mapCount = MAX_MAPS - 1;
   }
 }
 

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -656,7 +656,7 @@ typedef struct {
 #define MAX_HEADNAME 32
 #define MAX_TEAMS 64
 //#define MAX_GAMETYPES 16 // moved up
-#define MAX_MAPS 500
+#define MAX_MAPS 8192
 #define MAX_SPMAPS 16
 #define PLAYERS_PER_TEAM 5
 #define MAX_PINGREQUESTS 16


### PR DESCRIPTION
If player had more than 500 maps, `UI_SelectedMap` would sometimes return garbage data, which could cause a crash in some scenarios.