### PR TITLE
Fix callvote resetting event handler

### DIFF
--- a/src/cgame/etj_client_rtv_handler.cpp
+++ b/src/cgame/etj_client_rtv_handler.cpp
@@ -83,6 +83,8 @@ bool ClientRtvHandler::rtvVoteActive() const {
 }
 
 void ClientRtvHandler::resetRtvEventHandler() {
-  CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+  if (cgs.eventHandling == CGAME_EVENT_RTV) {
+    CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+  }
 }
 } // namespace ETJump


### PR DESCRIPTION
Perform event handler reset only if the event handler is currently rtv event handling, so we don't break other event handlers every time a vote is called/finished.

refs #1135 