### PR TITLE
Add scrolling text to dropdown menu previews

### DIFF
--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -1108,20 +1108,5 @@ void ETJump_DrawMapDetails();
 
 namespace ETJump {
 void parseMaplist();
-
-struct TextScroll {
-  // the item which we're currently bound to, used to reset the state when
-  // switching selection (e.g. selecting a new map to read briefing from)
-  int scrollItem;
-
-  int scrollStartTime;
-  int scrollEndTime;
-  float scrollDeltaTime; // for framerate independent scroll speed
-
-  float x;
-  float y;
-
-  bool scrolling;
-};
 } // namespace ETJump
 #endif

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -1643,7 +1643,7 @@ void UI_DrawGametypeDescription(rectDef_t *rect, float scale, vec4_t color,
   }
 }
 
-void UI_DrawMapDescription(rectDef_t *rect, float scale, vec4_t color,
+void UI_DrawMapDescription(rectDef_t *rect, float scale, const vec4_t color,
                            float text_x, int textStyle, int align) {
   fontInfo_t *font = &uiInfo.uiDC.Assets.fonts[uiInfo.activeFont];
   rectDef_t textRect = {0, 0, rect->w, rect->h};
@@ -1678,7 +1678,7 @@ void UI_DrawMapDescription(rectDef_t *rect, float scale, vec4_t color,
     return;
   }
 
-  static ETJump::TextScroll ts;
+  static textScroll_t ts;
 
   if (ts.scrollStartTime == 0 ||
       (!ts.scrolling && DC->realTime > ts.scrollEndTime) ||

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -261,6 +261,26 @@ struct colorSliderDef_t {
   int colorType; // HSV, RGB, Alpha
 };
 
+struct textScroll_t {
+  // the item which we're currently bound to, used to reset the state when
+  // switching selection (e.g. selecting a new map to read briefing from)
+  int scrollItem;
+  // the text currently being scrolled, used to reset the state if
+  // text updates mid-scroll
+  char scrollText[MAX_TOKEN_CHARS];
+
+  int scrollStartTime;
+  int scrollEndTime;
+  float scrollDeltaTime; // for framerate independent scroll speed
+
+  float x;
+  float y;
+
+  int textOffset; // text index when scrolling horizontally off-screen
+
+  bool scrolling;
+};
+
 #define CVAR_ENABLE 0x00000001
 #define CVAR_DISABLE 0x00000002
 #define CVAR_SHOW 0x00000004
@@ -351,6 +371,8 @@ typedef struct itemDef_s {
 
   colorSliderDef_t colorSliderData;
   bool tooltipAbove;
+
+  textScroll_t textScroll;
 } itemDef_t;
 
 typedef struct {


### PR DESCRIPTION
Scroll text if it's too long to fit into the textbox. This can often happen with color values when using the color picker.

No fancy fade in/out here, might add it in the future, but it's kinda ass to implement.

https://streamable.com/mv4s4q

fixes #1423 