### PR TITLE
Fix chat replays potentially recoloring player name

### DIFF
--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -86,9 +86,9 @@ void ChatReplay::sendChatMessages(gentity_t *ent) const {
   }
 }
 
-std::string ChatReplay::parseChatMessage(const ChatReplay::ChatMessage &msg) {
+std::string ChatReplay::parseChatMessage(const ChatMessage &msg) {
   const char *cmd = msg.encoded ? "enc_chat" : "chat";
-  return stringFormat("%s \"^g[REPLAY] %s%c%c%s\" %i %i 1", cmd, msg.name,
+  return stringFormat("%s \"^g[REPLAY] ^7%s%c%c%s\" %i %i 1", cmd, msg.name,
                       Q_COLOR_ESCAPE, COLOR_LTGREY, msg.message, msg.clientNum,
                       msg.localize);
 }


### PR DESCRIPTION
If the client had no color codes in the name, the color from `^g[REPLAY]` would carry over to the clients name.

refs #1335 