### PR TITLE
Fix colorpicker sliders not working correctly in some scenarios

### DIFF
--- a/src/ui/etj_colorpicker.cpp
+++ b/src/ui/etj_colorpicker.cpp
@@ -179,6 +179,8 @@ void ColorPicker::updateHSVSliderState(const vec4_t hsv) {
 }
 
 void ColorPicker::updateSliderState(itemDef_t *item) {
+  // note: regardless of which slider is being updated, 'normalizedRGB' must be
+  // updated as that's what 'colorPickerStateToCvar' uses to set the cvar value
   switch (item->colorSliderData.colorType) {
     case COLOR_HSV:
       setHSV(HSV, colorPickerValues[COLOR_PICKER_H],
@@ -186,9 +188,12 @@ void ColorPicker::updateSliderState(itemDef_t *item) {
              colorPickerValues[COLOR_PICKER_V],
              colorPickerValues[COLOR_PICKER_A]);
       BG_HSVtoRGB(HSV, fullRGB, false);
+      setRGBNormalized(normalizedRGB, fullRGB[0], fullRGB[1], fullRGB[2],
+                       fullRGB[3]);
       updateRGBSliderState(fullRGB);
       break;
     case COLOR_RGB:
+    case COLOR_ALPHA:
       if (normalizedRGBSliders) {
         setRGB(normalizedRGB, colorPickerValues[COLOR_PICKER_R],
                colorPickerValues[COLOR_PICKER_G],
@@ -200,20 +205,24 @@ void ColorPicker::updateSliderState(itemDef_t *item) {
                colorPickerValues[COLOR_PICKER_G],
                colorPickerValues[COLOR_PICKER_B],
                colorPickerValues[COLOR_PICKER_A]);
+        setRGBNormalized(normalizedRGB, colorPickerValues[COLOR_PICKER_R],
+                         colorPickerValues[COLOR_PICKER_G],
+                         colorPickerValues[COLOR_PICKER_B],
+                         colorPickerValues[COLOR_PICKER_A]);
       }
 
       BG_RGBtoHSV(fullRGB, HSV);
       updateHSVSliderState(HSV);
       break;
-    case COLOR_ALPHA:
     case COLOR_UNKNOWN:
+    default:
       break;
   }
 
   colorPickerStateToCvar(false);
 }
 
-const char *ColorPicker::getColorSliderString(int handle) {
+const char *ColorPicker::getColorSliderString(const int handle) {
   const char *colorVar = nullptr;
 
   if (!PC_String_Parse(handle, &colorVar)) {

--- a/src/ui/etj_colorpicker.cpp
+++ b/src/ui/etj_colorpicker.cpp
@@ -46,7 +46,7 @@ ColorPicker::ColorPicker() {
   normalizedRGBSliders = false;
 }
 
-void ColorPicker::drawPreviewOld(rectDef_t *rect) const {
+void ColorPicker::drawPreviewOld(const rectDef_t *rect) const {
   DC->fillRect(rect->x, rect->y, rect->w, rect->h, oldRGB);
 }
 
@@ -108,7 +108,7 @@ void ColorPicker::cvarToColorPickerState(const std::string &cvar) {
   colorPickerValues[COLOR_PICKER_A] = normalizedRGB[3];
 }
 
-void ColorPicker::colorPickerStateToCvar(bool reset) {
+void ColorPicker::colorPickerStateToCvar(const bool reset) const {
   if (currentCvar.empty()) {
     Com_Printf(S_COLOR_YELLOW "%s: cannot set slider state to empty cvar\n",
                __func__);
@@ -178,7 +178,7 @@ void ColorPicker::updateHSVSliderState(const vec4_t hsv) {
   colorPickerValues[COLOR_PICKER_V] = hsv[2];
 }
 
-void ColorPicker::updateSliderState(itemDef_t *item) {
+void ColorPicker::updateSliderState(const itemDef_t *item) {
   // note: regardless of which slider is being updated, 'normalizedRGB' must be
   // updated as that's what 'colorPickerStateToCvar' uses to set the cvar value
   switch (item->colorSliderData.colorType) {
@@ -276,7 +276,7 @@ void ColorPicker::setColorSliderValue(const std::string &colorVar,
 }
 
 void ColorPicker::toggleRGBSliderValues() {
-  menuDef_t *menu = Menus_FindByName(COLOR_PICKER_MENU);
+  const menuDef_t *menu = Menus_FindByName(COLOR_PICKER_MENU);
 
   // this should never happen, we already have the menu open...
   if (menu == nullptr) {
@@ -352,8 +352,9 @@ void ColorPicker::toggleRGBSliderValues() {
   }
 }
 
-void ColorPicker::colorPickerDragFunc(itemDef_t *item, const float cursorX,
-                                      const float cursorY, const int key) {
+void ColorPicker::colorPickerDragFunc(const itemDef_t *item,
+                                      const float cursorX, const float cursorY,
+                                      const int key) {
   rectDef_t rect = item->window.rect;
   shrinkRectForColorPicker(rect);
 

--- a/src/ui/etj_colorpicker.h
+++ b/src/ui/etj_colorpicker.h
@@ -62,7 +62,7 @@ public:
   ~ColorPicker() = default;
 
   void drawColorPicker(const rectDef_t *rect);
-  void drawPreviewOld(rectDef_t *rect) const;
+  void drawPreviewOld(const rectDef_t *rect) const;
   void drawPreviewNew(const rectDef_t *rect);
 
   // shrinks a rectDef to match the color area
@@ -73,7 +73,7 @@ public:
   void cvarToColorPickerState(const std::string &cvar);
 
   // if reset is true, value is taken from currentCvarOldValue
-  void colorPickerStateToCvar(bool reset);
+  void colorPickerStateToCvar(bool reset) const;
 
   // reset sliders to state at which they were in when the menu was opened
   void resetColorPickerState();
@@ -82,9 +82,9 @@ public:
   static void setColorSliderType(itemDef_t *item);
   static float getColorSliderValue(const std::string &colorVar);
   static void setColorSliderValue(const std::string &colorVar, float value);
-  void updateSliderState(itemDef_t *item);
+  void updateSliderState(const itemDef_t *item);
 
-  void colorPickerDragFunc(itemDef_t *item, float cursorX, float cursorY,
+  void colorPickerDragFunc(const itemDef_t *item, float cursorX, float cursorY,
                            int key);
 
   // toggle RGB sliders between normalized and full RGB

--- a/src/ui/etj_colorpicker.h
+++ b/src/ui/etj_colorpicker.h
@@ -51,7 +51,7 @@ class ColorPicker {
 
   static inline void setHSV(vec4_t hsv, float h, float s, float v, float a);
   static inline void setRGB(vec4_t rgb, float r, float g, float b, float a);
-  static inline void setRGBNormalized(vec4_t RGB, float r, float g, float b,
+  static inline void setRGBNormalized(vec4_t rgb, float r, float g, float b,
                                       float a);
 
   void updateRGBSliderState(const vec4_t rgb) const;


### PR DESCRIPTION
* Fix alpha slider not working if normalized RGB sliders were enabled
* Fix alpha slider having slight inaccuracy in full RGB mode
* Fix HSV sliders not updating cvar value correctly

refs #1422 