### PR TITLE
Fix chatreplay JSON value initialization

### DIFF
--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -56,7 +56,7 @@ void ChatReplay::storeChatMessage(int clientNum, const std::string &name,
   }
 }
 
-void ChatReplay::sendChatMessages(gentity_t *ent) {
+void ChatReplay::sendChatMessages(gentity_t *ent) const {
   if (!ent || !ent->client) {
     return;
   }
@@ -112,11 +112,12 @@ void ChatReplay::readChatsFromFile() {
   }
 }
 
-void ChatReplay::writeChatsToFile() {
+void ChatReplay::writeChatsToFile() const {
   Json::Value root;
-  Json::Value chat;
 
   for (const auto &msg : chatReplayBuffer) {
+    Json::Value chat;
+
     chat["clientNum"] = msg.clientNum;
     chat["name"] = msg.name;
     chat["message"] = msg.message;

--- a/src/game/etj_chat_replay.h
+++ b/src/game/etj_chat_replay.h
@@ -46,7 +46,7 @@ class ChatReplay {
 
   static std::string parseChatMessage(const ChatMessage &msg);
   void readChatsFromFile();
-  void writeChatsToFile();
+  void writeChatsToFile() const;
 
 public:
   ChatReplay();
@@ -56,6 +56,6 @@ public:
                         const std::string &message, bool localize,
                         bool encoded);
 
-  void sendChatMessages(gentity_t *ent);
+  void sendChatMessages(gentity_t *ent) const;
 };
 } // namespace ETJump

--- a/src/game/etj_game.h
+++ b/src/game/etj_game.h
@@ -41,7 +41,7 @@ class Timerun;
 class MapStatistics;
 
 struct Game {
-  Game() {}
+  Game() = default;
 
   std::shared_ptr<Levels> levels;
   std::shared_ptr<Commands> commands;
@@ -51,5 +51,5 @@ struct Game {
   std::shared_ptr<ETJump::Tokens> tokens;
   std::shared_ptr<ETJump::TimerunV2> timerunV2;
   std::shared_ptr<ETJump::RockTheVote> rtv;
-  std::shared_ptr<ETJump::ChatReplay> chatReplay;
+  std::unique_ptr<ETJump::ChatReplay> chatReplay;
 };

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -147,7 +147,7 @@ void OnGameInit() {
   game.motd = std::make_shared<Motd>();
   game.tokens = std::make_shared<ETJump::Tokens>();
   game.rtv = std::make_shared<ETJump::RockTheVote>();
-  game.chatReplay = std::make_shared<ETJump::ChatReplay>();
+  game.chatReplay = std::make_unique<ETJump::ChatReplay>();
 
   if (strlen(g_levelConfig.string)) {
     if (!game.levels->ReadFromConfig()) {


### PR DESCRIPTION
Re-initialize chat inside the loop so there's never lingering data from previous iteration.

Also make the chatreplay an `std::unique_ptr`, it doesn't need to be an `std::shared_ptr`. The `Game` struct previously didn't allow for unique pointers because it used an empty user-defined constructor, which doesn't allow move constructor/assignment. Use default constructor instead so we can use unique pointers.

refs #1335 