### PR TITLE
Parse custom string values in menu properly

### DIFF
--- a/src/game/etj_string_utilities.cpp
+++ b/src/game/etj_string_utilities.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <iomanip>
 
 #include "etj_string_utilities.h"
 
@@ -317,6 +318,26 @@ bool ETJump::StringUtil::iEqual(const std::string &str1,
 
 unsigned ETJump::StringUtil::countExtraPadding(const std::string &input) {
   return input.length() - sanitize(input).length();
+}
+
+std::string
+ETJump::StringUtil::normalizeNumberString(const std::string &input) {
+  double number = std::stod(input);
+
+  std::ostringstream oss;
+  oss << std::setprecision(10) << std::fixed << number;
+  std::string result = oss.str();
+
+  if (result.find('.') != std::string::npos) {
+    removeTrailingChars(result, '0');
+
+    // remove trailing dot if the result is just an integer
+    if (result.back() == '.') {
+      result.pop_back();
+    }
+  }
+
+  return result;
 }
 
 void ETJump::StringUtil::removeTrailingChars(std::string &str,

--- a/src/game/etj_string_utilities.h
+++ b/src/game/etj_string_utilities.h
@@ -108,6 +108,11 @@ bool iEqual(const std::string &str1, const std::string &str2,
 // %-20s with text that contains ET color codes
 unsigned countExtraPadding(const std::string &input);
 
+// removes any leading and trailing zeroes from a number
+// always returns at least 0 even if there are no significant numbers
+// e.g. 0000.0000 -> 0
+std::string normalizeNumberString(const std::string &input);
+
 void removeTrailingChars(std::string &str, char charToRemove);
 void removeLeadingChars(std::string &str, char charToRemove);
 

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -2940,7 +2940,7 @@ const char *Item_Multi_Setting(itemDef_t *item) {
       // at this point, we might still have nonsense strings such as
       // 'aaa.00.0000aaa.555' or some other stupid stuff, so ensure the
       // all the strings are actually proper ints or floats
-      for (auto &split : splits) {
+      for (const auto &split : splits) {
         if (split.find_first_not_of(".0123456789") != std::string::npos) {
           return va("Custom (%s)", buff);
         }

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -2929,15 +2929,32 @@ const char *Item_Multi_Setting(itemDef_t *item) {
     }
 
     if (multiPtr->strDef) {
-      return va("Custom (%s)", buff);
+      // if a string is empty or a hex color, return as-is
+      if (buff[0] == '\0' || ETJump::StringUtil::startsWith(buff, "#") ||
+          ETJump::StringUtil::startsWith(buff, "0x")) {
+        return va("Custom (%s)", buff);
+      }
+
+      std::vector<std::string> splits = ETJump::StringUtil::split(buff, " ");
+
+      // at this point, we might still have nonsense strings such as
+      // 'aaa.00.0000aaa.555' or some other stupid stuff, so ensure the
+      // all the strings are actually proper ints or floats
+      for (auto &split : splits) {
+        if (split.find_first_not_of(".0123456789") != std::string::npos) {
+          return va("Custom (%s)", buff);
+        }
+      }
+
+      for (auto &split : splits) {
+        split = ETJump::StringUtil::normalizeNumberString(split);
+      }
+
+      const std::string &val = ETJump::StringUtil::join(splits, " ");
+      return va("Custom (%s)", val.c_str());
     } else {
       std::string val = std::to_string(DC->getCVarValue(item->cvar));
-      ETJump::StringUtil::removeTrailingChars(val, '0');
-
-      // also strip trailing . if the value is just an integer
-      if (val.back() == '.') {
-        val.pop_back();
-      }
+      val = ETJump::StringUtil::normalizeNumberString(val);
 
       return va("Custom (%s)", val.c_str());
     }


### PR DESCRIPTION
Previously only `cvarFloatList` was parsed, strings are also now parsed for stuff like color cvars

refs #1416 