### PR TITLE
Make etj_file/filesystem module agnostic + refactor demo loading

### DIFF
--- a/src/game/etj_file.cpp
+++ b/src/game/etj_file.cpp
@@ -27,7 +27,10 @@
   #include "g_local.h"
 #elif CGAMEDLL
   #include "../cgame/cg_local.h"
+#elif UIDLL
+  #include "../ui/ui_local.h"
 #endif
+
 #include "etj_string_utilities.h"
 
 ETJump::File::File(const std::string &path, Mode mode)

--- a/src/game/etj_filesystem.cpp
+++ b/src/game/etj_filesystem.cpp
@@ -28,10 +28,13 @@
 #include "../game/etj_file.h"
 #include "../game/etj_string_utilities.h"
 #include "../game/etj_filesystem.h"
+
 #ifdef GAMEDLL
   #include "g_local.h"
 #elif CGAMEDLL
   #include "../cgame/cg_local.h"
+#elif UIDLL
+  #include "../ui/ui_local.h"
 #endif
 
 namespace ETJump {
@@ -49,13 +52,13 @@ void FileSystem::move(const std::string &src, const std::string &dst) {
 }
 
 bool FileSystem::remove(const std::string &path) {
-#ifdef CGAMEDLL
-  int success = trap_FS_Delete(path.c_str());
-  return success == 1;
-#elif GAMEDLL
-  // hacky fallback
+#ifdef GAMEDLL
+  // hacky fallback because qagame doesn't have trap_FS_Delete
   trap_FS_Rename(path.c_str(), "");
   return true;
+#else
+  int success = trap_FS_Delete(path.c_str());
+  return success == 1;
 #endif
 }
 
@@ -83,17 +86,30 @@ bool FileSystem::safeMove(const std::string &src, const std::string &dst) {
 }
 
 std::vector<std::string> FileSystem::getFileList(const std::string &path,
-                                                 const std::string &ext) {
-  const int BUFF_SIZE = 200000;
-  auto demoList = std::unique_ptr<char[]>(new char[BUFF_SIZE]);
-  auto numFiles =
-      trap_FS_GetFileList(path.c_str(), ext.c_str(), demoList.get(), BUFF_SIZE);
+                                                 const std::string &ext,
+                                                 const bool sort) {
+  const auto fileList = std::make_unique<char[]>(BIG_DIR_BUFFER);
+  const int numFiles = trap_FS_GetFileList(path.c_str(), ext.c_str(),
+                                           fileList.get(), BIG_DIR_BUFFER);
+
   std::vector<std::string> files;
-  auto namePtr = demoList.get();
+  files.reserve(numFiles);
+
+  char *namePtr = fileList.get();
+
   for (auto i = 0; i < numFiles; ++i) {
-    files.push_back(std::string(namePtr));
+    files.emplace_back(namePtr);
     namePtr += strlen(namePtr) + 1;
   }
+
+  if (sort) {
+    std::sort(files.begin(), files.end(),
+              [](const std::string &lhs, const std::string &rhs) {
+                return StringUtil::toUpperCase(lhs) <
+                       StringUtil::toUpperCase(rhs);
+              });
+  }
+
   return files;
 }
 

--- a/src/game/etj_filesystem.h
+++ b/src/game/etj_filesystem.h
@@ -29,6 +29,9 @@
 
 namespace ETJump {
 class FileSystem {
+  // this can hold ~8192 filenames
+  static constexpr int BIG_DIR_BUFFER = 2 << 18;
+
 public:
   static void copy(const std::string &src, const std::string &dst);
   static void move(const std::string &src, const std::string &dst);
@@ -36,8 +39,8 @@ public:
   static bool exists(const std::string &path);
   static bool safeCopy(const std::string &src, const std::string &dst);
   static bool safeMove(const std::string &src, const std::string &dst);
-  static std::vector<std::string> getFileList(const std::string &path,
-                                              const std::string &ext);
+  static std::vector<std::string>
+  getFileList(const std::string &path, const std::string &ext, bool sort);
   class Path {
     static std::string buildOSPath(const std::string &file);
 

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -13,6 +13,8 @@ add_library(ui MODULE
 	"../game/q_math.cpp"
 	"../game/q_shared.cpp"
 	"../cgame/etj_utilities.cpp"
+	"../game/etj_file.cpp"
+	"../game/etj_filesystem.cpp"
 	"../game/etj_string_utilities.cpp"
 	${UI_HEADERS}
 )


### PR DESCRIPTION
Both files can now be included in any module to perform filesystem operations.

Demo list is also now correctly sorted case-insensitively again, it used to be already but the sorting was changed to case sensitive when folder support was added.

Before:
![image](https://github.com/user-attachments/assets/06f3f100-948d-4898-911d-b2d6d9f4a70e)

After:
![image](https://github.com/user-attachments/assets/f4968f40-c897-46f0-9252-29aa97ed7644)
