### PR TITLE
Add newlines to maplist commands

### DIFF
--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -427,17 +427,15 @@ qboolean CG_ServerCommandExt(const char *cmd) {
   //  we could use a local cache for map list instead of requesting it again.
   if (command == "maplist") {
     char arg[MAX_QPATH];
-    std::string uiCommand = "uiParseMaplist ";
+    std::string uiCommand = "uiParseMaplist";
 
     // start iterating from 1 to skip the command string
     for (int i = 1, len = trap_Argc(); i < len; i++) {
       trap_Argv(i, arg, sizeof(arg));
-      uiCommand += std::string(arg) + " ";
+      uiCommand += " " + std::string(arg);
     }
 
-    if (uiCommand.back() == ' ') {
-      uiCommand.pop_back();
-    }
+    uiCommand += '\n';
 
     // we need to forward this command to UI to parse the list there,
     // so we can populate the map vote list
@@ -733,7 +731,7 @@ void runFrameEnd() {
 
   // populate map vote menu
   if (!cg.demoPlayback && cg.clientFrame >= 10 && !cg.maplistRequested) {
-    trap_SendClientCommand("requestMaplist");
+    trap_SendClientCommand("requestmaplist\n");
     cg.maplistRequested = true;
   }
 }

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -1092,21 +1092,6 @@ void clearSaves(gentity_t *ent) {
   saveSystem->resetSavedPositions(ent);
   Printer::center(clientNum, "^7Your saves were removed.\n");
 }
-
-static void sendMaplist(gentity_t *ent) {
-  std::string mapList = StringUtil::join(game.mapStatistics->getMaps(), " ");
-  const std::string prefix = "maplist ";
-  const size_t msgLen = BYTES_PER_PACKET - prefix.length();
-
-  // split to multiple commands to ensure client gets the full list
-  // each command is prefixed with 'maplist' so client recognizes
-  // this command is part of the map list, and parses it correctly
-  auto splits = wrapWords(mapList, ' ', msgLen);
-  for (auto &split : splits) {
-    split.insert(0, prefix);
-    trap_SendServerCommand(ClientNum(ent), split.c_str());
-  }
-}
 } // namespace ETJump
 
 /*
@@ -4849,7 +4834,6 @@ static const command_t noIntermissionCommands[] = {
     {"tracker_print", qtrue, ETJump::printTracker},
     {"tracker_set", qtrue, ETJump::setTracker},
     {"clearsaves", qtrue, ETJump::clearSaves},
-    {"requestMaplist", qtrue, ETJump::sendMaplist},
 };
 
 qboolean ClientIsFlooding(gentity_t *ent) {

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -1341,7 +1341,7 @@ void UI_LoadMenus(const char *menuFile, qboolean reset) {
   // if we're already in-game, re-request the map list from server
   // this only ever executes if a client does 'ui_restart' while connected
   if (cstate.connState == CA_ACTIVE) {
-    trap_Cmd_ExecuteText(EXEC_APPEND, "requestMapList");
+    trap_Cmd_ExecuteText(EXEC_APPEND, "requestmaplist\n");
   }
 
   Com_DPrintf("UI menu load time = %d milli seconds\n",


### PR DESCRIPTION
2.60b and ETL have trouble handling these commands when newlines aren't present, and the command parsing breaks.

Also move the sendMaplist command from `g_cmds.cpp` to `etj_commands.cpp`.

refs #1431 