### PR TITLE
Increase UI memory pool

### DIFF
--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -7131,6 +7131,8 @@ void _UI_Init(int legacyClient, int clientVersion) {
              sizeof(translated_yes));
   Q_strncpyz(translated_no, DC->translateString("NO"), sizeof(translated_no));
 
+  trap_AddCommand("ui_report");
+
   Com_Printf(S_COLOR_LTGREY GAME_NAME " " S_COLOR_GREEN GAME_VERSION
                                       " " S_COLOR_LTGREY GAME_BINARY_NAME
                                       " init... " S_COLOR_GREEN "DONE\n");

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -77,9 +77,9 @@ static qboolean Menu_OverActiveItem(menuDef_t *menu, float x, float y);
   #endif
 #else
   #if id386
-    #define MEM_POOL_SIZE (4096 * 1024) // Arnout: was 1024
+    #define MEM_POOL_SIZE (8192 * 1024) // Arnout: was 1024
   #else
-    #define MEM_POOL_SIZE (8192 * 1024)
+    #define MEM_POOL_SIZE (16384 * 1024)
   #endif
 #endif
 


### PR DESCRIPTION
Recent UI work has increased UI memory usage quite a bit, and x86 wasn't actually even running anymore, was ~20% over memory limits. Also add `ui_report` to autocomplete.