### PR TITLE
Deprecate g_debugTimeruns

### DIFF
--- a/src/game/etj_timerun_entities.cpp
+++ b/src/game/etj_timerun_entities.cpp
@@ -137,72 +137,73 @@ void TimerunEntity::validateTimerunEntities() {
   }
 }
 
-bool TimerunEntity::canStartTimerun(gentity_t *self, gentity_t *activator,
+bool TimerunEntity::canStartTimerun(const gentity_t *self,
+                                    const gentity_t *activator,
                                     const int clientNum, const float speed) {
-  auto client = activator->client;
+  const auto client = activator->client;
 
   if (!client->pers.enableTimeruns || client->sess.timerunActive) {
     return false;
   }
 
-  // disable some checks if we're on a debugging session
-  if (!g_debugTimeruns.integer) {
-    if (client->noclip || activator->flags & FL_GODMODE) {
-      Printer::center(
-          clientNum,
-          "^3WARNING: ^7Timerun was not started. Invalid playerstate!");
-      return false;
-    }
+  // disable checks if cheats are enabled
+  if (g_cheats.integer) {
+    return true;
+  }
 
-    if (client->noclipThisLife) {
-      Printer::center(clientNum,
-                      "^3WARNING: ^7Timerun was not started. ^3noclip "
-                      "^7activated this life, ^3/kill ^7required!");
-      return false;
-    }
+  if (client->noclip || activator->flags & FL_GODMODE) {
+    Printer::center(
+        clientNum,
+        "^3WARNING: ^7Timerun was not started. Invalid playerstate!");
+    return false;
+  }
 
-    if (client->setoffsetThisLife) {
-      Printer::center(clientNum,
-                      "^3WARNING: ^7Timerun was not started. ^3setoffset "
-                      "^7activated this life, ^3/kill ^7required!");
-      return false;
-    }
+  if (client->noclipThisLife) {
+    Printer::center(clientNum, "^3WARNING: ^7Timerun was not started. ^3noclip "
+                               "^7activated this life, ^3/kill ^7required!");
+    return false;
+  }
 
-    if (client->ftNoGhostThisLife &&
-        !(self->spawnflags &
-          static_cast<int>(TimerunSpawnflags::AllowFTNoGhost))) {
-      Printer::center(
-          clientNum,
-          "^3WARNING: ^7Timerun was not started. ^3fireteam noghost ^7enabled "
-          "this life & run does not allow noghost, ^3/kill ^7required!");
-      return false;
-    }
+  if (client->setoffsetThisLife) {
+    Printer::center(clientNum,
+                    "^3WARNING: ^7Timerun was not started. ^3setoffset "
+                    "^7activated this life, ^3/kill ^7required!");
+    return false;
+  }
 
-    if (client->pmoveOffThisLife &&
-        (!self->spawnflags ||
-         self->spawnflags &
-             static_cast<int>(TimerunSpawnflags::ResetNoPmove))) {
-      Printer::center(clientNum,
-                      "^3WARNING: ^7Timerun was not started. ^3pmove_fixed 0 "
-                      "^7set this life, ^3/kill ^7required!");
-      return false;
-    }
+  if (client->ftNoGhostThisLife &&
+      !(self->spawnflags &
+        static_cast<int>(TimerunSpawnflags::AllowFTNoGhost))) {
+    Printer::center(
+        clientNum,
+        "^3WARNING: ^7Timerun was not started. ^3fireteam noghost ^7enabled "
+        "this life & run does not allow noghost, ^3/kill ^7required!");
+    return false;
+  }
 
-    if (speed > self->velocityUpperLimit) {
-      Printer::center(clientNum,
-                      stringFormat("^3WARNING: ^7Timerun was not started. Too "
-                                   "high starting speed (%.2f > %.2f)\n",
-                                   speed, self->velocityUpperLimit));
-      return false;
-    }
+  if (client->pmoveOffThisLife &&
+      (!self->spawnflags ||
+       self->spawnflags & static_cast<int>(TimerunSpawnflags::ResetNoPmove))) {
+    Printer::center(clientNum,
+                    "^3WARNING: ^7Timerun was not started. ^3pmove_fixed 0 "
+                    "^7set this life, ^3/kill ^7required!");
+    return false;
+  }
 
-    if (client->ps.viewangles[ROLL] != 0) {
-      Printer::center(clientNum,
-                      stringFormat("^3WARNING: ^7Timerun was not started. "
-                                   "Illegal roll angles (%.2f != 0)",
-                                   client->ps.viewangles[ROLL]));
-      return false;
-    }
+  if (speed > self->velocityUpperLimit) {
+    Printer::center(clientNum,
+                    stringFormat("^3WARNING: ^7Timerun was not started. Too "
+                                 "high starting speed (%.2f > %.2f)\n",
+                                 speed, self->velocityUpperLimit));
+    return false;
+  }
+
+  if (client->ps.viewangles[ROLL] != 0) {
+    Printer::center(clientNum,
+                    stringFormat("^3WARNING: ^7Timerun was not started. "
+                                 "Illegal roll angles (%.2f != 0)",
+                                 client->ps.viewangles[ROLL]));
+    return false;
   }
 
   return true;

--- a/src/game/etj_timerun_entities.h
+++ b/src/game/etj_timerun_entities.h
@@ -41,7 +41,7 @@ protected:
   static void setTimerunIndex(gentity_t *self);
   static bool canActivate(gentity_t *activator);
   static int getOrSetTimerunIndex(const std::string &runName);
-  static bool canStartTimerun(gentity_t *self, gentity_t *activator,
+  static bool canStartTimerun(const gentity_t *self, const gentity_t *activator,
                               int clientNum, float speed);
 
 public:

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -1117,29 +1117,25 @@ void ETJump::TimerunV2::startNotify(Player *player) const {
           .serialize());
 }
 
-bool ETJump::TimerunV2::isDebugging(int clientNum) {
+bool ETJump::TimerunV2::isDebugging(const int clientNum) {
   std::vector<std::string> debuggers;
 
-  if (g_debugTimeruns.integer > 0) {
-    debuggers.emplace_back("Timerun");
-  }
-
-  if (g_debugTrackers.integer > 0) {
+  if (g_debugTrackers.integer) {
     debuggers.emplace_back("Tracker");
   }
 
-  if (!debuggers.empty()) {
-    Printer::popup(clientNum, "Record not saved:\n");
-
-    for (auto &debugger : debuggers) {
-      std::string fmt = stringFormat("- ^3%s ^7debugging enabled.\n", debugger);
-      Printer::popup(clientNum, fmt);
-    }
-
-    return true;
+  if (debuggers.empty()) {
+    return false;
   }
 
-  return false;
+  Printer::popup(clientNum, "Record not saved:\n");
+
+  for (auto &debugger : debuggers) {
+    std::string fmt = stringFormat("- ^3%s ^7debugging enabled.\n", debugger);
+    Printer::popup(clientNum, fmt);
+  }
+
+  return true;
 }
 
 int ETJump::TimerunV2::indexForRunname(const std::string &runName) {

--- a/src/game/etj_utilities.cpp
+++ b/src/game/etj_utilities.cpp
@@ -101,8 +101,8 @@ void Utilities::startRun(int clientNum) {
     ETJump::saveSystem->clearTimerunSaves(player);
   }
 
-  // If we are debugging, just exit here
-  if (g_debugTimeruns.integer > 0) {
+  // if cheats are enabled, just exit here
+  if (g_cheats.integer) {
     return;
   }
 

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2063,7 +2063,6 @@ extern vmCvar_t g_chatOptions;
 extern vmCvar_t shared;
 extern vmCvar_t g_moverScale;
 extern vmCvar_t g_debugTrackers;
-extern vmCvar_t g_debugTimeruns;
 extern vmCvar_t g_spectatorVote;
 extern vmCvar_t g_enableVote;
 

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -254,7 +254,6 @@ vmCvar_t shared;
 vmCvar_t vote_minVoteDuration;
 vmCvar_t g_moverScale;
 vmCvar_t g_debugTrackers;
-vmCvar_t g_debugTimeruns;
 vmCvar_t g_spectatorVote;
 vmCvar_t g_enableVote;
 
@@ -504,7 +503,6 @@ cvarTable_t gameCvarTable[] = {
     {&vote_minVoteDuration, "vote_minVoteDuration", "5000", CVAR_ARCHIVE},
     {&g_moverScale, "g_moverScale", "1.0", 0},
     {&g_debugTrackers, "g_debugTrackers", "0", CVAR_ARCHIVE | CVAR_LATCH},
-    {&g_debugTimeruns, "g_debugTimeruns", "0", CVAR_ARCHIVE | CVAR_LATCH},
     {&g_spectatorVote, "g_spectatorVote", "0", CVAR_ARCHIVE | CVAR_SERVERINFO},
     {&g_enableVote, "g_enableVote", "1", CVAR_ARCHIVE},
     {&g_oss, "g_oss", "399", CVAR_SERVERINFO | CVAR_ROM, 0, qfalse, qfalse},


### PR DESCRIPTION
This has been redundant for a while now, it was originally added because timeruns were not playable in devmap, but now that they are, we don't need this anymore.