### PR TITLE
Fix potential OOB read in menu->onKey

### DIFF
--- a/src/ui/keycodes.h
+++ b/src/ui/keycodes.h
@@ -129,8 +129,10 @@ typedef enum {
   K_AUX15,
   K_AUX16,
 
-  K_LAST_KEY // this had better be <256!
+  K_LAST_KEY = 256,
 } keyNum_t;
+
+static constexpr int K_MAX_KEYS = K_LAST_KEY;
 
 // The menu code needs to get both key and char events, but
 // to avoid duplicating the paths, the char events are just

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -4067,7 +4067,7 @@ void Menu_HandleKey(menuDef_t *menu, int key, qboolean down) {
   if (!menu->itemHotkeyMode) {
     // END - TAT 9/16/2002
 
-    if (key > 0 && key <= 255 && menu->onKey[key]) {
+    if (key > 0 && key < K_MAX_KEYS && menu->onKey[key]) {
       itemDef_t it;
       it.parent = menu;
       Item_RunScript(&it, nullptr, menu->onKey[key]);
@@ -4075,7 +4075,7 @@ void Menu_HandleKey(menuDef_t *menu, int key, qboolean down) {
     }
 
     // START - TAT 9/16/2002
-  } else if (key > 0 && key <= 255) {
+  } else if (key > 0 && key < K_MAX_KEYS) {
     itemDef_t *it;
 
     // we're using the item hotkey mode, so we want to loop

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -357,8 +357,9 @@ typedef struct {
   int openTime;          // ydnar: time menu opened
   const char *onTimeout; // ydnar: run when menu times out
 
-  const char *onKey[255]; // NERVE - SMF - execs commands when a key is pressed
-  const char *soundName;  // background loop sound for menu
+  // NERVE - SMF - execs commands when a key is pressed
+  const char *onKey[K_MAX_KEYS];
+  const char *soundName; // background loop sound for menu
 
   vec4_t focusColor;               // focus color for items
   vec4_t disableColor;             // focus color for items


### PR DESCRIPTION
Set an actual cap for keycodes and use that as the array size for `onKey` array.