### PR TITLE
Add option to draw snaphud with only borders

### DIFF
--- a/assets/ui/etjump_settings_hud2_snaphud.menu
+++ b/assets/ui/etjump_settings_hud2_snaphud.menu
@@ -50,7 +50,7 @@ menuDef {
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "SNAPHUD")
     
-        MULTI               (SETTINGS_ITEM_POS(1), "Draw snaphud:", 0.2, SETTINGS_ITEM_H, "etj_drawSnapHUD", cvarFloatList { "No" 0 "Full zones" 1 "Edges only" 2 }, "Draw velocity snapping HUD\netj_drawSnapHUD")
+        MULTI               (SETTINGS_ITEM_POS(1), "Draw snaphud:", 0.2, SETTINGS_ITEM_H, "etj_drawSnapHUD", cvarFloatList { "No" 0 "Full zones" 1 "Edges only" 2 "Borders only" 3 }, "Draw velocity snapping HUD\netj_drawSnapHUD")
         CVARINTLABEL        (SETTINGS_ITEM_POS(2), "etj_snapHUDOffsetY", 0.2, ITEM_ALIGN_RIGHT, SLIDER_LABEL_X, SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(2), "Snaphud offset Y:", 0.2, SETTINGS_ITEM_H, etj_snapHUDOffsetY 0 -240 240 5, "Sets Y offset of snaphud\netj_snapHUDOffsetY")
         CVARINTLABEL        (SETTINGS_ITEM_POS(3), "etj_snapHUDHeight", 0.2, ITEM_ALIGN_RIGHT, SLIDER_LABEL_X, SETTINGS_ITEM_H)

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -78,7 +78,7 @@ CG_FillAngleYaw
 ==============
 */
 void CG_FillAngleYaw(float start, float end, float yaw, float y, float h,
-                     float fov, vec4_t const color) {
+                     float fov, vec4_t const color, bool borderOnly) {
   // don't try to draw lines with no width
   if (start == end) {
     return;
@@ -87,10 +87,20 @@ void CG_FillAngleYaw(float start, float end, float yaw, float y, float h,
   const range_t range = AnglesToRange(start, end, yaw, fov);
 
   if (!range.split) {
-    CG_FillRect(range.x1, y, range.x2 - range.x1, h, color);
+    if (borderOnly) {
+      CG_DrawRect_FixedBorder(range.x1, y, range.x2 - range.x1, h, 1, color);
+    } else {
+      CG_FillRect(range.x1, y, range.x2 - range.x1, h, color);
+    }
   } else {
-    CG_FillRect(0, y, range.x1, h, color);
-    CG_FillRect(range.x2, y, SCREEN_WIDTH - range.x2, h, color);
+    if (borderOnly) {
+      CG_DrawRect_FixedBorder(0, y, range.x1, h, 1, color);
+      CG_DrawRect_FixedBorder(range.x2, y, SCREEN_WIDTH - range.x2, h, 1,
+                              color);
+    } else {
+      CG_FillRect(0, y, range.x1, h, color);
+      CG_FillRect(range.x2, y, SCREEN_WIDTH - range.x2, h, color);
+    }
   }
 }
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2836,7 +2836,7 @@ void CG_AdjustFrom640(float *x, float *y, float *w, float *h);
 void CG_FillRect(float x, float y, float width, float height,
                  const float *color);
 void CG_FillAngleYaw(float start, float end, float yaw, float y, float h,
-                     float fov, vec4_t const color);
+                     float fov, vec4_t const color, bool borderOnly = false);
 void DrawLine(float x1, float y1, float x2, float y2, const vec4_t color);
 void DrawLine(float x1, float y1, float x2, float y2, float w, float h,
               const vec4_t color);

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -288,8 +288,13 @@ bool Snaphud::beforeRender() {
     UpdateSnapState();
   }
 
-  edgesOnly = etj_drawSnapHUD.integer == 2;
-  edgeThickness = Numeric::clamp(etj_snapHUDEdgeThickness.integer, 1, 128);
+  hudType = static_cast<HudType>(etj_drawSnapHUD.integer);
+
+  if (hudType == HudType::SNAP_EDGE) {
+    edgeThickness = Numeric::clamp(etj_snapHUDEdgeThickness.integer, 1, 128);
+  } else {
+    borderOnly = (hudType == HudType::SNAP_BORDER);
+  }
 
   PrepareDrawables();
 
@@ -336,14 +341,14 @@ void Snaphud::render() const {
       color += 2;
     }
 
-    if (edgesOnly) {
+    if (hudType == HudType::SNAP_EDGE) {
       CG_FillAngleYaw(SHORT2RAD(ds.bSnap), SHORT2RAD(ds.bSnap + edgeThickness),
                       SHORT2RAD(yaw), y, h, fov, snaphudColors[color]);
       CG_FillAngleYaw(SHORT2RAD(ds.eSnap), SHORT2RAD(ds.eSnap - edgeThickness),
                       SHORT2RAD(yaw), y, h, fov, snaphudColors[color]);
     } else {
       CG_FillAngleYaw(SHORT2RAD(ds.bSnap), SHORT2RAD(ds.eSnap), SHORT2RAD(yaw),
-                      y, h, fov, snaphudColors[color]);
+                      y, h, fov, snaphudColors[color], borderOnly);
     }
   }
 }

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -46,7 +46,7 @@ public:
   static bool inMainAccelZone(const playerState_t &ps, pmove_t *pm);
 
   Snaphud();
-  ~Snaphud(){};
+  ~Snaphud() {};
 
 private:
   bool canSkipDraw() const;
@@ -57,6 +57,13 @@ private:
   void startListeners();
 
   enum class SnapTrueness { SNAP_JUMPCROUCH = 1, SNAP_GROUND = 2 };
+
+  enum class HudType {
+    SNAP_OFF = 0,
+    SNAP_NORMAL = 1,
+    SNAP_EDGE = 2,
+    SNAP_BORDER = 3,
+  };
 
   struct snaphud_t {
     float a = 0.0f;
@@ -73,8 +80,9 @@ private:
 
   int yaw{};
   vec4_t snaphudColors[4]{};
-  bool edgesOnly{};
   int edgeThickness{};
+  HudType hudType{};
+  bool borderOnly{};
   int lastUpdateTime{};
 
   playerState_t *ps = &cg.predictedPlayerState;


### PR DESCRIPTION
`etj_drawSnapHUD 3` = draw snapzones as non-filled rectangles.

![image](https://github.com/user-attachments/assets/80c5530e-74a3-4a55-93c9-6b2b3b9ac260)

fixes #1326 