### PR TITLE
Setup runtimer for sv_fps 125 servers/demos

### DIFF
--- a/src/cgame/etj_timerun_view.h
+++ b/src/cgame/etj_timerun_view.h
@@ -65,6 +65,8 @@ private:
 
   static const int popupFadeTime = 100;
 
+  int demoSvFps;
+
   static bool canSkipDraw();
 };
 } // namespace ETJump


### PR DESCRIPTION
Use `cg.snap->ps.commandTime` while spectating/in demo playback if `sv_fps` is 125, instead of `cg.time`.