### PR TITLE
Remove sort from player shaders

### DIFF
--- a/assets/scripts/models_players.shader
+++ b/assets/scripts/models_players.shader
@@ -296,7 +296,7 @@ models/players/temperate/axis/medic/acc/backpack
 }
 
 models/players/temperate/axis/medic/acc/backpack2 
-{	
+{
 	{
 		map models/players/temperate/axis/medic/acc/backpack2.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -307,7 +307,7 @@ models/players/temperate/axis/medic/acc/backpack2
 }
 
 models/players/temperate/axis/cvops/acc/backpack 
-{	
+{
 	{
 		map models/players/temperate/axis/cvops/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -318,7 +318,7 @@ models/players/temperate/axis/cvops/acc/backpack
 }
 
 models/players/temperate/axis/cvops/acc/fieldkit 
-{	
+{
 	{
 		map models/players/temperate/axis/cvops/acc/fieldkit.tga 
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -329,7 +329,7 @@ models/players/temperate/axis/cvops/acc/fieldkit
 }
 
 models/players/temperate/axis/engineer/acc/backpack 
-{	
+{
 	{
 		map models/players/temperate/axis/engineer/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -340,7 +340,7 @@ models/players/temperate/axis/engineer/acc/backpack
 }
 
 models/players/temperate/axis/engineer/acc/shovel 
-{	
+{
 	{
 		map models/players/temperate/axis/engineer/acc/shovel.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -351,7 +351,7 @@ models/players/temperate/axis/engineer/acc/shovel
 }
 
 models/players/temperate/axis/fieldops/acc/backpack 
-{	
+{
 	{
 		map models/players/temperate/axis/fieldops/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -362,7 +362,7 @@ models/players/temperate/axis/fieldops/acc/backpack
 }
 
 models/players/temperate/axis/soldier/acc/backpack 
-{	
+{
 	{
 		map models/players/temperate/axis/soldier/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -460,7 +460,7 @@ models/players/hud/axis_medic
 }
 
 models/players/hud/axis_cvops 
-{	
+{
 	{
 		map models/players/hud/axis_cvops.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -585,7 +585,7 @@ models/players/temperate/allied/leg01
 //
 //*****************************************
 models/players/temperate/allied/medic/acc/backpack 
-{	
+{
 	{
 		map models/players/temperate/allied/medic/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -596,7 +596,7 @@ models/players/temperate/allied/medic/acc/backpack
 }
 
 models/players/temperate/allied/medic/acc/backpack2 
-{	
+{
 	{
 		map models/players/temperate/allied/medic/acc/backpack2.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -607,7 +607,7 @@ models/players/temperate/allied/medic/acc/backpack2
 }
 
 models/players/temperate/allied/engineer/acc/backpack 
-{	
+{
 	{
 		map models/players/temperate/allied/engineer/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -618,7 +618,7 @@ models/players/temperate/allied/engineer/acc/backpack
 }
 
 models/players/temperate/allied/engineer/acc/shovel 
-{	
+{
 	{
 		map models/players/temperate/allied/engineer/acc/shovel.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -629,7 +629,7 @@ models/players/temperate/allied/engineer/acc/shovel
 }
 
 models/players/temperate/allied/fieldops/acc/backpack 
-{	
+{
 	{
 		map models/players/temperate/allied/fieldops/acc/backpack.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -795,10 +795,10 @@ models/players/hud/allied_soldier
 models/players/hud/teeth01 
 {
 	// lets hide teeth, so it won't look ugly with transparency
-    {
-    	map models/players/hud/teeth01.tga
-    	blendFunc GL_ZERO GL_ONE
-    }
+	{
+		map models/players/hud/teeth01.tga
+		blendFunc GL_ZERO GL_ONE
+	}
 }
 
 models/players/hud/eye01 
@@ -837,13 +837,13 @@ models/players/hud/eye03
 // alternative simple players representation through single shader
 etjump/simple_player
 {
-    cull none
-    {
-        map models/players/ghost.tga
+	cull none
+	{
+		map models/players/ghost.tga
 		tcmod scale 4 6
 		tcmod scroll 0 -0.1
-        blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
-        rgbGen entity
-        alphaGen entity
-    }
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen entity
+		alphaGen entity
+	}
 }

--- a/assets/scripts/models_players.shader
+++ b/assets/scripts/models_players.shader
@@ -640,7 +640,7 @@ models/players/temperate/allied/fieldops/acc/backpack
 }
 
 models/players/temperate/allied/soldier/acc/backpack 
-{	
+{
 	{
 		map models/players/temperate/allied/soldier/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -749,7 +749,7 @@ models/players/hud/allied_medic
 }
 
 models/players/hud/allied_cvops 
-{	
+{
 	{
 		map models/players/hud/allied_cvops.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA

--- a/assets/scripts/models_players.shader
+++ b/assets/scripts/models_players.shader
@@ -183,7 +183,6 @@ models/players/temperate/allied/ranks/1stclass
 //****************************************
 models/players/temperate/axis/engineer/body_engineer
 {
-	sort 16
 	{
 		map models/players/temperate/axis/engineer/body_engineer.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -195,7 +194,6 @@ models/players/temperate/axis/engineer/body_engineer
 
 models/players/temperate/axis/cvops/body_cvops
 {
-	sort 16
 	{
 		map models/players/temperate/axis/cvops/body_cvops.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -207,7 +205,6 @@ models/players/temperate/axis/cvops/body_cvops
 
 models/players/temperate/axis/fieldops/body_fieldops
 {
-	sort 16
 	{
 		map models/players/temperate/axis/fieldops/body_fieldops.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -219,7 +216,6 @@ models/players/temperate/axis/fieldops/body_fieldops
 
 models/players/temperate/axis/medic/axis_medic
 {
-	sort 16
 	{
 		map models/players/temperate/axis/medic/axis_medic.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -231,7 +227,6 @@ models/players/temperate/axis/medic/axis_medic
 
 models/players/temperate/axis/soldier/body_soldier
 {
-	sort 16
 	{
 		map models/players/temperate/axis/soldier/body_soldier.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -248,7 +243,6 @@ models/players/temperate/axis/soldier/body_soldier
 //*****************************************
 models/players/temperate/axis/body01
 {
-	sort 16
 	{
 		map models/players/temperate/axis/body01.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -265,7 +259,6 @@ models/players/temperate/axis/body01
 //******************************************
 models/players/temperate/axis/medic/legs_medic
 {
-	sort 16
 	{
 		map models/players/temperate/axis/medic/legs_medic.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -277,7 +270,6 @@ models/players/temperate/axis/medic/legs_medic
 
 models/players/temperate/axis/legs01 
 {
-	sort 16
 	{
 		map models/players/temperate/axis/legs01.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -294,7 +286,6 @@ models/players/temperate/axis/legs01
 //*******************************************
 models/players/temperate/axis/medic/acc/backpack 
 {
-	sort 16
 	{
 		map models/players/temperate/axis/medic/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -305,8 +296,7 @@ models/players/temperate/axis/medic/acc/backpack
 }
 
 models/players/temperate/axis/medic/acc/backpack2 
-{
-	sort 16	
+{	
 	{
 		map models/players/temperate/axis/medic/acc/backpack2.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -317,8 +307,7 @@ models/players/temperate/axis/medic/acc/backpack2
 }
 
 models/players/temperate/axis/cvops/acc/backpack 
-{
-	sort 16	
+{	
 	{
 		map models/players/temperate/axis/cvops/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -329,8 +318,7 @@ models/players/temperate/axis/cvops/acc/backpack
 }
 
 models/players/temperate/axis/cvops/acc/fieldkit 
-{
-	sort 16	
+{	
 	{
 		map models/players/temperate/axis/cvops/acc/fieldkit.tga 
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -341,8 +329,7 @@ models/players/temperate/axis/cvops/acc/fieldkit
 }
 
 models/players/temperate/axis/engineer/acc/backpack 
-{
-	sort 16	
+{	
 	{
 		map models/players/temperate/axis/engineer/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -353,8 +340,7 @@ models/players/temperate/axis/engineer/acc/backpack
 }
 
 models/players/temperate/axis/engineer/acc/shovel 
-{
-	sort 16	
+{	
 	{
 		map models/players/temperate/axis/engineer/acc/shovel.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -365,8 +351,7 @@ models/players/temperate/axis/engineer/acc/shovel
 }
 
 models/players/temperate/axis/fieldops/acc/backpack 
-{
-	sort 16	
+{	
 	{
 		map models/players/temperate/axis/fieldops/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -377,8 +362,7 @@ models/players/temperate/axis/fieldops/acc/backpack
 }
 
 models/players/temperate/axis/soldier/acc/backpack 
-{
-	sort 16	
+{	
 	{
 		map models/players/temperate/axis/soldier/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -395,7 +379,6 @@ models/players/temperate/axis/soldier/acc/backpack
 //********************************************
 models/players/temperate/axis/medic/helmet 
 {
-	sort 16
 	{
 		map models/players/temperate/axis/medic/helmet.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -407,7 +390,6 @@ models/players/temperate/axis/medic/helmet
 
 models/players/temperate/axis/cvops/cap 
 {
-	sort 16
 	{
 		map models/players/temperate/axis/cvops/cap.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -419,7 +401,6 @@ models/players/temperate/axis/cvops/cap
 
 models/players/temperate/axis/engineer/helmet 
 {
-	sort 16
 	{
 		map models/players/temperate/axis/engineer/helmet.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -431,7 +412,6 @@ models/players/temperate/axis/engineer/helmet
 
 models/players/temperate/axis/fieldops/helmet 
 {
-	sort 16
 	{
 		map models/players/temperate/axis/fieldops/helmet.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -443,7 +423,6 @@ models/players/temperate/axis/fieldops/helmet
 
 models/players/temperate/axis/soldier/helmet 
 {
-	sort 16
 	{
 		map models/players/temperate/axis/soldier/helmet.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -455,7 +434,6 @@ models/players/temperate/axis/soldier/helmet
 
 models/players/temperate/axis/inside
 {
-	sort 16
 	{
 		map models/players/temperate/axis/inside.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -472,7 +450,6 @@ models/players/temperate/axis/inside
 //*****************************************
 models/players/hud/axis_medic 
 {
-	sort 16
 	{
 		map models/players/hud/axis_medic.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -483,8 +460,7 @@ models/players/hud/axis_medic
 }
 
 models/players/hud/axis_cvops 
-{
-	sort 16	
+{	
 	{
 		map models/players/hud/axis_cvops.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -496,7 +472,6 @@ models/players/hud/axis_cvops
 
 models/players/hud/axis_engineer 
 {
-	sort 16
 	{
 		map models/players/hud/axis_engineer.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -508,7 +483,6 @@ models/players/hud/axis_engineer
 
 models/players/hud/axis_field 
 {
-	sort 16
 	{
 		map models/players/hud/axis_field.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -520,7 +494,6 @@ models/players/hud/axis_field
 
 models/players/hud/axis_soldier 
 {
-	sort 16
 	{
 		map models/players/hud/axis_soldier.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -537,7 +510,6 @@ models/players/hud/axis_soldier
 //*****************************************
 models/players/temperate/allied/soldier/body
 {
-	sort 16
 	{
 		map models/players/temperate/allied/soldier/body.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -549,7 +521,6 @@ models/players/temperate/allied/soldier/body
 
 models/players/temperate/allied/medic/body
 {
-	sort 16
 	{
 		map models/players/temperate/allied/medic/body.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -561,7 +532,6 @@ models/players/temperate/allied/medic/body
 
 models/players/temperate/allied/engineer/body
 {
-	sort 16
 	{
 		map models/players/temperate/allied/engineer/body.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -573,7 +543,6 @@ models/players/temperate/allied/engineer/body
 
 models/players/temperate/allied/fieldops/body
 {
-	sort 16
 	{
 		map models/players/temperate/allied/fieldops/body.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -585,7 +554,6 @@ models/players/temperate/allied/fieldops/body
 
 models/players/temperate/allied/cvops/body
 {
-	sort 16
 	{
 		map models/players/temperate/allied/cvops/body.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -602,7 +570,6 @@ models/players/temperate/allied/cvops/body
 //*****************************************
 models/players/temperate/allied/leg01 
 {
-	sort 16
 	{
 		map models/players/temperate/allied/leg01.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -618,8 +585,7 @@ models/players/temperate/allied/leg01
 //
 //*****************************************
 models/players/temperate/allied/medic/acc/backpack 
-{
-	sort 16	
+{	
 	{
 		map models/players/temperate/allied/medic/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -630,8 +596,7 @@ models/players/temperate/allied/medic/acc/backpack
 }
 
 models/players/temperate/allied/medic/acc/backpack2 
-{
-	sort 16	
+{	
 	{
 		map models/players/temperate/allied/medic/acc/backpack2.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -642,8 +607,7 @@ models/players/temperate/allied/medic/acc/backpack2
 }
 
 models/players/temperate/allied/engineer/acc/backpack 
-{
-	sort 16	
+{	
 	{
 		map models/players/temperate/allied/engineer/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -654,8 +618,7 @@ models/players/temperate/allied/engineer/acc/backpack
 }
 
 models/players/temperate/allied/engineer/acc/shovel 
-{
-	sort 16	
+{	
 	{
 		map models/players/temperate/allied/engineer/acc/shovel.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -666,8 +629,7 @@ models/players/temperate/allied/engineer/acc/shovel
 }
 
 models/players/temperate/allied/fieldops/acc/backpack 
-{
-	sort 16	
+{	
 	{
 		map models/players/temperate/allied/fieldops/acc/backpack.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -678,8 +640,7 @@ models/players/temperate/allied/fieldops/acc/backpack
 }
 
 models/players/temperate/allied/soldier/acc/backpack 
-{
-	sort 16	
+{	
 	{
 		map models/players/temperate/allied/soldier/acc/backpack.jpg
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -696,7 +657,6 @@ models/players/temperate/allied/soldier/acc/backpack
 //******************************************
 models/players/temperate/allied/medic/helmet
 {
-	sort 16
 	{
 		map models/players/temperate/allied/medic/helmet.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -708,7 +668,6 @@ models/players/temperate/allied/medic/helmet
 
 models/players/temperate/allied/cvops/cap 
 {
-	sort 16
 	{
 		map models/players/temperate/allied/cvops/cap.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -720,7 +679,6 @@ models/players/temperate/allied/cvops/cap
 
 models/players/temperate/allied/engineer/helmet 
 {
-	sort 16
 	{
 		map models/players/temperate/allied/engineer/helmet.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -732,7 +690,6 @@ models/players/temperate/allied/engineer/helmet
 
 models/players/temperate/allied/fieldops/helmet 
 {
-	sort 16
 	{
 		map models/players/temperate/allied/fieldops/helmet.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -744,7 +701,6 @@ models/players/temperate/allied/fieldops/helmet
 
 models/players/temperate/allied/soldier/helmet 
 {
-	sort 16
 	{
 		map models/players/temperate/allied/soldier/helmet.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -756,7 +712,6 @@ models/players/temperate/allied/soldier/helmet
 
 models/players/temperate/allied/strap
 {
-	sort 16
 	{
 		map models/players/temperate/allied/inside.tga 
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -768,7 +723,6 @@ models/players/temperate/allied/strap
 
 models/players/temperate/allied/inside
 {
-	sort 16
 	{
 		map models/players/temperate/allied/inside.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -785,7 +739,6 @@ models/players/temperate/allied/inside
 //*******************************************
 models/players/hud/allied_medic 
 {
-	sort 16
 	{
 		map models/players/hud/allied_medic.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -796,8 +749,7 @@ models/players/hud/allied_medic
 }
 
 models/players/hud/allied_cvops 
-{
-	sort 16	
+{	
 	{
 		map models/players/hud/allied_cvops.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -809,7 +761,6 @@ models/players/hud/allied_cvops
 
 models/players/hud/allied_engineer 
 {
-	sort 16
 	{
 		map models/players/hud/allied_engineer.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -821,7 +772,6 @@ models/players/hud/allied_engineer
 
 models/players/hud/allied_field 
 {
-	sort 16
 	{
 		map models/players/hud/allied_field.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -833,7 +783,6 @@ models/players/hud/allied_field
 
 models/players/hud/allied_soldier 
 {
-	sort 16
 	{
 		map models/players/hud/allied_soldier.tga
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
@@ -845,7 +794,7 @@ models/players/hud/allied_soldier
 
 models/players/hud/teeth01 
 {
-	/* lets hide teeth, so it won't look ugly with transparency */
+	// lets hide teeth, so it won't look ugly with transparency
     {
     	map models/players/hud/teeth01.tga
     	blendFunc GL_ZERO GL_ONE


### PR DESCRIPTION
This causes nothing but sorting bugs (e.g. players draw over muzzleflashes), `depthWrite` is enough to make player transparency work correctly.

refs #54