### PR TITLE
Fix json write not being able to create directories

### DIFF
--- a/src/game/etj_file.cpp
+++ b/src/game/etj_file.cpp
@@ -23,15 +23,16 @@
  */
 
 #include "etj_file.h"
+
 #ifdef GAMEDLL
   #include "g_local.h"
+  #include "etj_string_utilities.h"
 #elif CGAMEDLL
   #include "../cgame/cg_local.h"
 #endif
-#include "etj_string_utilities.h"
 
-ETJump::File::File(const std::string &path, Mode mode)
-    : _path(path), _handle(INVALID_FILE_HANDLE), _mode(mode) {
+ETJump::File::File(std::string path, Mode mode)
+    : _path(std::move(path)), _handle(INVALID_FILE_HANDLE), _mode(mode) {
   fsMode_t fsMode;
   switch (_mode) {
     case Mode::Read:
@@ -77,11 +78,11 @@ std::vector<char> ETJump::File::read(int bytes) {
 }
 
 void ETJump::File::write(const std::string &data) const {
-  write(data.c_str(), data.length());
+  write(data.c_str(), static_cast<int>(data.length()));
 }
 
 void ETJump::File::write(const std::vector<char> &data) const {
-  write(data.data(), data.size());
+  write(data.data(), static_cast<int>(data.size()));
 }
 
 void ETJump::File::write(const char *data, int len) const {
@@ -99,41 +100,4 @@ void ETJump::File::write(const char *data, int len) const {
 #else
   trap_FS_Write(data, len, _handle);
 #endif
-}
-
-std::vector<std::string> ETJump::File::fileList(const std::string &path,
-                                                const std::string &extension) {
-  std::vector<std::string> files;
-  auto buffer = std::unique_ptr<char[]>(new char[1 << 16]);
-  auto numDirs = trap_FS_GetFileList(path.c_str(), extension.c_str(),
-                                     buffer.get(), sizeof(buffer));
-  auto dirPtr = buffer.get();
-  auto dirLen = 0;
-
-  for (auto i = 0; i < numDirs; i++, dirPtr += dirLen + 1) {
-    dirLen = strlen(dirPtr);
-    if (strlen(dirPtr) > 4) {
-      dirPtr[strlen(dirPtr) - 4] = 0;
-    }
-
-    char file[MAX_QPATH] = "";
-    Q_strncpyz(file, dirPtr, sizeof(file));
-    files.push_back(file);
-  }
-  return files;
-}
-
-std::string ETJump::File::getPath(const std::string file) {
-  char game[MAX_CVAR_VALUE_STRING] = "";
-  char base[MAX_CVAR_VALUE_STRING] = "";
-  trap_Cvar_VariableStringBuffer("fs_game", game, sizeof(game));
-  trap_Cvar_VariableStringBuffer("fs_homepath", base, sizeof(base));
-
-  auto path = ETJump::stringFormat("%s/%s/%s", base, game, file);
-  for (auto &c : path) {
-    if (c == '/' || c == '\\') {
-      c = PATH_SEP;
-    }
-  }
-  return path;
 }

--- a/src/game/etj_file.h
+++ b/src/game/etj_file.h
@@ -24,17 +24,11 @@
 
 #pragma once
 
-#ifdef min
-  #undef min
-#endif
-#ifdef max
-  #undef max
-#endif
-
 #include <string>
 #include <vector>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 namespace ETJump {
 class File {
@@ -61,7 +55,7 @@ public:
   // throws FileNotFoundException if the mode is read and there's no
   // such file.
   // Write will create the file in that case
-  explicit File(const std::string &path, Mode mode = Mode::Read);
+  explicit File(std::string path, Mode mode = Mode::Read);
   ~File();
 
   // reads `bytes` bytes from the file.
@@ -75,13 +69,6 @@ public:
   void write(const std::string &data) const;
   void write(const std::vector<char> &data) const;
   void write(const char *data, int len) const;
-
-  // lists files in a dir with extension
-  static std::vector<std::string> fileList(const std::string &path,
-                                           const std::string &extension);
-
-  // builds the quake file system path from the file name
-  static std::string getPath(const std::string file);
 
 private:
   std::string _path;

--- a/src/game/etj_json_utilities.cpp
+++ b/src/game/etj_json_utilities.cpp
@@ -25,6 +25,7 @@
 #include <fstream>
 #include "etj_json_utilities.h"
 #include "etj_filesystem.h"
+#include "etj_file.h"
 
 namespace ETJump {
 Log JsonUtils::logger = Log("JSON-utils");
@@ -32,15 +33,21 @@ Log JsonUtils::logger = Log("JSON-utils");
 bool JsonUtils::writeFile(const std::string &file, const Json::Value &root) {
   Json::StyledWriter writer;
   const std::string &output = writer.write(root);
-  std::ofstream fOut(FileSystem::Path::getPath(file));
 
-  if (!fOut) {
-    fOut.close();
+  if (file.empty()) {
+    logger.error("Failed to write JSON file: empty filename\n");
     return false;
   }
 
-  fOut << output;
-  fOut.close();
+  File fOut(file, File::Mode::Write);
+
+  try {
+    fOut.write(output);
+  } catch (const File::WriteFailedException &e) {
+    logger.error("Failed to write JSON file: %s\n", e.what());
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
`std::ofstream` is unable to create a directory, so if `JsonUtils::writeFile` was called with `foo/bar.json`, the writing would fail if the directory `foo` was not already present in the filesystem.

Also clean up `etj_file.cpp/h` a bit.