### PR TITLE
Fix 2.60b client getting detected as ETL

### DIFF
--- a/assets/ui/etjump_settings_general_client.menu
+++ b/assets/ui/etjump_settings_general_client.menu
@@ -46,9 +46,15 @@ menuDef {
 
         MULTI               (SETTINGS_ITEM_POS(1), "Max FPS:", 0.2, SETTINGS_ITEM_H, "com_maxfps", cvarFloatList { "43" 43 "76" 76 "125" 125 "250" 250 "333" 333 }, "Sets the FPS limit\ncom_maxfps")
         MULTI               (SETTINGS_ITEM_POS(2), "Memory limit:", 0.2, SETTINGS_ITEM_H, "com_hunkmegs", cvarFloatList { "56MB" 56 "64MB" 64 "128MB" 128 "256MB" 256 "512MB" 512 }, "How much memory the client is allowed to use (restart required)\ncom_hunkmegs")
+
+#ifdef VET
         MULTI               (SETTINGS_ITEM_POS(3), "Rendering primitives:", 0.2, SETTINGS_ITEM_H, "r_primitives", cvarFloatList { "Auto" 0 "Multiple glArrayElement" 1 "Single glDrawElements" 2 }, "Sets rendering primitives mode (ET 2.60b only)\nSetting this to 'Single glDrawElements' is recommended on modern systems for best performance\nr_primitives")
         CVARFLOATLABEL      (SETTINGS_ITEM_POS(4), "etj_menuSensitivity", 0.2, ITEM_ALIGN_RIGHT, SLIDER_LABEL_X, SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(4), "Menu sensitivity:", 0.2, SETTINGS_ITEM_H, etj_menuSensitivity 1.0 0.05 4.0 0.05, "Sets mouse sensitivity for menus\netj_menuSensitivity")
+#else
+        CVARFLOATLABEL      (SETTINGS_ITEM_POS(3), "etj_menuSensitivity", 0.2, ITEM_ALIGN_RIGHT, SLIDER_LABEL_X, SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(3), "Menu sensitivity:", 0.2, SETTINGS_ITEM_H, etj_menuSensitivity 1.0 0.05 4.0 0.05, "Sets mouse sensitivity for menus\netj_menuSensitivity")
+#endif
 
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -901,6 +901,7 @@ typedef struct {
 
   int etLegacyClient;
   bool eteClient;
+  bool vetClient; // original 2.60b, steam 2.60b or 2.60d
 } uiInfo_t;
 
 extern uiInfo_t uiInfo;

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -6719,7 +6719,7 @@ namespace ETJump {
  * string, along with the regular 'version' string. So this means, we can
  * identify the client by doing the following:
  *
- * 1. read both 'version' and 'etVersion' strings
+ * 1. parse 'etVersion' string
  * 2. if 'etVersion string is empty, we can parse the 'version' string safely
  * to differentiate between vanilla client and ETe
  * 3. if 'etVersion' string is not empty, we can parse arg1/2 to grab
@@ -6727,13 +6727,14 @@ namespace ETJump {
  */
 
 static void detectClientEngine(int legacyClient, int clientVersion) {
-  char versionStr[MAX_CVAR_VALUE_STRING];
   char etVersionStr[MAX_CVAR_VALUE_STRING]; // ET: Legacy exclusive
-  trap_Cvar_VariableStringBuffer("version", versionStr, sizeof(versionStr));
   trap_Cvar_VariableStringBuffer("etVersion", etVersionStr,
                                  sizeof(etVersionStr));
 
-  if (versionStr[0] && etVersionStr[0] == '\0') {
+  if (etVersionStr[0] == '\0') {
+    char versionStr[MAX_CVAR_VALUE_STRING];
+    trap_Cvar_VariableStringBuffer("version", versionStr, sizeof(versionStr));
+
     // we can use this length for every detection
     const auto len = static_cast<int>(strlen("ET 2.60b"));
 


### PR DESCRIPTION
Due to 2.60b reading garbage memory for varargs, it was getting detected as ET: Legacy client.

Also hide r_primitives for non-vanilla clients.

refs #1413 