### PR TITLE
Exception handling fixes for timeruns/time utils

### DIFF
--- a/src/game/etj_time_utilities.h
+++ b/src/game/etj_time_utilities.h
@@ -30,6 +30,7 @@
 #include <array>
 
 #include "etj_string_utilities.h"
+#include "etj_printer.h"
 
 namespace ETJump {
 struct Clock {
@@ -180,11 +181,23 @@ struct Time {
   }
 
   // https://en.cppreference.com/w/cpp/io/manip/get_time
+  // if parsing fails, returns timestamp from '1900-01-01 00:00:00'
   static Time fromString(const std::string &input,
                          const std::string &format = "%Y-%m-%d %H:%M:%S") {
     std::istringstream ss(input);
     std::tm t = {};
     ss >> std::get_time(&t, format.c_str());
+
+    if (ss.fail()) {
+      Printer::logLn(
+          stringFormat("%s: Failed to parse timestamp string '%s' in given "
+                       "format '%s', using default timestamp.",
+                       __func__, input, format));
+
+      t = {};
+      std::istringstream defaultTime("1900-01-01 00:00:00");
+      defaultTime >> std::get_time(&t, "%Y-%m-%d %H:%M:%S");
+    }
 
     Time time;
     time.date.year = t.tm_year + 1900;

--- a/src/game/etj_timerun_repository.cpp
+++ b/src/game/etj_timerun_repository.cpp
@@ -43,16 +43,11 @@ ETJump::Timerun::Record getRecordFromStandardQueryResult(
       [](const std::string &checkpoint) {
         try {
           return std::stoi(ETJump::trim(checkpoint));
-        } catch (const std::runtime_error &e) {
+        } catch (const std::logic_error &) {
           return TIMERUN_CHECKPOINT_NOT_SET;
         }
       });
-  ETJump::Time recordDateTime{};
-  try {
-    recordDateTime = ETJump::Time::fromString(recordDate);
-  } catch (const std::runtime_error &e) {
-    recordDateTime = ETJump::Time::fromString("1900-01-01 00:00:00");
-  }
+  ETJump::Time recordDateTime = ETJump::Time::fromString(recordDate);
 
   std::map<std::string, std::string> metadata;
   for (const auto &kvp :


### PR DESCRIPTION
* Fix wrong exception catch type when parsing checkpoints in `getRecordFromStandardQueryResult`
* Remove unnecessary exception handling for `recordDateTime` parsing in `getRecordFromStandardQueryResult`, `fromString` never throw exceptions to begin with, and now handles parsing errors internally and uses default time if the input is invalid