### PR TITLE
Improve fireteam teamjump mode & target_ftrelay

### DIFF
--- a/src/cgame/cg_fireteamoverlay.cpp
+++ b/src/cgame/cg_fireteamoverlay.cpp
@@ -114,6 +114,9 @@ void CG_ParseFireteams() {
     s = Info_ValueForKey(p, "ng");
     cg.fireTeams[i].noGhost = Q_atoi(s);
 
+    s = Info_ValueForKey(p, "tj");
+    cg.fireTeams[i].teamJumpMode = Q_atoi(s);
+
     s = Info_ValueForKey(p, "c");
     Q_strncpyz(hexbuffer + 2, s, 9);
     sscanf(hexbuffer, "%x", &tmp);
@@ -312,7 +315,8 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect) {
   CG_FillRect(x, y, FT_WIDTH - 4, FT_HEADER_HEIGHT, clr1);
 
   buffer = ETJump::StringUtil::toUpperCase(
-      ETJump::stringFormat("Fireteam: %s", bg_fireteamNames[f->ident]));
+      ETJump::stringFormat("FT: %s%s", bg_fireteamNames[f->ident],
+                           f->teamJumpMode ? " (TJ MODE)" : ""));
   CG_Text_Paint_Ext(x + 3, y + FT_BAR_HEIGHT, .19f, .19f, tclr, buffer, 0, 0, 0,
                     &cgs.media.limboFont1);
 

--- a/src/cgame/cg_fireteams.cpp
+++ b/src/cgame/cg_fireteams.cpp
@@ -272,11 +272,12 @@ const char *ftOnMenuRulesListAlphaChars[] = {
 };
 
 const char *ftLeaderMenuList[] = {
-    "Disband", "Leave", "Invite", "Kick", "Warn", "Rules", nullptr,
+    "Disband", "Leave", "Invite",           "Kick",
+    "Warn",    "Rules", "%s teamjump mode", nullptr,
 };
 
 const char *ftLeaderMenuListAlphachars[] = {
-    "D", "L", "I", "K", "W", "R", nullptr,
+    "D", "L", "I", "K", "W", "R", "T", nullptr,
 };
 
 int CG_CountFireteamsByTeam(team_t t) {
@@ -698,6 +699,13 @@ void CG_Fireteams_MenuText_Draw(panel_button_t *button) {
                        ftLeaderMenuList[i]);
             }
 
+            if (i == static_cast<int>(FTMenuOptions::FT_TJMODE)) {
+              str = va(str,
+                       cgs.clientinfo[cg.clientNum].fireteamData->teamJumpMode
+                           ? "Disable"
+                           : "Enable");
+            }
+
             CG_Text_Paint_Ext(button->rect.x, y, button->font->scalex,
                               button->font->scaley, button->font->colour, str,
                               0, 0, button->font->style, button->font->font);
@@ -978,24 +986,33 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
 
           return qtrue;
         } else {
-          if (i >= 6) {
+          if (i >= static_cast<int>(FTMenuOptions::FT_MAX_OPTIONS)) {
             break;
           }
 
-          if (i == 2 && !CG_CountPlayersNF()) {
+          if (i == static_cast<int>(FTMenuOptions::FT_INVITE) &&
+              !CG_CountPlayersNF()) {
             break;
           }
 
-          if ((i == 3 || i == 4) && !CG_CountPlayersSF()) {
+          if ((i == static_cast<int>(FTMenuOptions::FT_KICK) ||
+               i == static_cast<int>(FTMenuOptions::FT_WARN)) &&
+              !CG_CountPlayersSF()) {
             break;
           }
 
           if (doaction) {
-            if (i == 0) {
+            if (i == static_cast<int>(FTMenuOptions::FT_DISBAND_PROPOSE)) {
               trap_SendConsoleCommand("fireteam disband\n");
               CG_EventHandling(CGAME_EVENT_NONE, qfalse);
-            } else if (i == 1) {
+            } else if (i == static_cast<int>(FTMenuOptions::FT_CREATE_LEAVE)) {
               trap_SendConsoleCommand("fireteam leave\n");
+              CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+            } else if (i == static_cast<int>(FTMenuOptions::FT_TJMODE)) {
+              trap_SendConsoleCommand(va(
+                  "fireteam teamjump %i",
+                  cgs.clientinfo[cg.clientNum].fireteamData->teamJumpMode ? 0
+                                                                          : 1));
               CG_EventHandling(CGAME_EVENT_NONE, qfalse);
             } else {
               cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_ADMIN);
@@ -1007,7 +1024,7 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
           return qtrue;
         }
       }
-    } break;
+    }
     case FTMenuMode::FT_APPLY: {
       int i;
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2145,6 +2145,17 @@ struct range_t {
 };
 // End CGaz 5
 
+enum class FTMenuOptions {
+  FT_DISBAND_PROPOSE = 0,
+  FT_CREATE_LEAVE = 1,
+  FT_INVITE = 2,
+  FT_KICK = 3,
+  FT_WARN = 4,
+  FT_RULES = 5,
+  FT_TJMODE = 6,
+  FT_MAX_OPTIONS = 7,
+};
+
 enum class FTMenuMode {
   FT_VSAY = 0,
   FT_MANAGE = 1, // create, leave, disband
@@ -2159,7 +2170,7 @@ enum class FTMenuPos {
   FT_MENUPOS_INVITE = 2,
   FT_MENUPOS_KICK = 3,
   FT_MENUPOS_WARN = 4,
-  FT_MENUPOS_RULES = 5
+  FT_MENUPOS_RULES = 5,
 };
 
 enum class FTMenuRulesPos {

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2304,7 +2304,7 @@ typedef struct {
   int saveLimit;
   // Toggle whether target_relay_fireteam will activate for all ft
   // members or just one
-  qboolean teamJumpMode;
+  bool teamJumpMode;
   qboolean inuse;
   qboolean priv;
 

--- a/src/game/g_fireteams.cpp
+++ b/src/game/g_fireteams.cpp
@@ -675,14 +675,15 @@ static void setSaveLimitForFTMembers(fireteamData_t *ft, int limit) {
       ent = g_entities + ft->joinOrder[i];
       ent->client->sess.saveLimitFt = limit;
       Printer::SendPopupMessage(
-          ClientNum(ent), va("fireteam: ^3savelimit ^7was set to ^3%i", limit));
+          ClientNum(ent),
+          stringFormat("fireteam: ^3savelimit ^7was set to ^3%i", limit));
     }
   }
 }
 
 static void setFireTeamGhosting(fireteamData_t *ft, bool noGhost) {
-  const std::string &msg = ETJump::stringFormat(
-      "fireteam: ^3noghost ^7has been ^3%s", noGhost ? "enabled" : "disabled");
+  const std::string &msg = stringFormat("fireteam: ^3noghost ^7has been ^3%s",
+                                        noGhost ? "enabled" : "disabled");
 
   ft->noGhost = noGhost;
 

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1668,6 +1668,10 @@ void target_ftrelay_use(gentity_t *self, gentity_t *other,
     return;
   }
 
+  const bool noActivator =
+      self->spawnflags &
+      static_cast<int>(ETJump::FTRelaySpawnflags::NoActivator);
+
   for (int i = 0; i < level.numConnectedClients; i++) {
     if (ft->joinOrder[i] == -1) {
       continue;
@@ -1675,9 +1679,7 @@ void target_ftrelay_use(gentity_t *self, gentity_t *other,
 
     gentity_t *ent = g_entities + ft->joinOrder[i];
 
-    if (activator == ent &&
-        self->spawnflags &
-            static_cast<int>(ETJump::FTRelaySpawnflags::NoActivator)) {
+    if (noActivator && activator == ent) {
       continue;
     }
 

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1611,23 +1611,22 @@ static bool canFireFTRelay(gentity_t *self, gentity_t *activator) {
     return false;
   }
 
-  if ((self->spawnflags &
-           static_cast<int>(ETJump::FTRelaySpawnflags::AxisOnly) &&
-       activator->client->sess.sessionTeam != TEAM_AXIS) ||
-      (self->spawnflags &
-           static_cast<int>(ETJump::FTRelaySpawnflags::AlliesOnly) &&
-       activator->client->sess.sessionTeam != TEAM_ALLIES)) {
+  if (self->spawnflags & static_cast<int>(FTRelaySpawnflags::AxisOnly) &&
+      activator->client->sess.sessionTeam != TEAM_AXIS) {
     return false;
   }
 
-  if (self->spawnflags &
-          static_cast<int>(ETJump::FTRelaySpawnflags::TimerunOnly) &&
+  if (self->spawnflags & static_cast<int>(FTRelaySpawnflags::AlliesOnly) &&
+      activator->client->sess.sessionTeam != TEAM_ALLIES) {
+    return false;
+  }
+
+  if (self->spawnflags & static_cast<int>(FTRelaySpawnflags::TimerunOnly) &&
       !activator->client->sess.timerunActive) {
     return false;
   }
 
-  if (self->spawnflags &
-          static_cast<int>(ETJump::FTRelaySpawnflags::NoTimerun) &&
+  if (self->spawnflags & static_cast<int>(FTRelaySpawnflags::NoTimerun) &&
       activator->client->sess.timerunActive) {
     return false;
   }

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1604,6 +1604,7 @@ enum class FTRelaySpawnflags {
   AllTargets = 4,
   TimerunOnly = 8,
   NoTimerun = 16,
+  NoActivator = 32,
 };
 
 static bool canFireFTRelay(gentity_t *self, gentity_t *activator) {
@@ -1673,6 +1674,12 @@ void target_ftrelay_use(gentity_t *self, gentity_t *other,
     }
 
     gentity_t *ent = g_entities + ft->joinOrder[i];
+
+    if (activator == ent &&
+        self->spawnflags &
+            static_cast<int>(ETJump::FTRelaySpawnflags::NoActivator)) {
+      continue;
+    }
 
     if (!ETJump::canFireFTRelay(self, ent)) {
       continue;


### PR DESCRIPTION
* Improvements to `target_ftrelay`
  * Targets no longer fire to spectators (likely never desired + can cause crashes on some entities)
  * Added spawnflags `1`, `2`, `4`, `8`, `16` and `32`
    * `1 = axis only`
    * `2 = allies only`
    * `4 = all targets` (opposite of `target_relay` random as this fires random by default)
    * `8 = only fire if timerunning`
    * `16 = only fire if not timerunning`
      * `8 & 16` are checked for each fireteam member separately: if e.g. `8` is set, only fireteam members who are timerunning fire targets
    * `32 = only fire for other fireteam members`
* Improve teamjump mode setup with better prints
* Add fireteam menu option to toggle teamjump mode
* Add indication to fireteam overlay that teamjump mode is enabled
* Cleanup some magic numbers from fireteam menu code

This is gonna conflict with #1357 but I will deal with that later as I'm still unsure about few things with that.

Also need to cleanup the fireteam rule/teamjump mode prints a bit as they are kinda all over the place and lack consistency, but I will deal with that once the shove stuff is merged.