### PR TITLE
Allow any cg_fov value in demo playback

### DIFF
--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -988,7 +988,7 @@ static int CG_CalcFov(void) {
     fov_x = 90;
   } else {
     fov_x = cg_fov.value;
-    if (!developer.integer) {
+    if (!developer.integer && !cg.demoPlayback) {
       if (fov_x < 90) {
         fov_x = 90;
       } else if (fov_x > 160) {


### PR DESCRIPTION
Previously required `developer 1` even in demo playback.