### PR TITLE
Flamethrower fps dependency fixes

### DIFF
--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -80,34 +80,13 @@
 
 #define MAX_ITEMS 256
 
-#define RANK_TIED_FLAG 0x4000
-
-// #define DEFAULT_SHOTGUN_SPREAD	700
-// #define DEFAULT_SHOTGUN_COUNT	11
-
 // #define	ITEM_RADIUS			15		// item sizes
 //  are needed for client side pickup detection
 #define ITEM_RADIUS                                                            \
   10 // Rafael changed the radius so that the items would fit in the 3
      // new containers
 
-// RF, zombie getup
-// #define	TIMER_RESPAWN	(38*(1000/15)+100)
-
-// #define	LIGHTNING_RANGE		600
-// #define	TESLA_RANGE			800
-
-#define FLAMETHROWER_RANGE                                                     \
-  2500 // DHM - Nerve :: multiplayer range, was 850 in SP
-
-// #define ZOMBIE_FLAME_RADIUS 300
-
-// RF, AI effects
-// #define	PORTAL_ZOMBIE_SPAWNTIME		3000
-// #define	PORTAL_FEMZOMBIE_SPAWNTIME	3000
-
-#define SCORE_NOT_PRESENT                                                      \
-  -9999 // for the CS_SCORES[12] when only one player is present
+static constexpr int FLAMETHROWER_RANGE = 2500;
 
 #define VOTE_TIME 30000 // 30 seconds before vote times out
 

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -461,8 +461,7 @@ struct gentity_s {
   int lastHintCheckTime;     // DHM - Nerve
   int voiceChatSquelch;      // DHM - Nerve
   int voiceChatPreviousTime; // DHM - Nerve
-  int lastBurnedFrameNumber; // JPW - Nerve   : to fix FT instant-kill
-                             // exploit
+  int lastBurnedFrametime;   // last server timestamp where burn damage occurred
 
   entState_t entstate;
   char *constages;
@@ -1751,7 +1750,7 @@ void AddIPBan(const char *str);
 // g_weapon.c
 //
 void FireWeapon(gentity_t *ent);
-void G_BurnMeGood(gentity_t *self, gentity_t *body);
+void G_BurnMeGood(gentity_t *self, gentity_t *body, bool directhit);
 
 //
 // IsSilencedWeapon


### PR DESCRIPTION
* Normalize dps to `sv_fps 20`
* Fix chunks growing too fast on high `sv_fps`
* Cleanup flamethrower constants

This isn't really all that important for us since flamer can only do self-damage or other entity damage, but this makes those consistent on high `sv_fps` values.

refs #894 