### PR TITLE
Fix mounted mg42 overheating + refactor mounted gun handling

### DIFF
--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -1014,6 +1014,12 @@ void CG_PredictPlayerState() {
     cg.pmext.noclipScale = etj_noclipScale.value;
   }
 
+  // let server handle mounted MG42 cooldown since client doesn't know
+  // the heat values of each individual mounted gun in the map
+  // otherwise we fire excess overheat events when client exits and re-enters
+  // the gun, as the correct heat value is never assigned client side
+  cg.pmext.weapHeat[WP_DUMMY_MG42] = 0.0f;
+
   memcpy(&oldpmext[current & CMD_MASK], &cg.pmext, sizeof(pmoveExt_t));
 
   // if we don't have the commands right after the snapshot, we

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -276,7 +276,8 @@ void CG_OffsetThirdPersonView(void) {
   // rain - if dead, look at medic or allow freelook if none in range
   if (cg.predictedPlayerState.stats[STAT_HEALTH] <= 0) {
     // rain - #254 - force yaw to 0 if we're tracking a medic
-    if (cg.snap->ps.viewlocked != 7) {
+    if (cg.snap->ps.viewlocked !=
+        static_cast<int>(ETJump::ViewlockState::Medic)) {
       // rain - do short2angle AFTER the network part
       focusAngles[YAW] =
           SHORT2ANGLE(cg.predictedPlayerState.stats[STAT_DEAD_YAW]);
@@ -636,7 +637,8 @@ static void CG_OffsetFirstPersonView(void) {
     // rain - #254 - force yaw to 0 if we're tracking a medic
     // rain - medic tracking doesn't seem to happen in this
     // case?
-    if (cg.snap->ps.viewlocked == 7) {
+    if (cg.snap->ps.viewlocked ==
+        static_cast<int>(ETJump::ViewlockState::Medic)) {
       angles[YAW] = 0;
     } else {
       // rain - do short2angle AFTER the network part
@@ -1382,27 +1384,16 @@ int CG_CalcViewValues(void) {
 
     // Ridah, lock the viewangles if the game has told us to
     if (ps->viewlocked && !cgs.demoCam.renderingFreeCam) {
-
-      /*
-      if (ps->viewlocked == 4)
-      {
-          centity_t *tent;
-          tent = &cg_entities[ps->viewlocked_entNum];
-          VectorCopy (tent->currentState.apos.trBase,
-      cg.refdefViewAngles);
-      }
-      else
-      */
-      // DHM - Nerve :: don't bother evaluating if set
-      // to 7 (look at medic)
-      if (ps->viewlocked != 7 && ps->viewlocked != 3 && ps->viewlocked != 2) {
+      if (ps->viewlocked != static_cast<int>(ETJump::ViewlockState::Medic) &&
+          ps->viewlocked != static_cast<int>(ETJump::ViewlockState::Mounted) &&
+          ps->viewlocked != static_cast<int>(ETJump::ViewlockState::Jitter)) {
         BG_EvaluateTrajectory(
             &cg_entities[ps->viewlocked_entNum].currentState.apos, cg.time,
             cg.refdefViewAngles, qtrue,
             cg_entities[ps->viewlocked_entNum].currentState.effect2Time);
       }
 
-      if (ps->viewlocked == 2) {
+      if (ps->viewlocked == static_cast<int>(ETJump::ViewlockState::Jitter)) {
         cg.refdefViewAngles[0] += crandom();
         cg.refdefViewAngles[1] += crandom();
       }
@@ -1433,7 +1424,7 @@ int CG_CalcViewValues(void) {
       // do nothing
     }
     // Ridah, lock the viewangles if the game has told us to
-    else if (ps->viewlocked == 7) {
+    else if (ps->viewlocked == static_cast<int>(ETJump::ViewlockState::Medic)) {
       centity_t *tent;
       vec3_t vec;
 
@@ -1441,11 +1432,6 @@ int CG_CalcViewValues(void) {
       VectorCopy(tent->lerpOrigin, vec);
       VectorSubtract(vec, cg.refdef_current->vieworg, vec);
       vectoangles(vec, cg.refdefViewAngles);
-    } else if (ps->viewlocked == 4) {
-      vec3_t fwd;
-      AngleVectors(cg.refdefViewAngles, fwd, NULL, NULL);
-      VectorMA(cg_entities[ps->viewlocked_entNum].lerpOrigin, 16, fwd,
-               cg.refdef_current->vieworg);
     } else if (ps->viewlocked) {
       vec3_t fwd;
       float oldZ;

--- a/src/game/bg_local.h
+++ b/src/game/bg_local.h
@@ -11,8 +11,6 @@
 
 #define DOUBLE_TAP_DELAY 400
 
-#define MAX_MG42_HEAT 1500.f
-
 // all of the locals will be zeroed before each
 // pmove, just to make damn sure we don't have
 // any differences when running on client or server

--- a/src/game/bg_misc.cpp
+++ b/src/game/bg_misc.cpp
@@ -3991,13 +3991,14 @@ void BG_AddPredictableEventToPlayerstate(int newEvent, int eventParm,
 }
 
 void BG_SetupMountedGunStatus(playerState_t *ps) {
-  switch (ps->persistant[PERS_HWEAPON_USE]) {
-    case 1:
+  switch (
+      static_cast<ETJump::HeavyWeaponState>(ps->persistant[PERS_HWEAPON_USE])) {
+    case ETJump::HeavyWeaponState::MountedMG:
       ps->eFlags |= EF_MG42_ACTIVE;
       ps->eFlags &= ~EF_AAGUN_ACTIVE;
       ps->powerups[PW_OPS_DISGUISED] = 0;
       break;
-    case 2:
+    case ETJump::HeavyWeaponState::AAGun:
       ps->eFlags |= EF_AAGUN_ACTIVE;
       ps->eFlags &= ~EF_MG42_ACTIVE;
       ps->powerups[PW_OPS_DISGUISED] = 0;

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -3632,27 +3632,7 @@ static bool PM_MountedFire() {
       }
 
       pm->ps->weaponTime += MG42_RATE_OF_FIRE_MP;
-
-      // The client is not aware of the current heat level of a mounted MG42
-      // when entering it (only server knows this, and it's not communicated),
-      // so when client exits and re-enters a mounted MG42,
-      // the client/server pmext->weapHeat values get desynced.
-
-      // Previously, when weapHeat was used in ps, due to a bug it was never
-      // actually correctly updated on client side, only server side
-      // (client side value remained constantly at MG42_RATE_OF_FIRE_MP).
-      // This bug however meant that Pmove called via CG_PredictPlayerState
-      // never fired the overheat event, and that was left entirely to the
-      // Pmove call made from Clientthink_real. With a fixed behavior,
-      // overheat events would get sent in excess to client as the weapHeat
-      // is now correctly set for client too, so let's recreate this
-      // buggy behavior and keep the client/server pmext desynced
-      // to avoid excess event firing
-#ifdef CGAMEDLL
-      pm->pmext->weapHeat[WP_DUMMY_MG42] = MG42_RATE_OF_FIRE_MP;
-#else
       pm->pmext->weapHeat[WP_DUMMY_MG42] += MG42_RATE_OF_FIRE_MP;
-#endif
 
       if (pm->pmext->weapHeat[WP_DUMMY_MG42] >= MAX_MG42_HEAT) {
         // cap heat to max

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -11,6 +11,7 @@
 #endif // CGAMEDLL
 
 #include "bg_local.h"
+#include "etj_numeric_utilities.h"
 
 #ifdef CGAMEDLL
   #define PM_Cheats cgs.cheats
@@ -3358,58 +3359,46 @@ int PM_WeaponClipEmpty(int inWp) {
 PM_CoolWeapons
 ==============
 */
-void PM_CoolWeapons(void) {
-  int wp, maxHeat;
+void PM_CoolWeapons() {
+  for (int wp = 0; wp < WP_NUM_WEAPONS; wp++) {
 
-  for (wp = 0; wp < WP_NUM_WEAPONS; wp++) {
-
-    // if you have the weapon
-    if (COM_BitCheck(pm->ps->weapons, wp)) {
+    // if you have the weapon, and it can overheat (or using mounted MG42)
+    if ((GetAmmoTableData(wp)->maxHeat && COM_BitCheck(pm->ps->weapons, wp)) ||
+        wp == WP_DUMMY_MG42) {
       // and it's hot
       if (pm->pmext->weapHeat[wp] != 0) {
         if (pm->skill[SK_HEAVY_WEAPONS] >= 2 &&
             pm->ps->stats[STAT_PLAYER_CLASS] == PC_SOLDIER) {
           pm->pmext->weapHeat[wp] -=
-              static_cast<float>(GetAmmoTableData(wp)->coolRate) * 2.f *
-              pml.frametime;
+              (static_cast<float>(GetAmmoTableData(wp)->coolRate) * 2.0f *
+               pml.frametime);
         } else {
           pm->pmext->weapHeat[wp] -=
-              static_cast<float>(GetAmmoTableData(wp)->coolRate) *
-              pml.frametime;
+              (static_cast<float>(GetAmmoTableData(wp)->coolRate) *
+               pml.frametime);
         }
 
-        if (pm->pmext->weapHeat[wp] < 0) {
-          pm->pmext->weapHeat[wp] = 0;
-        }
+        pm->pmext->weapHeat[wp] = std::max(pm->pmext->weapHeat[wp], 0.0f);
       }
     }
   }
 
-  // a weapon is currently selected, convert current heat value to 0-255
-  // range for client transmission
-  if (pm->ps->weapon) {
-    if (pm->ps->persistant[PERS_HWEAPON_USE] ||
-        pm->ps->eFlags & EF_MOUNTEDTANK) {
-      // rain - floor to prevent 8-bit wrap
-      pm->ps->curWeapHeat =
-          std::floor(((static_cast<float>(pm->pmext->weapHeat[WP_DUMMY_MG42]) /
-                       MAX_MG42_HEAT)) *
-                     255.0f);
-    } else {
-      // rain - #172 - don't divide by 0
-      maxHeat = GetAmmoTableData(pm->ps->weapon)->maxHeat;
+  if (BG_PlayerMounted(pm->ps->eFlags)) {
+    pm->ps->curWeapHeat = std::floor(
+        ((pm->pmext->weapHeat[WP_DUMMY_MG42] / MAX_MG42_HEAT)) * 255.0f);
+  } else {
+    const float maxHeat = GetAmmoTableData(pm->ps->weapon)->maxHeat;
 
-      // rain - floor to prevent 8-bit wrap
-      if (maxHeat != 0) {
-        pm->ps->curWeapHeat = std::floor(
-            ((static_cast<float>(pm->pmext->weapHeat[pm->ps->weapon]) /
-              static_cast<float>(maxHeat))) *
-            255.0f);
-      } else {
-        pm->ps->curWeapHeat = 0;
-      }
+    if (maxHeat != 0) {
+      pm->ps->curWeapHeat = std::floor(
+          ((pm->pmext->weapHeat[pm->ps->weapon] / maxHeat)) * 255.0f);
+    } else { // weapon can't overheat
+      pm->ps->curWeapHeat = 0;
     }
   }
+
+  // sanity check, cap weapon heat for 8-bit transmission to prevent wrap
+  Numeric::clamp(pm->ps->curWeapHeat, 0, 255);
 }
 
 /*
@@ -3604,11 +3593,81 @@ static void PM_HandleRecoil() {
   pm->pmext->lastRecoilDeltaTime = deltaTime;
 }
 
+// handles mounted MG42 firing
+// returns true if we successfully fired a mounted gun
+static bool PM_MountedFire() {
+  if (!BG_PlayerMounted(pm->ps->eFlags)) {
+    return false;
+  }
+
+  // cooldown active
+  if (pm->ps->weaponTime > 0) {
+    pm->ps->weaponTime -= pml.msec;
+
+    if (pm->ps->weaponTime <= 0) {
+      if (!(pm->cmd.buttons & BUTTON_ATTACK) &&
+          !(pm->cmd.wbuttons & WBUTTON_ATTACK2)) {
+        pm->ps->weaponTime = 0;
+        return true;
+      }
+    } else {
+      return true;
+    }
+  }
+
+  if (pm->cmd.buttons & BUTTON_ATTACK || pm->cmd.wbuttons & WBUTTON_ATTACK2) {
+    BG_AnimScriptEvent(pm->ps, pm->character->animModelInfo, ANIM_ET_FIREWEAPON,
+                       qfalse, qtrue);
+
+    // does this even work?
+    if (pm->ps->eFlags & EF_AAGUN_ACTIVE) {
+      PM_AddEvent(EV_FIRE_WEAPON_AAGUN);
+      pm->ps->weaponTime += AAGUN_RATE_OF_FIRE;
+    } else { // EF_MOUNTEDTANK | EF_MG42_ACTIVE
+      PM_AddEvent(pm->ps->eFlags & EF_MG42_ACTIVE ? EV_FIRE_WEAPON_MG42
+                                                  : EV_FIRE_WEAPON_MOUNTEDMG42);
+      pm->ps->viewlocked = static_cast<int>(ETJump::ViewlockState::Jitter);
+
+      pm->ps->weaponTime += MG42_RATE_OF_FIRE_MP;
+
+      // The client is not aware of the current heat level of a mounted MG42
+      // when entering it (only server knows this, and it's not communicated),
+      // so when client exits and re-enters a mounted MG42,
+      // the client/server pmext->weapHeat values get desynced.
+
+      // Previously, when weapHeat was used in ps, due to a bug it was never
+      // actually correctly updated on client side, only server side
+      // (client side value remained constantly at MG42_RATE_OF_FIRE_MP).
+      // This bug however meant that Pmove called via CG_PredictPlayerState
+      // never fired the overheat event, and that was left entirely to the
+      // Pmove call made from Clientthink_real. With a fixed behavior,
+      // overheat events would get sent in excess to client as the weapHeat
+      // is now correctly set for client too, so let's recreate this
+      // buggy behavior and keep the client/server pmext desynced
+      // to avoid excess event firing
+#ifdef CGAMEDLL
+      pm->pmext->weapHeat[WP_DUMMY_MG42] = MG42_RATE_OF_FIRE_MP;
+#else
+      pm->pmext->weapHeat[WP_DUMMY_MG42] += MG42_RATE_OF_FIRE_MP;
+#endif
+
+      if (pm->pmext->weapHeat[WP_DUMMY_MG42] >= MAX_MG42_HEAT) {
+        // cap heat to max
+        pm->pmext->weapHeat[WP_DUMMY_MG42] = MAX_MG42_HEAT;
+        PM_AddEvent(EV_WEAP_OVERHEAT);
+
+        // force "heat recovery minimum" to 2 sec right now
+        pm->ps->weaponTime = MG42_HEAT_RECOVERY;
+      }
+    }
+  }
+
+  return true;
+}
+
 #define weaponstateFiring                                                      \
   (pm->ps->weaponstate == WEAPON_FIRING ||                                     \
    pm->ps->weaponstate == WEAPON_FIRINGALT)
-
-#define GRENADE_DELAY 250
 
 /*
 ==============
@@ -3720,147 +3779,13 @@ static void PM_Weapon(void) {
       PM_CoolWeapons();
     }
 
-    // pm->ps->weapon = WP_NONE;
     return;
   }
 
-  //%	if( pm->ps->eFlags & EF_PRONE_MOVING )
-  //%		return;
+  // weapon cool down
+  PM_CoolWeapons();
 
-  // special mounted mg42 handling
-  switch (pm->ps->persistant[PERS_HWEAPON_USE]) {
-    case 1:
-      //			PM_CoolWeapons(); //
-      // Gordon: Arnout says this is
-      // how it's wanted ( bleugh ) no cooldown on weaps
-      // while using mg42, but need to update heat on
-      // mg42 itself
-      if (pm->pmext->weapHeat[WP_DUMMY_MG42] != 9) {
-        pm->pmext->weapHeat[WP_DUMMY_MG42] -= (300.f * pml.frametime);
-
-        if (pm->pmext->weapHeat[WP_DUMMY_MG42] < 0) {
-          pm->pmext->weapHeat[WP_DUMMY_MG42] = 0;
-        }
-
-        // rain - floor() to prevent 8-bit wrap
-        pm->ps->curWeapHeat = std::floor(
-            ((static_cast<float>(pm->pmext->weapHeat[WP_DUMMY_MG42]) /
-              MAX_MG42_HEAT)) *
-            255.0f);
-      }
-
-      if (pm->ps->weaponTime > 0) {
-        pm->ps->weaponTime -= pml.msec;
-        if (pm->ps->weaponTime <= 0) {
-          if (!(pm->cmd.buttons & BUTTON_ATTACK)) {
-            pm->ps->weaponTime = 0;
-            return;
-          }
-        } else {
-          return;
-        }
-      }
-
-      if (pm->cmd.buttons & BUTTON_ATTACK) {
-        pm->pmext->weapHeat[WP_DUMMY_MG42] += MG42_RATE_OF_FIRE_MP;
-
-        PM_AddEvent(EV_FIRE_WEAPON_MG42);
-
-        pm->ps->weaponTime += MG42_RATE_OF_FIRE_MP;
-
-        BG_AnimScriptEvent(pm->ps, pm->character->animModelInfo,
-                           ANIM_ET_FIREWEAPON, qfalse, qtrue);
-        pm->ps->viewlocked = 2; // this enable screen jitter when
-                                // firing
-
-        if (pm->pmext->weapHeat[WP_DUMMY_MG42] >= MAX_MG42_HEAT) {
-          pm->ps->weaponTime = MAX_MG42_HEAT; // cap heat
-                                              // to max
-          PM_AddEvent(EV_WEAP_OVERHEAT);
-          pm->ps->weaponTime = 2000; // force "heat
-                                     // recovery minimum"
-                                     // to 2 sec right
-                                     // now
-        }
-      }
-      return;
-    case 2:
-      if (pm->ps->weaponTime > 0) {
-        pm->ps->weaponTime -= pml.msec;
-        if (pm->ps->weaponTime <= 0) {
-          if (!(pm->cmd.buttons & BUTTON_ATTACK)) {
-            pm->ps->weaponTime = 0;
-            return;
-          }
-        } else {
-          return;
-        }
-      }
-
-      if (pm->cmd.buttons & BUTTON_ATTACK) {
-        PM_AddEvent(EV_FIRE_WEAPON_AAGUN);
-
-        pm->ps->weaponTime += AAGUN_RATE_OF_FIRE;
-
-        BG_AnimScriptEvent(pm->ps, pm->character->animModelInfo,
-                           ANIM_ET_FIREWEAPON, qfalse, qtrue);
-        //				pm->ps->viewlocked
-        //= 2;		// this
-        // enable screen jitter when firing
-      }
-      return;
-  }
-
-  if (pm->ps->eFlags & EF_MOUNTEDTANK) {
-    //		PM_CoolWeapons(); // Gordon: Arnout says this is how
-    // it's wanted ( bleugh ) no cooldown on weaps while using
-    // mg42, but need to update heat
-    // on mg42 itself
-    if (pm->pmext->weapHeat[WP_DUMMY_MG42] != 0) {
-      pm->pmext->weapHeat[WP_DUMMY_MG42] -= (300.f * pml.frametime);
-
-      if (pm->pmext->weapHeat[WP_DUMMY_MG42] < 0) {
-        pm->pmext->weapHeat[WP_DUMMY_MG42] = 0;
-      }
-
-      // rain - floor() to prevent 8-bit wrap
-      pm->ps->curWeapHeat =
-          std::floor(((static_cast<float>(pm->pmext->weapHeat[WP_DUMMY_MG42]) /
-                       MAX_MG42_HEAT)) *
-                     255.0f);
-    }
-
-    if (pm->ps->weaponTime > 0) {
-      pm->ps->weaponTime -= pml.msec;
-      if (pm->ps->weaponTime <= 0) {
-        if (!(pm->cmd.buttons & BUTTON_ATTACK)) {
-          pm->ps->weaponTime = 0;
-          return;
-        }
-      } else {
-        return;
-      }
-    }
-
-    if (pm->cmd.buttons & BUTTON_ATTACK) {
-      pm->pmext->weapHeat[WP_DUMMY_MG42] += MG42_RATE_OF_FIRE_MP;
-
-      PM_AddEvent(EV_FIRE_WEAPON_MOUNTEDMG42);
-
-      pm->ps->weaponTime += MG42_RATE_OF_FIRE_MP;
-
-      BG_AnimScriptEvent(pm->ps, pm->character->animModelInfo,
-                         ANIM_ET_FIREWEAPON, qfalse, qtrue);
-      // pm->ps->viewlocked = 2;		// this
-      // enable screen jitter when firing
-
-      if (pm->pmext->weapHeat[WP_DUMMY_MG42] >= MAX_MG42_HEAT) {
-        pm->ps->weaponTime = MAX_MG42_HEAT; // cap heat to max
-        PM_AddEvent(EV_WEAP_OVERHEAT);
-        pm->ps->weaponTime = 2000; // force "heat recovery
-                                   // minimum" to 2 sec right now
-      }
-    }
+  if (PM_MountedFire()) {
     return;
   }
 
@@ -3921,9 +3846,6 @@ static void PM_Weapon(void) {
     weaponstate_last = pm->ps->weaponstate;
   }
 #endif
-
-  // weapon cool down
-  PM_CoolWeapons();
 
   // check for weapon recoil
   // do the recoil before setting the values, that way it will be shown
@@ -6461,13 +6383,4 @@ void Pmove(pmove_t *pmove) {
       pmove->cmd.upmove = 20;
     }
   }
-
-  // rain - sanity check weapon heat
-  if (pmove->ps->curWeapHeat > 255) {
-    pmove->ps->curWeapHeat = 255;
-  } else if (pmove->ps->curWeapHeat < 0) {
-    pmove->ps->curWeapHeat = 0;
-  }
-
-  // PM_CheckStuck();
 }

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -3624,9 +3624,12 @@ static bool PM_MountedFire() {
       PM_AddEvent(EV_FIRE_WEAPON_AAGUN);
       pm->ps->weaponTime += AAGUN_RATE_OF_FIRE;
     } else { // EF_MOUNTEDTANK | EF_MG42_ACTIVE
-      PM_AddEvent(pm->ps->eFlags & EF_MG42_ACTIVE ? EV_FIRE_WEAPON_MG42
-                                                  : EV_FIRE_WEAPON_MOUNTEDMG42);
-      pm->ps->viewlocked = static_cast<int>(ETJump::ViewlockState::Jitter);
+      if (pm->ps->eFlags & EF_MG42_ACTIVE) {
+        PM_AddEvent(EV_FIRE_WEAPON_MG42);
+        pm->ps->viewlocked = static_cast<int>(ETJump::ViewlockState::Jitter);
+      } else {
+        PM_AddEvent(EV_FIRE_WEAPON_MOUNTEDMG42);
+      }
 
       pm->ps->weaponTime += MG42_RATE_OF_FIRE_MP;
 

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -3550,7 +3550,8 @@ void PM_AdjustAimSpreadScale(void) {
       (int)pm->ps->aimSpreadScaleFloat; // update the int for the client
 }
 
-static void PM_HandleRecoil() {
+namespace ETJump {
+static void handleRecoil() {
   vec3_t muzzlebounce;
   const int deltaTime = pm->cmd.serverTime - pm->pmext->weapRecoilTime;
 
@@ -3594,8 +3595,8 @@ static void PM_HandleRecoil() {
 }
 
 // handles mounted MG42 firing
-// returns true if we successfully fired a mounted gun
-static bool PM_MountedFire() {
+// returns false if we're not on a mounted gun
+static bool mountedFire() {
   if (!BG_PlayerMounted(pm->ps->eFlags)) {
     return false;
   }
@@ -3647,6 +3648,7 @@ static bool PM_MountedFire() {
 
   return true;
 }
+} // namespace ETJump
 
 #define weaponstateFiring                                                      \
   (pm->ps->weaponstate == WEAPON_FIRING ||                                     \
@@ -3768,7 +3770,7 @@ static void PM_Weapon(void) {
   // weapon cool down
   PM_CoolWeapons();
 
-  if (PM_MountedFire()) {
+  if (ETJump::mountedFire()) {
     return;
   }
 
@@ -3834,7 +3836,7 @@ static void PM_Weapon(void) {
   // do the recoil before setting the values, that way it will be shown
   // next frame and not this
   if (pm->pmext->weapRecoilTime) {
-    PM_HandleRecoil();
+    ETJump::handleRecoil();
   }
 
   delayedFire = qfalse;

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -3627,7 +3627,7 @@ static bool mountedFire() {
     } else { // EF_MOUNTEDTANK | EF_MG42_ACTIVE
       if (pm->ps->eFlags & EF_MG42_ACTIVE) {
         PM_AddEvent(EV_FIRE_WEAPON_MG42);
-        pm->ps->viewlocked = static_cast<int>(ETJump::ViewlockState::Jitter);
+        pm->ps->viewlocked = static_cast<int>(ViewlockState::Jitter);
       } else {
         PM_AddEvent(EV_FIRE_WEAPON_MOUNTEDMG42);
       }

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -153,10 +153,10 @@ extern vec3_t playerlegsProneMaxs;
 #define MG42_SPREAD_MP 100
 
 #define MG42_DAMAGE_MP 20
-#define MG42_RATE_OF_FIRE_MP 66
+static constexpr int MG42_RATE_OF_FIRE_MP = 66;
 
-#define MG42_DAMAGE_SP 40
-#define MG42_RATE_OF_FIRE_SP 100
+static constexpr float MAX_MG42_HEAT = 1500.0f;
+static constexpr int MG42_HEAT_RECOVERY = 2000;
 
 #define AAGUN_RATE_OF_FIRE 100
 #define MG42_YAWSPEED 300.f // degrees per second
@@ -2710,6 +2710,18 @@ enum class PusherSpawnFlags {
   AltSound = 1 << 0,
   AddXY = 1 << 1,
   AddZ = 1 << 2
+};
+
+// PERS_HWEAPON_USE
+enum class HeavyWeaponState {
+  MountedMG = 1,
+  AAGun = 2, // not sure if this is actually used/functional
+};
+
+enum class ViewlockState {
+  Jitter = 2,      // screen jitter (firing mounted MG42)
+  Mounted = 3,     // lock to direction of mounted gun
+  Medic = 7,       // look at nearest medic
 };
 } // namespace ETJump
 

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -912,7 +912,8 @@ void WolfFindMedic(gentity_t *self) {
 
   if (medic >= 0) {
     self->client->ps.viewlocked_entNum = medic;
-    self->client->ps.viewlocked = 7;
+    self->client->ps.viewlocked =
+        static_cast<int>(ETJump::ViewlockState::Medic);
   }
 }
 

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -41,8 +41,6 @@
 
 static constexpr int BODY_TIME = 10000;
 
-#define MAX_MG42_HEAT 1500.f
-
 // gentity->flags
 #define FL_GODMODE 0x00000010
 #define FL_NOTARGET 0x00000020

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -1784,7 +1784,8 @@ void aagun_think(gentity_t *self) {
     if (VectorLengthSquared(vec) < SQR(96) && owner->active &&
         owner->health > 0) {
       self->active = qtrue;
-      owner->client->ps.persistant[PERS_HWEAPON_USE] = 2;
+      owner->client->ps.persistant[PERS_HWEAPON_USE] =
+          static_cast<int>(ETJump::HeavyWeaponState::AAGun);
       aagun_track(self, owner);
       self->nextthink = level.time + 50;
       self->timestamp = level.time + 1000;
@@ -1795,7 +1796,8 @@ void aagun_think(gentity_t *self) {
 
       // now tell the client to lock the view in the
       // direction of the gun
-      owner->client->ps.viewlocked = 3;
+      owner->client->ps.viewlocked =
+          static_cast<int>(ETJump::ViewlockState::Mounted);
       owner->client->ps.viewlocked_entNum = self->s.number;
 
       clamp_playerbehindgun(self, owner, dang);
@@ -1951,7 +1953,8 @@ void mg42_touch(gentity_t *self, gentity_t *other, trace_t *trace) {
 
     // now tell the client to lock the view in the direction of
     // the gun
-    other->client->ps.viewlocked = 3;
+    other->client->ps.viewlocked =
+        static_cast<int>(ETJump::ViewlockState::Mounted);
     other->client->ps.viewlocked_entNum = self->s.number;
 
     // if (self->s.frame)
@@ -2054,7 +2057,7 @@ void mg42_think(gentity_t *self) {
       if (owner->client) {
         self->flameQuotaTime = level.time + owner->client->ps.weaponTime;
       } else {
-        self->flameQuotaTime = level.time + 2000;
+        self->flameQuotaTime = level.time + MG42_HEAT_RECOVERY;
       }
     }
   } else if (self->flameQuotaTime < level.time &&
@@ -2074,7 +2077,8 @@ void mg42_think(gentity_t *self) {
       owner->client->ps.pm_flags &= ~PMF_DUCKED;
 
       self->active = qtrue;
-      owner->client->ps.persistant[PERS_HWEAPON_USE] = 1;
+      owner->client->ps.persistant[PERS_HWEAPON_USE] =
+          static_cast<int>(ETJump::HeavyWeaponState::MountedMG);
       mg42_track(self, owner);
       self->nextthink = level.time + 50;
       self->timestamp = level.time + 1000;


### PR DESCRIPTION
* Fix mounted MG42s excessively firing overheat events if player exited and re-entered the gun
* Refactor mounted weapon handling completely
* Mounted gun cooldown is now handled in `PM_CoolWeapons` along with other weapons
* Fix `+attack2` not working on mounted MG42s (for consistency since it fires other weapons normally)

refs #1229, #894 