### PR TITLE
Fix diagonal pack throws

### DIFF
--- a/src/game/bg_misc.cpp
+++ b/src/game/bg_misc.cpp
@@ -2853,20 +2853,12 @@ Items can be picked up without actually touching their physical bounds to make
 grabbing them easier
 ============
 */
-qboolean BG_PlayerTouchesItem(playerState_t *ps, entityState_t *item,
-                              int atTime) {
+bool BG_PlayerTouchesItem(playerState_t *ps, entityState_t *item, int atTime) {
   vec3_t origin;
 
   BG_EvaluateTrajectory(&item->pos, atTime, origin, qfalse, item->effect2Time);
 
-  // we are ignoring ducked differences here
-  if (ps->origin[0] - origin[0] > 36 || ps->origin[0] - origin[0] < -36 ||
-      ps->origin[1] - origin[1] > 36 || ps->origin[1] - origin[1] < -36 ||
-      ps->origin[2] - origin[2] > 36 || ps->origin[2] - origin[2] < -36) {
-    return qfalse;
-  }
-
-  return qtrue;
+  return (VectorDistance(ps->origin, origin) < (playerMaxs[0] - playerMins[0]));
 }
 
 /*

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -1777,8 +1777,7 @@ gitem_t *BG_ValidStatWeapon(weapon_t weap);
 weapon_t BG_WeaponForMOD(int MOD);
 
 qboolean BG_WeaponInWolfMP(int weapon);
-qboolean BG_PlayerTouchesItem(playerState_t *ps, entityState_t *item,
-                              int atTime);
+bool BG_PlayerTouchesItem(playerState_t *ps, entityState_t *item, int atTime);
 int BG_GrenadesForClass(int cls, int *skills);
 weapon_t BG_GrenadeTypeForTeam(team_t team);
 

--- a/src/game/q_math.cpp
+++ b/src/game/q_math.cpp
@@ -613,7 +613,6 @@ float AngleNormalize180(float angle) {
   return angle;
 }
 
-
 /*
 =================
 AngleNormalize90
@@ -625,8 +624,7 @@ float AngleNormalize90(float angle) {
   angle = AngleNormalize180(angle);
   if (angle >= 90.0) {
     angle -= 180.0;
-  }
-  else if (angle < 0) {
+  } else if (angle < 0) {
     angle = 90 + angle;
   }
   return angle;
@@ -1549,14 +1547,14 @@ void AxisToAngles(vec3_t axis[3], vec3_t angles) {
   angles[ROLL] = -roll_angles[PITCH];
 }
 
-float VectorDistance(vec3_t v1, vec3_t v2) {
+float VectorDistance(const vec3_t v1, const vec3_t v2) {
   vec3_t dir;
 
   VectorSubtract(v2, v1, dir);
   return VectorLength(dir);
 }
 
-float VectorDistanceSquared(vec3_t v1, vec3_t v2) {
+float VectorDistanceSquared(const vec3_t v1, const vec3_t v2) {
   vec3_t dir;
 
   VectorSubtract(v2, v1, dir);

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -678,8 +678,8 @@ void AnglesToAxis(const vec3_t angles, vec3_t axis[3]);
 // TTimo: const vec_t ** would require explicit casts for ANSI C conformance
 // see unix/const-arg.c
 void AxisToAngles(/*const*/ vec3_t axis[3], vec3_t angles);
-float VectorDistance(vec3_t v1, vec3_t v2);
-float VectorDistanceSquared(vec3_t v1, vec3_t v2);
+float VectorDistance(const vec3_t v1, const vec3_t v2);
+float VectorDistanceSquared(const vec3_t v1, const vec3_t v2);
 
 void AxisClear(vec3_t axis[3]);
 void AxisCopy(vec3_t in[3], vec3_t out[3]);


### PR DESCRIPTION
Avoid picking up health/ammo packs instantly when thrown at specific angles.