### PR TITLE
Fix being unable to turn off coronas in old demos

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -4726,10 +4726,6 @@ void CG_DrawCoronas() {
     return;
   }
 
-  if (!cg_coronas.integer || !cg_coronafardist.integer) {
-    return;
-  }
-
   for (int i = 0; i < cg.numCoronas; i++) {
     centity_t *corona = &cgs.coronas[i];
 

--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -1446,6 +1446,12 @@ void CG_Corona(centity_t *cent) {
   float dot, dist;
   vec3_t dir;
 
+  // must be here instead of 'CG_DrawCoronas' so server side coronas
+  // can be turned off, as they are processed as packet entities
+  if (!cg_coronas.integer || cg_coronafardist.integer <= 0) {
+    return;
+  }
+
   dli = cent->currentState.dl_intensity;
   r = static_cast<float>(dli & 255);
   g = static_cast<float>((dli >> 8) & 255);


### PR DESCRIPTION
Old demos contained coronas as packet entities since they were server side, so they bypassed the checks in CG_DrawCoronas as they were processed directly in CG_ProcessEntity.

refs #1311 