### PR TITLE
Update customvotes for clients automatically during map

### DIFF
--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -387,6 +387,16 @@ void shutdown() {
                                      " " S_COLOR_LTGREY GAME_BINARY_NAME
                                      " shutdown... " S_COLOR_GREEN "DONE\n");
 }
+
+// FIXME: this should probably be somewhere else
+void resetCustomvoteInfo() {
+  cg.numCustomvotesRequested = false;
+  cg.customvoteInfoRequested = false;
+  cg.numCustomvotes = -1;
+  cg.numCustomvoteInfosRequested = 0;
+
+  trap_SendConsoleCommand("uiResetCustomvotes\n");
+}
 } // namespace ETJump
 
 /**
@@ -438,6 +448,11 @@ qboolean CG_ServerCommandExt(const char *cmd) {
     // we need to forward this command to UI to parse the list there,
     // so we can populate the map vote list
     trap_SendConsoleCommand(uiCommand.c_str());
+    return qtrue;
+  }
+
+  if (command == "forceCustomvoteRefresh") {
+    ETJump::resetCustomvoteInfo();
     return qtrue;
   }
 
@@ -628,10 +643,7 @@ qboolean CG_ConsoleCommandExt(const char *cmd) {
   }
 
   if (command == "forceCustomvoteRefresh") {
-    cg.numCustomvotesRequested = false;
-    cg.customvoteInfoRequested = false;
-    cg.numCustomvotes = -1;
-    cg.numCustomvoteInfosRequested = 0;
+    ETJump::resetCustomvoteInfo();
     return qtrue;
   }
 

--- a/src/game/etj_custom_map_votes.cpp
+++ b/src/game/etj_custom_map_votes.cpp
@@ -49,9 +49,7 @@ CustomMapVotes::getTypeInfo(std::string const &type) const {
   return {false, ""};
 }
 
-void CustomMapVotes::initialize() { loadCustomvotes(); }
-
-void CustomMapVotes::loadCustomvotes() {
+void CustomMapVotes::loadCustomvotes(const bool init) {
   const std::string filename = g_customMapVotesFile.string;
 
   if (filename.empty()) {
@@ -64,7 +62,10 @@ void CustomMapVotes::loadCustomvotes() {
   const auto parsingFailed = [&](const std::string &errMsg) {
     logger->error(errMsg);
     customMapVotes_.clear();
-    Printer::commandAll("forceCustomvoteRefresh");
+
+    if (!init) {
+      Printer::commandAll("forceCustomvoteRefresh");
+    }
   };
 
   if (!FileSystem::exists(filename)) {
@@ -134,8 +135,10 @@ void CustomMapVotes::loadCustomvotes() {
     }
   }
 
-  // invalidate cached customvote lists for all clients
-  Printer::commandAll("forceCustomvoteRefresh");
+  if (!init) {
+    // invalidate cached customvote lists for all clients
+    Printer::commandAll("forceCustomvoteRefresh");
+  }
 
   logger->info("Succesfully loaded %i custom votes from '%s'",
                static_cast<int>(customMapVotes_.size()), filename);
@@ -201,7 +204,7 @@ void CustomMapVotes::generateVotesFile() {
   }
 
   G_Printf("Generated new custom map votes file '%s'\n", filename.c_str());
-  loadCustomvotes();
+  loadCustomvotes(false);
 }
 
 void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
@@ -262,7 +265,7 @@ void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
     return;
   }
 
-  loadCustomvotes();
+  loadCustomvotes(false);
   Printer::chat(clientNum, stringFormat("^3add-customvote: ^7successfully "
                                         "added a new custom vote list ^3'%s'",
                                         sanitizedName));
@@ -313,7 +316,7 @@ void CustomMapVotes::deleteCustomvoteList(int clientNum,
     return;
   }
 
-  loadCustomvotes();
+  loadCustomvotes(false);
   Printer::chat(
       clientNum,
       stringFormat(
@@ -439,7 +442,7 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
     return;
   }
 
-  loadCustomvotes();
+  loadCustomvotes(false);
   Printer::chat(
       clientNum,
       stringFormat(

--- a/src/game/etj_custom_map_votes.cpp
+++ b/src/game/etj_custom_map_votes.cpp
@@ -49,6 +49,8 @@ CustomMapVotes::getTypeInfo(std::string const &type) const {
   return {false, ""};
 }
 
+void CustomMapVotes::initialize() { loadCustomvotes(); }
+
 void CustomMapVotes::loadCustomvotes() {
   const std::string filename = g_customMapVotesFile.string;
 
@@ -62,6 +64,7 @@ void CustomMapVotes::loadCustomvotes() {
   const auto parsingFailed = [&](const std::string &errMsg) {
     logger->error(errMsg);
     customMapVotes_.clear();
+    Printer::commandAll("forceCustomvoteRefresh");
   };
 
   if (!FileSystem::exists(filename)) {
@@ -130,6 +133,9 @@ void CustomMapVotes::loadCustomvotes() {
       customMapVotes_[curr].otherMaps.emplace_back(map);
     }
   }
+
+  // invalidate cached customvote lists for all clients
+  Printer::commandAll("forceCustomvoteRefresh");
 
   logger->info("Succesfully loaded %i custom votes from '%s'",
                static_cast<int>(customMapVotes_.size()), filename);

--- a/src/game/etj_custom_map_votes.h
+++ b/src/game/etj_custom_map_votes.h
@@ -51,6 +51,10 @@ public:
   CustomMapVotes(const std::shared_ptr<MapStatistics> &mapStats,
                  std::unique_ptr<Log> log);
   ~CustomMapVotes() = default;
+
+  // this simply calls 'loadCustomvotes', we use this on game init to avoid
+  // invalidating cache for custom map votes on clients
+  void initialize();
   void loadCustomvotes();
   TypeInfo getTypeInfo(const std::string &type) const;
   std::string randomMap(const std::string &type);

--- a/src/game/etj_custom_map_votes.h
+++ b/src/game/etj_custom_map_votes.h
@@ -52,10 +52,9 @@ public:
                  std::unique_ptr<Log> log);
   ~CustomMapVotes() = default;
 
-  // this simply calls 'loadCustomvotes', we use this on game init to avoid
-  // invalidating cache for custom map votes on clients
-  void initialize();
-  void loadCustomvotes();
+  // if 'init' is true, clients aren't forced to invalidate cached customvotes
+  // any calls made outside of game init should call this with 'false'
+  void loadCustomvotes(bool init);
   TypeInfo getTypeInfo(const std::string &type) const;
   std::string randomMap(const std::string &type);
   static bool isValidMap(const std::string &mapName);

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -189,7 +189,7 @@ void OnGameInit() {
 
   game.mapStatistics->initialize(std::string(g_mapDatabase.string),
                                  level.rawmapname);
-  game.customMapVotes->initialize();
+  game.customMapVotes->loadCustomvotes(true);
   game.motd->initialize();
   game.timerunV2->initialize();
 
@@ -306,7 +306,7 @@ qboolean OnConsoleCommand() {
   }
 
   if (command == "readcustomvotes") {
-    game.customMapVotes->loadCustomvotes();
+    game.customMapVotes->loadCustomvotes(false);
     // force voteflag re-check so UI can turn on/off custom vote button
     G_voteFlags();
     return qtrue;

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -189,7 +189,7 @@ void OnGameInit() {
 
   game.mapStatistics->initialize(std::string(g_mapDatabase.string),
                                  level.rawmapname);
-  game.customMapVotes->loadCustomvotes();
+  game.customMapVotes->initialize();
   game.motd->initialize();
   game.timerunV2->initialize();
 

--- a/src/ui/ui_atoms.cpp
+++ b/src/ui/ui_atoms.cpp
@@ -215,6 +215,11 @@ qboolean UI_ConsoleCommand(int realTime) {
     return qtrue;
   }
 
+  if (!Q_stricmp(cmd, "uiResetCustomvotes")) {
+    ETJump::resetCustomvotes();
+    return qtrue;
+  }
+
   trap_GetClientState(&cstate);
 
   return qfalse;

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -1118,5 +1118,6 @@ namespace ETJump {
 void parseMaplist();
 void parseNumCustomvotes();
 void parseCustomvote();
+void resetCustomvotes();
 } // namespace ETJump
 #endif

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -7344,6 +7344,14 @@ void parseCustomvote() {
     }
   }
 }
+
+void resetCustomvotes() {
+  uiInfo.customVotes.clear();
+  uiInfo.numCustomvotes = -1;
+  uiInfo.customvoteIndex = 0;
+  uiInfo.customvoteMapsOnServerIndex = 0;
+  uiInfo.customvoteOtherMapsIndex = 0;
+}
 } // namespace ETJump
 
 void _UI_SetActiveMenu(uiMenuCommand_t menu) {

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -7351,6 +7351,21 @@ void resetCustomvotes() {
   uiInfo.customvoteIndex = 0;
   uiInfo.customvoteMapsOnServerIndex = 0;
   uiInfo.customvoteOtherMapsIndex = 0;
+
+  static constexpr char DETAILS_MENU[] = "ingame_customvote_details";
+  static constexpr char VOTE_MENU[] = "ingame_vote_customvote";
+
+  const menuDef_t *detailsMenu = Menus_FindByName(DETAILS_MENU);
+  const menuDef_t *voteMenu = Menus_FindByName(VOTE_MENU);
+
+  if (detailsMenu && detailsMenu->window.flags & WINDOW_VISIBLE) {
+    Menus_CloseByName(DETAILS_MENU);
+  }
+
+  if (voteMenu && voteMenu->window.flags & WINDOW_VISIBLE) {
+    Menus_CloseByName(VOTE_MENU);
+    Menus_OpenByName("ingame_vote");
+  }
 }
 } // namespace ETJump
 


### PR DESCRIPTION
If server edits custom votes using admin commands, or manually and executes `readCustomvotes`, invalidate current custom vote lists for all clients and have them request new ones the next time they open the vote menu.

Without this, the client would also crash if the customvote parsing failed on the server.

fixes #1462 
refs #1447 