### PR TITLE
Cleanup & fix ETL client detection

### DIFF
--- a/assets/ui/main.menu
+++ b/assets/ui/main.menu
@@ -142,7 +142,7 @@ menuDef {
 	WINDOW( "MAIN", 50 )
 	
 // Buttons //
-#ifdef LEGACY
+#ifdef ETLEGACY
 	BUTTON( 6, 32, WINDOW_WIDTH-12, 18, "PLAY ONLINE", .3, 14, close main ; /*close backgroundmusic ; open backgroundmusic_server ;*/ uiScript UpdateFilter ; uiScript ServerSortDown 4 ; open playonline )
 #else
 	BUTTON( 6, 32, WINDOW_WIDTH-12, 18, "PLAY ONLINE", .3, 14, close main ; open playonline )

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -28,14 +28,10 @@
 
 // #define LOCALIZATION_SUPPORT
 
-#define NEW_ANIMS
-#define MAX_TEAMNAME 32
-
-#define MOD_VERSION_DATA_CHECK(x) (x && x >= 272 && x < 3000)
-#define MOD_CHECK_LEGACY(islegacy, versionNum, outputValue)                    \
-  outputValue = (islegacy == qtrue ? qtrue : qfalse);                          \
-  if (outputValue && MOD_VERSION_DATA_CHECK(versionNum)) {                     \
-    outputValue = versionNum;                                                  \
+#define MOD_CHECK_ETLEGACY(isETLegacy, versionNum, outputValue)                \
+  outputValue = ((isETLegacy) ? true : false);                                 \
+  if (outputValue) {                                                           \
+    (outputValue) = versionNum;                                                \
   }
 
 #if defined _WIN32 && !defined __GNUC__

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -782,7 +782,7 @@ typedef struct {
 enum class FileSystemObjectType { Item, Folder };
 
 struct FileSystemObjectInfo {
-  FileSystemObjectInfo() : type(FileSystemObjectType::Item), name(""){};
+  FileSystemObjectInfo() : type(FileSystemObjectType::Item), name("") {};
   FileSystemObjectType type;
   std::string name;
   std::string displayName;
@@ -899,7 +899,7 @@ typedef struct {
   fontInfo_t loadscreenfont1;
   fontInfo_t loadscreenfont2;
 
-  int legacyClient;
+  int etLegacyClient;
 } uiInfo_t;
 
 extern uiInfo_t uiInfo;

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -1242,8 +1242,8 @@ void UI_LoadMenus(const char *menuFile, qboolean reset) {
     trap_PC_AddGlobalDefine("FUI");
   }
 
-  if (uiInfo.legacyClient) {
-    trap_PC_AddGlobalDefine("LEGACY");
+  if (uiInfo.etLegacyClient) {
+    trap_PC_AddGlobalDefine("ETLEGACY");
   }
 
   handle = trap_PC_LoadSource(menuFile);
@@ -6781,7 +6781,7 @@ void _UI_Init(int legacyClient, int clientVersion) {
     uiInfo.uiDC.bias = 0;
   }
 
-  MOD_CHECK_LEGACY(legacyClient, clientVersion, uiInfo.legacyClient);
+  MOD_CHECK_ETLEGACY(legacyClient, clientVersion, uiInfo.etLegacyClient);
 
   // UI_Load();
   uiInfo.uiDC.registerShaderNoMip = &trap_R_RegisterShaderNoMip;


### PR DESCRIPTION
There was an old versioning check which wasn't compatible anymore with the way ETL sends it's version string, which broke the actual detectable version for the client.

refs #294 