### PR TITLE
Refactor mapvote details menu

### DIFF
--- a/assets/ui/hostgame.menu
+++ b/assets/ui/hostgame.menu
@@ -210,7 +210,7 @@ menuDef {
       	group			GROUP_NAME
 		rect			$evalfloat(6+4) $evalfloat(320+16) $evalfloat(WINDOW_WIDTH-12-8-8) $evalfloat(96-16-4)
 		type			ITEM_TYPE_OWNERDRAW
-		ownerdraw		UI_CAMPAIGNDESCRIPTION
+		ownerdraw		UI_MAPDESCRIPTION
 		textfont		UI_FONT_COURBD_21
 		textstyle		ITEM_TEXTSTYLE_SHADOWED
 		textscale		.2

--- a/assets/ui/ingame_map_details.menu
+++ b/assets/ui/ingame_map_details.menu
@@ -4,52 +4,71 @@
      
 #define WINDOW_X        276
 #define WINDOW_Y        16
-//#define WINDOW_WIDTH  128
 #define WINDOW_WIDTH    252
-#define WINDOW_HEIGHT   360
-#define GROUP_NAME	"grpMapDetails"// Macros //
+#define WINDOW_HEIGHT   374
+
+#define GROUP_NAME      "grpMapDetails"
+
+#define LEVELSHOT_W     171
+#define LEVELSHOT_H     128
+
+// Macros //
      
 #include "ui/menumacros.h"
-                   
-// Options Menu //
            
 menuDef {
-	name            "ingame_map_details"
-	visible         0
-	fullscreen      0
-	rect            WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
-	style           WINDOW_STYLE_FILLED
-           
-	onOpen {
-		uiScript ui_openMapDetails
-	}	
-	
-	onESC {
-		uiScript ui_closeMapDetails
-		close ingame_map_details ;
-		open ingame_vote_map 
-	}
+    name            "ingame_map_details"
+    visible         0
+    fullscreen      0
+    rect            WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
+    style           WINDOW_STYLE_FILLED
+    
+    onESC {
+        close ingame_map_details ;
+        open ingame_vote_map 
+    }
 
-	itemDef {
-		name			"mapList_maps"
-		group			GROUP_NAME
-		rect			282 32 240 278
-		type			ITEM_TYPE_LISTBOX
-		textfont		UI_FONT_COURBD_21
-		textscale		.2
-		textaligny		-3
-		forecolor		.6 .6 .6 1
-		outlinecolor	.5 .5 .5 .4
-		border			WINDOW_BORDER_FULL
-		bordercolor		.1 .1 .1 .5
-		feeder			FEEDER_ALLMAPS
-		elementtype		LISTBOX_TEXT
-		elementwidth	200
-		elementheight	12
-		columns			1 0 200 33
-		visible			0
-	}
+    // Window //
+    WINDOW( "DETAILS", 50)
 
-     	// Window //
-     	WINDOW( "DETAILS", 50)
+    itemDef {
+        name            "levelshotPreview"
+        group           GROUP_NAME
+        rect            $evalfloat(WINDOW_WIDTH * 0.5 - LEVELSHOT_W * 0.5) 32 LEVELSHOT_W LEVELSHOT_H
+        type            ITEM_TYPE_OWNERDRAW
+        ownerdraw       UI_LEVELSHOT_PREVIEW
+        border          WINDOW_BORDER_NONE
+        visible         1
+        decoration
+    }
+
+    itemDef {
+        name            "mapName"
+        group           GROUP_NAME
+        rect            16 $evalfloat(32 + LEVELSHOT_H + 16) $evalfloat(WINDOW_WIDTH - 32) $evalfloat(WINDOW_HEIGHT - LEVELSHOT_H - 32 - 32)
+        type            ITEM_TYPE_OWNERDRAW
+        ownerdraw       UI_MAPNAME
+        border          WINDOW_BORDER_NONE
+        textfont        UI_FONT_COURBD_21
+        textstyle       ITEM_TEXTSTYLE_SHADOWED
+        textscale       .25
+        visible         1
+        decoration
+    }
+    
+    itemDef {
+        name            "mapDetails"
+        group           GROUP_NAME
+        rect            16 $evalfloat(32 + LEVELSHOT_H + 16 + 8) $evalfloat(WINDOW_WIDTH - 32) $evalfloat(WINDOW_HEIGHT - LEVELSHOT_H - 32 - 32 - 8)
+        type            ITEM_TYPE_OWNERDRAW
+        ownerdraw       UI_MAPDESCRIPTION
+        textfont        UI_FONT_COURBD_21
+        textstyle       ITEM_TEXTSTYLE_SHADOWED
+        textscale       .2
+        textaligny      8
+        forecolor       .6 .6 .6 1
+        visible         1
+        decoration
+        autowrapped
+    }
 }

--- a/assets/ui/ingame_vote_map.menu
+++ b/assets/ui/ingame_vote_map.menu
@@ -2,11 +2,11 @@
 
 // Defines //
 
-#define WINDOW_X		16
-#define WINDOW_Y		16
-#define WINDOW_WIDTH	252
-#define WINDOW_HEIGHT	374
-#define GROUP_NAME		"grpIngameVoteMap"
+#define WINDOW_X        16
+#define WINDOW_Y        16
+#define WINDOW_WIDTH    252
+#define WINDOW_HEIGHT   374
+#define GROUP_NAME      "grpIngameVoteMap"
 
 // Macros //
 
@@ -15,56 +15,46 @@
 // Map Vote Menu //
 
 menuDef {
-	name		"ingame_vote_map"
-	visible		0
-	fullscreen	0
-	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
-	style		WINDOW_STYLE_FILLED
+    name        "ingame_vote_map"
+    visible     0
+    fullscreen  0
+    rect        WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
+    style       WINDOW_STYLE_FILLED
 
-	onOpen {
-		copyCvar g_gametype ui_netgametype ;
-		uiScript loadArenas ;
-		
-		conditionalScript ui_netgametype 3	// 3: cvartest
-			( "hide bttnSelectionMaps ; hide bttnSelectionCampaigns ; hide mapList_maps ; show mapList_campaigns" )
-			( "show bttnSelectionMaps ; show bttnSelectionCampaigns ; show mapList_maps ; hide mapList_campaigns" ) "4" ;
-	}
+    onOpen {
+        uiScript loadArenas
+    }
 
-	onEsc {
-		uiScript ui_closeMapDetails ;
-		close ingame_vote_map ;
-		close ingame_map_details ;
-		open ingame_vote ;
-	}
+    onEsc {
+        close ingame_vote_map ;
+        close ingame_map_details ;
+        open ingame_vote ;
+    }
 
-// Window //
+    WINDOW( "MAPS", 50)
 
-	WINDOW( "MAPS", 50)
+    itemDef {
+        name            "mapList_maps"
+        group           GROUP_NAME
+        rect            6 32 240 278
+        type            ITEM_TYPE_LISTBOX
+        textfont        UI_FONT_COURBD_21
+        textscale       .2
+        textaligny      -3
+        forecolor       .6 .6 .6 1
+        outlinecolor    .5 .5 .5 .4
+        border          WINDOW_BORDER_FULL
+        bordercolor     .1 .1 .1 .5
+        feeder          FEEDER_ALLMAPS
+        elementtype     LISTBOX_TEXT
+        elementwidth    200
+        elementheight   12
+        columns         1 0 200 33
+        visible         1
+    }
 
-// Map Selection //
-
-	itemDef {
-		name			"mapList_maps"
-		group			GROUP_NAME
-		rect			6 32 240 278
-		type			ITEM_TYPE_LISTBOX
-		textfont		UI_FONT_COURBD_21
-		textscale		.2
-		textaligny		-3
-		forecolor		.6 .6 .6 1
-		outlinecolor	.5 .5 .5 .4
-		border			WINDOW_BORDER_FULL
-		bordercolor		.1 .1 .1 .5
-		feeder			FEEDER_ALLMAPS
-		elementtype		LISTBOX_TEXT
-		elementwidth	200
-		elementheight	12
-		columns			1 0 200 33
-		visible			0
-	}
-
-	YESNO(6, WINDOW_HEIGHT-60, (WINDOW_WIDTH-12), 8, "Enable cheats:", 0.2, 8, "ui_voteCheats", "Vote map with cheats enabled\nui_voteCheats")
-	BUTTON( 6, WINDOW_HEIGHT-46, (WINDOW_WIDTH-12), 18, "DETAILS", .3, 14, clearFocus ; open ingame_map_details )
-	BUTTON( 6, WINDOW_HEIGHT-24, .5*(WINDOW_WIDTH-18), 18, "BACK", .3, 14, close ingame_vote_map ; close ingame_map_details ; open ingame_vote ; uiScript ui_closeMapDetails )
-	BUTTON( 6+.5*(WINDOW_WIDTH-18)+6, WINDOW_HEIGHT-24, .5*(WINDOW_WIDTH-18), 18, "OK", .3, 14, uiScript ui_closeMapDetails ; close ingame_map_details ; uiScript voteMap ; uiScript closeingame)
+    YESNO   ( 6, WINDOW_HEIGHT-60, (WINDOW_WIDTH-12), 8, "Enable cheats:", 0.2, 8, "ui_voteCheats", "Vote map with cheats enabled\nui_voteCheats")
+    BUTTON  ( 6, WINDOW_HEIGHT-46, (WINDOW_WIDTH-12), 18, "DETAILS", .3, 14, open ingame_map_details )
+    BUTTON  ( 6, WINDOW_HEIGHT-24, .5*(WINDOW_WIDTH-18), 18, "BACK", .3, 14, close ingame_vote_map ; close ingame_map_details ; open ingame_vote )
+    BUTTON  ( 6+.5*(WINDOW_WIDTH-18)+6, WINDOW_HEIGHT-24, .5*(WINDOW_WIDTH-18), 18, "OK", .3, 14, close ingame_map_details ; uiScript voteMap ; uiScript closeingame)
 }

--- a/assets/ui/menudef.h
+++ b/assets/ui/menudef.h
@@ -287,7 +287,7 @@
 // -NERVE - SMF
 
 // Arnout: Enemy Territory
-#define UI_CAMPAIGNDESCRIPTION		262
+#define UI_MAPDESCRIPTION		262
 #define UI_GAMETYPEDESCRIPTION		280
 
 // Gordon: Mission briefing
@@ -299,6 +299,9 @@
 #define UI_COLOR_PICKER 303
 #define UI_COLOR_PICKER_PREVIEW_OLD 304
 #define UI_COLOR_PICKER_PREVIEW_NEW 305
+
+#define UI_MAPNAME 306
+#define UI_LEVELSHOT_PREVIEW 307
 
 #define VOICECHAT_GETFLAG			"getflag"				// command someone to get the flag
 #define VOICECHAT_OFFENSE			"offense"				// command someone to go on offense

--- a/src/ui/ui_gameinfo.cpp
+++ b/src/ui/ui_gameinfo.cpp
@@ -197,6 +197,9 @@ void UI_LoadArenas() {
           uiInfo.mapList[uiInfo.mapCount].typeBits = (1 << ETJUMP_GAMETYPE);
         }
 
+        uiInfo.mapList[uiInfo.mapCount].cinematic = -1;
+        uiInfo.mapList[uiInfo.mapCount].levelShot = -1;
+
         uiInfo.mapList[uiInfo.mapCount].mapLoadName = String_Alloc(map.c_str());
         uiInfo.mapList[uiInfo.mapCount].mapName = String_Alloc(map.c_str());
 

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -895,7 +895,7 @@ typedef struct {
   int etLegacyClient;
   bool eteClient;
   bool vetClient; // original 2.60b, steam 2.60b or 2.60d
-  
+
   std::vector<std::string> serverMaplist;
 } uiInfo_t;
 
@@ -1108,5 +1108,20 @@ void ETJump_DrawMapDetails();
 
 namespace ETJump {
 void parseMaplist();
-}
+
+struct TextScroll {
+  // the item which we're currently bound to, used to reset the state when
+  // switching selection (e.g. selecting a new map to read briefing from)
+  int scrollItem;
+
+  int scrollStartTime;
+  int scrollEndTime;
+  float scrollDeltaTime; // for framerate independent scroll speed
+
+  float x;
+  float y;
+
+  bool scrolling;
+};
+} // namespace ETJump
 #endif

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -25,55 +25,11 @@ USER INTERFACE MAIN
 #define SPECT_TEAM 2
 // -NERVE - SMF
 
-namespace ETJump {
-std::unique_ptr<ColorPicker> colorPicker;
-
-static void initColorPicker() {
-  colorPicker = std::make_unique<ColorPicker>();
-
-  uiInfo.uiDC.updateSliderState = [p = colorPicker.get()](itemDef_t *item) {
-    p->updateSliderState(item);
-  };
-
-  uiInfo.uiDC.cvarToColorPickerState =
-      [p = colorPicker.get()](const std::string &cvar) {
-        p->cvarToColorPickerState(cvar);
-      };
-
-  uiInfo.uiDC.resetColorPickerState = [p = colorPicker.get()] {
-    p->resetColorPickerState();
-  };
-
-  uiInfo.uiDC.colorPickerDragFunc =
-      [p = colorPicker.get()](itemDef_t *item, const float cursorX,
-                              const float cursorY, const int key) {
-        p->colorPickerDragFunc(item, cursorX, cursorY, key);
-      };
-
-  uiInfo.uiDC.toggleRGBSliderValues = [p = colorPicker.get()] {
-    p->toggleRGBSliderValues();
-  };
-
-  uiInfo.uiDC.RGBSlidersAreNormalized = [p = colorPicker.get()] {
-    return p->RGBSlidersAreNormalized();
-  };
-
-  uiInfo.uiDC.getColorSliderString = &ColorPicker::getColorSliderString;
-  uiInfo.uiDC.setColorSliderType = &ColorPicker::setColorSliderType;
-  uiInfo.uiDC.getColorSliderValue = &ColorPicker::getColorSliderValue;
-  uiInfo.uiDC.setColorSliderValue = &ColorPicker::setColorSliderValue;
-}
-
-} // namespace ETJump
-
 extern qboolean g_waitingForKey;
 extern qboolean g_editingField;
 extern itemDef_t *g_editItem;
 
 uiInfo_t uiInfo;
-
-static const int glyphxSkipMax =
-    14; // the biggest xSkip value used in glyph mapping
 
 static const char *MonthAbbrev[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
                                     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
@@ -848,6 +804,97 @@ void UI_ShowPostGame(qboolean newHigh) {
   _UI_SetActiveMenu(UIMENU_POSTGAME);
 }
 
+namespace ETJump {
+std::unique_ptr<ColorPicker> colorPicker;
+
+static void initColorPicker() {
+  colorPicker = std::make_unique<ColorPicker>();
+
+  uiInfo.uiDC.updateSliderState = [p = colorPicker.get()](itemDef_t *item) {
+    p->updateSliderState(item);
+  };
+
+  uiInfo.uiDC.cvarToColorPickerState =
+      [p = colorPicker.get()](const std::string &cvar) {
+        p->cvarToColorPickerState(cvar);
+      };
+
+  uiInfo.uiDC.resetColorPickerState = [p = colorPicker.get()] {
+    p->resetColorPickerState();
+  };
+
+  uiInfo.uiDC.colorPickerDragFunc =
+      [p = colorPicker.get()](itemDef_t *item, const float cursorX,
+                              const float cursorY, const int key) {
+        p->colorPickerDragFunc(item, cursorX, cursorY, key);
+      };
+
+  uiInfo.uiDC.toggleRGBSliderValues = [p = colorPicker.get()] {
+    p->toggleRGBSliderValues();
+  };
+
+  uiInfo.uiDC.RGBSlidersAreNormalized = [p = colorPicker.get()] {
+    return p->RGBSlidersAreNormalized();
+  };
+
+  uiInfo.uiDC.getColorSliderString = &ColorPicker::getColorSliderString;
+  uiInfo.uiDC.setColorSliderType = &ColorPicker::setColorSliderType;
+  uiInfo.uiDC.getColorSliderValue = &ColorPicker::getColorSliderValue;
+  uiInfo.uiDC.setColorSliderValue = &ColorPicker::setColorSliderValue;
+}
+
+static void drawLevelshotPreview(rectDef_t &rect) {
+  // unregistered levelshot is -1, not 0
+  if (uiInfo.mapList[ui_mapIndex.integer].levelShot == -1) {
+    uiInfo.mapList[ui_mapIndex.integer].levelShot = trap_R_RegisterShaderNoMip(
+        va("levelshots/%s", uiInfo.mapList[ui_mapIndex.integer].mapLoadName));
+
+    if (!uiInfo.mapList[ui_mapIndex.integer].levelShot) {
+      uiInfo.mapList[ui_mapIndex.integer].levelShot =
+          trap_R_RegisterShaderNoMip("levelshots/unknownmap");
+    }
+  }
+
+  uiInfo.uiDC.drawHandlePic(rect.x, rect.y, rect.w, rect.h,
+                            uiInfo.mapList[ui_mapIndex.integer].levelShot);
+}
+
+void drawMapname(rectDef_t &rect, float scale, vec4_t color, float text_x,
+                 int textStyle, int align) {
+  rectDef_t textRect = {0, 0, rect.w, rect.h};
+
+  const int map = ui_currentNetMap.integer;
+  std::string mapname;
+
+  if (uiInfo.mapList[map].mapLoadName != nullptr) {
+    mapname = uiInfo.mapList[map].mapLoadName;
+  } else {
+    mapname = "unknownmap";
+  }
+
+  const auto width = static_cast<float>(Text_Width(mapname.c_str(), scale, 0));
+
+  switch (align) {
+    case ITEM_ALIGN_LEFT:
+      textRect.x = text_x;
+      break;
+    case ITEM_ALIGN_RIGHT:
+      textRect.x = text_x - width;
+      break;
+    case ITEM_ALIGN_CENTER:
+      textRect.x = text_x - (width * 0.5f);
+      break;
+    default:
+      break;
+  }
+
+  textRect.x += rect.x;
+  textRect.y += rect.y;
+  Text_Paint(textRect.x, textRect.y, scale, color, mapname.c_str(), 0, 0,
+             textStyle);
+}
+} // namespace ETJump
+
 /*
 =================
 _UI_Refresh
@@ -916,8 +963,6 @@ void _UI_Refresh(int realtime) {
     UI_BuildServerStatus(qfalse);
     // refresh find player list
     UI_BuildFindPlayerList(qfalse);
-
-    ETJump_DrawMapDetails();
   }
 
   // draw cursor
@@ -1599,80 +1644,96 @@ void UI_DrawGametypeDescription(rectDef_t *rect, float scale, vec4_t color,
 }
 
 void UI_DrawMapDescription(rectDef_t *rect, float scale, vec4_t color,
-                           float text_x, float text_y, int textStyle, int align,
-                           qboolean net) {
-  const char *p, *textPtr, *newLinePtr = nullptr;
-  char buff[1024];
-  int height, len, textWidth, newLine, newLineWidth;
-  float y;
-  rectDef_t textRect;
-  int map = (net) ? ui_currentNetMap.integer : ui_currentMap.integer;
+                           float text_x, int textStyle, int align) {
+  fontInfo_t *font = &uiInfo.uiDC.Assets.fonts[uiInfo.activeFont];
+  rectDef_t textRect = {0, 0, rect->w, rect->h};
 
-  textPtr = uiInfo.mapList[map].briefing;
+  const int map = ui_currentNetMap.integer;
+  std::string briefing;
 
-  if (!textPtr || !*textPtr) {
-    textPtr = "^1No text supplied";
+  if (uiInfo.mapList[map].briefing != nullptr) {
+    briefing = uiInfo.mapList[map].briefing;
+
+    if (!briefing.empty()) {
+      // replace any carriage returns with whitespace
+      ETJump::StringUtil::replaceAll(briefing, "\r", " ");
+
+      // replace special '*' char with a regular linebreak char
+      ETJump::StringUtil::replaceAll(briefing, "*", "\n");
+    }
+  } else {
+    briefing = "^1No text supplied";
   }
 
-  height = Text_Height(textPtr, scale, 0);
+  BG_FitTextToWidth_Ext(briefing, scale, textRect.w, font);
+  std::vector<std::string> lines = ETJump::StringUtil::split(briefing, "\n");
 
-  textRect.x = 0;
-  textRect.y = 0;
-  textRect.w = rect->w;
-  textRect.h = rect->h;
+  // remove any potential empty strings from the back of the vector
+  while (!lines.empty() && lines.back().empty()) {
+    lines.pop_back();
+  }
 
-  // y = text_y;
-  y = 0;
-  len = 0;
-  buff[0] = '\0';
-  newLine = 0;
-  newLineWidth = 0;
-  p = textPtr;
+  // nothing left to draw, exit
+  if (lines.empty()) {
+    return;
+  }
 
-  while (p) {
-    textWidth = DC->textWidth(buff, scale, 0);
-    if (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\0' || *p == '*') {
-      newLine = len;
-      newLinePtr = p + 1;
-      newLineWidth = textWidth;
-    }
-    if ((newLine && textWidth > rect->w) || *p == '\n' || *p == '\0' ||
-        *p == '*' /*( *p == '*' && *(p+1) == '*' )*/) {
-      if (len) {
-        if (align == ITEM_ALIGN_LEFT) {
-          textRect.x = text_x;
-        } else if (align == ITEM_ALIGN_RIGHT) {
-          textRect.x = text_x - newLineWidth;
-        } else if (align == ITEM_ALIGN_CENTER) {
-          textRect.x = text_x - newLineWidth / 2;
-        }
-        textRect.y = y;
+  static ETJump::TextScroll ts;
 
-        textRect.x += rect->x;
-        textRect.y += rect->y;
-        //
-        buff[newLine] = '\0';
-        DC->drawText(textRect.x, textRect.y, scale, color, buff, 0, 0,
-                     textStyle);
-      }
-      if (*p == '\0') {
+  if (ts.scrollStartTime == 0 ||
+      (!ts.scrolling && DC->realTime > ts.scrollEndTime) ||
+      ts.scrollItem != ui_currentNetMap.integer) {
+    ts.scrollStartTime = DC->realTime + 2000;
+    ts.scrolling = true;
+    ts.y = 0;
+    ts.scrollItem = ui_currentNetMap.integer;
+  }
+
+  constexpr int lineHeight = 10;
+  const float totalHeight = static_cast<float>(lines.size()) * lineHeight;
+  float y = 0.0f + ts.y;
+
+  ts.scrollDeltaTime = static_cast<float>(DC->frameTime) * 0.001f;
+
+  if (totalHeight > rect->h && ts.scrolling &&
+      DC->realTime > ts.scrollStartTime) {
+    float scrollSpeed = 25.0f; // pixels per second
+    ts.y -= scrollSpeed * ts.scrollDeltaTime;
+  }
+
+  for (const auto &line : lines) {
+    const auto width = static_cast<float>(Text_Width(line.c_str(), scale, 0));
+
+    switch (align) {
+      case ITEM_ALIGN_LEFT:
+        textRect.x = text_x;
         break;
-      }
-      //
-      y += height + AUTOWRAP_OFFSET;
-      p = newLinePtr;
-      len = 0;
-      newLine = 0;
-      newLineWidth = 0;
-      continue;
-    }
-    buff[len++] = *p++;
-
-    if (buff[len - 1] == 13) {
-      buff[len - 1] = ' ';
+      case ITEM_ALIGN_RIGHT:
+        textRect.x = text_x - width;
+        break;
+      case ITEM_ALIGN_CENTER:
+        textRect.x = text_x - (width * 0.5f);
+        break;
+      default:
+        break;
     }
 
-    buff[len] = '\0';
+    textRect.y = y;
+    textRect.x += rect->x;
+    textRect.y += rect->y;
+
+    // only draw the line if it's within rect boundaries
+    if (textRect.y >= rect->y && textRect.y + lineHeight <= rect->y + rect->h) {
+      Text_Paint(textRect.x, textRect.y, scale, color, line.c_str(), 0, 0,
+                 textStyle);
+    }
+
+    y += lineHeight;
+  }
+
+  if (ts.scrolling && ts.y + totalHeight < textRect.h) {
+    ts.scrollEndTime = DC->realTime + 2000;
+    ts.scrolling = false;
   }
 }
 
@@ -2310,11 +2371,8 @@ static void UI_OwnerDraw(float x, float y, float w, float h, float text_x,
     case UI_STARTMAPCINEMATIC:
       UI_DrawMapCinematic(&rect, scale, color, qtrue);
       break;
-    // confusingly this draws the arena file contents
-    // when selecting a map in the map selection list
-    case UI_CAMPAIGNDESCRIPTION:
-      UI_DrawMapDescription(&rect, scale, color, text_x, text_y, textStyle,
-                            align, qtrue);
+    case UI_MAPDESCRIPTION:
+      UI_DrawMapDescription(&rect, scale, color, text_x, textStyle, align);
       break;
     case UI_GAMETYPEDESCRIPTION:
       UI_DrawGametypeDescription(&rect, scale, color, text_x, text_y, textStyle,
@@ -2417,6 +2475,12 @@ static void UI_OwnerDraw(float x, float y, float w, float h, float text_x,
     case UI_COLOR_PICKER_PREVIEW_NEW:
       ETJump::ColorPicker::shrinkRectForColorPicker(rect);
       ETJump::colorPicker->drawPreviewNew(&rect);
+      break;
+    case UI_MAPNAME:
+      ETJump::drawMapname(rect, scale, color, text_x, textStyle, align);
+      break;
+    case UI_LEVELSHOT_PREVIEW:
+      ETJump::drawLevelshotPreview(rect);
       break;
     default:
       break;
@@ -3845,7 +3909,6 @@ void UI_RunMenuScript(const char **args) {
       trap_Key_SetCatcher(trap_Key_GetCatcher() & ~KEYCATCH_UI);
       trap_Key_ClearStates();
       trap_Cvar_Set("cl_paused", "0");
-      trap_Cvar_Set("ui_map_details", "0");
       Menus_CloseAll();
       return;
     }
@@ -4842,18 +4905,6 @@ void UI_RunMenuScript(const char **args) {
         trap_Cmd_ExecuteText(EXEC_APPEND, "exec default_left.cfg\n");
         Controls_SetDefaults(qtrue);
       }
-      return;
-    }
-    if (!Q_stricmp(name, "ui_openMapDetails")) {
-      trap_Cvar_Set("ui_map_details", "1");
-      trap_Cvar_Set("ui_details_map_name",
-                    uiInfo.mapList[ui_currentNetMap.integer].mapLoadName);
-      trap_Cvar_Set("ui_details_briefing",
-                    uiInfo.mapList[ui_currentNetMap.integer].briefing);
-      return;
-    }
-    if (!Q_stricmp(name, "ui_closeMapDetails")) {
-      trap_Cvar_Set("ui_map_details", "0");
       return;
     }
     if (!Q_stricmp(name, "voteAutoRtv")) {

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -1689,7 +1689,7 @@ void UI_DrawMapDescription(rectDef_t *rect, float scale, vec4_t color,
     ts.scrollItem = ui_currentNetMap.integer;
   }
 
-  constexpr int lineHeight = 10;
+  static constexpr int lineHeight = 10;
   const float totalHeight = static_cast<float>(lines.size()) * lineHeight;
   float y = 0.0f + ts.y;
 
@@ -1697,7 +1697,7 @@ void UI_DrawMapDescription(rectDef_t *rect, float scale, vec4_t color,
 
   if (totalHeight > rect->h && ts.scrolling &&
       DC->realTime > ts.scrollStartTime) {
-    float scrollSpeed = 25.0f; // pixels per second
+    static constexpr float scrollSpeed = 15.0f; // pixels per second
     ts.y -= scrollSpeed * ts.scrollDeltaTime;
   }
 

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -9019,6 +9019,18 @@ void BG_PanelButtons_SetFocusButton(panel_button_t *button) {
   bg_focusButton = button;
 }
 
+void BG_FitTextToWidth_Ext(std::string &instr, float scale, float w,
+                           fontInfo_t *font) {
+  char buffer[1024];
+
+  Q_strncpyz(buffer, instr.c_str(), sizeof(buffer));
+  buffer[sizeof(buffer) - 1] = '\0';
+
+  BG_FitTextToWidth_Ext(buffer, scale, w, sizeof(buffer), font);
+
+  instr = buffer;
+}
+
 void BG_FitTextToWidth_Ext(char *instr, float scale, float w, int size,
                            fontInfo_t *font) {
   char buffer[1024];
@@ -9065,122 +9077,6 @@ void BG_FitTextToWidth_Ext(char *instr, float scale, float w, int size,
 
   *c = '\0';
 }
-
-#ifndef CGAMEDLL
-
-  #define MAX_BRIEFING_LINE_LEN 40
-
-void UI_PrintMapDetailsBriefing() {
-
-  /*
-  MapDetails UI menu size
-  */
-  int x = 276;
-  int y = 16;
-  int w = 252;
-
-  int lineCount = 0;
-
-  const char *p1 = 0;
-  char *p2 = 0;
-
-  char briefing[MAX_CVAR_VALUE_STRING];
-  char lineToPrint[MAX_BRIEFING_LINE_LEN + 1];
-
-  // Get briefing
-  trap_Cvar_LatchedVariableStringBuffer("ui_details_briefing", briefing,
-                                        sizeof(briefing));
-
-  p1 = briefing;
-  p2 = lineToPrint;
-
-  *p2 = 0;
-
-  for (; *p1; p1++) {
-    if (*p1 == '*' || (p2 - lineToPrint) == MAX_BRIEFING_LINE_LEN) {
-      if (lineCount > 8) {
-        break;
-      }
-      if (*lineToPrint) {
-        *p2 = 0;
-        uiInfo.uiDC.drawTextExt(x + 32, y + w + (10 * lineCount), 0.15, 0.15,
-                                colorWhite, lineToPrint, 0, 0,
-                                ITEM_TEXTSTYLE_SHADOWED,
-                                &uiInfo.loadscreenfont2);
-        lineCount++;
-        p1--;
-      }
-
-      p2 = lineToPrint;
-      continue;
-    }
-    if (*p1 == '*') {
-      continue;
-    }
-    *p2++ = *p1;
-  }
-
-  if (*lineToPrint) {
-    *p2 = 0;
-    uiInfo.uiDC.drawTextExt(x + 32, y + w + (10 * lineCount), 0.15, 0.15,
-                            colorWhite, lineToPrint, 0, 0,
-                            ITEM_TEXTSTYLE_SHADOWED, &uiInfo.loadscreenfont2);
-  }
-
-  if (lineCount > 8) {
-    uiInfo.uiDC.drawTextExt(x + 32, y + w + (10 * lineCount), 0.15, 0.15,
-                            colorWhite, "...", 0, 0, ITEM_TEXTSTYLE_SHADOWED,
-                            &uiInfo.loadscreenfont2);
-  }
-}
-
-void ETJump_DrawMapDetails() {
-  int x = 276;
-  int y = 16;
-  int w = 252;
-
-  char isUIopen_str[MAX_CVAR_VALUE_STRING];
-  char mapName[128] = "\0";
-  qhandle_t bg_mappic;
-
-  trap_Cvar_LatchedVariableStringBuffer("ui_map_details", isUIopen_str,
-                                        sizeof(isUIopen_str));
-
-  if (Q_atoi(isUIopen_str) != 1) {
-    return;
-  }
-
-  trap_Cvar_LatchedVariableStringBuffer("ui_details_map_name", mapName,
-                                        sizeof(mapName));
-
-  /*
-  map levelshot
-  */
-
-  bg_mappic = uiInfo.uiDC.registerShaderNoMip(va("levelshots/%s", mapName));
-
-  if (!bg_mappic) {
-    bg_mappic = uiInfo.uiDC.registerShaderNoMip("levelshots/unknownmap");
-  }
-
-  trap_R_SetColor(colorBlack);
-  uiInfo.uiDC.drawHandlePic(x + 32, y + 32, w - 64, w - 64, bg_mappic);
-
-  trap_R_SetColor(NULL);
-  uiInfo.uiDC.drawHandlePic(x + 32, y + 32, w - 64, w - 64, bg_mappic);
-
-  /*
-  map briefing
-  */
-  UI_PrintMapDetailsBriefing();
-
-  // Print map name
-  uiInfo.uiDC.drawTextExt(x + 32, y + w - 16, 0.25, 0.25, colorWhite, mapName,
-                          0, 0, ITEM_TEXTSTYLE_SHADOWED,
-                          &uiInfo.loadscreenfont2);
-}
-
-#endif
 
 /*
 ================

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -718,6 +718,8 @@ qboolean BG_CursorInRectWide(rectDef_t *rect);
 
 void BG_FitTextToWidth_Ext(char *instr, float scale, float w, int size,
                            fontInfo_t *font);
+void BG_FitTextToWidth_Ext(std::string &instr, float scale, float w,
+                           fontInfo_t *font);
 
 void AdjustFrom640(float *x, float *y, float *w, float *h);
 void SetupRotatedThing(polyVert_t *verts, vec2_t org, float w, float h,


### PR DESCRIPTION
* Draw the map details with an actual menu item using ownerdraw
* Details panel now updates as you select a new map in the list, instead of requiring a new click on details button
* Fix levelshot aspect ratio, was 1:1 when it should be 4:3
* Add text scroll to map briefing if text doesn't fit, also used in Host Game menu

https://streamable.com/dutgcu