### PR TITLE
Clear solid flag in G_InitGentity

### DIFF
--- a/src/game/g_utils.cpp
+++ b/src/game/g_utils.cpp
@@ -468,12 +468,13 @@ void G_SetMovedir(vec3_t angles, vec3_t movedir) {
 void G_InitGentity(gentity_t *e) {
   e->inuse = qtrue;
   e->classname = "noclass";
-  e->s.number = e - g_entities;
+  e->s.number = ClientNum(e);
   e->r.ownerNum = ENTITYNUM_NONE;
   e->aiInactive = 0xffffffff;
   e->nextthink = 0;
   memset(e->goalPriority, 0, sizeof(e->goalPriority));
-  e->free = NULL;
+  e->free = nullptr;
+  e->s.solid = 0;
 
   // RF, init scripting
   e->scriptStatus.scriptEventIndex = -1;


### PR DESCRIPTION
`gentity_t` struct isn't wiped entirely for clients when they disconnect, and if a client reuses a slot which was previously on a client who was in a solid state, a client reusing that slot would become effectively solid while in spec initially, since spectators are never linked and their `r.currentOrigin` is never updated from the spectator spawnpoint. This causes other clients to think they are stuck inside a client on a spectator spawnpoint. Fortunately this doesn't really cause any harm in etjump with mostly nonsolid players.