### PR TITLE
Fix UI sending client commands on vid_restart

### DIFF
--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -5074,6 +5074,13 @@ void ClientCommand(int clientNum) {
     return;
   }
 
+  // if we execute a `vid_restart`, UI will send these while cgame isn't loaded,
+  // and they end up here as unrecognized console commands
+  if (!Q_stricmp(cmd, "forceMaplistRefresh") ||
+      !Q_stricmp(cmd, "forceCustomvoteRefresh")) {
+    return;
+  }
+
   CP(va("print \"Unknown command %s^7.\n\"", cmd));
 }
 

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -1346,7 +1346,7 @@ void UI_LoadMenus(const char *menuFile, qboolean reset) {
   uiInfo.customVotes.clear();
 
   // if we're already in-game, force a re-request for map list and customvotes
-  // this only ever executes if we do 'ui_restart' while in-game
+  // this only ever executes if we do 'ui/vid_restart' while in-game
   if (cstate.connState == CA_ACTIVE) {
     trap_Cmd_ExecuteText(EXEC_APPEND, "forceMaplistRefresh\n");
     trap_Cmd_ExecuteText(EXEC_APPEND, "forceCustomvoteRefresh\n");


### PR DESCRIPTION
cgame isn't loaded at the time this code executes if a client does vid_restart while on server, so they get forwarded to qagame as client commands

refs #1447, #1431 