### PR TITLE
Refactor demo compatibility checks + add demo info print

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -4571,10 +4571,7 @@ void CG_DrawMiscGamemodels() {
 }
 
 void CG_DrawCoronas() {
-  static bool clientSideCoronas =
-      ETJump::demoCompatibility->isCompatible({3, 2, 0});
-
-  if (cg.demoPlayback && !clientSideCoronas) {
+  if (ETJump::demoCompatibility->flags.serverSideCoronas) {
     return;
   }
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1258,8 +1258,6 @@ typedef struct {
   // ETJump: hold last jump position for chs
   vec3_t etjLastJumpPos;
 
-  bool requiresEntityTypeAdjustment; // ETJump 2.3.0 specific hack
-
   char deformText[MAX_RENDER_STRINGS][MAX_RENDER_STRING_LENGTH];
 
   bool shadowCvarsSet;
@@ -4221,7 +4219,7 @@ extern std::vector<std::shared_ptr<CvarShadow>> cvarShadows;
 extern std::shared_ptr<EventLoop> eventLoop;
 extern std::shared_ptr<PlayerEventsHandler> playerEventsHandler;
 extern std::shared_ptr<ClientRtvHandler> rtvHandler;
-extern std::shared_ptr<DemoCompatibility> demoCompatibility;
+extern std::unique_ptr<DemoCompatibility> demoCompatibility;
 extern std::array<bool, MAX_CLIENTS> tempTraceIgnoredClients;
 extern std::shared_ptr<PlayerBBox> playerBBox;
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -12,6 +12,7 @@
 #include "etj_init.h"
 #include "etj_cvar_shadow.h"
 #include "etj_cvar_update_handler.h"
+#include "etj_demo_compatibility.h"
 #include "etj_utilities.h"
 #include "etj_rtv_drawable.h"
 
@@ -4047,19 +4048,6 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum,
   cgs.demoCam.startLean = qfalse;
   cgs.demoCam.noclip = qfalse;
 
-  if (cg.demoPlayback) {
-    // Marks the right 2.3.0 version to perform the entity type
-    // adjustement hack
-    char *pakBaseName = strchr(Info_ValueForKey(CG_ConfigString(CS_SYSTEMINFO),
-                                                "sv_referencedPakNames"),
-                               '/') +
-                        1;
-    if (!Q_strncmp(pakBaseName, "etjump-2_3_0-RC4 ", 17) ||
-        !Q_strncmp(pakBaseName, "etjump-2_3_0 ", 13)) {
-      cg.requiresEntityTypeAdjustment = true;
-    }
-  }
-
   CG_InitLocations();
 
   ETJump::init();
@@ -4073,6 +4061,10 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum,
   }
 
   Com_Printf("CG_Init... DONE\n");
+
+  if (cg.demoPlayback) {
+    ETJump::demoCompatibility->printDemoInformation();
+  }
 }
 
 /*

--- a/src/cgame/cg_snapshot.cpp
+++ b/src/cgame/cg_snapshot.cpp
@@ -2,6 +2,7 @@
 // not necessarily every single rendered frame
 
 #include "cg_local.h"
+#include "etj_demo_compatibility.h"
 #if __MACOS__
   #ifdef GAMERANGER
     #include "GameRanger SDK/GameRanger.h"
@@ -416,27 +417,17 @@ static snapshot_t *CG_ReadNextSnapshot(void) {
         CG_ResetTransitionEffects();
       }
 
-      // ETJump: This whole block is pretty hacky, but
-      // it fixes the bug, that was introduced in 2.3.0,
-      // which made some old demos unplayable due to the
-      // introduced shifting in the entityType_t. This
-      // code just tries to remap everything back, when
-      // necessary. This is perfomed for all new
-      // snapshots (so should roughly run just 20 times
-      // a second).
-      if (cg.requiresEntityTypeAdjustment) {
+      // adjust entity types to be compatible with 2.3.0/2.3.0 RC4
+      if (ETJump::demoCompatibility->flags.adjustEntityTypes) {
         for (int i = 0; i < dest->numEntities; i++) {
           entityState_t *es = &dest->entities[i];
-          // ET_VELOCITY_PUSH_TRIGGER =
-          // 9 in 2.3.0, so we should
-          // remap it to the current
-          // position
+          // ET_VELOCITY_PUSH_TRIGGER = 9 in 2.3.0,
+          // so we should remap it to the current position
           if (es->eType == 9) {
             es->eType = ET_VELOCITY_PUSH_TRIGGER;
           }
-          // shifting back all eTypes in
-          // demo, so it would match the
-          // current enum order
+          // shifting back all eTypes in demo,
+          // so it would match the current enum order
           else if (es->eType > 9) {
             --es->eType;
           }

--- a/src/cgame/etj_demo_compatibility.cpp
+++ b/src/cgame/etj_demo_compatibility.cpp
@@ -32,6 +32,7 @@ namespace ETJump {
 DemoCompatibility::DemoCompatibility() {
   if (cg.demoPlayback) {
     parseDemoVersion();
+    setupCompatibilityFlags();
   }
 }
 
@@ -42,7 +43,7 @@ void DemoCompatibility::parseDemoVersion() {
   // mod_version is present from '2.0.3 Alpha' onwards
   // if not present, look for sv_referencedPakNames as a fallback
   if (!versionStr.empty()) {
-    fillVersionInfo(&demoVersion, versionStr, ".");
+    fillVersionInfo(demoVersion, versionStr, ".");
   } else {
     const char *sysInfoCS = CG_ConfigString(CS_SYSTEMINFO);
     const char *pakNames = Info_ValueForKey(sysInfoCS, "sv_referencedPakNames");
@@ -77,11 +78,11 @@ void DemoCompatibility::parseDemoVersion() {
     versionStr.erase(0, idx);
 
     // pre 2.4.0 used '_' in pk3 name as delimiter
-    fillVersionInfo(&demoVersion, versionStr, "_");
+    fillVersionInfo(demoVersion, versionStr, "_");
   }
 }
 
-void DemoCompatibility::fillVersionInfo(Version *version,
+void DemoCompatibility::fillVersionInfo(Version &version,
                                         const std::string &versionStr,
                                         const std::string &delimiter) {
   const auto splits = StringUtil::split(versionStr, delimiter);
@@ -92,12 +93,68 @@ void DemoCompatibility::fillVersionInfo(Version *version,
     return;
   }
 
-  version->major = std::stoi(splits[0].substr(0, 1));
-  version->minor = std::stoi(splits[1].substr(0, 1));
-  version->patch = std::stoi(splits[2].substr(0, 1));
+  version.major = std::stoi(splits[0].substr(0, 1));
+  version.minor = std::stoi(splits[1].substr(0, 1));
+  version.patch = std::stoi(splits[2].substr(0, 1));
+
+  // special entity type adjustment for ETJump 2.3.0/2.3.0 RC4
+  // this is kinda awkward to do in setupCompatibilityFlags (and we don't
+  // parse extra versions anyway), so for simplicity's sake parse this here
+  if (isExactVersion({2, 3, 0}) ||
+      !Q_stricmpn(versionStr.c_str(), "etjump-2_3_0-RC4", 17)) {
+    flags.adjustEntityTypes = true;
+    compatibilityStrings.emplace_back(
+        "- Adjusted entity type order for ET_VELOCITY_PUSH_TRIGGER");
+  }
 }
 
-bool DemoCompatibility::isCompatible(Version minimum) const {
+void DemoCompatibility::setupCompatibilityFlags() {
+  if (!isCompatible({3, 2, 0})) {
+    flags.serverSideCoronas = true;
+    compatibilityStrings.emplace_back("- Using fully server-side coronas");
+  }
+
+  if (isCompatible({3, 2, 0})) {
+    flags.svFpsInSysteminfo = true;
+    compatibilityStrings.emplace_back(
+        "- sv_fps can be read from systeminfo string");
+  }
+
+  if (isCompatible({3, 3, 0})) {
+    flags.svFpsInCgs = true;
+    compatibilityStrings.emplace_back(
+        "- sv_fps can be read from client game static struct");
+  }
+}
+
+void DemoCompatibility::printDemoInformation() const {
+  const char *cs = CG_ConfigString(CS_SERVERINFO);
+  const char *server = Info_ValueForKey(cs, "sv_hostname");
+
+  if (!server || !*server) {
+    server = "Unknown";
+  }
+
+  const char *player = cgs.clientinfo[cg.clientNum].name;
+
+  CG_Printf("\n^g========================================\n");
+  CG_Printf(" Demo information:\n Mod version: ETJump ^2%i.%i.%i\n ^7Player: "
+            "%s\n ^7Map: %s\n ^7Server: %s\n",
+            demoVersion.major, demoVersion.minor, demoVersion.patch, player,
+            cgs.rawmapname, server);
+
+  if (!compatibilityStrings.empty()) {
+    CG_Printf("\nActive compatibility settings:\n");
+
+    for (const auto &str : compatibilityStrings) {
+      CG_Printf("%s\n", str.c_str());
+    }
+  }
+
+  CG_Printf("^g========================================\n\n");
+}
+
+bool DemoCompatibility::isCompatible(const Version &minimum) const {
   if (demoVersion.major != minimum.major) {
     return demoVersion.major > minimum.major;
   }
@@ -108,4 +165,11 @@ bool DemoCompatibility::isCompatible(Version minimum) const {
 
   return demoVersion.patch >= minimum.patch;
 }
+
+bool DemoCompatibility::isExactVersion(const Version &version) const {
+  return demoVersion.major == version.major &&
+         demoVersion.minor == version.minor &&
+         demoVersion.patch == version.patch;
+}
+
 } // namespace ETJump

--- a/src/cgame/etj_demo_compatibility.h
+++ b/src/cgame/etj_demo_compatibility.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <vector>
+
 namespace ETJump {
 class DemoCompatibility {
   struct Version {
@@ -33,16 +35,36 @@ class DemoCompatibility {
   };
 
   void parseDemoVersion();
-  static void fillVersionInfo(Version *version, const std::string &versionStr,
-                              const std::string &delimiter);
+  void fillVersionInfo(Version &version, const std::string &versionStr,
+                       const std::string &delimiter);
+
+  void setupCompatibilityFlags();
+
+  // returns true if the demo version is newer or same as 'minimum'
+  bool isCompatible(const Version &minimum) const;
+
+  // returns true if 'version' is the exact same as demo version
+  bool isExactVersion(const Version &version) const;
 
   Version demoVersion{};
 
 public:
+  struct CompatibilityFlags {
+    bool serverSideCoronas = false;
+    bool svFpsInSysteminfo = false;
+    bool svFpsInCgs = false;
+    bool adjustEntityTypes = false;
+  };
+
+  // everything in here will be set to false unless we're on demo playback
+  CompatibilityFlags flags{};
+
+  // stores the strings to print for compatibility info
+  std::vector<std::string> compatibilityStrings{};
+
+  void printDemoInformation() const;
+
   DemoCompatibility();
   ~DemoCompatibility() = default;
-
-  // returns true if the demo version is newer or same as minimumVersion
-  bool isCompatible(Version minimum) const;
 };
 } // namespace ETJump

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -85,7 +85,7 @@ std::shared_ptr<TimerunView> timerunView;
 std::shared_ptr<TrickjumpLines> trickjumpLines;
 std::shared_ptr<ClientRtvHandler> rtvHandler;
 std::shared_ptr<AreaIndicator> areaIndicator;
-std::shared_ptr<DemoCompatibility> demoCompatibility;
+std::unique_ptr<DemoCompatibility> demoCompatibility;
 std::shared_ptr<AccelColor> accelColor;
 std::array<bool, MAX_CLIENTS> tempTraceIgnoredClients;
 std::shared_ptr<PlayerBBox> playerBBox;
@@ -231,7 +231,7 @@ void init() {
   rtvHandler = std::make_shared<ClientRtvHandler>();
   rtvHandler->initialize();
 
-  demoCompatibility = std::make_shared<DemoCompatibility>();
+  demoCompatibility = std::make_unique<DemoCompatibility>();
   accelColor = std::make_shared<AccelColor>();
 
   playerBBox = std::make_shared<PlayerBBox>();

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -214,12 +214,10 @@ int ETJump::getSvFps() {
   int fps;
 
   if (cg.demoPlayback) {
-    static bool svFpsAvailable = demoCompatibility->isCompatible({3, 3, 0});
-    static bool csAvailable = demoCompatibility->isCompatible({3, 2, 0});
 
-    if (svFpsAvailable) {
+    if (demoCompatibility->flags.svFpsInCgs) {
       fps = cgs.sv_fps;
-    } else if (csAvailable) {
+    } else if (demoCompatibility->flags.svFpsInSysteminfo) {
       const char *cs = CG_ConfigString(CS_SYSTEMINFO);
       fps = Q_atoi(Info_ValueForKey(cs, "sv_fps"));
     } else {


### PR DESCRIPTION
Process all demo compatibility information on init, so we don't need to do any runtime checks for the version, and can simply check for boolean flags. Also add a small info print at the start of demo playback.

![image](https://github.com/user-attachments/assets/bced77af-0c8a-4af5-92c6-054477c9254d)

refs #1210 