### PR TITLE
Add "delete" scriptaction

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -243,6 +243,29 @@ typedef struct commanderTeamChat_s {
   int index;
 } commanderTeamChat_t;
 
+//
+// fields are needed for spawning from the entity string
+//
+typedef enum {
+  F_INT,
+  F_FLOAT,
+  F_LSTRING, // string on disk, pointer in memory, TAG_LEVEL
+  F_GSTRING, // string on disk, pointer in memory, TAG_GAME
+  F_VECTOR,
+  F_ANGLEHACK,
+  F_ENTITY, // index on disk, pointer in memory
+  F_ITEM,   // index on disk, pointer in memory
+  F_CLIENT, // index on disk, pointer in memory
+  F_IGNORE
+} fieldtype_t;
+
+typedef struct {
+  const char *name;
+  size_t ofs;
+  fieldtype_t type;
+  int flags;
+} field_t;
+
 struct gentity_s {
   entityState_t s;  // communicated by server to clients
   entityShared_t r; // shared by both the server system and game
@@ -1535,6 +1558,9 @@ qboolean G_IsWeaponDisabled(gentity_t *ent, weapon_t weapon);
 void G_TeamCommand(team_t team, char *cmd);
 void G_KillBox(gentity_t *ent);
 gentity_t *G_Find(gentity_t *from, size_t fieldofs, const char *match);
+gentity_t *G_FindInt(gentity_t *from, size_t fieldofs, int match);
+gentity_t *G_FindFloat(gentity_t *from, size_t fieldofs, float match);
+gentity_t *G_FindVec(gentity_t *from, size_t fieldofs, const vec3_t match);
 gentity_t *G_FindByTargetname(gentity_t *from, const char *match);
 gentity_t *G_FindByTargetnameFast(gentity_t *from, const char *match, int hash);
 gentity_t *G_PickTarget(char *targetname);

--- a/src/game/g_script.cpp
+++ b/src/game/g_script.cpp
@@ -121,6 +121,7 @@ qboolean G_ScriptAction_ConstructibleDuration(gentity_t *ent, char *params);
 // bani
 qboolean etpro_ScriptAction_SetValues(gentity_t *ent, char *params);
 qboolean G_ScriptAction_Create(gentity_t *ent, char *params);
+qboolean G_ScriptAction_Delete(gentity_t *ent, char *params);
 
 qboolean G_ScriptAction_UseTarget(gentity_t *ent, char *params);
 qboolean G_ScriptAction_Announce_Private(gentity_t *ent, char *params);
@@ -208,6 +209,7 @@ g_script_stack_action_t gScriptActions[] = {
     {"killplayer", G_ScriptAction_KillPlayer},
 
     {"create", G_ScriptAction_Create},
+    {"delete", G_ScriptAction_Delete},
 
     // Gordon: going for longest silly script command ever here :) (sets a model
     // for a brush to one stolen from a func_brushmodel
@@ -665,11 +667,10 @@ void G_Script_ScriptParse(gentity_t *ent) {
 
         memset(params, 0, sizeof(params));
 
-        // Ikkyo - Parse for {}'s if this is a
-        // set command parse for {}'s if this is
-        // a set or create command
+        // parse for {} if this is a 'set', 'create' or 'delete' command
         if (!Q_stricmp(action->actionString, "set") ||
-            !Q_stricmp(action->actionString, "create")) {
+            !Q_stricmp(action->actionString, "create") ||
+            !Q_stricmp(action->actionString, "delete")) {
           token = COM_Parse(&pScript);
           if (token[0] != '{') {
             COM_ParseError("'{' expected, "

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -4716,7 +4716,7 @@ qboolean G_ScriptAction_Delete(gentity_t *ent, char *params) {
   int numDeleted = 0;
 
   // delete all entities that passed the tests
-  for (int i = MAX_CLIENTS + BODY_QUEUE_SIZE; i < MAX_GENTITIES; i++) {
+  for (int i = MAX_CLIENTS + BODY_QUEUE_SIZE; i < ENTITYNUM_MAX_NORMAL; i++) {
     if (pass[i] == count) {
       numDeleted++;
       G_Printf("%s: entity %i [^z%s^7] removed, matched params ^3'%s'\n",

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -4729,7 +4729,6 @@ qboolean G_ScriptAction_Delete(gentity_t *ent, char *params) {
   if (!numDeleted) {
     G_Printf("%s: no entities found matching params ^3'%s'\n", __func__,
              params);
-    return qtrue;
   }
 
   return qtrue;

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -79,29 +79,8 @@ qboolean G_SpawnVector2DExt(const char *key, const char *defaultString,
   return present;
 }
 
-//
-// fields are needed for spawning from the entity string
-//
-typedef enum {
-  F_INT,
-  F_FLOAT,
-  F_LSTRING, // string on disk, pointer in memory, TAG_LEVEL
-  F_GSTRING, // string on disk, pointer in memory, TAG_GAME
-  F_VECTOR,
-  F_ANGLEHACK,
-  F_ENTITY, // index on disk, pointer in memory
-  F_ITEM,   // index on disk, pointer in memory
-  F_CLIENT, // index on disk, pointer in memory
-  F_IGNORE
-} fieldtype_t;
-
-typedef struct {
-  const char *name;
-  size_t ofs;
-  fieldtype_t type;
-  int flags;
-} field_t;
-
+// FIXME: this is woefully out of date, it doesn't contain *ANY* custom keys
+//  we've added for ETJump, and is also lacking a lot of stock entity keys
 field_t fields[] = {
     {"classname", FOFS(classname), F_LSTRING},
     {"origin", FOFS(s.origin), F_VECTOR},
@@ -193,7 +172,7 @@ field_t fields[] = {
     {"targetShaderName", FOFS(targetShaderName), F_LSTRING},
     {"targetShaderNewName", FOFS(targetShaderNewName), F_LSTRING},
 
-    {NULL}};
+    {nullptr}};
 
 typedef struct {
   const char *name;

--- a/src/game/g_utils.cpp
+++ b/src/game/g_utils.cpp
@@ -167,9 +167,8 @@ NULL will be returned if the end of the list is reached.
 
 =============
 */
-gentity_t *G_Find(gentity_t *from, size_t fieldofs, const char *match) {
-  char *s;
-  gentity_t *max = &g_entities[level.num_entities];
+gentity_t *G_Find(gentity_t *from, const size_t fieldofs, const char *match) {
+  const gentity_t *max = &g_entities[level.num_entities];
 
   if (!from) {
     from = g_entities;
@@ -181,16 +180,105 @@ gentity_t *G_Find(gentity_t *from, size_t fieldofs, const char *match) {
     if (!from->inuse) {
       continue;
     }
-    s = *(char **)((byte *)from + fieldofs);
+
+    const char *s =
+        *reinterpret_cast<char **>(reinterpret_cast<byte *>(from) + fieldofs);
+
     if (!s) {
       continue;
     }
+
     if (!Q_stricmp(s, match)) {
       return from;
     }
   }
 
-  return NULL;
+  return nullptr;
+}
+
+// like G_Find, but searches for an int
+gentity_t *G_FindInt(gentity_t *from, const size_t fieldofs, const int match) {
+  const gentity_t *max = &g_entities[level.num_entities];
+
+  if (!from) {
+    from = g_entities;
+  } else {
+    from++;
+  }
+
+  for (; from < max; from++) {
+    if (!from->inuse) {
+      continue;
+    }
+
+    const int i =
+        *reinterpret_cast<int *>(reinterpret_cast<byte *>(from) + fieldofs);
+
+    if (i == match) {
+      return from;
+    }
+  }
+
+  return nullptr;
+}
+
+// like G_Find, but searches for a float
+gentity_t *G_FindFloat(gentity_t *from, const size_t fieldofs,
+                       const float match) {
+  const gentity_t *max = &g_entities[level.num_entities];
+
+  if (!from) {
+    from = g_entities;
+  } else {
+    from++;
+  }
+
+  for (; from < max; from++) {
+    if (!from->inuse) {
+      continue;
+    }
+
+    const float f =
+        *reinterpret_cast<float *>(reinterpret_cast<byte *>(from) + fieldofs);
+
+    if (f == match) {
+      return from;
+    }
+  }
+
+  return nullptr;
+}
+
+// like G_Find, but searches for a vec3_t
+gentity_t *G_FindVec(gentity_t *from, const size_t fieldofs,
+                     const vec3_t match) {
+  const gentity_t *max = &g_entities[level.num_entities];
+
+  if (!from) {
+    from = g_entities;
+  } else {
+    from++;
+  }
+
+  for (; from < max; from++) {
+    if (!from->inuse) {
+      continue;
+    }
+
+    vec3_t v;
+    v[0] = *reinterpret_cast<vec_t *>(reinterpret_cast<byte *>(from) +
+                                      fieldofs + 0);
+    v[1] = *reinterpret_cast<vec_t *>(reinterpret_cast<byte *>(from) +
+                                      fieldofs + 4);
+    v[2] = *reinterpret_cast<vec_t *>(reinterpret_cast<byte *>(from) +
+                                      fieldofs + 8);
+
+    if (VectorCompare(v, match)) {
+      return from;
+    }
+  }
+
+  return nullptr;
 }
 
 /*


### PR DESCRIPTION
```
delete
{
  key1 "value"
  key2 "value"
  key3 "value"
  ...
}
```

Allows deleting entities by key/value pair(s). If multiple k/v pairs are given, all of the must match for the entity to be deleted.

Thanks to ET:Legacy for the implementation details.
https://github.com/etlegacy/etlegacy/commit/d71ff9447c99f6a5fe5f1ccf88cadc1a280f926f