### PR TITLE
Fix permanent ban not working if seconds or reason was given

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -616,7 +616,9 @@ bool Ban(gentity_t *ent, Arguments argv) {
       return false;
     }
 
-    expires = static_cast<unsigned>(t) + expires;
+    if (expires != 0) {
+      expires = static_cast<unsigned>(t) + expires;
+    }
   }
 
   if (argv->size() >= 4) {


### PR DESCRIPTION
Don't force expiration to be current date + seconds if the seconds is 0 (aka permanent ban).