### PR TITLE
Add customvotes to vote UI

### DIFF
--- a/assets/ui/ingame_customvote_details.menu
+++ b/assets/ui/ingame_customvote_details.menu
@@ -1,0 +1,88 @@
+#include "ui/menudef.h"
+
+// Defines //
+
+#define WINDOW_X        276
+#define WINDOW_Y        16
+#define WINDOW_WIDTH    252
+#define WINDOW_HEIGHT   374
+
+#define GROUP_NAME      "grpCustomvoteDetails"
+
+#include "ui/menumacros.h"
+#include "ui/menumacros_ext.h"
+
+#define MENU_NAME       "ingame_customvote_details"
+
+#define NUM_BUTTONS     2
+#define BUTTON_W        ((WINDOW_WIDTH - (16 * (NUM_BUTTONS)) - 8) / NUM_BUTTONS)
+
+#define MAPS_ONSERVER_ACTIVE        show listMapsOnServer ; show bttnMapsOnServerActive ; hide bttnMapsOnServer ; hide listMapsUnavailable ; hide bttnMapsUnavailableActive ; show bttnMapsUnavailable
+#define MAPS_UNAVAILABLE_ACTIVE     hide listMapsOnServer ; hide bttnMapsOnServerActive ; show bttnMapsOnServer ; show listMapsUnavailable ; show bttnMapsUnavailableActive ; hide bttnMapsUnavailable
+
+menuDef {
+    name            MENU_NAME
+    visible         0
+    fullscreen      0
+    rect            WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
+    style           WINDOW_STYLE_FILLED
+
+    onOpen {
+        uiScript resetCustomvoteDetailsIndex ;
+        MAPS_ONSERVER_ACTIVE
+    }
+
+    onESC {
+        close MENU_NAME ;
+        open ingame_vote_customvote
+    }
+
+    WINDOW( "LIST INFO", 50)
+
+    // this is kinda wack but eh, it works
+    NAMEDBUTTON         (bttnMapsOnServer, 16, WINDOW_Y + 16, BUTTON_W, 18, "MAPS ON SERVER", 0.2, 12, uiScript resetCustomvoteDetailsIndex; MAPS_ONSERVER_ACTIVE)
+    NAMEDBUTTONACTIVE   (bttnMapsOnServerActive, 16, WINDOW_Y + 16, BUTTON_W, 18, "MAPS ON SERVER", 0.2, 12, none)
+
+    NAMEDBUTTON         (bttnMapsUnavailable, 16 + 8 + BUTTON_W, WINDOW_Y + 16, BUTTON_W, 18, "UNAVAILABLE", 0.2, 12, uiScript resetCustomvoteDetailsIndex; MAPS_UNAVAILABLE_ACTIVE)
+    NAMEDBUTTONACTIVE   (bttnMapsUnavailableActive, 16 + 8 + BUTTON_W, WINDOW_Y + 16, BUTTON_W, 18, "UNAVAILABLE", 0.2, 12, none)
+
+    itemDef {
+        name            "listMapsOnServer"
+        group           GROUP_NAME
+        rect            16 $evalfloat(WINDOW_Y + 16 + 18 + 8) $evalfloat(WINDOW_WIDTH - 32) $evalfloat(WINDOW_HEIGHT - WINDOW_Y - 16 - 16 - 8 - 18)
+        type            ITEM_TYPE_LISTBOX
+        textfont        UI_FONT_COURBD_21
+        textscale       .2
+        textaligny      -3
+        forecolor       .6 .6 .6 1
+        outlinecolor    .5 .5 .5 0
+        border          WINDOW_BORDER_FULL
+        bordercolor     .1 .1 .1 .5
+        feeder          FEEDER_CUSTOMVOTES_MAPS_ONSERVER
+        elementtype     LISTBOX_TEXT
+        elementwidth    200
+        elementheight   12
+        columns         1 0 200 33
+        visible         0
+    }
+
+    itemDef {
+        name            "listMapsUnavailable"
+        group           GROUP_NAME
+        rect            16 $evalfloat(WINDOW_Y + 16 + 18 + 8) $evalfloat(WINDOW_WIDTH - 32) $evalfloat(WINDOW_HEIGHT - WINDOW_Y - 16 - 16 - 8 - 18)
+        type            ITEM_TYPE_LISTBOX
+        textfont        UI_FONT_COURBD_21
+        textscale       .2
+        textaligny      -3
+        forecolor       .6 .6 .6 1
+        outlinecolor    .5 .5 .5 0
+        border          WINDOW_BORDER_FULL
+        bordercolor     .1 .1 .1 .5
+        feeder          FEEDER_CUSTOMVOTES_MAPS_UNAVAILABLE
+        elementtype     LISTBOX_TEXT
+        elementwidth    200
+        elementheight   12
+        columns         1 0 200 33
+        visible         0
+    }
+}

--- a/assets/ui/ingame_vote.menu
+++ b/assets/ui/ingame_vote.menu
@@ -6,7 +6,7 @@
 #define WINDOW_Y		16
 //#define WINDOW_WIDTH	128
 #define WINDOW_WIDTH	160
-#define WINDOW_HEIGHT	192
+#define WINDOW_HEIGHT	216
 #define GROUP_NAME		"grpIngameVote"
 
 // Macros //
@@ -56,7 +56,7 @@ menuDef {
 	itemDef {
 		name		"nfleftbackAutoRtv:"
 		group		GROUP_NAME
-		rect		$evalfloat(4+(.5*WINDOW_WIDTH)) $evalfloat(124+3) $evalfloat(.5*(WINDOW_WIDTH-22)) 12
+		rect		$evalfloat(4+(.5*WINDOW_WIDTH)) $evalfloat(148+3) $evalfloat(.5*(WINDOW_WIDTH-22)) 12
 		style		WINDOW_STYLE_FILLED
 		backcolor	.5 .5 .5 .2
 		visible		1
@@ -67,12 +67,13 @@ menuDef {
 	BUTTONEXT( 6, 32, WINDOW_WIDTH-12, 18, "RESTART MAP", .3, 14, exec "cmd callvote maprestart"; uiScript closeingame, voteFlag CV_SVF_MATCHRESET )
 	BUTTONEXT( 6, 56, WINDOW_WIDTH-12, 18, "RANDOM MAP", .3, 14, exec "cmd callvote randommap"; uiScript closeingame, voteFlag CV_SVF_RANDOMMAP )
 	BUTTONEXT( 6, 80, WINDOW_WIDTH-12, 18, "MAP", .3, 14, close ingame_vote ; open ingame_vote_map, voteflag CV_SVF_MAP )
-	BUTTONEXT( 6, 104, WINDOW_WIDTH-12, 18, "ROCK THE VOTE", .3, 14, exec "cmd callvote rtv"; uiScript closeingame, voteflag CV_SVF_RTV )
+	BUTTONEXT( 6, 104, WINDOW_WIDTH-12, 18, "CUSTOM VOTES", .3, 14, close ingame_vote ; open ingame_vote_customvote, voteflag CV_SVF_CUSTOMVOTE )
+	BUTTONEXT( 6, 128, WINDOW_WIDTH-12, 18, "ROCK THE VOTE", .3, 14, exec "cmd callvote rtv"; uiScript closeingame, voteflag CV_SVF_RTV )
 
-	NUMERICFIELDLEFTEXT( 22, 124, WINDOW_WIDTH-12, 18, "Auto RTV:", .2, 12, "ui_voteAutoRtv", 9, voteFlag CV_SVF_AUTORTV, "Interval for automatic Rock The Vote, in minutes\ng_autoRtv" )
-	NAMEDBUTTONEXT( "bttnextAutoRtv", 6, 144, .5*(WINDOW_WIDTH-12), 18, "OK", .3, 14, uiScript voteAutoRtv; uiScript closeingame, voteFlag CV_SVF_AUTORTV )
-	NAMEDBUTTONEXT( "bttnextAutoRtvOff", 3+(.5*WINDOW_WIDTH), 144, .5*(WINDOW_WIDTH-18), 18, "OFF", .3, 14, exec "cmd callvote autoRtv 0"; uiScript closeingame, voteFlag CV_SVF_AUTORTV )
+	NUMERICFIELDLEFTEXT( 22, 148, WINDOW_WIDTH-12, 18, "Auto RTV:", .2, 12, "ui_voteAutoRtv", 9, voteFlag CV_SVF_AUTORTV, "Interval for automatic Rock The Vote, in minutes\ng_autoRtv" )
+	NAMEDBUTTONEXT( "bttnextAutoRtv", 6, 168, .5*(WINDOW_WIDTH-12), 18, "OK", .3, 14, uiScript voteAutoRtv; uiScript closeingame, voteFlag CV_SVF_AUTORTV )
+	NAMEDBUTTONEXT( "bttnextAutoRtvOff", 3+(.5*WINDOW_WIDTH), 168, .5*(WINDOW_WIDTH-18), 18, "OFF", .3, 14, exec "cmd callvote autoRtv 0"; uiScript closeingame, voteFlag CV_SVF_AUTORTV )
 
 
-	BUTTON( 6, 168, WINDOW_WIDTH-12, 18, "BACK", .3, 14, close ingame_vote ; open ingame_main )
+	BUTTON( 6, 192, WINDOW_WIDTH-12, 18, "BACK", .3, 14, close ingame_vote ; open ingame_main )
 }

--- a/assets/ui/ingame_vote_customvote.menu
+++ b/assets/ui/ingame_vote_customvote.menu
@@ -1,0 +1,66 @@
+#include "ui/menudef.h"
+
+// Defines //
+
+#define WINDOW_X        16
+#define WINDOW_Y        16
+#define WINDOW_WIDTH    252
+#define WINDOW_HEIGHT   374
+#define GROUP_NAME      "grpIngameVoteCustomVote"
+
+#define MENU_NAME       "ingame_vote_customvote"
+
+// Macros //
+
+#include "ui/menumacros.h"
+
+// Map Vote Menu //
+
+menuDef {
+    name        MENU_NAME
+    visible     0
+    fullscreen  0
+    rect        WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
+    style       WINDOW_STYLE_FILLED
+
+    onOpen {
+        uiScript loadCustomvotes
+    }
+
+    onEsc {
+        close MENU_NAME ;
+        close ingame_customvote_details ;
+        open ingame_vote ;
+    }
+
+    // Window //
+
+    WINDOW( "CUSTOM VOTES", 50)
+
+    // Map Selection //
+
+    itemDef {
+        name            "mapList_customvotes"
+        group           GROUP_NAME
+        rect            6 32 240 278
+        type            ITEM_TYPE_LISTBOX
+        textfont        UI_FONT_COURBD_21
+        textscale       .2
+        textaligny      -3
+        forecolor       .6 .6 .6 1
+        outlinecolor    .5 .5 .5 .4
+        border          WINDOW_BORDER_FULL
+        bordercolor     .1 .1 .1 .5
+        feeder          FEEDER_CUSTOMVOTES
+        elementtype     LISTBOX_TEXT
+        elementwidth    200
+        elementheight   12
+        columns         1 0 200 33
+        visible         1
+    }
+
+    YESNO   ( 6, WINDOW_HEIGHT-60, (WINDOW_WIDTH-12), 8, "Rock the Vote:", 0.2, 8, "ui_voteCustomRTV", "Call Rock the Vote with selected list\nui_voteCustomRTV")
+    BUTTON  ( 6, WINDOW_HEIGHT-46, (WINDOW_WIDTH-12), 18, "DETAILS", .3, 14, open ingame_customvote_details )
+    BUTTON  ( 6, WINDOW_HEIGHT-24, .5*(WINDOW_WIDTH-18), 18, "BACK", .3, 14, close MENU_NAME ; close ingame_customvote_details ; open ingame_vote )
+    BUTTON  ( 6+.5*(WINDOW_WIDTH-18)+6, WINDOW_HEIGHT-24, .5*(WINDOW_WIDTH-18), 18, "OK", .3, 14, close MENU_NAME ; close ingame_customvote_details ; uiScript voteCustomvote ; uiScript closeingame)
+}

--- a/assets/ui/menudef.h
+++ b/assets/ui/menudef.h
@@ -71,6 +71,9 @@
 #define FEEDER_SERVERSTATUS 		0x0d	// server status
 #define FEEDER_FINDPLAYER			0x0e	// find player
 #define FEEDER_CINEMATICS			0x0f	// cinematics
+#define FEEDER_CUSTOMVOTES			0x10	// ETJump: custom vote lists
+#define FEEDER_CUSTOMVOTES_MAPS_ONSERVER	0x11	// ETJump: maps available on server from customvote list
+#define FEEDER_CUSTOMVOTES_MAPS_UNAVAILABLE	0x12	// ETJump: maps not available on server from customvote list
 #define FEEDER_PROFILES				0x1c	// Arnout: profiles
 #define FEEDER_GLINFO				0x1d	// Arnout: glinfo
 
@@ -402,6 +405,9 @@
 #define CV_SVF_RANDOMMAP		4
 #define CV_SVF_RTV			8
 #define CV_SVF_AUTORTV			16
+// there's no actual cvar associated with this flag, but we turn this off
+// if there are no custom votes defined on the server
+#define CV_SVF_CUSTOMVOTE		32
 
 // referee level
 #define RL_NONE					0

--- a/assets/ui/menumacros_ext.h
+++ b/assets/ui/menumacros_ext.h
@@ -59,6 +59,46 @@
     }                                                                          \
   }
 
+#define NAMEDBUTTONACTIVE( BUTTON_NAME, BUTTON_X, BUTTON_Y, BUTTON_W,          \
+                           BUTTON_H, BUTTON_TEXT, BUTTON_TEXT_SCALE,           \
+                           BUTTON_TEXT_ALIGN_Y, BUTTON_ACTION )                \
+  itemDef {                                                                    \
+    name          BUTTON_NAME                                                  \
+    group         GROUP_NAME                                                   \
+    rect          $evalfloat(BUTTON_X) $evalfloat(BUTTON_Y)                    \
+                  $evalfloat(BUTTON_W) $evalfloat(BUTTON_H)                    \
+    type          ITEM_TYPE_BUTTON                                             \
+    text          BUTTON_TEXT                                                  \
+    textfont      UI_FONT_COURBD_30                                            \
+    textscale     BUTTON_TEXT_SCALE                                            \
+    textalign     ITEM_ALIGN_CENTER                                            \
+    textalignx    $evalfloat(0.5 * BUTTON_W)                                   \
+    textaligny    BUTTON_TEXT_ALIGN_Y                                          \
+    style         WINDOW_STYLE_FILLED                                          \
+    backcolor     .5 .5 .5 .4                                                  \
+    forecolor     .9 .9 .9 1                                                   \
+    border        WINDOW_BORDER_FULL                                           \
+    bordercolor   .1 .1 .1 .5                                                  \
+    visible       1                                                            \
+                                                                               \
+    mouseEnter {                                                               \
+      setitemcolor "bttn"##BUTTON_TEXT forecolor .9 .9 .9 1 ;                  \
+      setitemcolor "bttn"##BUTTON_TEXT backcolor .5 .5 .5 .4                   \
+    }                                                                          \
+                                                                               \
+    mouseExit {                                                                \
+      setitemcolor "bttn"##BUTTON_TEXT forecolor .9 .9 .9 1 ;                  \
+      setitemcolor "bttn"##BUTTON_TEXT backcolor .5 .5 .5 .4                   \
+    }                                                                          \
+                                                                               \
+    action {                                                                   \
+      setitemcolor "bttn"##BUTTON_TEXT forecolor .6 .6 .6 1 ;                  \
+      setitemcolor "bttn"##BUTTON_TEXT backcolor .3 .3 .3 .4 ;                 \
+      play "sound/menu/select.wav" ;                                           \
+      BUTTON_ACTION                                                            \
+    }                                                                          \
+  }
+
 // blank rectangle with no background
 #define WINDOW_BLANK( WINDOW_BLANK_X, WINDOW_BLANK_Y,                          \
                       WINDOW_BLANK_W, WINDOW_BLANK_H )                         \

--- a/assets/ui/menus.txt
+++ b/assets/ui/menus.txt
@@ -56,11 +56,17 @@
 	loadMenu { "ui/wm_ftquickmessage.menu" }
 	loadMenu { "ui/wm_ftquickmessageAlt.menu" }
 
+
+	// these need to be registered before the vote menus, so the tooltips in them draw over these
+	loadMenu { "ui/ingame_map_details.menu" }
+	loadMenu { "ui/ingame_customvote_details.menu" }
+
 	// ingame
 	loadMenu { "ui/ingame_main.menu" }
 	loadMenu { "ui/ingame_vote.menu" }
 	loadMenu { "ui/ingame_vote_disabled.menu" }
 	loadMenu { "ui/ingame_vote_map.menu" }
+	loadMenu { "ui/ingame_vote_customvote.menu" }
 	loadMenu { "ui/ingame_serverinfo.menu" }
 	loadMenu { "ui/ingame_disconnect.menu" }
 	loadMenu { "ui/ingame_messagemode.menu" }
@@ -71,8 +77,6 @@
 	loadMenu { "ui/etjump.menu" }
 	loadMenu { "ui/etjump_controls.menu" }
 	loadMenu { "ui/etjump_credits.menu" }
-
-	loadMenu { "ui/ingame_map_details.menu" }
 	loadMenu { "ui/ingame_ft_savelimit.menu" }
 
 	loadMenu { "ui/etjump_settings_general_gameplay.menu" }

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1266,6 +1266,15 @@ typedef struct {
   bool chatReplayReceived;
   bool maplistRequested;
 
+  // have we requested the amount of custom votes yet?
+  bool numCustomvotesRequested;
+  // have we requested the customvote infos to be sent?
+  bool customvoteInfoRequested;
+  // -1 if we haven't gotten the amount yet
+  int numCustomvotes;
+  // how many lists we've requested info for so far
+  int numCustomvoteInfosRequested;
+
   // portalgun auto-binding
   bool portalgunBindingsAdjusted;
   int weapAltB1;

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2671,6 +2671,11 @@ const int BG_LEVEL_NO_WALLBUG = 1 << 7;
 const int BG_LEVEL_NO_NOCLIP = 1 << 8;
 
 namespace ETJump {
+static constexpr char CUSTOMVOTE_TYPE[] = "type";
+static constexpr char CUSTOMVOTE_CVTEXT[] = "cvtext";
+static constexpr char CUSTOMVOTE_SERVERMAPS[] = "servermaps";
+static constexpr char CUSTOMVOTE_OTHERMAPS[] = "othermaps";
+
 enum class CheatCvarFlags {
   None = 0,
   LookYaw = 1,

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -385,6 +385,9 @@ static bool sendNumCustomvotes(gentity_t *ent, Arguments argv) {
 
 static bool sendCustomvoteInfo(gentity_t *ent, Arguments argv) {
   if (argv->size() < 2) {
+    Printer::console(
+        ent, ETJump::stringFormat("^3%s: ^7no list given as an argument.\n",
+                                  __func__));
     return false;
   }
 
@@ -392,6 +395,9 @@ static bool sendCustomvoteInfo(gentity_t *ent, Arguments argv) {
   const auto list = game.customMapVotes->getVotelistByIndex(index);
 
   if (list == nullptr) {
+    Printer::console(ent, ETJump::stringFormat(
+                              "^3%s: ^7no list with a given index ^3'%i'^7.\n",
+                              __func__, index));
     return false;
   }
 

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -363,7 +363,7 @@ static bool sendMaplist(gentity_t *ent, Arguments argv) {
   std::string mapList =
       ETJump::StringUtil::join(game.mapStatistics->getMaps(), " ");
   const std::string prefix = "maplist ";
-  const size_t msgLen = BYTES_PER_PACKET - prefix.length();
+  const size_t msgLen = BYTES_PER_PACKET - prefix.length() - 1;
 
   // split to multiple commands to ensure client gets the full list
   // each command is prefixed with 'maplist' so client recognizes
@@ -372,6 +372,87 @@ static bool sendMaplist(gentity_t *ent, Arguments argv) {
   for (auto &split : splits) {
     split.insert(0, prefix);
     trap_SendServerCommand(ClientNum(ent), std::string(split + '\n').c_str());
+  }
+
+  return true;
+}
+
+static bool sendNumCustomvotes(gentity_t *ent, Arguments argv) {
+  const size_t numlists = game.customMapVotes->getNumVotelists();
+  trap_SendServerCommand(ClientNum(ent), va("numcustomvotes %i\n", numlists));
+  return true;
+}
+
+static bool sendCustomvoteInfo(gentity_t *ent, Arguments argv) {
+  if (argv->size() < 2) {
+    return false;
+  }
+
+  const int index = Q_atoi(argv->at(1).c_str());
+  const auto list = game.customMapVotes->getVotelistByIndex(index);
+
+  if (list == nullptr) {
+    return false;
+  }
+
+  const std::string prefix = "customvotelist";
+  const int clientNum = ClientNum(ent);
+
+  /* The commands sent to client consist of following fields:
+   *
+   * cmd <type> <field> <data>
+   *
+   * Each command includes the list type as the first argument, so client knows
+   * which list the data in this command belongs to. This way we can ensure
+   * the client can construct the complete struct for any given list, regardless
+   * of the order in which the packets arrive in. They *should* arrive
+   * sequentially in the order we send them, this is just extra guarantee.
+   */
+
+  const std::string cmd = ETJump::stringFormat("%s \"%s\"", prefix, list->type);
+
+  // we could omit the type from the end here, but this simplifies parsing
+  const std::string typeCmd = ETJump::stringFormat(
+      "%s %s \"%s\"\n", cmd, ETJump::CUSTOMVOTE_TYPE, list->type);
+  const std::string cvTextCmd = ETJump::stringFormat(
+      "%s %s \"%s\"\n", cmd, ETJump::CUSTOMVOTE_CVTEXT, list->callvoteText);
+
+  trap_SendServerCommand(clientNum, typeCmd.c_str());
+  trap_SendServerCommand(clientNum, cvTextCmd.c_str());
+
+  const std::string serverMapsCmd =
+      ETJump::stringFormat("%s %s ", cmd, ETJump::CUSTOMVOTE_SERVERMAPS);
+  const std::string otherMapsCmd =
+      ETJump::stringFormat("%s %s ", cmd, ETJump::CUSTOMVOTE_OTHERMAPS);
+
+  const std::string serverMaps =
+      ETJump::StringUtil::join(list->mapsOnServer, " ");
+  const std::string otherMaps = ETJump::StringUtil::join(list->otherMaps, " ");
+
+  // we have to check if the combined string would be over max message length,
+  // because we need to always attach the command prefix in front
+  if (serverMapsCmd.length() + serverMaps.length() > BYTES_PER_PACKET - 1) {
+    const auto splits = ETJump::wrapWords(
+        serverMaps, ' ', BYTES_PER_PACKET - serverMapsCmd.length() - 1);
+
+    for (const auto &split : splits) {
+      trap_SendServerCommand(clientNum, (serverMapsCmd + split + '\n').c_str());
+    }
+  } else {
+    trap_SendServerCommand(clientNum,
+                           (serverMapsCmd + serverMaps + '\n').c_str());
+  }
+
+  if (otherMapsCmd.length() + otherMaps.length() > BYTES_PER_PACKET) {
+    const auto splits = ETJump::wrapWords(
+        otherMaps, ' ', BYTES_PER_PACKET - otherMapsCmd.length() - 1);
+
+    for (const auto &split : splits) {
+      trap_SendServerCommand(clientNum, (otherMapsCmd + split + '\n').c_str());
+    }
+  } else {
+    trap_SendServerCommand(clientNum,
+                           (otherMapsCmd + otherMaps + '\n').c_str());
   }
 
   return true;
@@ -2510,6 +2591,8 @@ Commands::Commands() {
   commands_["seasons"] = ClientCommands::ListSeasons;
   commands_["getchatreplay"] = ClientCommands::GetChatReplay;
   commands_["requestmaplist"] = ClientCommands::sendMaplist;
+  commands_["requestnumcustomvotes"] = ClientCommands::sendNumCustomvotes;
+  commands_["requestcustomvoteinfo"] = ClientCommands::sendCustomvoteInfo;
 }
 
 bool Commands::ClientCommand(gentity_t *ent, const std::string &commandStr) {

--- a/src/game/etj_custom_map_votes.cpp
+++ b/src/game/etj_custom_map_votes.cpp
@@ -453,6 +453,18 @@ CustomMapVotes::getMapsOnList(const std::string &name) {
   return mapList;
 }
 
+size_t CustomMapVotes::getNumVotelists() const {
+  return customMapVotes_.size();
+}
+
+CustomMapVotes::MapType *CustomMapVotes::getVotelistByIndex(const int index) {
+  if (index < 0 || index >= customMapVotes_.size()) {
+    return nullptr;
+  }
+
+  return &customMapVotes_[index];
+}
+
 std::string const CustomMapVotes::RandomMap(std::string const &type) {
   for (unsigned i = 0; i < customMapVotes_.size(); i++) {
     auto &customMapVote = customMapVotes_[i];

--- a/src/game/etj_custom_map_votes.h
+++ b/src/game/etj_custom_map_votes.h
@@ -56,6 +56,9 @@ public:
   std::string ListInfo(const std::string &name);
   std::vector<std::string> getMapsOnList(const std::string &name);
   void GenerateVotesFile();
+  size_t getNumVotelists() const;
+  // returns nullptr on invalid index
+  CustomMapVotes::MapType *getVotelistByIndex(int index);
 
   void addCustomvoteList(int clientNum, const std::string &name,
                          const std::string &fullName, const std::string &maps);

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -295,6 +295,8 @@ qboolean OnConsoleCommand() {
 
   if (command == "readcustomvotes") {
     game.customMapVotes->Load();
+    // force voteflag re-check so UI can turn on/off custom vote button
+    G_voteFlags();
     return qtrue;
   }
 

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -1957,6 +1957,10 @@ void G_InitGame(int levelTime, int randomSeed, int restart) {
   OnGameInit();
   ETJump_InitGame(levelTime, randomSeed, restart);
 
+  // setup voteflags, must be called after ETJump init because we need
+  // to check the amount of custom votes on server in here
+  G_voteFlags();
+
   if (G_PatchFixEnabled()) {
     G_Printf("\n^7--------- ^1!!! WARNING !!! ^7---------\n\n^7Server started "
              "with ^3cm_optimizePatchPlanes 0\n^7Patch collision is different "

--- a/src/game/g_match.cpp
+++ b/src/game/g_match.cpp
@@ -26,9 +26,6 @@ void G_loadMatchGame() {
   trap_SetConfigstring(CS_CUSTMOTD + 4, server_motd4.string);
   trap_SetConfigstring(CS_CUSTMOTD + 5, server_motd5.string);
 
-  // Voting flags
-  G_voteFlags();
-
   // Set up the random reinforcement seeds for both teams and send to clients
   dwBlueOffset = rand() % MAX_REINFSEEDS;
   dwRedOffset = rand() % MAX_REINFSEEDS;

--- a/src/game/g_vote.cpp
+++ b/src/game/g_vote.cpp
@@ -8,6 +8,7 @@
 #include "etj_map_statistics.h"
 #include "etj_numeric_utilities.h"
 #include "etj_rtv.h"
+#include "etj_custom_map_votes.h"
 #include <set>
 
 #define T_FFA 0x01
@@ -24,6 +25,9 @@ static const char *ACTIVATED = "ACTIVATED";
 static const char *DEACTIVATED = "DEACTIVATED";
 static const char *ENABLED = "ENABLED";
 static const char *DISABLED = "DISABLED";
+
+// note: this is also defined in ui/menudef.h for usage in .menu files
+static constexpr int CV_SVF_CUSTOMVOTE = 32;
 
 //
 // Update info:
@@ -169,6 +173,10 @@ void G_voteFlags(void) {
       if (trap_Cvar_VariableIntegerValue(voteToggles[i].pszCvar) == 0) {
         flags |= voteToggles[i].flag;
       }
+    }
+
+    if (game.customMapVotes->getNumVotelists() == 0) {
+      flags |= CV_SVF_CUSTOMVOTE;
     }
   }
   if (flags != voteFlags.integer) {

--- a/src/ui/ui_atoms.cpp
+++ b/src/ui/ui_atoms.cpp
@@ -205,6 +205,16 @@ qboolean UI_ConsoleCommand(int realTime) {
     return qtrue;
   }
 
+  if (!Q_stricmp(cmd, "uiNumCustomvotes")) {
+    ETJump::parseNumCustomvotes();
+    return qtrue;
+  }
+
+  if (!Q_stricmp(cmd, "uiParseCustomvote")) {
+    ETJump::parseCustomvote();
+    return qtrue;
+  }
+
   trap_GetClientState(&cstate);
 
   return qfalse;

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -7,6 +7,7 @@
 #include "keycodes.h"
 #include "../game/bg_public.h"
 #include "ui_shared.h"
+#include "../game/etj_custom_map_votes.h"
 
 #include <vector>
 #include <stack>
@@ -120,6 +121,7 @@ extern vmCvar_t cl_bypassMouseInput;
 extern vmCvar_t ui_autoredirect;
 
 extern vmCvar_t ui_voteCheats;
+extern vmCvar_t ui_voteCustomRTV;
 
 extern vmCvar_t etj_menuSensitivity;
 
@@ -897,6 +899,12 @@ typedef struct {
   bool vetClient; // original 2.60b, steam 2.60b or 2.60d
 
   std::vector<std::string> serverMaplist;
+
+  std::vector<CustomMapVotes::MapType> customVotes;
+  int numCustomvotes; // -1 if we haven't gotten the count yet
+  int customvoteIndex;
+  int customvoteMapsOnServerIndex;
+  int customvoteOtherMapsIndex;
 } uiInfo_t;
 
 extern uiInfo_t uiInfo;
@@ -1108,6 +1116,9 @@ void ETJump_DrawMapDetails();
 
 namespace ETJump {
 void parseMaplist();
+
+void parseNumCustomvotes();
+void parseCustomvote();
 
 struct TextScroll {
   // the item which we're currently bound to, used to reset the state when


### PR DESCRIPTION
Display custom votes in UI for voting.

* Lists are requested on demand when the menu is opened, so there's usually a small hitch + delay when the menu is opened for the first time. Results are cached, so this is only on initial open for each map.
* UI includes a toggle for voting with `randommap` or `rtv`
* `Details` panel displays the maps on the list, as well as maps on the list but not on server

While making this, I discovered few issues with #1431 as well as some improvements that can be done for that (`vid_restart` = double entires, list can be requested on demand), but I will address those in a separate PR.

![image](https://github.com/user-attachments/assets/9cd8179a-65dc-4f0c-b572-cc9320d9975c)

fixes #991 
