### PR TITLE
Fix ui_restart breaking mapvote menu

### DIFF
--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -622,6 +622,11 @@ qboolean CG_ConsoleCommandExt(const char *cmd) {
     return qtrue;
   }
 
+  if (command == "forceMaplistRefresh") {
+    cg.maplistRequested = false;
+    return qtrue;
+  }
+
   if (command == "forceCustomvoteRefresh") {
     cg.numCustomvotesRequested = false;
     cg.customvoteInfoRequested = false;

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -1347,8 +1347,7 @@ void UI_LoadMenus(const char *menuFile, qboolean reset) {
   // if we're already in-game, force a re-request for map list and customvotes
   // this only ever executes if we do 'ui_restart' while in-game
   if (cstate.connState == CA_ACTIVE) {
-    // FIXME: this does nothing
-    // trap_Cmd_ExecuteText(EXEC_APPEND, "requestmaplist\n");
+    trap_Cmd_ExecuteText(EXEC_APPEND, "forceMaplistRefresh\n");
     trap_Cmd_ExecuteText(EXEC_APPEND, "forceCustomvoteRefresh\n");
   }
 


### PR DESCRIPTION
Force resend of maplist from server to client if ui_restart is called.

refs #1431 