### PR TITLE
Move chat replay writing out of destructor

### DIFF
--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -36,8 +36,6 @@ ChatReplay::ChatReplay() {
   readChatsFromFile();
 }
 
-ChatReplay::~ChatReplay() { writeChatsToFile(); }
-
 void ChatReplay::storeChatMessage(int clientNum, const std::string &name,
                                   const std::string &message, bool localize,
                                   bool encoded) {

--- a/src/game/etj_chat_replay.h
+++ b/src/game/etj_chat_replay.h
@@ -46,16 +46,17 @@ class ChatReplay {
 
   static std::string parseChatMessage(const ChatMessage &msg);
   void readChatsFromFile();
-  void writeChatsToFile() const;
 
 public:
   ChatReplay();
-  ~ChatReplay();
+  ~ChatReplay() = default;
 
   void storeChatMessage(int clientNum, const std::string &name,
                         const std::string &message, bool localize,
                         bool encoded);
 
   void sendChatMessages(gentity_t *ent) const;
+
+  void writeChatsToFile() const;
 };
 } // namespace ETJump

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -210,14 +210,21 @@ void OnGameShutdown() {
   if (ETJump::database != nullptr) {
     ETJump::database->CloseDatabase();
   }
+
   if (game.mapStatistics != nullptr) {
     game.mapStatistics->saveChanges();
   }
+
   if (game.tokens != nullptr) {
-    game.tokens->reset();
+    ETJump::Tokens::reset();
   }
+
   if (game.timerunV2) {
     game.timerunV2->shutdown();
+  }
+
+  if (game.chatReplay) {
+    game.chatReplay->writeChatsToFile();
   }
 
   game.levels = nullptr;
@@ -229,6 +236,7 @@ void OnGameShutdown() {
   game.timerunV2 = nullptr;
   game.rtv = nullptr;
   game.chatReplay = nullptr;
+
   ETJump::Log::processMessages();
 }
 


### PR DESCRIPTION
`JsonUtils::writeFile` can throw an exception so it should not be called from the destructor.

refs #1335 