### PR TITLE
Refactor JSON parsing + logging

### DIFF
--- a/src/game/etj_chat_replay.h
+++ b/src/game/etj_chat_replay.h
@@ -37,26 +37,28 @@ class ChatReplay {
     bool encoded;
   };
 
-  static Log logger;
-
   static constexpr int MAX_CHAT_REPLAY_BUFFER = 10;
   const std::string chatReplayFile = "chatreplay.json";
+
+  std::unique_ptr<Log> logger;
+  std::string errors{};
 
   std::list<ChatMessage> chatReplayBuffer;
 
   static std::string parseChatMessage(const ChatMessage &msg);
   void readChatsFromFile();
+  void storeChatMessage(const ChatMessage &msg);
 
 public:
-  ChatReplay();
+  explicit ChatReplay(std::unique_ptr<Log> log);
   ~ChatReplay() = default;
 
-  void storeChatMessage(int clientNum, const std::string &name,
-                        const std::string &message, bool localize,
-                        bool encoded);
+  void createChatMessage(int clientNum, const std::string &name,
+                         const std::string &message, bool localize,
+                         bool encoded);
 
   void sendChatMessages(gentity_t *ent) const;
 
-  void writeChatsToFile() const;
+  void writeChatsToFile();
 };
 } // namespace ETJump

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -1912,9 +1912,9 @@ bool createToken(gentity_t *ent, Arguments argv) {
   }
 
   Printer::chat(ent, ETJump::stringFormat(
-                         "Creating a token at (%f, %f, %f) for difficulty (%d)",
+                         "Creating a token at (%f, %f, %f) for difficulty '%s'",
                          coordinates[0], coordinates[1], coordinates[2],
-                         static_cast<int>(difficulty)));
+                         ETJump::Tokens::tokenDifficultyToString(difficulty)));
 
   auto result = game.tokens->createToken(difficulty, coordinates);
   if (!result.first) {

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -113,7 +113,13 @@ bool listCustomVotes(gentity_t *ent, Arguments argv) {
   const std::string &cmd = argv->at(0);
 
   if (argv->size() != 2) {
-    std::string types = game.customMapVotes->ListTypes();
+    std::string types = game.customMapVotes->listTypes();
+
+    if (types.empty()) {
+      Printer::console(clientNum, "No custom map votes found on the server.\n");
+      return true;
+    }
+
     Printer::console(
         clientNum,
         ETJump::stringFormat(
@@ -124,7 +130,7 @@ bool listCustomVotes(gentity_t *ent, Arguments argv) {
   }
 
   const auto &type = argv->at(1);
-  const std::string maplist = game.customMapVotes->ListInfo(type);
+  const std::string maplist = game.customMapVotes->listInfo(type);
   if (maplist.empty()) {
     Printer::console(
         clientNum, ETJump::stringFormat("^3%s: ^gcould not find list ^3'%s'\n",
@@ -1413,7 +1419,7 @@ bool Map(gentity_t *ent, Arguments argv) {
     return false;
   }
 
-  if (MapStatistics::isBlockedMap(requestedMap)) {
+  if (ETJump::MapStatistics::isBlockedMap(requestedMap)) {
     Printer::chat(ent, "^3map: ^7'" + requestedMap +
                            "' cannot be played on this server.");
     return false;

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -1925,8 +1925,11 @@ bool moveToken(gentity_t *ent) {
   }
   std::array<float, 3> coordinates{};
   VectorCopy(ent->r.currentOrigin, coordinates);
+  // move closer to ground, but not quite to ground level
+  // to avoid clipping into slopes a bit
+  coordinates[2] += ent->client->ps.mins[2] + 2;
 
-  auto result = game.tokens->moveNearestToken(coordinates);
+  const auto result = game.tokens->moveNearestToken(coordinates);
   if (!result.first) {
     Printer::chat(ent, "^3error: ^7" + result.second);
     return false;
@@ -1950,7 +1953,7 @@ bool deleteToken(gentity_t *ent, Arguments argv) {
   if (argv->size() == 2) {
     std::array<float, 3> coordinates{};
     VectorCopy(ent->r.currentOrigin, coordinates);
-    auto result = game.tokens->deleteNearestToken(coordinates);
+    const auto result = game.tokens->deleteNearestToken(coordinates);
     if (!result.first) {
       Printer::chat(ent, "^3error: ^7" + result.second);
       return false;

--- a/src/game/etj_custom_map_votes.cpp
+++ b/src/game/etj_custom_map_votes.cpp
@@ -34,99 +34,110 @@
 #include "etj_json_utilities.h"
 #include "etj_filesystem.h"
 
-CustomMapVotes::CustomMapVotes(MapStatistics *mapStats) : _mapStats(mapStats) {}
-
-CustomMapVotes::~CustomMapVotes() {}
+namespace ETJump {
+CustomMapVotes::CustomMapVotes(const std::shared_ptr<MapStatistics> &mapStats,
+                               std::unique_ptr<Log> log)
+    : _mapStats(mapStats), logger(std::move(log)) {}
 
 CustomMapVotes::TypeInfo
-CustomMapVotes::GetTypeInfo(std::string const &type) const {
-  for (unsigned i = 0; i < customMapVotes_.size(); i++) {
-    if (customMapVotes_[i].type == type) {
-      return TypeInfo(true, customMapVotes_[i].callvoteText);
+CustomMapVotes::getTypeInfo(std::string const &type) const {
+  for (const auto &customMapVote : customMapVotes_) {
+    if (customMapVote.type == type) {
+      return {true, customMapVote.callvoteText};
     }
   }
-  return TypeInfo(false, "");
+  return {false, ""};
 }
 
-bool CustomMapVotes::Load() {
-  if (strlen(g_customMapVotesFile.string) == 0) {
-    return false;
+void CustomMapVotes::loadCustomvotes() {
+  const std::string filename = g_customMapVotesFile.string;
+
+  if (filename.empty()) {
+    return;
   }
+
   _currentMapsOnServer = _mapStats->getCurrentMaps();
-
   customMapVotes_.clear();
-  std::string path =
-      ETJump::FileSystem::Path::getPath(g_customMapVotesFile.string);
-  std::ifstream f(path.c_str());
 
-  if (!f) {
-    G_LogPrintf("Couldn't open \"%s\". Use /rcon "
-                "generatecustomvotes to "
-                "generate an example file.\n",
-                g_customMapVotesFile.string);
-    return false;
+  const auto parsingFailed = [&](const std::string &errMsg) {
+    logger->error(errMsg);
+    customMapVotes_.clear();
+  };
+
+  if (!FileSystem::exists(filename)) {
+    logger->info("Customvote file not found. Use '/generatecustomvotes' to "
+                 "generate an example file.");
+    return;
   }
-  std::string content((std::istreambuf_iterator<char>(f)),
-                      std::istreambuf_iterator<char>());
 
   Json::Value root;
-  Json::Reader reader;
 
-  if (!reader.parse(content, root)) {
-    G_LogPrintf("There was a parsing error in the %s: %s\n",
-                reader.getFormattedErrorMessages().c_str(),
-                g_customMapVotesFile.string);
-    return false;
+  if (!JsonUtils::readFile(filename, root, &errors)) {
+    logger->error(errors);
+    return;
   }
 
-  try {
-    for (const auto &list : root) {
-      customMapVotes_.emplace_back();
-      unsigned curr = customMapVotes_.size() - 1;
+  for (const auto &list : root) {
+    customMapVotes_.emplace_back();
+    const size_t curr = customMapVotes_.size() - 1;
 
-      Json::Value maps = list["maps"];
-      customMapVotes_[curr].type =
-          ETJump::sanitize(list["name"].asString(), true);
-      customMapVotes_[curr].callvoteText =
-          ETJump::sanitize(list["callvote_text"].asString());
+    if (!JsonUtils::parseValue(customMapVotes_[curr].type, list["name"],
+                               &errors, "name")) {
+      parsingFailed(errors);
+      return;
+    }
 
-      std::set<std::string> uniqueMapsOnServer{};
-      std::set<std::string> uniqueMapsOther{};
+    customMapVotes_[curr].type = sanitize(customMapVotes_[curr].type, true);
 
-      // clean up the list from potential duplicates
-      // FIXME: we should rather erase the duplicates from the json file itself
-      for (const auto &map : maps) {
-        const std::string &mapName = ETJump::sanitize(map.asString(), true);
+    if (!JsonUtils::parseValue(customMapVotes_[curr].callvoteText,
+                               list["callvote_text"], &errors,
+                               "callvote_text")) {
+      parsingFailed(errors);
+      return;
+    }
 
-        if (std::binary_search(_currentMapsOnServer->begin(),
-                               _currentMapsOnServer->end(), mapName)) {
-          uniqueMapsOnServer.insert(mapName);
-        } else {
-          uniqueMapsOther.insert(mapName);
-        }
+    customMapVotes_[curr].callvoteText =
+        sanitize(customMapVotes_[curr].callvoteText);
+
+    std::set<std::string> uniqueMapsOnServer{};
+    std::set<std::string> uniqueMapsOther{};
+
+    Json::Value maps = list["maps"];
+
+    // clean up the list from potential duplicates
+    for (const auto &map : maps) {
+      std::string mapName;
+      if (!JsonUtils::parseValue(mapName, map, &errors, "map")) {
+        parsingFailed(errors);
+        return;
       }
 
-      for (const auto &map : uniqueMapsOnServer) {
-        customMapVotes_[curr].mapsOnServer.emplace_back(map);
-      }
+      mapName = sanitize(mapName, true);
 
-      for (const auto &map : uniqueMapsOther) {
-        customMapVotes_[curr].otherMaps.emplace_back(map);
+      if (std::binary_search(_currentMapsOnServer->begin(),
+                             _currentMapsOnServer->end(), mapName)) {
+        uniqueMapsOnServer.insert(mapName);
+      } else {
+        uniqueMapsOther.insert(mapName);
       }
     }
-  } catch (...) {
-    G_LogPrintf("There was a read error in %s parser\n",
-                g_customMapVotesFile.string);
-    return false;
+
+    for (const auto &map : uniqueMapsOnServer) {
+      customMapVotes_[curr].mapsOnServer.emplace_back(map);
+    }
+
+    for (const auto &map : uniqueMapsOther) {
+      customMapVotes_[curr].otherMaps.emplace_back(map);
+    }
   }
 
-  G_LogPrintf("Successfully initialized custom votes.\n");
-  return true;
+  logger->info("Succesfully loaded %i custom votes from '%s'",
+               static_cast<int>(customMapVotes_.size()), filename);
 }
 
-std::string CustomMapVotes::ListTypes() const {
+std::string CustomMapVotes::listTypes() const {
   std::string buf;
-  for (unsigned i = 0; i < customMapVotes_.size(); i++) {
+  for (int i = 0; i < customMapVotes_.size(); i++) {
     if (i != (customMapVotes_.size() - 1)) {
       buf += customMapVotes_[i].type + ", ";
     } else {
@@ -136,29 +147,29 @@ std::string CustomMapVotes::ListTypes() const {
   return buf;
 }
 
-void CustomMapVotes::GenerateVotesFile() {
+void CustomMapVotes::generateVotesFile() {
   Arguments argv = GetArgs();
-  std::ifstream in(
-      ETJump::FileSystem::Path::getPath(g_customMapVotesFile.string));
-  if (in.good()) {
-    if (argv->size() == 1) {
-      G_Printf("A custom map votes file exists. Are you "
-               "sure you want to overwrite "
-               "the write? Do /rcon generatecustomvotes -f "
-               "if you are sure.");
-      return;
-    }
-    if (argv->size() == 2 && argv->at(1) == "-f") {
-      G_LogPrintf("Overwriting custom map votes file "
-                  "with a default one.\n");
-    } else {
-      G_Printf("Unknown argument \"%s\".\n", argv->at(1).c_str());
+
+  const bool overwrite = argv->size() > 1 && argv->at(1) == "-f";
+  const std::string filename = g_customMapVotesFile.string;
+
+  if (argv->size() == 1 || !overwrite) {
+    if (FileSystem::exists(filename)) {
+      G_Printf("A custom map vote file '%s' already exists. Use "
+               "'generatecustomvotes -f' to overwrite the existing file.\n",
+               filename.c_str());
       return;
     }
   }
-  in.close();
+
+  if (overwrite) {
+    G_Printf("Overwriting custom map vote file '%s' with a default one.\n",
+             filename.c_str());
+  }
+
   Json::Value root = Json::arrayValue;
   Json::Value vote;
+
   vote["name"] = "originals";
   vote["callvote_text"] = "Original 6 Maps";
   vote["maps"] = Json::arrayValue;
@@ -168,28 +179,23 @@ void CustomMapVotes::GenerateVotesFile() {
   vote["maps"].append("goldrush");
   vote["maps"].append("railgun");
   vote["maps"].append("battery");
+
   root.append(vote);
+
   vote["name"] = "just_oasis";
   vote["callvote_text"] = "Just oasis";
   vote["maps"] = Json::arrayValue;
   vote["maps"].append("oasis");
+
   root.append(vote);
 
-  Json::StyledWriter writer;
-  std::string output = writer.write(root);
-  std::ofstream fOut(
-      ETJump::FileSystem::Path::getPath(g_customMapVotesFile.string));
-  if (!fOut) {
-    G_Printf("Couldn't open file \"%s\" defined in "
-             "g_customMapVotesFile.\n",
-             g_customMapVotesFile.string);
+  if (!JsonUtils::writeFile(filename, root, &errors)) {
+    G_Printf("%s\n", errors.c_str());
     return;
   }
-  fOut << output;
-  fOut.close();
-  G_Printf("Generated new custom map votes file \"%s\"\n",
-           g_customMapVotesFile.string);
-  Load();
+
+  G_Printf("Generated new custom map votes file '%s'\n", filename.c_str());
+  loadCustomvotes();
 }
 
 void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
@@ -197,20 +203,20 @@ void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
                                        const std::string &maps) {
   const std::string &customVotesFile = g_customMapVotesFile.string;
   Json::Value root;
-  const std::string sanitizedName = ETJump::sanitize(name, true);
+  const std::string sanitizedName = sanitize(name, true);
 
   // read and append to existing file if present
-  if (ETJump::FileSystem::exists(customVotesFile)) {
-    if (ETJump::JsonUtils::readFile(customVotesFile, root)) {
+  if (FileSystem::exists(customVotesFile)) {
+    if (JsonUtils::readFile(customVotesFile, root, &errors)) {
       // make sure we don't already have a list with this name
       for (const auto &lists : customMapVotes_) {
         if (sanitizedName == lists.type) {
           Printer::chat(clientNum, "^3add-customvote: ^7operation failed, "
                                    "check console for more information.");
-          Printer::console(clientNum, ETJump::stringFormat(
-                                          "^3add-customvote: ^7a list with the "
-                                          "name ^3'%s' ^7already exists.\n",
-                                          sanitizedName));
+          Printer::console(clientNum,
+                           stringFormat("^3add-customvote: ^7a list with the "
+                                        "name ^3'%s' ^7already exists.\n",
+                                        sanitizedName));
           return;
         }
       }
@@ -218,41 +224,42 @@ void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
       Printer::chat(clientNum, "^3add-customvote: ^7operation failed, check "
                                "console for more information.");
       Printer::console(clientNum,
-                       ETJump::stringFormat("^3add-customvote: ^7couldn't open "
-                                            "the file ^3'%s' ^7for reading.\n",
-                                            customVotesFile));
+                       stringFormat("^3add-customvote: ^7couldn't open the "
+                                    "file ^3'%s' ^7for reading:\n",
+                                    customVotesFile));
+      Printer::console(clientNum, errors);
       return;
     }
   }
 
   Json::Value vote;
   vote["name"] = sanitizedName;
-  vote["callvote_text"] = ETJump::sanitize(fullName);
+  vote["callvote_text"] = sanitize(fullName);
   vote["maps"] = Json::arrayValue;
 
-  const auto mapList = ETJump::StringUtil::split(maps, " ");
+  const auto mapList = StringUtil::split(maps, " ");
 
   for (const auto &map : mapList) {
-    vote["maps"].append(ETJump::sanitize(map, true));
+    vote["maps"].append(sanitize(map, true));
   }
 
   root.append(vote);
 
-  if (!ETJump::JsonUtils::writeFile(customVotesFile, root)) {
+  if (!JsonUtils::writeFile(customVotesFile, root, &errors)) {
     Printer::chat(clientNum, "^3add-customvote: ^7operation failed, check "
                              "console for more information.");
     Printer::console(clientNum,
-                     ETJump::stringFormat("^3add-customvote: ^7couldn't open "
-                                          "the file ^3'%s' ^7for writing.\n",
-                                          customVotesFile));
+                     stringFormat("^3add-customvote: ^7couldn't open the file "
+                                  "^3'%s' ^7for writing:\n",
+                                  customVotesFile));
+    Printer::console(clientNum, errors);
     return;
   }
 
-  Load();
-  Printer::chat(clientNum,
-                ETJump::stringFormat("^3add-customvote: ^7successfully added a "
-                                     "new custom vote list ^3'%s'",
-                                     sanitizedName));
+  loadCustomvotes();
+  Printer::chat(clientNum, stringFormat("^3add-customvote: ^7successfully "
+                                        "added a new custom vote list ^3'%s'",
+                                        sanitizedName));
 }
 
 void CustomMapVotes::deleteCustomvoteList(int clientNum,
@@ -260,13 +267,14 @@ void CustomMapVotes::deleteCustomvoteList(int clientNum,
   const std::string &customVotesFile = g_customMapVotesFile.string;
   Json::Value root;
 
-  if (!ETJump::JsonUtils::readFile(customVotesFile, root)) {
+  if (!JsonUtils::readFile(customVotesFile, root, &errors)) {
     Printer::chat(clientNum, "^3delete-customvote: ^7operation failed, check "
                              "console for more information.");
-    Printer::console(
-        clientNum, ETJump::stringFormat("^3delete-customvote: ^7couldn't open "
-                                        "the file ^3'%s' ^7for reading.\n",
-                                        customVotesFile));
+    Printer::console(clientNum,
+                     stringFormat("^3delete-customvote: ^7couldn't open the "
+                                  "file ^3'%s' ^7for reading.\n",
+                                  customVotesFile));
+    Printer::console(clientNum, errors);
     return;
   }
 
@@ -282,27 +290,27 @@ void CustomMapVotes::deleteCustomvoteList(int clientNum,
   }
 
   if (!found) {
-    Printer::chat(clientNum,
-                  ETJump::stringFormat("^3delete-customvote: ^7a list with the "
-                                       "name ^3'%s' ^7was not found.\n",
-                                       name));
+    Printer::chat(clientNum, stringFormat("^3delete-customvote: ^7a list with "
+                                          "the name ^3'%s' ^7was not found.\n",
+                                          name));
     return;
   }
 
-  if (!ETJump::JsonUtils::writeFile(customVotesFile, root)) {
+  if (!JsonUtils::writeFile(customVotesFile, root, &errors)) {
     Printer::chat(clientNum, "^3delete-customvote: ^7operation failed, check "
                              "console for more information.");
-    Printer::console(
-        clientNum, ETJump::stringFormat("^3delete-customvote: ^7couldn't open "
-                                        "the file ^3'%s' ^7for writing.\n",
-                                        customVotesFile));
+    Printer::console(clientNum,
+                     stringFormat("^3delete-customvote: ^7couldn't open the "
+                                  "file ^3'%s' ^7for writing.\n",
+                                  customVotesFile));
+    Printer::console(clientNum, errors);
     return;
   }
 
-  Load();
+  loadCustomvotes();
   Printer::chat(
       clientNum,
-      ETJump::stringFormat(
+      stringFormat(
           "^3delete-customvote: ^7successfully deleted custom vote list ^3'%s'",
           name));
 }
@@ -315,27 +323,46 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
   const std::string &customVotesFile = g_customMapVotesFile.string;
   Json::Value root;
 
-  if (!ETJump::JsonUtils::readFile(customVotesFile, root)) {
+  if (!JsonUtils::readFile(customVotesFile, root, &errors)) {
     Printer::chat(clientNum, "^3edit-customvote: ^7operation failed, check "
                              "console for more information.");
     Printer::console(clientNum,
-                     ETJump::stringFormat("^3edit-customvote: ^7couldn't open "
-                                          "the file ^3'%s' ^7for reading.\n",
-                                          customVotesFile));
+                     stringFormat("^3edit-customvote: ^7couldn't open the file "
+                                  "^3'%s' ^7for reading.\n",
+                                  customVotesFile));
+    Printer::console(clientNum, errors);
     return;
   }
 
-  const std::string sanitizedList = ETJump::sanitize(list, true);
-  const std::string sanitizedName = ETJump::sanitize(name, true);
-  const std::string sanitizedFName = ETJump::sanitize(fullName);
+  const std::string sanitizedList = sanitize(list, true);
+  const std::string sanitizedName = sanitize(name, true);
+  const std::string sanitizedFName = sanitize(fullName);
 
   bool found = false;
 
+  const auto parsingFailed = [&](const std::string &errMsg) {
+    Printer::chat(clientNum, "^3edit-customvote: ^7operation failed, check "
+                             "console for more information.");
+    Printer::console(clientNum, errMsg + "\n");
+  };
+
   for (auto &object : root) {
-    if (ETJump::sanitize(object["name"].asString(), true) == sanitizedList) {
+    std::string temp;
+
+    if (!JsonUtils::parseValue(temp, object["name"], &errors, "name")) {
+      parsingFailed(errors);
+      return;
+    }
+
+    if (sanitize(temp, true) == sanitizedList) {
       if (!sanitizedName.empty()) {
         for (const auto &key : object) {
-          if (key == object["name"].asString()) {
+          if (!JsonUtils::parseValue(temp, object["name"], &errors, "name")) {
+            parsingFailed(errors);
+            return;
+          }
+
+          if (key == temp) {
             object["name"] = sanitizedName;
           }
         }
@@ -343,26 +370,38 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
 
       if (!sanitizedFName.empty()) {
         for (const auto &key : object) {
-          if (key == object["callvote_text"].asString()) {
+          if (!JsonUtils::parseValue(temp, object["callvote_text"], &errors,
+                                     "callvote_text")) {
+            parsingFailed(errors);
+            return;
+          }
+
+          if (key == temp) {
             object["callvote_text"] = sanitizedFName;
           }
         }
       }
 
       if (!addMaps.empty()) {
-        const auto mapList = ETJump::StringUtil::split(addMaps, " ");
+        const auto mapList = StringUtil::split(addMaps, " ");
 
         for (const auto &map : mapList) {
-          object["maps"].append(ETJump::sanitize(map, true));
+          object["maps"].append(sanitize(map, true));
         }
       }
 
       if (!removeMaps.empty()) {
-        const auto mapList = ETJump::StringUtil::split(removeMaps, " ");
+        const auto mapList = StringUtil::split(removeMaps, " ");
 
         for (const auto &map : mapList) {
           for (Json::ArrayIndex i = 0; i < object["maps"].size(); i++) {
-            if (ETJump::StringUtil::iEqual(object["maps"][i].asString(), map)) {
+            if (!JsonUtils::parseValue(temp, object["maps"][i], &errors,
+                                       "maps")) {
+              parsingFailed(errors);
+              return;
+            }
+
+            if (StringUtil::iEqual(temp, map)) {
               Json::Value removed;
               object["maps"].removeIndex(i, &removed);
               break;
@@ -377,42 +416,42 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
   }
 
   if (!found) {
-    Printer::chat(clientNum,
-                  ETJump::stringFormat("^3edit-customvote: ^7a list with the "
-                                       "name ^3'%s' ^7was not found.\n",
-                                       sanitizedList));
+    Printer::chat(clientNum, stringFormat("^3edit-customvote: ^7a list with "
+                                          "the name ^3'%s' ^7was not found.\n",
+                                          sanitizedList));
     return;
   }
 
-  if (!ETJump::JsonUtils::writeFile(customVotesFile, root)) {
+  if (!JsonUtils::writeFile(customVotesFile, root, &errors)) {
     Printer::chat(clientNum, "^3edit-customvote: ^7operation failed, check "
                              "console for more information.");
     Printer::console(clientNum,
-                     ETJump::stringFormat("^3edit-customvote: ^7couldn't open "
-                                          "the file ^3'%s' ^7for writing.\n",
-                                          customVotesFile));
+                     stringFormat("^3edit-customvote: ^7couldn't open the file "
+                                  "^3'%s' ^7for writing.\n",
+                                  customVotesFile));
+    Printer::console(clientNum, errors);
     return;
   }
 
-  Load();
+  loadCustomvotes();
   Printer::chat(
       clientNum,
-      ETJump::stringFormat(
+      stringFormat(
           "^3edit-customvote: ^7successfully edited custom vote list ^3'%s'",
           sanitizedList));
 }
 
-std::string CustomMapVotes::ListInfo(const std::string &type) {
+std::string CustomMapVotes::listInfo(const std::string &type) {
   std::string buffer;
 
-  for (auto &customMapVote : customMapVotes_) {
+  for (const auto &customMapVote : customMapVotes_) {
     if (customMapVote.type == type) {
-      buffer += ETJump::stringFormat("^gMaps on the list ^3%s^g: \n", type);
+      buffer += stringFormat("^gMaps on the list ^3%s^g: \n", type);
       auto numMapsOnServer = customMapVote.mapsOnServer.size();
 
       int count = 0;
       for (auto &mapOnServer : customMapVote.mapsOnServer) {
-        buffer += ETJump::stringFormat("^7%-30s", mapOnServer);
+        buffer += stringFormat("^7%-30s", mapOnServer);
 
         ++count;
         if (count % 3 == 0 || count == numMapsOnServer) {
@@ -425,7 +464,7 @@ std::string CustomMapVotes::ListInfo(const std::string &type) {
         count = 0;
         auto numMapsNotOnServer = customMapVote.otherMaps.size();
         for (auto &mapNotOnServer : customMapVote.otherMaps) {
-          buffer += ETJump::stringFormat("^9%-30s", mapNotOnServer);
+          buffer += stringFormat("^9%-30s", mapNotOnServer);
 
           ++count;
           if (count % 3 == 0 || count == numMapsNotOnServer) {
@@ -465,35 +504,36 @@ CustomMapVotes::MapType *CustomMapVotes::getVotelistByIndex(const int index) {
   return &customMapVotes_[index];
 }
 
-std::string const CustomMapVotes::RandomMap(std::string const &type) {
-  for (unsigned i = 0; i < customMapVotes_.size(); i++) {
-    auto &customMapVote = customMapVotes_[i];
-    if (customMapVote.type == type && customMapVote.mapsOnServer.size() > 0) {
-      const int MAX_TRIES = 15;
-      std::random_device rd;
-      std::mt19937 re(rd());
-      std::uniform_int_distribution<int> ui(
-          0, customMapVote.mapsOnServer.size() - 1);
-
-      // try to select a valid random map
-      for (int tries = 0; tries < MAX_TRIES; tries++) {
-        int testIdx = ui(re);
-        if (isValidMap(customMapVote.mapsOnServer[testIdx])) {
-          return customMapVote.mapsOnServer[testIdx];
-        }
-      }
-      // fallback, iterate map list and select first
-      // valid map
-      for (int i = 0; i < static_cast<int>(customMapVote.mapsOnServer.size());
-           i++) {
-        if (isValidMap(customMapVote.mapsOnServer[i])) {
-          return customMapVote.mapsOnServer[i];
-        }
-      }
-
-      return "";
+std::string CustomMapVotes::randomMap(std::string const &type) {
+  for (const auto &list : customMapVotes_) {
+    if (list.type != type || list.mapsOnServer.empty()) {
+      continue;
     }
+
+    static constexpr int MAX_TRIES = 15;
+    std::random_device rd;
+    std::mt19937 re(rd());
+    std::uniform_int_distribution<int> ui(
+        0, static_cast<int>(list.mapsOnServer.size() - 1));
+
+    // try to select a valid random map
+    for (int tries = 0; tries < MAX_TRIES; tries++) {
+      int testIdx = ui(re);
+      if (isValidMap(list.mapsOnServer[testIdx])) {
+        return list.mapsOnServer[testIdx];
+      }
+    }
+
+    // fallback, iterate map list and select first valid map
+    for (const auto &map : list.mapsOnServer) {
+      if (isValidMap(map)) {
+        return map;
+      }
+    }
+
+    return "";
   }
+
   return "";
 }
 
@@ -503,3 +543,4 @@ std::string const CustomMapVotes::RandomMap(std::string const &type) {
 bool CustomMapVotes::isValidMap(const std::string &mapName) {
   return game.mapStatistics->mapExists(mapName) && mapName != level.rawmapname;
 }
+} // namespace ETJump

--- a/src/game/etj_custom_map_votes.h
+++ b/src/game/etj_custom_map_votes.h
@@ -26,7 +26,9 @@
 
 #include <vector>
 #include <string>
+#include "etj_log.h"
 
+namespace ETJump {
 class MapStatistics;
 
 class CustomMapVotes {
@@ -46,16 +48,17 @@ public:
     std::string callvoteText;
   };
 
-  CustomMapVotes(MapStatistics *mapStats);
-  ~CustomMapVotes();
-  bool Load();
-  TypeInfo GetTypeInfo(const std::string &type) const;
-  const std::string RandomMap(const std::string &type);
+  CustomMapVotes(const std::shared_ptr<MapStatistics> &mapStats,
+                 std::unique_ptr<Log> log);
+  ~CustomMapVotes() = default;
+  void loadCustomvotes();
+  TypeInfo getTypeInfo(const std::string &type) const;
+  std::string randomMap(const std::string &type);
   static bool isValidMap(const std::string &mapName);
-  std::string ListTypes() const;
-  std::string ListInfo(const std::string &name);
+  std::string listTypes() const;
+  std::string listInfo(const std::string &name);
   std::vector<std::string> getMapsOnList(const std::string &name);
-  void GenerateVotesFile();
+  void generateVotesFile();
   size_t getNumVotelists() const;
   // returns nullptr on invalid index
   CustomMapVotes::MapType *getVotelistByIndex(int index);
@@ -71,6 +74,9 @@ public:
 
 private:
   std::vector<MapType> customMapVotes_;
-  const std::vector<std::string> *_currentMapsOnServer;
-  MapStatistics *_mapStats;
+  const std::vector<std::string> *_currentMapsOnServer{};
+  const std::shared_ptr<MapStatistics> &_mapStats;
+  std::unique_ptr<Log> logger;
+  std::string errors;
 };
+} // namespace ETJump

--- a/src/game/etj_game.h
+++ b/src/game/etj_game.h
@@ -31,12 +31,12 @@ class TimerunV2;
 class RockTheVote;
 class Tokens;
 class ChatReplay;
+class Motd;
 } // namespace ETJump
 
 class Levels;
 class Commands;
 class CustomMapVotes;
-class Motd;
 class Timerun;
 class MapStatistics;
 
@@ -46,7 +46,7 @@ struct Game {
   std::shared_ptr<Levels> levels;
   std::shared_ptr<Commands> commands;
   std::shared_ptr<CustomMapVotes> customMapVotes;
-  std::shared_ptr<Motd> motd;
+  std::unique_ptr<ETJump::Motd> motd;
   std::shared_ptr<MapStatistics> mapStatistics;
   std::shared_ptr<ETJump::Tokens> tokens;
   std::shared_ptr<ETJump::TimerunV2> timerunV2;

--- a/src/game/etj_game.h
+++ b/src/game/etj_game.h
@@ -48,7 +48,7 @@ struct Game {
   std::shared_ptr<CustomMapVotes> customMapVotes;
   std::unique_ptr<ETJump::Motd> motd;
   std::shared_ptr<MapStatistics> mapStatistics;
-  std::shared_ptr<ETJump::Tokens> tokens;
+  std::unique_ptr<ETJump::Tokens> tokens;
   std::shared_ptr<ETJump::TimerunV2> timerunV2;
   std::shared_ptr<ETJump::RockTheVote> rtv;
   std::unique_ptr<ETJump::ChatReplay> chatReplay;

--- a/src/game/etj_game.h
+++ b/src/game/etj_game.h
@@ -32,24 +32,25 @@ class RockTheVote;
 class Tokens;
 class ChatReplay;
 class Motd;
+class CustomMapVotes;
+class MapStatistics;
 } // namespace ETJump
 
 class Levels;
 class Commands;
-class CustomMapVotes;
 class Timerun;
-class MapStatistics;
 
 struct Game {
   Game() = default;
 
   std::shared_ptr<Levels> levels;
   std::shared_ptr<Commands> commands;
-  std::shared_ptr<CustomMapVotes> customMapVotes;
-  std::unique_ptr<ETJump::Motd> motd;
-  std::shared_ptr<MapStatistics> mapStatistics;
-  std::unique_ptr<ETJump::Tokens> tokens;
+  std::shared_ptr<ETJump::MapStatistics> mapStatistics;
   std::shared_ptr<ETJump::TimerunV2> timerunV2;
   std::shared_ptr<ETJump::RockTheVote> rtv;
+
+  std::unique_ptr<ETJump::CustomMapVotes> customMapVotes;
+  std::unique_ptr<ETJump::Motd> motd;
+  std::unique_ptr<ETJump::Tokens> tokens;
   std::unique_ptr<ETJump::ChatReplay> chatReplay;
 };

--- a/src/game/etj_json_utilities.h
+++ b/src/game/etj_json_utilities.h
@@ -25,18 +25,18 @@
 #pragma once
 
 #include "json/json.h"
-#include "etj_log.h"
+#include "etj_string_utilities.h"
 
 namespace ETJump {
 class JsonUtils {
-  static Log logger;
-
 public:
   // returns true on successful read
-  static bool readFile(const std::string &file, Json::Value &root);
+  static bool readFile(const std::string &file, Json::Value &root,
+                       std::string *errors = nullptr);
 
   // returns true on successful write
-  static bool writeFile(const std::string &file, const Json::Value &root);
+  static bool writeFile(const std::string &file, const Json::Value &root,
+                        std::string *errors = nullptr);
 
   // tries to parse a JSON value
   // returns true if parse was successful, otherwise false

--- a/src/game/etj_json_utilities.h
+++ b/src/game/etj_json_utilities.h
@@ -37,5 +37,28 @@ public:
 
   // returns true on successful write
   static bool writeFile(const std::string &file, const Json::Value &root);
+
+  // tries to parse a JSON value
+  // returns true if parse was successful, otherwise false
+  // if provided, any errors are written to 'errors'
+  // 'field' can be provided as the key for more descriptive error messages
+  template <typename T>
+  static bool parseValue(T &value, const Json::Value &jsonValue,
+                         std::string *errors = nullptr,
+                         const std::string &field = "") {
+    try {
+      value = jsonValue.as<T>();
+      return true;
+    } catch (const Json::LogicError &e) {
+      if (errors) {
+        *errors = stringFormat(
+            "Failed to parse JSON value%s: %s",
+            field.empty() ? "" : stringFormat(" for field '%s'", field),
+            e.what());
+      }
+
+      return false;
+    }
+  }
 };
 } // namespace ETJump

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -146,7 +146,8 @@ void OnGameInit() {
       game.mapStatistics, std::make_unique<ETJump::Log>("customvotes"));
   game.motd =
       std::make_unique<ETJump::Motd>(std::make_unique<ETJump::Log>("MOTD"));
-  game.tokens = std::make_unique<ETJump::Tokens>();
+  game.tokens =
+      std::make_unique<ETJump::Tokens>(std::make_unique<ETJump::Log>("tokens"));
   game.rtv = std::make_shared<ETJump::RockTheVote>();
 
   game.chatReplay = std::make_unique<ETJump::ChatReplay>(

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -69,7 +69,7 @@ void OnClientConnect(int clientNum, qboolean firstTime, qboolean isBot) {
 void OnClientBegin(gentity_t *ent) {
   G_DPrintf("OnClientBegin called by %d\n", ClientNum(ent));
   if (!ent->client->sess.motdPrinted) {
-    game.motd->PrintMotd(ent);
+    game.motd->printMotd(ent);
     ent->client->sess.motdPrinted = qtrue;
   }
   ETJump::Log::processMessages();
@@ -144,7 +144,8 @@ void OnGameInit() {
   game.mapStatistics = std::make_shared<MapStatistics>();
   game.customMapVotes =
       std::make_shared<CustomMapVotes>(game.mapStatistics.get());
-  game.motd = std::make_shared<Motd>();
+  game.motd =
+      std::make_unique<ETJump::Motd>(std::make_unique<ETJump::Log>("MOTD"));
   game.tokens = std::make_shared<ETJump::Tokens>();
   game.rtv = std::make_shared<ETJump::RockTheVote>();
 
@@ -188,7 +189,7 @@ void OnGameInit() {
   game.mapStatistics->initialize(std::string(g_mapDatabase.string),
                                  level.rawmapname);
   game.customMapVotes->Load();
-  game.motd->Initialize();
+  game.motd->initialize();
   game.timerunV2->initialize();
 
   if (g_tokensMode.integer) {
@@ -294,7 +295,7 @@ qboolean OnConsoleCommand() {
   auto command = ETJump::StringUtil::toLowerCase((*argv)[0]);
 
   if (command == "generatemotd") {
-    game.motd->GenerateMotdFile();
+    game.motd->generateMotdFile();
     return qtrue;
   }
 

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -146,7 +146,7 @@ void OnGameInit() {
       std::make_shared<CustomMapVotes>(game.mapStatistics.get());
   game.motd =
       std::make_unique<ETJump::Motd>(std::make_unique<ETJump::Log>("MOTD"));
-  game.tokens = std::make_shared<ETJump::Tokens>();
+  game.tokens = std::make_unique<ETJump::Tokens>();
   game.rtv = std::make_shared<ETJump::RockTheVote>();
 
   game.chatReplay = std::make_unique<ETJump::ChatReplay>(

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -141,9 +141,9 @@ void RunFrame(int levelTime) {
 void OnGameInit() {
   game.levels = std::make_shared<Levels>();
   game.commands = std::make_shared<Commands>();
-  game.mapStatistics = std::make_shared<MapStatistics>();
-  game.customMapVotes =
-      std::make_shared<CustomMapVotes>(game.mapStatistics.get());
+  game.mapStatistics = std::make_shared<ETJump::MapStatistics>();
+  game.customMapVotes = std::make_unique<ETJump::CustomMapVotes>(
+      game.mapStatistics, std::make_unique<ETJump::Log>("customvotes"));
   game.motd =
       std::make_unique<ETJump::Motd>(std::make_unique<ETJump::Log>("MOTD"));
   game.tokens = std::make_unique<ETJump::Tokens>();
@@ -188,7 +188,7 @@ void OnGameInit() {
 
   game.mapStatistics->initialize(std::string(g_mapDatabase.string),
                                  level.rawmapname);
-  game.customMapVotes->Load();
+  game.customMapVotes->loadCustomvotes();
   game.motd->initialize();
   game.timerunV2->initialize();
 
@@ -300,12 +300,12 @@ qboolean OnConsoleCommand() {
   }
 
   if (command == "generatecustomvotes") {
-    game.customMapVotes->GenerateVotesFile();
+    game.customMapVotes->generateVotesFile();
     return qtrue;
   }
 
   if (command == "readcustomvotes") {
-    game.customMapVotes->Load();
+    game.customMapVotes->loadCustomvotes();
     // force voteflag re-check so UI can turn on/off custom vote button
     G_voteFlags();
     return qtrue;
@@ -378,7 +378,7 @@ const char *GetRandomMapByType(const char *customType) {
     G_Error("customType is NULL.");
   }
 
-  Q_strncpyz(buf, game.customMapVotes->RandomMap(customType).c_str(),
+  Q_strncpyz(buf, game.customMapVotes->randomMap(customType).c_str(),
              sizeof(buf));
   return buf;
 }
@@ -390,7 +390,8 @@ const char *CustomMapTypeExists(const char *mapType) {
     G_Error("mapType is NULL.");
   }
 
-  CustomMapVotes::TypeInfo info = game.customMapVotes->GetTypeInfo(mapType);
+  ETJump::CustomMapVotes::TypeInfo info =
+      game.customMapVotes->getTypeInfo(mapType);
 
   if (info.typeExists) {
     Q_strncpyz(buf, info.callvoteText.c_str(), sizeof(buf));

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -147,7 +147,9 @@ void OnGameInit() {
   game.motd = std::make_shared<Motd>();
   game.tokens = std::make_shared<ETJump::Tokens>();
   game.rtv = std::make_shared<ETJump::RockTheVote>();
-  game.chatReplay = std::make_unique<ETJump::ChatReplay>();
+
+  game.chatReplay = std::make_unique<ETJump::ChatReplay>(
+      std::make_unique<ETJump::Log>("chat-replay"));
 
   if (strlen(g_levelConfig.string)) {
     if (!game.levels->ReadFromConfig()) {

--- a/src/game/etj_map_statistics.cpp
+++ b/src/game/etj_map_statistics.cpp
@@ -32,6 +32,7 @@
 #include "g_local.h"
 #include "etj_filesystem.h"
 
+namespace ETJump {
 MapStatistics::MapStatistics()
     : _previousLevelTime(0), _currentMillisecondsPlayed(0),
       _currentMillisecondsOnServer(0), _currentMap(nullptr) {}
@@ -546,5 +547,4 @@ void MapStatistics::writeMapsToDisk(const std::string &fileName) {
   trap_FS_Write(str.c_str(), str.length(), f);
   trap_FS_FCloseFile(f);
 }
-
-MapStatistics::~MapStatistics() {}
+} // namespace ETJump

--- a/src/game/etj_map_statistics.h
+++ b/src/game/etj_map_statistics.h
@@ -22,16 +22,17 @@
  * SOFTWARE.
  */
 
-#ifndef MAP_STATISTICS_H
-#define MAP_STATISTICS_H
+#pragma once
+
 #include <string>
 #include <vector>
 #include <random>
 
+namespace ETJump {
 class MapStatistics {
 public:
   MapStatistics();
-  ~MapStatistics();
+  ~MapStatistics() = default;
 
   struct MapInformation {
     MapInformation()
@@ -87,5 +88,4 @@ private:
   std::string _databaseName;
   int _originalSecondsPlayed;
 };
-
-#endif
+} // namespace ETJump

--- a/src/game/etj_motd.cpp
+++ b/src/game/etj_motd.cpp
@@ -29,91 +29,88 @@
 #include "etj_filesystem.h"
 #include "etj_printer.h"
 #include <fstream>
+#include "etj_json_utilities.h"
 
-Motd::Motd() : initialized_(false) {}
+namespace ETJump {
+Motd::Motd(std::unique_ptr<Log> log)
+    : initialized(false), logger(std::move(log)) {}
 
-void Motd::Initialize() {
+void Motd::initialize() {
   if (strlen(g_motdFile.string) == 0) {
     return;
   }
 
-  std::ifstream f(ETJump::FileSystem::Path::getPath(g_motdFile.string));
-
-  if (!f) {
-    G_LogPrintf("MOTD: g_motdFile '%s' was defined but could not be found. To "
-                "generate a sample file, use '/generateMotd'.\n",
-                g_motdFile.string);
+  if (!FileSystem::exists(g_motdFile.string)) {
+    logger->info("MOTD file '%s' was defined but could not be found. To "
+                 "generate a sample file, use '/generateMotd'.",
+                 g_motdFile.string);
     return;
   }
-
-  std::string content((std::istreambuf_iterator<char>(f)),
-                      std::istreambuf_iterator<char>());
 
   Json::Value root;
-  Json::Reader reader;
 
-  if (!reader.parse(content, root)) {
-    G_LogPrintf("MOTD: failed to parse motd file: %s\n",
-                reader.getFormattedErrorMessages().c_str());
+  if (!JsonUtils::readFile(g_motdFile.string, root, &errors)) {
+    logger->error(errors);
     return;
   }
 
-  try {
-    chatMessage_ = root["chat_message"].asString();
-    motd_ = root["console_message"].asString();
-  } catch (...) {
-    G_LogPrintf("MOTD: missing information from motd file. Are you sure both "
-                "'chat_message' and 'console_message' are defined?\n");
+  if (!JsonUtils::parseValue(chatMotd, root["chat_message"], &errors,
+                             "chat_message")) {
+    logger->error(errors);
   }
 
-  G_LogPrintf("MOTD: initialized.\n");
+  if (!JsonUtils::parseValue(consoleMotd, root["console_message"], &errors,
+                             "console_message")) {
+    logger->error(errors);
+  }
 
-  initialized_ = true;
-}
-
-void Motd::PrintMotd(gentity_t *ent) {
-  if (initialized_) {
-    Printer::chat(ent, chatMessage_);
-    Printer::console(ent, motd_);
+  if (errors.empty()) {
+    logger->info("Successfully initialized MOTD system.");
+    initialized = true;
+  } else {
+    logger->error("Missing information from MOTD file '%s'. Make sure both "
+                  "'chat_message' and 'console_message' fields are defined.",
+                  g_motdFile.string);
   }
 }
 
-void Motd::GenerateMotdFile() {
-  Arguments argv = GetArgs();
-  std::ifstream in(ETJump::FileSystem::Path::getPath(g_motdFile.string));
+void Motd::printMotd(gentity_t *ent) const {
+  if (!initialized) {
+    return;
+  }
 
-  if (in.good()) {
-    if (argv->size() == 1) {
-      G_Printf("A motd file '%s' already exists. Use 'generateMotd -f' to "
+  Printer::chat(ent, chatMotd);
+  Printer::console(ent, consoleMotd + "\n");
+}
+
+void Motd::generateMotdFile() {
+  const Arguments argv = GetArgs();
+
+  const bool overwrite = argv->size() > 1 && argv->at(1) == "-f";
+
+  if (argv->size() == 1 || !overwrite) {
+    if (FileSystem::exists(g_motdFile.string)) {
+      G_Printf("A MOTD file '%s' already exists. Use '/generateMotd -f' to "
                "overwrite the existing file.\n",
                g_motdFile.string);
       return;
     }
-    if (argv->size() == 2 && argv->at(1) == "-f") {
-      G_LogPrintf("Overwriting motd file '%s' with a default one.\n",
-                  g_motdFile.string);
-    } else {
-      G_Printf("Unknown argument '%s'.\n", argv->at(1).c_str());
-      return;
-    }
+  }
+
+  if (overwrite) {
+    G_Printf("Overwriting MOTD file '%s' with a default one.\n",
+             g_motdFile.string);
   }
 
   Json::Value root;
   root["chat_message"] = "This is the chat message.";
   root["console_message"] = "This is the console message.";
-  Json::StyledWriter writer;
-  std::string output = writer.write(root);
-  std::ofstream fOut(ETJump::FileSystem::Path::getPath(g_motdFile.string));
 
-  if (!fOut) {
-    G_Printf("Couldn't open file '%s' defined in 'g_motdFile'.\n",
-             g_motdFile.string);
-    return;
+  if (JsonUtils::writeFile(g_motdFile.string, root, &errors)) {
+    G_Printf("Generated new motd file '%s'\n", g_motdFile.string);
+    initialize();
+  } else {
+    G_Printf("%s", errors.c_str());
   }
-
-  fOut << output;
-  fOut.close();
-
-  G_Printf("Generated new motd file '%s'\n", g_motdFile.string);
-  Initialize();
 }
+} // namespace ETJump

--- a/src/game/etj_motd.h
+++ b/src/game/etj_motd.h
@@ -35,22 +35,27 @@
  * }
  */
 
+#pragma once
+
 #include <string>
-#include <ostream>
+#include "g_local.h"
+#include "etj_log.h"
 
-struct gentity_s;
-typedef struct gentity_s gentity_t;
-
+namespace ETJump {
 class Motd {
-public:
-  Motd();
-  ~Motd() = default;
-  void Initialize();
-  void GenerateMotdFile();
-  void PrintMotd(gentity_t *ent);
+  bool initialized;
+  std::string chatMotd;
+  std::string consoleMotd;
 
-private:
-  bool initialized_;
-  std::string chatMessage_;
-  std::string motd_;
+  std::unique_ptr<Log> logger;
+  std::string errors;
+
+public:
+  explicit Motd(std::unique_ptr<Log> log);
+  ~Motd() = default;
+
+  void initialize();
+  void generateMotdFile();
+  void printMotd(gentity_t *ent) const;
 };
+} // namespace ETJump

--- a/src/game/etj_tokens.cpp
+++ b/src/game/etj_tokens.cpp
@@ -25,18 +25,22 @@
 #include "g_local.h"
 #include "etj_tokens.h"
 
+#include "etj_filesystem.h"
+
 #include <memory>
 #include "json/json.h"
 #include "etj_utilities.h"
 #include "etj_time_utilities.h"
 #include "etj_printer.h"
+#include "etj_json_utilities.h"
+#include "etj_log.h"
 
 namespace ETJump {
 static std::array<Tokens::Token, MAX_TOKENS_PER_DIFFICULTY> easyTokens;
 static std::array<Tokens::Token, MAX_TOKENS_PER_DIFFICULTY> mediumTokens;
 static std::array<Tokens::Token, MAX_TOKENS_PER_DIFFICULTY> hardTokens;
 
-std::string toString(Tokens::Difficulty difficulty) {
+std::string toString(const Tokens::Difficulty difficulty) {
   switch (difficulty) {
     case Tokens::Easy:
       return "easy";
@@ -49,78 +53,58 @@ std::string toString(Tokens::Difficulty difficulty) {
 }
 
 Tokens::NearestToken
-Tokens::findNearestToken(std::array<float, 3> coordinates) {
-  auto idx = 0;
-  auto tokenNum = 0;
+Tokens::findNearestToken(const std::array<float, 3> coordinates) {
+  int tokenNum = 0;
   Token *token = nullptr;
   auto difficulty = Easy;
   float nearestDistance = 1 << 20;
-  for (auto &t : easyTokens) {
-    if (t.isActive) {
-      auto newDistance =
-          VectorDistance(t.coordinates.data(), coordinates.data());
-      if (newDistance < nearestDistance) {
-        nearestDistance = newDistance;
-        token = &t;
-        tokenNum = idx + 1;
-        difficulty = Easy;
-      }
-    }
-    ++idx;
-  }
 
-  idx = 0;
-  for (auto &t : mediumTokens) {
-    if (t.isActive) {
-      auto newDistance =
-          VectorDistance(t.coordinates.data(), coordinates.data());
-      if (newDistance < nearestDistance) {
-        nearestDistance = newDistance;
-        token = &t;
-        tokenNum = idx + 1;
-        difficulty = Medium;
-      }
-    }
-    ++idx;
-  }
+  auto findNearest = [&](std::array<Token, MAX_TOKENS_PER_DIFFICULTY> &tokens,
+                         const Difficulty diff) {
+    int idx = 0;
 
-  idx = 0;
-  for (auto &t : hardTokens) {
-    if (t.isActive) {
-      auto newDistance =
+    for (auto &t : tokens) {
+      if (!t.isActive) {
+        idx++;
+        continue;
+      }
+
+      const float newDistance =
           VectorDistance(t.coordinates.data(), coordinates.data());
       if (newDistance < nearestDistance) {
         nearestDistance = newDistance;
         token = &t;
         tokenNum = idx + 1;
-        difficulty = Hard;
+        difficulty = diff;
       }
+
+      idx++;
     }
-    ++idx;
-  }
+  };
+
+  findNearest(easyTokens, Easy);
+  findNearest(mediumTokens, Medium);
+  findNearest(hardTokens, Hard);
 
   return NearestToken{tokenNum, token, nearestDistance, difficulty};
 }
 
-std::pair<bool, std::string> Tokens::deleteToken(Difficulty difficulty,
-                                                 int index) {
-  Token *token;
-  try {
-    switch (difficulty) {
-      case Easy:
-        token = &easyTokens[index];
-        break;
-      case Medium:
-        token = &mediumTokens[index];
-        break;
-      case Hard:
-        token = &hardTokens[index];
-        break;
-      default:
-        throw std::runtime_error("deleteToken: undefined difficulty.\n");
-    }
-  } catch (const std::exception &e) {
-    G_Error(e.what());
+std::pair<bool, std::string> Tokens::deleteToken(const Difficulty difficulty,
+                                                 const int index) {
+  Token *token = nullptr;
+
+  switch (difficulty) {
+    case Easy:
+      token = &easyTokens[index];
+      break;
+    case Medium:
+      token = &mediumTokens[index];
+      break;
+    case Hard:
+      token = &hardTokens[index];
+      break;
+    default:
+      return std::make_pair(false, "deleteToken: undefined difficulty.");
   }
 
   if (token->isActive) {
@@ -136,8 +120,8 @@ std::pair<bool, std::string> Tokens::deleteToken(Difficulty difficulty,
 }
 
 std::pair<bool, std::string>
-Tokens::deleteNearestToken(std::array<float, 3> coordinates) {
-  auto nearestToken = findNearestToken(coordinates);
+Tokens::deleteNearestToken(const std::array<float, 3> coordinates) {
+  const auto nearestToken = findNearestToken(coordinates);
 
   if (!nearestToken.token) {
     return std::make_pair(false, "no tokens in the map.");
@@ -154,7 +138,7 @@ Tokens::deleteNearestToken(std::array<float, 3> coordinates) {
 
 std::pair<bool, std::string>
 Tokens::moveNearestToken(std::array<float, 3> coordinates) {
-  auto nearestToken = findNearestToken(coordinates);
+  const auto nearestToken = findNearestToken(coordinates);
 
   if (!nearestToken.token) {
     return std::make_pair(false, "no tokens in the map.");
@@ -171,28 +155,27 @@ Tokens::moveNearestToken(std::array<float, 3> coordinates) {
 }
 
 std::pair<bool, std::string>
-Tokens::createToken(Difficulty difficulty, std::array<float, 3> coordinates) {
-  std::array<Token, MAX_TOKENS_PER_DIFFICULTY> *tokens;
-  try {
-    switch (difficulty) {
-      case Easy:
-        tokens = &easyTokens;
-        break;
-      case Medium:
-        tokens = &mediumTokens;
-        break;
-      case Hard:
-        tokens = &hardTokens;
-        break;
-      default:
-        throw std::runtime_error("createToken: undefined difficulty.\n");
-    }
-  } catch (const std::exception &e) {
-    G_Error(e.what());
+Tokens::createToken(const Difficulty difficulty,
+                    const std::array<float, 3> coordinates) {
+  std::array<Token, MAX_TOKENS_PER_DIFFICULTY> *tokens = nullptr;
+
+  switch (difficulty) {
+    case Easy:
+      tokens = &easyTokens;
+      break;
+    case Medium:
+      tokens = &mediumTokens;
+      break;
+    case Hard:
+      tokens = &hardTokens;
+      break;
+    default:
+      return std::make_pair(false, "createToken: undefined difficulty.");
   }
 
   Token *nextFreeToken = nullptr;
-  auto idx = 0;
+
+  int idx = 0;
   for (auto &token : *tokens) {
     if (!token.isActive) {
       nextFreeToken = &token;
@@ -202,7 +185,9 @@ Tokens::createToken(Difficulty difficulty, std::array<float, 3> coordinates) {
   }
 
   if (nextFreeToken == nullptr) {
-    return std::make_pair(false, "no free tokens left for the difficulty.");
+    return std::make_pair(
+        false, stringFormat("No free tokens left for '%s' difficulty.",
+                            toString(difficulty)));
   }
 
   nextFreeToken->isActive = true;
@@ -221,68 +206,76 @@ Tokens::createToken(Difficulty difficulty, std::array<float, 3> coordinates) {
   return std::make_pair(true, "");
 }
 
-bool Tokens::loadTokens(const std::string &filepath) {
+void Tokens::loadTokens(const std::string &filepath) {
+  if (!logger) {
+    logger = std::make_unique<Log>("tokens");
+  }
+
   _filepath = filepath;
-  std::string content;
-  try {
-    content = Utilities::ReadFile(filepath);
-  } catch (std::runtime_error &e) {
-    Utilities::Logln(std::string("Tokens: Could not read file: ") + e.what());
-    return false;
+
+  if (!FileSystem::exists(_filepath)) {
+    logger->info("No tokens configured for the current map.");
+    return;
   }
 
   Json::Value root;
-  Json::Reader reader;
 
-  if (!reader.parse(content, root)) {
-    Utilities::Logln("Tokens: Could not parse file \"" + filepath + "\".");
-    Utilities::Logln("Tokens: " + reader.getFormattedErrorMessages());
-    return false;
+  if (!JsonUtils::readFile(_filepath, root, &errors)) {
+    logger->error(errors);
+    return;
   }
 
-  try {
-    auto eTokens = root["easyTokens"];
-    auto mTokens = root["mediumTokens"];
-    auto hTokens = root["hardTokens"];
+  const Json::Value eTokens = root["easyTokens"];
+  const Json::Value mTokens = root["mediumTokens"];
+  const Json::Value hTokens = root["hardTokens"];
 
-    auto idx = 0;
-    for (const auto &token : eTokens) {
-      easyTokens[idx].fromJson(token);
-      easyTokens[idx].data->idx = idx;
-      ++idx;
+  const auto printError = [&](const std::string &error) {
+    logger->error("Could not load configuration from file '%s':", _filepath);
+    logger->error(error);
+  };
+
+  int idx = 0;
+
+  for (const auto &token : eTokens) {
+    if (!easyTokens[idx].fromJson(token)) {
+      printError(easyTokens[idx].errors);
+      return;
     }
 
-    idx = 0;
-    for (const auto &token : mTokens) {
-      mediumTokens[idx].fromJson(token);
-      mediumTokens[idx].data->idx = idx;
-      ++idx;
+    easyTokens[idx].data->idx = idx;
+    ++idx;
+  }
+
+  idx = 0;
+  for (const auto &token : mTokens) {
+    if (!mediumTokens[idx].fromJson(token)) {
+      printError(mediumTokens[idx].errors);
+      return;
     }
 
-    idx = 0;
-    for (const auto &token : hTokens) {
-      hardTokens[idx].fromJson(token);
-      hardTokens[idx].data->idx = idx;
-      ++idx;
+    mediumTokens[idx].data->idx = idx;
+    ++idx;
+  }
+
+  idx = 0;
+  for (const auto &token : hTokens) {
+    if (!hardTokens[idx].fromJson(token)) {
+      printError(hardTokens[idx].errors);
+      return;
     }
-  } catch (std::runtime_error &e) {
-    Utilities::Logln(
-        std::string("Tokens: Could not parse configuration from file \"" +
-                    filepath + "\": ") +
-        e.what());
-    return false;
+
+    hardTokens[idx].data->idx = idx;
+    ++idx;
   }
 
   createEntities();
-
-  Utilities::Logln("Tokens: Successfully loaded all tokens from \"" + filepath +
-                   "\" for current map.");
-
-  return true;
+  logger->info(
+      "Successfully loaded tokens all tokens from '%s' for the current map.",
+      _filepath);
 }
 
 bool Tokens::allTokensCollected(gentity_t *ent) {
-  auto tokenCounts = getTokenCounts();
+  const auto tokenCounts = getTokenCounts();
 
   auto easyCount = 0;
   auto mediumCount = 0;
@@ -311,25 +304,25 @@ void Tokens::tokenTouch(gentity_t *self, gentity_t *other, trace_t *trace) {
   }
 
   const char *difficulty;
-  bool *collected;
+  bool *collected = nullptr;
+
   switch (self->tokenInformation->difficulty) {
-    case Tokens::Difficulty::Easy:
+    case Easy:
       difficulty = "^2easy";
       collected =
           &other->client->pers.collectedEasyTokens[self->tokenInformation->idx];
       break;
-    case Tokens::Difficulty::Medium:
+    case Medium:
       difficulty = "^3medium";
       collected = &other->client->pers
                        .collectedMediumTokens[self->tokenInformation->idx];
       break;
-    case Tokens::Difficulty::Hard:
+    case Hard:
       difficulty = "^1hard";
       collected =
           &other->client->pers.collectedHardTokens[self->tokenInformation->idx];
       break;
     default:
-      G_Error("tokenThink: undefined difficulty.\n");
       return;
   }
 
@@ -349,7 +342,7 @@ void Tokens::tokenTouch(gentity_t *self, gentity_t *other, trace_t *trace) {
   }
 }
 
-void Tokens::createEntity(Token &token, Difficulty difficulty) {
+void Tokens::createEntity(Token &token, const Difficulty difficulty) const {
   token.entity = G_Spawn();
   token.entity->tokenInformation = token.data.get();
   Q_strncpyz(token.data->name, token.name.c_str(), sizeof(token.data->name));
@@ -370,7 +363,9 @@ void Tokens::createEntity(Token &token, Difficulty difficulty) {
       token.entity->s.eType = ET_TOKEN_HARD;
       break;
     default:
-      G_Error("createEntity: unknown token difficulty.\n");
+      logger->error("createEntity: unknown token difficulty.");
+      G_FreeEntity(token.entity);
+      return;
   }
 
   token.entity->touch = tokenTouch;
@@ -439,6 +434,7 @@ bool Tokens::saveTokens(const std::string &filepath) {
   root["easyTokens"] = Json::arrayValue;
   root["mediumTokens"] = Json::arrayValue;
   root["hardTokens"] = Json::arrayValue;
+
   for (const auto &token : easyTokens) {
     if (token.isActive) {
       root["easyTokens"].append(token.toJson());
@@ -457,30 +453,33 @@ bool Tokens::saveTokens(const std::string &filepath) {
     }
   }
 
-  Json::StyledWriter writer;
-  const std::string &output = writer.write(root);
-  try {
-    Utilities::WriteFile(filepath, output);
-  } catch (std::runtime_error &e) {
-    Utilities::Logln(std::string("Tokens: Could not save tokens to file: ") +
-                     e.what());
+  if (!JsonUtils::writeFile(filepath, root, &errors)) {
+    logger->error("Could not save tokens to file '%': ", errors);
     return false;
   }
 
-  Utilities::Logln("Tokens: Saved all tokens to \"" + filepath + "\"");
-
+  logger->info("Saved all tokens to '%s'.", filepath);
   return true;
 }
 
-void Tokens::Token::fromJson(const Json::Value &json) {
+bool Tokens::Token::fromJson(const Json::Value &json) {
   if (json["coordinates"].size() != 3) {
-    throw std::runtime_error("Coordinates array should have 3 items.");
+    errors = "Coordinates array should have 3 items.";
+    return false;
   }
-  coordinates[0] = json["coordinates"][0].asFloat();
-  coordinates[1] = json["coordinates"][1].asFloat();
-  coordinates[2] = json["coordinates"][2].asFloat();
-  name = json["name"].asString();
-  isActive = true;
+
+  for (int i = 0; i < 3; i++) {
+    if (!JsonUtils::parseValue(coordinates[i], json["coordinates"][i], &errors,
+                               "coordinates")) {
+      return false;
+    }
+  }
+
+  if (!JsonUtils::parseValue(name, json["name"], &errors, "name")) {
+    return false;
+  }
+
+  return isActive = true;
 }
 
 Json::Value Tokens::Token::toJson() const {

--- a/src/game/etj_tokens.h
+++ b/src/game/etj_tokens.h
@@ -28,6 +28,7 @@
 #include <array>
 #include "json/json-forwards.h"
 #include <memory>
+#include "etj_log.h"
 
 typedef struct TokenInformation_s TokenInformation;
 
@@ -47,6 +48,7 @@ public:
     std::string name;
     bool isActive;
     gentity_t *entity;
+    std::string errors;
 
     // Because we cannot capture values for the entity think lambda,
     // we must pass the data as a gentity pointer in gentity.
@@ -55,14 +57,14 @@ public:
     // Only tokens have the data.
     std::unique_ptr<TokenInformation> data;
     Json::Value toJson() const;
-    void fromJson(const Json::Value &json);
+    bool fromJson(const Json::Value &json);
   };
 
   std::pair<bool, std::string> createToken(Difficulty difficulty,
                                            std::array<float, 3> coordinates);
   struct NearestToken {
     int number;
-    Tokens::Token *token;
+    Token *token;
     float distance;
     Difficulty difficulty;
   };
@@ -74,11 +76,11 @@ public:
   deleteNearestToken(std::array<float, 3> coordinates);
   std::pair<bool, std::string> deleteToken(Difficulty difficulty, int index);
 
-  bool loadTokens(const std::string &filepath);
-  static bool saveTokens(const std::string &filepath);
-  static void createEntity(Token &token, Difficulty difficulty);
+  void loadTokens(const std::string &filepath);
+  bool saveTokens(const std::string &filepath);
+  void createEntity(Token &token, Difficulty difficulty) const;
   static void tokenTouch(gentity_t *self, gentity_t *other, trace_t *trace);
-  static void createEntities();
+  void createEntities();
   static void reset();
   static std::array<int, 3> getTokenCounts();
 
@@ -86,5 +88,7 @@ public:
 
 private:
   std::string _filepath;
+  std::unique_ptr<Log> logger;
+  std::string errors;
 };
 } // namespace ETJump

--- a/src/game/etj_tokens.h
+++ b/src/game/etj_tokens.h
@@ -35,6 +35,9 @@ typedef struct TokenInformation_s TokenInformation;
 namespace ETJump {
 class Tokens {
 public:
+  explicit Tokens(std::unique_ptr<Log> log);
+  ~Tokens() = default;
+
   enum Difficulty { Easy, Medium, Hard };
 
   // the entity is drawn as 32x32, but this feels more natural with touching
@@ -42,7 +45,7 @@ public:
 
   struct Token {
     Token()
-        : isActive(false), entity(nullptr), coordinates{0.0f, 0.0f, 0.0f},
+        : coordinates{0.0f, 0.0f, 0.0f}, isActive(false), entity(nullptr),
           data(std::make_unique<TokenInformation>()) {}
     std::array<float, 3> coordinates;
     std::string name;
@@ -83,6 +86,7 @@ public:
   void createEntities();
   static void reset();
   static std::array<int, 3> getTokenCounts();
+  static std::string tokenDifficultyToString(Tokens::Difficulty difficulty);
 
   static bool allTokensCollected(gentity_t *ent);
 

--- a/src/game/etj_utilities.cpp
+++ b/src/game/etj_utilities.cpp
@@ -196,40 +196,6 @@ void Utilities::Log(const std::string &message) {
   G_LogPrintf(message.c_str());
 }
 
-std::string Utilities::ReadFile(const std::string &filepath) {
-  fileHandle_t f;
-  auto len = trap_FS_FOpenFile(filepath.c_str(), &f, FS_READ);
-  if (len == -1) {
-    throw std::runtime_error("Could not open file for reading: " + filepath);
-  }
-
-  std::unique_ptr<char[]> buf(new char[len + 1]);
-  trap_FS_Read(buf.get(), len, f);
-  trap_FS_FCloseFile(f);
-  buf[len] = 0;
-  return std::string(buf.get());
-}
-
-void Utilities::WriteFile(const std::string &filepath,
-                          const std::string &content) {
-  fileHandle_t f;
-  auto len = trap_FS_FOpenFile(filepath.c_str(), &f, FS_WRITE);
-  if (len == -1) {
-    throw std::runtime_error("Could not open file for writing: " + filepath);
-  }
-
-  auto bytesWritten = trap_FS_Write(content.c_str(), content.length(), f);
-  if (bytesWritten == 0) {
-    trap_FS_FCloseFile(f);
-    throw std::runtime_error("Wrote 0 bytes to " + filepath);
-  }
-  trap_FS_FCloseFile(f);
-}
-
-void Utilities::Logln(const std::string &message) {
-  G_LogPrintf("%s\n", message.c_str());
-}
-
 void Utilities::Console(const std::string &message) {
   G_Printf(message.c_str());
 }

--- a/src/game/etj_utilities.cpp
+++ b/src/game/etj_utilities.cpp
@@ -204,7 +204,7 @@ void Utilities::Error(const std::string &error) { G_Error(error.c_str()); }
 
 std::vector<std::string> Utilities::getMaps() {
   std::vector<std::string> maps;
-  MapStatistics mapStats;
+  ETJump::MapStatistics mapStats;
 
   int i = 0;
   int numDirs = 0;
@@ -224,7 +224,7 @@ std::vector<std::string> Utilities::getMaps() {
     Q_strncpyz(buf, dirPtr, sizeof(buf));
     Q_strlwr(buf);
 
-    if (MapStatistics::isBlockedMap(buf)) {
+    if (ETJump::MapStatistics::isBlockedMap(buf)) {
       continue;
     }
 

--- a/src/game/etj_utilities.h
+++ b/src/game/etj_utilities.h
@@ -70,21 +70,6 @@ void Console(const std::string &message);
 void Log(const std::string &message);
 
 /**
- * Log a message & appends a newline
- */
-void Logln(const std::string &message);
-
-/**
- * Writes string to specified file
- */
-void WriteFile(const std::string &filepath, const std::string &content);
-
-/**
- * Reads contents of specified file and returns std moved string
- */
-std::string ReadFile(const std::string &filepath);
-
-/**
  * Returns true if there is atleast one player on team
  */
 bool anyonePlaying();

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -2065,8 +2065,8 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
   }
 
   if (mode == SAY_ALL) {
-    game.chatReplay->storeChatMessage(clientNum, escapedName, printText,
-                                      localize, encoded);
+    game.chatReplay->createChatMessage(clientNum, escapedName, printText,
+                                       localize, encoded);
   }
 
   if (target) {

--- a/src/game/g_vote.cpp
+++ b/src/game/g_vote.cpp
@@ -323,7 +323,7 @@ static bool matchMap(const char *voteArg, std::string &resultedMap,
     return false;
   }
 
-  if (MapStatistics::isBlockedMap(resultedMap)) {
+  if (ETJump::MapStatistics::isBlockedMap(resultedMap)) {
     resultedMap = stringFormat("^3callvote: ^7Voting for %s is not allowed.\n",
                                resultedMap);
     return false;

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -900,7 +900,7 @@ typedef struct {
 
   std::vector<std::string> serverMaplist;
 
-  std::vector<CustomMapVotes::MapType> customVotes;
+  std::vector<ETJump::CustomMapVotes::MapType> customVotes;
   int numCustomvotes; // -1 if we haven't gotten the count yet
   int customvoteIndex;
   int customvoteMapsOnServerIndex;


### PR DESCRIPTION
* Refactored all JSON parsing in the mod to use `JsonUtils` class
* Added safe JSON value parsing function. This fixes the game crashing with pretty much every JSON file we use, if the parsed field was not the type the parsing expected.
* Removed logging from `JsonUtils` - caller can now provide an optional pointer to an error string where errors are written. This makes more sense as having the logger in `JsonUtils` would just log errors for that class, instead of whatever was trying to do JSON parsing.
* Improved logging for tokens & custom votes
* Some small fixes:
  * Fixed `!tokens move` not placing tokens on ground level like `!tokens create` does
  * Fixed `/listinfo` message when no custom votes are defined on the server
  * Various errors with tokens no longer crash the game with `G_Error`, but rather gracefully return an error to user

Mapstatistics should also be eventually refactored in similar fashion as to here, but it's a bit more involved with all the database stuff so I left that out for now.