### PR TITLE
Add NoZOffset spawnflag to teleporters + refactor teleport functions

### DIFF
--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2696,9 +2696,10 @@ enum class TeleporterSpawnflags {
   None = 0,
   ResetSpeed = 1 << 0,
   ConvertSpeed = 1 << 1,
-  RelativePitch = 1 << 2,
+  RelativeYaw = 1 << 2,
   RelativePitchYaw = 1 << 3,
-  Knockback = 1 << 4
+  Knockback = 1 << 4,
+  NoZOffset = 1 << 5,
 };
 
 enum class PusherSpawnFlags {

--- a/src/game/etj_entity_utilities_shared.cpp
+++ b/src/game/etj_entity_utilities_shared.cpp
@@ -129,7 +129,10 @@ void EntityUtilsShared::teleportPlayer(playerState_t *ps, entityState_t *player,
   }
 
   VectorCopy(origin, ps->origin);
-  ps->origin[2] += 1;
+
+  if (!(spawnflags & static_cast<int>(TeleporterSpawnflags::NoZOffset))) {
+    ps->origin[2] += 1;
+  }
 
   // toggle the teleport bit so the client knows to not lerp
   ps->eFlags ^= EF_TELEPORT_BIT;

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1669,18 +1669,19 @@ void InitTrigger(gentity_t *self);
 //
 // g_misc.c
 //
-void TeleportPlayer(gentity_t *player, vec3_t origin, vec3_t angles);
-void TeleportPlayerExt(gentity_t *player, vec3_t origin, vec3_t angles);
-void TeleportPlayerKeepAngles_Clank(gentity_t *player, gentity_t *trigger,
-                                    const vec3_t origin, const vec3_t angles);
-void TeleportPlayerKeepAngles(gentity_t *player, gentity_t *trigger,
-                              const vec3_t origin, const vec3_t angles);
-void DirectTeleport(gentity_t *player, vec3_t origin, vec3_t angles);
+// this is only used by tank exiting and some weird spectator door teleport
+void TeleportPlayer(gentity_t *player, const vec3_t origin, vec3_t angles);
+void DirectTeleport(gentity_t *player, const vec3_t origin, vec3_t angles);
 void PortalTeleport(gentity_t *player, vec3_t origin,
                     vec3_t angles); // Feen: PGM
 void mg42_fire(gentity_t *other);
 void mg42_stopusing(gentity_t *self);
 void aagun_fire(gentity_t *other);
+
+namespace ETJump {
+void teleportPlayer(gentity_t *self, gentity_t *other, const vec3_t origin,
+                    const vec3_t angles, const int &spawnflags);
+}
 
 //
 // g_weapon.c

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -586,7 +586,7 @@ void target_teleporter_use(gentity_t *self, gentity_t *other,
     // If we don't have any velocity when teleporting,
     // there's nothing to scale from, so let's add some
     if (VectorCompare(activator->client->ps.velocity, vec3_origin)) {
-      VectorSet(activator->client->ps.velocity, 0.01, 0.01, 0.0);
+      VectorSet(activator->client->ps.velocity, 0.01f, 0.01f, 0.01f);
     }
 
     VectorNormalize(activator->client->ps.velocity);
@@ -598,39 +598,8 @@ void target_teleporter_use(gentity_t *self, gentity_t *other,
     G_AddEvent(activator, EV_GENERAL_SOUND, self->noise_index);
   }
 
-  if (self->spawnflags &
-      static_cast<int>(ETJump::TeleporterSpawnflags::Knockback)) {
-    activator->client->ps.pm_time = 160; // hold time
-    activator->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;
-  }
-
-  if (self->spawnflags &
-      static_cast<int>(ETJump::TeleporterSpawnflags::ResetSpeed)) {
-    // We need some speed to make TeleportPlayerKeepAngles work with
-    // this spawnflag, else it doesn't know which trigger side we enter
-    VectorSet(activator->client->ps.velocity, 0.01, 0.01, 0.0);
-  }
-
-  if (self->spawnflags &
-      static_cast<int>(ETJump::TeleporterSpawnflags::ConvertSpeed)) {
-    TeleportPlayerExt(activator, dest->s.origin, dest->s.angles);
-    return;
-  }
-
-  if (self->spawnflags &
-      static_cast<int>(ETJump::TeleporterSpawnflags::RelativePitch)) {
-    TeleportPlayerKeepAngles_Clank(activator, other, dest->s.origin,
-                                   dest->s.angles);
-    return;
-  }
-
-  if (self->spawnflags &
-      static_cast<int>(ETJump::TeleporterSpawnflags::RelativePitchYaw)) {
-    TeleportPlayerKeepAngles(activator, other, dest->s.origin, dest->s.angles);
-    return;
-  }
-
-  TeleportPlayer(activator, dest->s.origin, dest->s.angles);
+  ETJump::teleportPlayer(activator, other, dest->s.origin, dest->s.angles,
+                         self->spawnflags);
 }
 
 /*QUAKED target_teleporter (1 0 0) (-8 -8 -8) (8 8 8)

--- a/src/game/g_trigger.cpp
+++ b/src/game/g_trigger.cpp
@@ -399,7 +399,7 @@ void trigger_teleporter_touch(gentity_t *self, gentity_t *other,
     // If we don't have any velocity when teleporting,
     // there's nothing to scale from, so let's add some
     if (VectorCompare(other->client->ps.velocity, vec3_origin)) {
-      VectorSet(other->client->ps.velocity, 0.01, 0.01, 0.0);
+      VectorSet(other->client->ps.velocity, 0.01f, 0.01f, 0.01f);
     }
 
     VectorNormalize(other->client->ps.velocity);
@@ -411,38 +411,8 @@ void trigger_teleporter_touch(gentity_t *self, gentity_t *other,
     G_AddEvent(other, EV_GENERAL_SOUND, self->noise_index);
   }
 
-  if (self->spawnflags &
-      static_cast<int>(ETJump::TeleporterSpawnflags::Knockback)) {
-    other->client->ps.pm_time = 160; // hold time
-    other->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;
-  }
-
-  if (self->spawnflags &
-      static_cast<int>(ETJump::TeleporterSpawnflags::ResetSpeed)) {
-    // We need some speed to make TeleportPlayerKeepAngles work with
-    // this spawnflag, else it doesn't know which trigger side we enter
-    VectorSet(other->client->ps.velocity, 0.01, 0.01, 0.0);
-  }
-
-  if (self->spawnflags &
-      static_cast<int>(ETJump::TeleporterSpawnflags::ConvertSpeed)) {
-    TeleportPlayerExt(other, dest->s.origin, dest->s.angles);
-    return;
-  }
-
-  if (self->spawnflags &
-      static_cast<int>(ETJump::TeleporterSpawnflags::RelativePitch)) {
-    TeleportPlayerKeepAngles_Clank(other, self, dest->s.origin, dest->s.angles);
-    return;
-  }
-
-  if (self->spawnflags &
-      static_cast<int>(ETJump::TeleporterSpawnflags::RelativePitchYaw)) {
-    TeleportPlayerKeepAngles(other, self, dest->s.origin, dest->s.angles);
-    return;
-  }
-
-  TeleportPlayer(other, dest->s.origin, dest->s.angles);
+  ETJump::teleportPlayer(other, self, dest->s.origin, dest->s.angles,
+                         self->spawnflags);
 }
 
 /*QUAKED trigger_teleport (.5 .5 .5) ?


### PR DESCRIPTION
Adds `spawnflags 32` to all teleporters, which disables any z offset done by teleporters (`+1u` for regular teleporters, `trigger origin - ps.origin` for relative angle teleporters).

Also refactored the teleportation code to just use single `teleportPlayer` function that handles the various teleport spawnflags.

fixes #266 