### PR TITLE
Tweak GCC/Clang debug flags

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -33,7 +33,7 @@ function(create_compiler_opts target)
 			-O3					# max optimization
 			-ffast-math>		# fast floating point math
 		$<$<CONFIG:Debug>:
-			-Og					# supress optimizations
+			-O0					# suppress optimizations
 			-g3					# generate debug info
 			-ggdb3>)			# generate gdb friendly debug info
 
@@ -57,7 +57,7 @@ function(create_compiler_opts target)
 			-flto				# link time optimizations
 			-ffast-math>		# fast floating point math
 		$<$<CONFIG:Debug>:
-			-Og					# supress optimizations
+			-O0					# suppress optimizations
 			-g3					# generate debug info
 			-ggdb3>)			# generate gdb friendly debug info
 


### PR DESCRIPTION
`-Og` does certain optimizations which makes debugging harder in some scenarios, it's often too aggressive in optimization which makes things like breaking on return statements impossible, as well as optimizing values out while stepping through a function.
