### PR TITLE
Add cached menu sliders

### DIFF
--- a/assets/ui/etjump_settings_general_client.menu
+++ b/assets/ui/etjump_settings_general_client.menu
@@ -50,10 +50,10 @@ menuDef {
 #ifdef VET
         MULTI               (SETTINGS_ITEM_POS(3), "Rendering primitives:", 0.2, SETTINGS_ITEM_H, "r_primitives", cvarFloatList { "Auto" 0 "Multiple glArrayElement" 1 "Single glDrawElements" 2 }, "Sets rendering primitives mode (ET 2.60b only)\nSetting this to 'Single glDrawElements' is recommended on modern systems for best performance\nr_primitives")
         CVARFLOATLABEL      (SETTINGS_ITEM_POS(4), "etj_menuSensitivity", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS(4), "Menu sensitivity:", 0.2, SETTINGS_ITEM_H, etj_menuSensitivity 1.0 0.05 4.0 0.05, "Sets mouse sensitivity for menus\netj_menuSensitivity")
+        CACHEDSLIDER        (SETTINGS_ITEM_POS(4), "Menu sensitivity:", 0.2, SETTINGS_ITEM_H, etj_menuSensitivity 1.0 0.05 4.0 0.05, "Sets mouse sensitivity for menus\netj_menuSensitivity")
 #else
         CVARFLOATLABEL      (SETTINGS_ITEM_POS(3), "etj_menuSensitivity", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS(3), "Menu sensitivity:", 0.2, SETTINGS_ITEM_H, etj_menuSensitivity 1.0 0.05 4.0 0.05, "Sets mouse sensitivity for menus\netj_menuSensitivity")
+        CACHEDSLIDER        (SETTINGS_ITEM_POS(3), "Menu sensitivity:", 0.2, SETTINGS_ITEM_H, etj_menuSensitivity 1.0 0.05 4.0 0.05, "Sets mouse sensitivity for menus\netj_menuSensitivity")
 #endif
 
 

--- a/assets/ui/etjump_settings_general_gameplay.menu
+++ b/assets/ui/etjump_settings_general_gameplay.menu
@@ -52,7 +52,7 @@ menuDef {
         MULTI               (SETTINGS_ITEM_POS(6), "Enable +activate lean:", 0.2, SETTINGS_ITEM_H, "etj_noActivateLean", cvarFloatList { "Yes" 0 "No" 1 }, "Enable leaning by pressing left/right movement keys when '+activate' is held\netj_noActivateLean")
         MULTI               (SETTINGS_ITEM_POS(7), "Quick follow:", 0.2, SETTINGS_ITEM_H, "etj_quickFollow", cvarFloatList { "No" 0 "Yes" 1 "Yes + draw hint" 2 }, "Spectate other players by aiming and pressing '+activate'\netj_quickFollow")
         CVARFLOATLABEL      (SETTINGS_ITEM_POS(8), "etj_noclipScale", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS(8), "Noclip scale:", 0.2, SETTINGS_ITEM_H, etj_noclipScale 1 0 10 0.2, "Scales the speed of noclip\netj_noclipScale")
+        CACHEDSLIDER        (SETTINGS_ITEM_POS(8), "Noclip scale:", 0.2, SETTINGS_ITEM_H, etj_noclipScale 1 0 10 0.2, "Scales the speed of noclip\netj_noclipScale")
         MULTI               (SETTINGS_ITEM_POS(9), "Auto weapon pickup:", 0.2, SETTINGS_ITEM_H, "etj_touchPickupWeapons", cvarFloatList { "No" 0 "Own + Spawned" 1 "All" 2 }, "Automatically pickup weapons when touching them\netj_touchPickupWeapons")
         YESNO               (SETTINGS_ITEM_POS(10), "Optimized prediction:", 0.2, SETTINGS_ITEM_H, "etj_optimizePrediction", "Enable optimized playerstate prediction to improve client side prediction performance\netj_optimizePrediction")
         YESNO               (SETTINGS_ITEM_POS(11), "No panzer autoswitch:", 0.2, SETTINGS_ITEM_H, "etj_noPanzerAutoswitch", "Disable automatic weapon switching after firing a panzerfaust\netj_noPanzerAutoswitch")

--- a/assets/ui/menumacros_ext.h
+++ b/assets/ui/menumacros_ext.h
@@ -453,3 +453,36 @@
     visible       1                                                            \
     decoration                                                                 \
   }
+
+// slider that only updates the cvar when mouse button is released
+#define CACHEDSLIDER( CACHEDSLIDER_X, CACHEDSLIDER_Y, CACHEDSLIDER_W,          \
+                      CACHEDSLIDER_H, CACHEDSLIDER_TEXT,                       \
+                      CACHEDSLIDER_TEXT_SCALE, CACHEDSLIDER_TEXT_ALIGN_Y,      \
+                      CACHEDSLIDER_CVARFLOAT, CACHEDSLIDER_TOOLTIP )           \
+  itemDef {                                                                    \
+    name        "cachedslider"##CACHEDSLIDER_TEXT                              \
+    group       GROUP_NAME                                                     \
+    rect        $evalfloat(CACHEDSLIDER_X) $evalfloat(CACHEDSLIDER_Y)          \
+                $evalfloat(CACHEDSLIDER_W) $evalfloat(CACHEDSLIDER_H)          \
+    type        ITEM_TYPE_SLIDER                                               \
+    text        CACHEDSLIDER_TEXT                                              \
+    textfont    UI_FONT_COURBD_21                                              \
+    textstyle   ITEM_TEXTSTYLE_SHADOWED                                        \
+    textscale   CACHEDSLIDER_TEXT_SCALE                                        \
+    textalign   ITEM_ALIGN_RIGHT                                               \
+    textalignx  $evalfloat(0.5*(CACHEDSLIDER_W))                               \
+    textaligny  CACHEDSLIDER_TEXT_ALIGN_Y                                      \
+    forecolor   .6 .6 .6 1                                                     \
+    cvarFloat   CACHEDSLIDER_CVARFLOAT                                         \
+    visible     1                                                              \
+    tooltip     CACHEDSLIDER_TOOLTIP                                           \
+    cacheCvar                                                                  \
+                                                                               \
+    mouseEnter {                                                               \
+      setitemcolor "cachedslider"##CACHEDSLIDER_TEXT forecolor .9 .9 .9 1 ;    \
+    }                                                                          \
+                                                                               \
+    mouseExit {                                                                \
+      setitemcolor "cachedslider"##CACHEDSLIDER_TEXT forecolor .6 .6 .6 1 ;    \
+    }                                                                          \
+  }

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -3772,7 +3772,8 @@ qboolean Item_HandleKey(itemDef_t *item, int key, qboolean down) {
 
   if (itemCapture) {
     if (itemCapture->cvar && itemCapture->cacheCvar &&
-        itemCapture->cacheCvarValue) {
+        itemCapture->cacheCvarValue && scrollInfo.item &&
+        scrollInfo.item->cacheCvarValue) {
       DC->setCVar(scrollInfo.item->cvar, scrollInfo.item->cacheCvarValue);
       scrollInfo.item->cacheCvarValue = nullptr;
     }

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -373,6 +373,9 @@ typedef struct itemDef_s {
   bool tooltipAbove;
 
   textScroll_t textScroll;
+
+  bool cacheCvar; // update cvar value only when itemCapture ends
+  const char *cacheCvarValue;
 } itemDef_t;
 
 typedef struct {


### PR DESCRIPTION
Works just like regular slider, except only updates the cvar value when item capture starts and stops, to avoid spamming cvar updates every time the slider value changes.

This is atm used for `etj_noclipScale` to avoid excess userinfo updates, and for `etj_menuSensitivity` to make the slider easier to use.

refs #1453 