### PR TITLE
Fix sliders spamming cvar updates

### DIFF
--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -3608,6 +3608,17 @@ static void Scroll_Slider_ThumbFunc(void *p) {
     value = std::roundf(value / editDef->step) * editDef->step;
   }
 
+  const float oldValue =
+      si->item->cvar
+          ? DC->getCVarValue(si->item->cvar)
+          : DC->getColorSliderValue(si->item->colorSliderData.colorVar);
+
+  // if we haven't moved the mouse enough to update the cvar value,
+  // don't spam cvar updates for no reason
+  if (oldValue == value) {
+    return;
+  }
+
   if (si->item->cvar) {
     DC->setCVar(si->item->cvar, va("%f", value));
   } else {


### PR DESCRIPTION
If we haven't moved the mouse enough to switch into a new value, don't spam cvar updates for no reason.

refs #1453 