### PR TITLE
Ignore build* in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,7 +156,7 @@ Desktop.ini
 *.egg
 *.egg-info
 dist
-build
+build*
 eggs
 parts
 bin
@@ -192,4 +192,3 @@ scons.signatures.dblite
 out
 cmake-build*/
 checks.json
-build-linux-x64/


### PR DESCRIPTION
Since Visual Studio solutions must be generated per architecture, this allows you to use directories such as `build`, `build-x86` and `build-x64` to have solutions for both architectures.