### PR TITLE
Add g_chatReplayMaxMessageAge

### DIFF
--- a/src/game/etj_chat_replay.h
+++ b/src/game/etj_chat_replay.h
@@ -35,6 +35,10 @@ class ChatReplay {
     std::string message;
     bool localize;
     bool encoded;
+
+    // true if timestamp is older than current time - g_chatReplayMaxMessageAge
+    bool expired;
+    int timestamp;
   };
 
   static constexpr int MAX_CHAT_REPLAY_BUFFER = 10;
@@ -57,7 +61,7 @@ public:
                          const std::string &message, bool localize,
                          bool encoded);
 
-  void sendChatMessages(gentity_t *ent) const;
+  void sendChatMessages(gentity_t *ent);
 
   void writeChatsToFile();
 };

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2097,6 +2097,8 @@ extern vmCvar_t vote_minRtvDuration;
 
 extern vmCvar_t g_adminChat;
 
+extern vmCvar_t g_chatReplayMaxMessageAge;
+
 void trap_Printf(const char *fmt);
 void trap_Error(const char *fmt);
 int trap_Milliseconds(void);

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -263,6 +263,8 @@ vmCvar_t vote_minRtvDuration;
 
 vmCvar_t g_adminChat;
 
+vmCvar_t g_chatReplayMaxMessageAge;
+
 // ETLegacy server browser integration
 // os support - this SERVERINFO cvar specifies supported client operating
 // systems on server
@@ -512,6 +514,9 @@ cvarTable_t gameCvarTable[] = {
     {&g_rtvMapCount, "g_rtvMapCount", "5", CVAR_ARCHIVE},
 
     {&g_adminChat, "g_adminChat", "1", CVAR_ARCHIVE},
+
+    {&g_chatReplayMaxMessageAge, "g_chatReplayMaxMessageAge", "0",
+     CVAR_ARCHIVE},
 };
 
 // bk001129 - made static to avoid aliasing

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -516,7 +516,7 @@ cvarTable_t gameCvarTable[] = {
     {&g_adminChat, "g_adminChat", "1", CVAR_ARCHIVE},
 
     {&g_chatReplayMaxMessageAge, "g_chatReplayMaxMessageAge", "0",
-     CVAR_ARCHIVE},
+     CVAR_ARCHIVE | CVAR_LATCH},
 };
 
 // bk001129 - made static to avoid aliasing


### PR DESCRIPTION
Can be set to > 0 to make chat replay messages expire. Any chat message older than current time - `g_chatReplayMaxMessageAge <minutes>` will be excluded from chat replay. The chat is still included in the replay file, it just won't be sent to clients. Off by default (messages don't expire).

refs #1335 