### PR TITLE
Fix prediction on func_fakebrush with CONTENTS_PLAYERCLIP

### DIFF
--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -159,8 +159,12 @@ static void CG_ClipMoveToEntities(const vec3_t start, const vec3_t mins,
       BG_EvaluateTrajectory(&cent->currentState.pos, cg.physicsTime, origin,
                             qfalse, cent->currentState.effect2Time);
     } else {
-      // see g_misc.c SP_func_fakebrush...
-      if (ent->eType == ET_FAKEBRUSH) {
+      // dmgFlags are set to r.contents if the fakebrush is playerclip,
+      // so only grab mins/maxs if we're doing a player trace (capsule),
+      // or if dmgFlags are not set (regular CONTENTS_SOLID), otherwise stuff
+      // like bullets and flame particles collide with playerclip fakebrushes
+      // on client side, visually
+      if (ent->eType == ET_FAKEBRUSH && (capsule || !ent->dmgFlags)) {
         VectorCopy(ent->origin2, bmins);
         VectorCopy(ent->angles2, bmaxs);
       } else {

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -3084,5 +3084,9 @@ void SP_func_fakebrush(gentity_t *ent) {
   // it won't have solid flag set and prediction is broken
   if (ent->r.contents & CONTENTS_PLAYERCLIP && !ent->s.solid) {
     ent->s.solid = 1;
+
+    // also pass along contents so we can filter this out for stuff
+    // such as bullet traces, to avoid bullet marks on playerclip fakebrushes
+    ent->s.dmgFlags = ent->r.contents;
   }
 }

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -3077,4 +3077,12 @@ void SP_func_fakebrush(gentity_t *ent) {
   ent->s.eType = ET_FAKEBRUSH;
 
   trap_LinkEntity(ent);
+
+  // SV_LinkEntity only sets the entity to solid if entity has a bmodel
+  // or r.contents is either CONTENTS_SOLID or CONTENTS_BODY,
+  // so if we try to make a playerclip fakebrush,
+  // it won't have solid flag set and prediction is broken
+  if (ent->r.contents & CONTENTS_PLAYERCLIP && !ent->s.solid) {
+    ent->s.solid = 1;
+  }
 }


### PR DESCRIPTION
Engine doesn't mark entities without a bmodel and `CONTENTS_PLAYERCLIP` as solid, so set the flag manually so that fakebrushes with `CONTENTS_PLAYERCLIP` are added to solid entity list and can be predicted on client.

fixes #1399 