### PR TITLE
Fix syscall vararg expansion on 64-bit

### DIFF
--- a/src/cgame/cg_syscalls.cpp
+++ b/src/cgame/cg_syscalls.cpp
@@ -10,10 +10,12 @@ static intptr_t(QDECL *syscall)(intptr_t arg,
     #pragma export on
   #endif
 #endif
+
 extern "C" FN_PUBLIC void dllEntry(intptr_t(QDECL *syscallptr)(intptr_t arg,
                                                                ...)) {
   syscall = syscallptr;
 }
+
 #if defined(__MACOS__)
   #ifndef __GNUC__
     #pragma export off

--- a/src/cgame/cg_syscalls.cpp
+++ b/src/cgame/cg_syscalls.cpp
@@ -22,6 +22,13 @@ extern "C" FN_PUBLIC void dllEntry(intptr_t(QDECL *syscallptr)(intptr_t arg,
   #endif
 #endif
 
+template <typename T, typename... Types>
+static intptr_t ExpandSyscall(T syscallArg, Types... args) {
+  // we have to do C-style casting here to support all types
+  // of arguments passed onto syscalls
+  return syscall((intptr_t)syscallArg, (intptr_t)args...);
+}
+
 inline int PASSFLOAT(const float &f) noexcept {
   floatint_t fi;
   fi.f = f;

--- a/src/game/etj_syscalls.h
+++ b/src/game/etj_syscalls.h
@@ -24,8 +24,6 @@
 
 #pragma once
 
-#include "q_shared.h"
-
 #if defined(__linux__) || defined(__APPLE__)
   #define FN_PUBLIC __attribute__((visibility("default")))
 #elif defined(_WIN32)
@@ -37,10 +35,3 @@
 
 static constexpr intptr_t VM_CALL_END = -1337;
 #define SystemCall(...) ExpandSyscall(__VA_ARGS__, VM_CALL_END)
-
-template <typename T, typename... Types>
-static intptr_t ExpandSyscall(T syscallArg, Types... args) {
-  // we have to do C-style casting here to support all types
-  // of arguments passed onto syscalls
-  return syscall((intptr_t)syscallArg, (intptr_t)args...);
-}

--- a/src/game/etj_syscalls.h
+++ b/src/game/etj_syscalls.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include "q_shared.h"
+
 #if defined(__linux__) || defined(__APPLE__)
   #define FN_PUBLIC __attribute__((visibility("default")))
 #elif defined(_WIN32)
@@ -32,3 +34,13 @@
 #else
   #error "Unsupported compiler"
 #endif
+
+static constexpr intptr_t VM_CALL_END = -1337;
+#define SystemCall(...) ExpandSyscall(__VA_ARGS__, VM_CALL_END)
+
+template <typename T, typename... Types>
+static intptr_t ExpandSyscall(T syscallArg, Types... args) {
+  // we have to do C-style casting here to support all types
+  // of arguments passed onto syscalls
+  return syscall((intptr_t)syscallArg, (intptr_t)args...);
+}

--- a/src/game/g_syscalls.cpp
+++ b/src/game/g_syscalls.cpp
@@ -25,6 +25,13 @@ extern "C" FN_PUBLIC void dllEntry(intptr_t(QDECL *syscallptr)(intptr_t arg,
   #endif
 #endif
 
+template <typename T, typename... Types>
+static intptr_t ExpandSyscall(T syscallArg, Types... args) {
+  // we have to do C-style casting here to support all types
+  // of arguments passed onto syscalls
+  return syscall((intptr_t)syscallArg, (intptr_t)args...);
+}
+
 inline int PASSFLOAT(const float &f) noexcept {
   floatint_t fi;
   fi.f = f;

--- a/src/game/g_syscalls.cpp
+++ b/src/game/g_syscalls.cpp
@@ -13,10 +13,12 @@ static intptr_t(QDECL *syscall)(intptr_t arg,
     #pragma export on
   #endif
 #endif
+
 extern "C" FN_PUBLIC void dllEntry(intptr_t(QDECL *syscallptr)(intptr_t arg,
                                                                ...)) {
   syscall = syscallptr;
 }
+
 #if defined(__MACOS__)
   #ifndef __GNUC__
     #pragma export off

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -106,10 +106,11 @@
   #include <float.h>
   #include <cstdlib>
   #include <string>
+  #include <cstdint>
 
 #endif
 
-#include "etj_public.h"
+#include "etj_syscalls.h"
 
 #ifdef _WIN32
 
@@ -1915,14 +1916,5 @@ typedef enum {
 
 constexpr int MAX_TIMERUN_CHECKPOINTS = 16;
 constexpr int TIMERUN_CHECKPOINT_NOT_SET = -1;
-
-/**
- * @def VM_CALL_END
- *
- * @brief This should be something like INT_MAX but that would need limits.h
- * everywhere so meh and negative values should be somewhat safe
- */
-#define VM_CALL_END -1337
-#define SystemCall(...) syscall(__VA_ARGS__, VM_CALL_END)
 
 #endif // __Q_SHARED_H

--- a/src/ui/ui_syscalls.cpp
+++ b/src/ui/ui_syscalls.cpp
@@ -23,6 +23,13 @@ extern "C" FN_PUBLIC void dllEntry(intptr_t(QDECL *syscallptr)(intptr_t arg,
   #endif
 #endif
 
+template <typename T, typename... Types>
+static intptr_t ExpandSyscall(T syscallArg, Types... args) {
+  // we have to do C-style casting here to support all types
+  // of arguments passed onto syscalls
+  return syscall((intptr_t)syscallArg, (intptr_t)args...);
+}
+
 inline int PASSFLOAT(const float &f) noexcept {
   floatint_t fi;
   fi.f = f;

--- a/src/ui/ui_syscalls.cpp
+++ b/src/ui/ui_syscalls.cpp
@@ -1,4 +1,3 @@
-#include <cstdint>
 #include "ui_local.h"
 
 // this file is only included when building a dll
@@ -12,10 +11,12 @@ static intptr_t(QDECL *syscall)(intptr_t arg,
     #pragma export on
   #endif
 #endif
+
 extern "C" FN_PUBLIC void dllEntry(intptr_t(QDECL *syscallptr)(intptr_t arg,
                                                                ...)) {
   syscall = syscallptr;
 }
+
 #if defined(__MACOS__)
   #ifndef __GNUC__
     #pragma export off


### PR DESCRIPTION
Cast all arguments passed into syscalls to `intptr_t` to ensure correct behavior on both x86 and x64.