### PR TITLE
Sanitize chat replay messages

### DIFF
--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -47,7 +47,7 @@ void ChatReplay::storeChatMessage(int clientNum, const std::string &name,
   msg.name = name;
   msg.localize = localize;
   msg.encoded = encoded;
-  msg.message = message;
+  msg.message = sanitize(message);
 
   chatReplayBuffer.emplace_back(msg);
 


### PR DESCRIPTION
Name tag parsing and custom chat colors break everything too hard that I really just cba to deal with it, so sanitize the messages.

refs #1335 