### PR TITLE
Tweak multiline tooltip padding

### DIFF
--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -4631,7 +4631,7 @@ void Item_Text_Wrapped_Paint(itemDef_t *item) {
     strncpy(buff, start, p - start + 1);
     buff[p - start] = '\0';
     DC->drawText(x, y, item->textscale, color, buff, 0, 0, item->textStyle);
-    y += height + 5;
+    y += height + AUTOWRAP_OFFSET;
     start += p - start + 1;
     p = strchr(p + 1, '\r');
   }

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -118,6 +118,9 @@ static constexpr float SLIDER_THUMB_HEIGHT = 12.0f;
 
 static constexpr int NUM_CROSSHAIRS = 17;
 
+// y offset applied to each line of autowrapped text, along with text height
+static constexpr int AUTOWRAP_OFFSET = 5;
+
 typedef struct scriptDef_s {
   const char *command;
   const char *args[MAX_SCRIPT_ARGS];


### PR DESCRIPTION
Simplified the implementations greatly and corrected the multiline height calculations (was not using textscale-aware line spacing). Should also fix the chatbox line spacing like this too but it's a bit more involved so I'm just gonna keep that for now.