### PR TITLE
Sanitize custom vote parsing + admin commands

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -2254,6 +2254,23 @@ bool RockTheVote(gentity_t *ent, Arguments argv) {
   return true;
 }
 
+// ensures custom vote command options are not just color codes
+bool validateCustomVoteCommand(const std::string &cmdName, const int &clientNum,
+                               const ETJump::CommandParser::Command &command) {
+  bool commandOk = true;
+
+  for (const auto &op : command.options) {
+    if (ETJump::sanitize(op.second.text).empty()) {
+      Printer::SendChatMessage(
+          clientNum, ETJump::stringFormat("^3%s: ^7'%s' cannot be empty.",
+                                          cmdName, op.first));
+      commandOk = false;
+    }
+  }
+
+  return commandOk;
+}
+
 bool addCustomVote(gentity_t *ent, Arguments argv) {
   const int clientNum = ClientNum(ent);
 
@@ -2281,6 +2298,10 @@ bool addCustomVote(gentity_t *ent, Arguments argv) {
   const std::string &name = command.options["name"].text;
   const std::string &fullName = command.options["full-name"].text;
   const std::string &maps = command.options["maps"].text;
+
+  if (!validateCustomVoteCommand(def.name, clientNum, command)) {
+    return false;
+  }
 
   game.customMapVotes->addCustomvoteList(clientNum, name, fullName, maps);
   return true;
@@ -2354,6 +2375,10 @@ bool editCustomVote(gentity_t *ent, Arguments argv) {
       optAddMaps.hasValue() ? optAddMaps.value().text : "";
   const std::string &removeMaps =
       optRemoveMaps.hasValue() ? optRemoveMaps.value().text : "";
+
+  if (!validateCustomVoteCommand(def.name, clientNum, command)) {
+    return false;
+  }
 
   game.customMapVotes->editCustomvoteList(clientNum, list, name, fullName,
                                           addMaps, removeMaps);

--- a/src/game/etj_map_statistics.cpp
+++ b/src/game/etj_map_statistics.cpp
@@ -507,18 +507,11 @@ std::vector<std::string> MapStatistics::blockedMaps() {
 }
 
 bool MapStatistics::isBlockedMap(const std::string &mapName) {
-  bool isBlocked = false;
-  const auto blockedMaps = MapStatistics::blockedMaps();
-  const auto numBlockedMaps = blockedMaps.size();
-
-  for (int i = 0; i < numBlockedMaps; i++) {
-    if (ETJump::StringUtil::matches(blockedMaps[i], mapName)) {
-      isBlocked = true;
-      break;
-    }
-  }
-
-  return isBlocked;
+  const auto &blockedMaps = MapStatistics::blockedMaps();
+  return std::any_of(blockedMaps.begin(), blockedMaps.end(),
+                     [&mapName](const std::string &map) {
+                       return ETJump::StringUtil::iEqual(map, mapName);
+                     });
 }
 
 bool MapStatistics::isValidMap(const MapInformation *mapInfo) const {

--- a/src/game/etj_string_utilities.cpp
+++ b/src/game/etj_string_utilities.cpp
@@ -303,9 +303,16 @@ bool ETJump::StringUtil::contains(const std::string &str,
   return str.find(text) != std::string::npos;
 }
 
-bool ETJump::StringUtil::matches(const std::string &str,
-                                 const std::string &text) {
-  return str == text;
+bool ETJump::StringUtil::iEqual(const std::string &str1,
+                                const std::string &str2, bool sanitized) {
+  if (sanitized) {
+    return sanitize(str1, true) == sanitize(str2, true);
+  }
+
+  return std::equal(str1.begin(), str1.end(), str2.begin(), str2.end(),
+                    [](unsigned char a, unsigned char b) {
+                      return std::tolower(a) == std::tolower(b);
+                    });
 }
 
 unsigned ETJump::StringUtil::countExtraPadding(const std::string &input) {

--- a/src/game/etj_string_utilities.h
+++ b/src/game/etj_string_utilities.h
@@ -101,7 +101,9 @@ void stringSubstitute(std::string &input, char character,
 bool startsWith(const std::string &str, const std::string &prefix);
 bool endsWith(const std::string &str, const std::string &suffix);
 bool contains(const std::string &str, const std::string &text);
-bool matches(const std::string &str, const std::string &text);
+// case-insensitive string comparison, optionally with sanitized strings
+bool iEqual(const std::string &str1, const std::string &str2,
+            bool sanitized = false);
 // Counts the extra padding needed when using format specifiers like
 // %-20s with text that contains ET color codes
 unsigned countExtraPadding(const std::string &input);

--- a/tests/string_utilities_tests.cpp
+++ b/tests/string_utilities_tests.cpp
@@ -88,7 +88,7 @@ TEST_F(StringUtilitiesTests,
 }
 
 TEST_F(StringUtilitiesTests,
-       toLowerCase_ShouldConvertStringIntoUppercasedCopy) {
+       toUpperCase_ShouldConvertStringIntoUppercasedCopy) {
   std::string input = "hello world";
   auto fixedString = StringUtil::toUpperCase(input);
   EXPECT_EQ(fixedString, "HELLO WORLD");
@@ -113,4 +113,15 @@ TEST_F(StringUtilitiesTests, countExtraPadding_ShouldWorkCorrectly) {
   EXPECT_EQ(StringUtil::countExtraPadding("^1123"), 2);
   EXPECT_EQ(StringUtil::countExtraPadding("^^1123"), 2);
   EXPECT_EQ(StringUtil::countExtraPadding("^1t^2e^3s^4t"), 8);
+}
+
+TEST_F(StringUtilitiesTests, iEqual_ShouldWorkCorrectly) {
+  EXPECT_EQ(StringUtil::iEqual("FOO", "foo"), true);
+  EXPECT_EQ(StringUtil::iEqual("FOO", "bar"), false);
+
+  EXPECT_EQ(StringUtil::iEqual("FOO", "^1foo", true), true);
+  EXPECT_EQ(StringUtil::iEqual("^2FOO", "^1foo", true), true);
+  EXPECT_EQ(StringUtil::iEqual("^2FOO", "^1bar", true), false);
+
+  EXPECT_EQ(StringUtil::iEqual("FOO", "^1foo"), false);
 }

--- a/tests/string_utilities_tests.cpp
+++ b/tests/string_utilities_tests.cpp
@@ -116,12 +116,33 @@ TEST_F(StringUtilitiesTests, countExtraPadding_ShouldWorkCorrectly) {
 }
 
 TEST_F(StringUtilitiesTests, iEqual_ShouldWorkCorrectly) {
+  // basic case-insensitive comparison
   EXPECT_EQ(StringUtil::iEqual("FOO", "foo"), true);
   EXPECT_EQ(StringUtil::iEqual("FOO", "bar"), false);
 
+  // case-insensitive comparison with sanitization
   EXPECT_EQ(StringUtil::iEqual("FOO", "^1foo", true), true);
   EXPECT_EQ(StringUtil::iEqual("^2FOO", "^1foo", true), true);
   EXPECT_EQ(StringUtil::iEqual("^2FOO", "^1bar", true), false);
 
+  // case-insensitive comparison without sanitization
   EXPECT_EQ(StringUtil::iEqual("FOO", "^1foo"), false);
+
+  // empty strings comparison
+  EXPECT_EQ(StringUtil::iEqual("", ""), true);
+  EXPECT_EQ(StringUtil::iEqual("", "foo"), false);
+  EXPECT_EQ(StringUtil::iEqual("foo", ""), false);
+
+  // different lengths
+  EXPECT_EQ(StringUtil::iEqual("FOO", "FOOBAR"), false);
+  EXPECT_EQ(StringUtil::iEqual("FOOBAR", "FOO"), false);
+
+  // mixed case with color codes
+  EXPECT_EQ(StringUtil::iEqual("^1FoO", "^2fOo", true), true);
+  EXPECT_EQ(StringUtil::iEqual("^1FoO", "^2BaR", true), false);
+
+  // no sanitization parameter specified
+  // (default behavior should be case-insensitive)
+  EXPECT_EQ(StringUtil::iEqual("FoO", "foO"), true);
+  EXPECT_EQ(StringUtil::iEqual("FoO", "BaR"), false);
 }


### PR DESCRIPTION
Custom votes are now sanitized upon reading and writing - color codes are stripped, listnames and mapnames are forced to lowercase (callvote text is allowed to have mixed case), and `!add/edit/delete-customvote` commands can no longer be issues by just using color codes as arguments.

fixes #1312 