### PR TITLE
Disallow entity classname changes outside of spawn script events

### DIFF
--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -4546,7 +4546,7 @@ qboolean etpro_ScriptAction_SetValues(gentity_t *ent, char *params) {
       // tries to do this while spawning is disabled
       if (!level.spawning) {
         G_Error(
-            "%s: 'classname' must be changed inside a 'spawn' script event.",
+            "%s: 'classname' must be changed inside a 'spawn' script event.\n",
             __func__);
       }
 

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -4542,9 +4542,15 @@ qboolean etpro_ScriptAction_SetValues(gentity_t *ent, char *params) {
   // rain - if the classname was changed, call the spawn func again
   if (classchanged) {
     if (!nospawn) {
-      level.spawning = qtrue;
+      // provide a bit more meaningful error message if someone
+      // tries to do this while spawning is disabled
+      if (!level.spawning) {
+        G_Error(
+            "%s: 'classname' must be changed inside a 'spawn' script event.",
+            __func__);
+      }
+
       G_CallSpawn(ent);
-      level.spawning = qfalse;
     }
 
     trap_LinkEntity(ent);


### PR DESCRIPTION
This really shouldn't be done as this doesn't setup spawnvars correctly, and setting this up correctly would be a ton of work for very little benefit.

This was enabled in #1228, but disabling it now because the implementation is just wrong and doesn't work correctly. There's a more explicit error message added now if somebody tries to do this, rather than the somewhat cryptic error messages thrown via various `G_Spawn*` functions.