### PR TITLE
Fix slider step parsing ignoring return value

### DIFF
--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -7386,7 +7386,7 @@ qboolean ItemParse_cvarFloat(itemDef_t *item, int handle) {
       PC_Float_Parse(handle, &editPtr->minVal) &&
       PC_Float_Parse(handle, &editPtr->maxVal)) {
     if (ETJump::PC_hasFloat(handle)) {
-      PC_Float_Parse(handle, &editPtr->step);
+      return PC_Float_Parse(handle, &editPtr->step);
     }
     return qtrue;
   }
@@ -7686,7 +7686,7 @@ qboolean ItemParse_colorSliderVar(itemDef_t *item, int handle) {
       PC_Float_Parse(handle, &editPtr->minVal) &&
       PC_Float_Parse(handle, &editPtr->maxVal)) {
     if (ETJump::PC_hasFloat(handle)) {
-      PC_Float_Parse(handle, &editPtr->step);
+      return PC_Float_Parse(handle, &editPtr->step);
     }
     return qtrue;
   }


### PR DESCRIPTION
`PC_hasFloat` should already take care of validating the input, but regardless we should not ignore the return value of `PC_Float_Parse`.

refs #334, #1422 