### PR TITLE
Add g_allowSpeclock to let server disable speclocking

### DIFF
--- a/src/game/g_cmds_ext.cpp
+++ b/src/game/g_cmds_ext.cpp
@@ -815,6 +815,14 @@ static void Cmd_SpecLock_f(gentity_t *ent, unsigned int dwCommand,
   auto client = ClientNum(ent);
   std::string msg;
 
+  // turning off speclock clears speclock status, so we don't need to worry
+  // about clients trying to turn off speclock when g_allowSpeclock is 0
+  if (!g_allowSpeclock.integer) {
+    msg = "Speclock is disabled on this server.\n";
+    Printer::SendConsoleMessage(client, msg);
+    return;
+  }
+
   if (ent->client->sess.sessionTeam == TEAM_SPECTATOR) {
     msg = ETJump::stringFormat(
         "^7You cannot use ^3spec%slock ^7while spectating!\n",

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2019,6 +2019,7 @@ extern vmCvar_t g_weapons;
 extern vmCvar_t g_noclip;
 extern vmCvar_t g_nameChangeLimit;
 extern vmCvar_t g_nameChangeInterval;
+extern vmCvar_t g_allowSpeclock;
 
 extern vmCvar_t g_mapScriptDir;
 extern vmCvar_t g_blockedMaps;


### PR DESCRIPTION
When set to `0`, clients cannot use `speclock` to lock themselves from spectators. Changes to this cvar are announced to clients, and when set to `0`, speclock status is cleared from any clients who are currently speclocked. This does not clear specinvites, so when turned back on, clients who turn speclock back on retain the specinvited clients without having to re-invite any clients.

This also changes announcement from modifying server cvars with `trackChange` flag to be announced via popups instead of console prints.