### PR TITLE
Add etj_snapHUDBorderThickness to adjust border-only snaphud

### DIFF
--- a/assets/ui/etjump_settings_hud2_snaphud.menu
+++ b/assets/ui/etjump_settings_hud2_snaphud.menu
@@ -65,7 +65,9 @@ menuDef {
         COMBO               (SETTINGS_COMBO_POS(10), "Highlight color 2:", 0.2, SETTINGS_ITEM_H, "etj_snapHUDHLColor2", COLOR_LIST, uiScript uiPreviousMenu MENU_NAME, "Sets color of active secondary snapzone\netj_snapHUDHLColor2")
         CVARINTLABEL        (SETTINGS_ITEM_POS(11), "etj_snapHUDEdgeThickness", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(11), "Edge thickness:", 0.2, SETTINGS_ITEM_H, etj_snapHUDEdgeThickness 10 1 128 1, "Thickness of snapzone edges when using edge-only snaphud\netj_snapHUDEdgeThickness")
-        YESNO               (SETTINGS_ITEM_POS(12), "Color 1 is active zone:", 0.2, SETTINGS_ITEM_H, "etj_snapHUDActiveIsPrimary", "Always use primary color for currently active snapzone and flip colors when switching zones\netj_snapHUDActiveIsPrimary")
+        CVARFLOATLABEL      (SETTINGS_ITEM_POS(12), "etj_snapHUDBorderThickness", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(12), "Border thickness:", 0.2, SETTINGS_ITEM_H, etj_snapHUDBorderThickness 1 0.1 10 0.1, "Thickness of snapzone borders when using border-only snaphud\netj_snapHUDBorderThickness")
+        YESNO               (SETTINGS_ITEM_POS(13), "Color 1 is active zone:", 0.2, SETTINGS_ITEM_H, "etj_snapHUDActiveIsPrimary", "Always use primary color for currently active snapzone and flip colors when switching zones\netj_snapHUDActiveIsPrimary")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -74,11 +74,12 @@ void CG_FillRectGradient(float x, float y, float width, float height,
 
 /*
 ==============
-CG_FillAngleYaw
+CG_FillAngleYawExt
 ==============
 */
-void CG_FillAngleYaw(float start, float end, float yaw, float y, float h,
-                     float fov, vec4_t const color, bool borderOnly) {
+void CG_FillAngleYawExt(float start, float end, float yaw, float y, float h,
+                        float fov, vec4_t const color, bool borderOnly,
+                        float borderThickness) {
   // don't try to draw lines with no width
   if (start == end) {
     return;
@@ -88,20 +89,31 @@ void CG_FillAngleYaw(float start, float end, float yaw, float y, float h,
 
   if (!range.split) {
     if (borderOnly) {
-      CG_DrawRect_FixedBorder(range.x1, y, range.x2 - range.x1, h, 1, color);
+      CG_DrawRect_FixedBorder(range.x1, y, range.x2 - range.x1, h,
+                              borderThickness, color);
     } else {
       CG_FillRect(range.x1, y, range.x2 - range.x1, h, color);
     }
   } else {
     if (borderOnly) {
-      CG_DrawRect_FixedBorder(0, y, range.x1, h, 1, color);
-      CG_DrawRect_FixedBorder(range.x2, y, SCREEN_WIDTH - range.x2, h, 1,
-                              color);
+      CG_DrawRect_FixedBorder(0, y, range.x1, h, borderThickness, color);
+      CG_DrawRect_FixedBorder(range.x2, y, SCREEN_WIDTH - range.x2, h,
+                              borderThickness, color);
     } else {
       CG_FillRect(0, y, range.x1, h, color);
       CG_FillRect(range.x2, y, SCREEN_WIDTH - range.x2, h, color);
     }
   }
+}
+
+/*
+==============
+CG_FillAngleYaw
+==============
+*/
+void CG_FillAngleYaw(float start, float end, float yaw, float y, float h,
+                     float fov, const vec4_t color) {
+  CG_FillAngleYawExt(start, end, yaw, y, h, fov, color, false, 1);
 }
 
 /*
@@ -513,7 +525,7 @@ void CG_DrawRect(float x, float y, float width, float height, float size,
 }
 
 void CG_DrawRect_FixedBorder(float x, float y, float width, float height,
-                             int border, const vec4_t color) {
+                             float border, const vec4_t color) {
   trap_R_SetColor(color);
 
   CG_DrawTopBottom_NoScale(x, y, width, height, border);

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2693,6 +2693,7 @@ extern vmCvar_t etj_snapHUDFov;
 extern vmCvar_t etj_snapHUDHLActive;
 extern vmCvar_t etj_snapHUDTrueness;
 extern vmCvar_t etj_snapHUDEdgeThickness;
+extern vmCvar_t etj_snapHUDBorderThickness;
 extern vmCvar_t etj_snapHUDActiveIsPrimary;
 
 extern vmCvar_t etj_gunSway;
@@ -2847,7 +2848,10 @@ void CG_AdjustFrom640(float *x, float *y, float *w, float *h);
 void CG_FillRect(float x, float y, float width, float height,
                  const float *color);
 void CG_FillAngleYaw(float start, float end, float yaw, float y, float h,
-                     float fov, vec4_t const color, bool borderOnly = false);
+                     float fov, vec4_t const color);
+void CG_FillAngleYawExt(float start, float end, float yaw, float y, float h,
+                        float fov, vec4_t const color, bool borderOnly,
+                        float borderThickness);
 void DrawLine(float x1, float y1, float x2, float y2, const vec4_t color);
 void DrawLine(float x1, float y1, float x2, float y2, float w, float h,
               const vec4_t color);
@@ -2929,7 +2933,7 @@ void UI_DrawProportionalString(int x, int y, const char *str, int style,
 void CG_DrawRect(float x, float y, float width, float height, float size,
                  const float *color);
 void CG_DrawRect_FixedBorder(float x, float y, float width, float height,
-                             int border, const vec4_t color);
+                             float border, const vec4_t color);
 void CG_DrawSides(float x, float y, float w, float h, float size);
 void CG_DrawSides_NoScale(float x, float y, float w, float h, float size);
 void CG_DrawTopBottom(float x, float y, float w, float h, float size);

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -586,6 +586,7 @@ vmCvar_t etj_snapHUDFov;
 vmCvar_t etj_snapHUDHLActive;
 vmCvar_t etj_snapHUDTrueness;
 vmCvar_t etj_snapHUDEdgeThickness;
+vmCvar_t etj_snapHUDBorderThickness;
 vmCvar_t etj_snapHUDActiveIsPrimary;
 
 vmCvar_t etj_gunSway;
@@ -1154,6 +1155,8 @@ cvarTable_t cvarTable[] = {
     {&etj_snapHUDHLActive, "etj_snapHUDHLActive", "0", CVAR_ARCHIVE},
     {&etj_snapHUDTrueness, "etj_snapHUDTrueness", "0", CVAR_ARCHIVE},
     {&etj_snapHUDEdgeThickness, "etj_snapHUDEdgeThickness", "10", CVAR_ARCHIVE},
+    {&etj_snapHUDBorderThickness, "etj_snapHUDBorderThickness", "1",
+     CVAR_ARCHIVE},
     {&etj_snapHUDActiveIsPrimary, "etj_snapHUDActiveIsPrimary", "0",
      CVAR_ARCHIVE},
 

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -297,7 +297,8 @@ bool Snaphud::beforeRender() {
     case HudType::SNAP_BORDER:
       borderOnly = true;
       borderThickness =
-          Numeric::clamp(etj_snapHUDBorderThickness.value, 0.1f, 10.0f);
+          Numeric::clamp(etj_snapHUDBorderThickness.value, 0.1f,
+                         std::min(etj_snapHUDHeight.value * 2, 10.0f));
       break;
     default:
       borderOnly = false;

--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -290,10 +290,18 @@ bool Snaphud::beforeRender() {
 
   hudType = static_cast<HudType>(etj_drawSnapHUD.integer);
 
-  if (hudType == HudType::SNAP_EDGE) {
-    edgeThickness = Numeric::clamp(etj_snapHUDEdgeThickness.integer, 1, 128);
-  } else {
-    borderOnly = (hudType == HudType::SNAP_BORDER);
+  switch (hudType) {
+    case HudType::SNAP_EDGE:
+      edgeThickness = Numeric::clamp(etj_snapHUDEdgeThickness.integer, 0, 128);
+      break;
+    case HudType::SNAP_BORDER:
+      borderOnly = true;
+      borderThickness =
+          Numeric::clamp(etj_snapHUDBorderThickness.value, 0.1f, 10.0f);
+      break;
+    default:
+      borderOnly = false;
+      break;
   }
 
   PrepareDrawables();
@@ -347,8 +355,9 @@ void Snaphud::render() const {
       CG_FillAngleYaw(SHORT2RAD(ds.eSnap), SHORT2RAD(ds.eSnap - edgeThickness),
                       SHORT2RAD(yaw), y, h, fov, snaphudColors[color]);
     } else {
-      CG_FillAngleYaw(SHORT2RAD(ds.bSnap), SHORT2RAD(ds.eSnap), SHORT2RAD(yaw),
-                      y, h, fov, snaphudColors[color], borderOnly);
+      CG_FillAngleYawExt(SHORT2RAD(ds.bSnap), SHORT2RAD(ds.eSnap),
+                         SHORT2RAD(yaw), y, h, fov, snaphudColors[color],
+                         borderOnly, borderThickness);
     }
   }
 }

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -81,6 +81,7 @@ private:
   int yaw{};
   vec4_t snaphudColors[4]{};
   int edgeThickness{};
+  float borderThickness{};
   HudType hudType{};
   bool borderOnly{};
   int lastUpdateTime{};

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -406,12 +406,12 @@ void _UI_DrawRect(float x, float y, float width, float height, float size,
 }
 
 void _UI_DrawRect_DrawRect_FixedBorder(float x, float y, float width,
-                                       float height, int size,
+                                       float height, float border,
                                        const float *color) {
   trap_R_SetColor(color);
 
-  _UI_DrawSides_NoScale(x, y, width, height, size);
-  _UI_DrawTopBottom_NoScale(x, y, width, height, size);
+  _UI_DrawSides_NoScale(x, y, width, height, border);
+  _UI_DrawTopBottom_NoScale(x, y, width, height, border);
 
   trap_R_SetColor(NULL);
 }

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -490,7 +490,7 @@ typedef struct {
   void (*fillRect)(float x, float y, float w, float h, const vec4_t color);
   void (*drawRect)(float x, float y, float w, float h, float size,
                    const vec4_t color);
-  void (*drawRectFixed)(float x, float y, float w, float h, int size,
+  void (*drawRectFixed)(float x, float y, float w, float h, float border,
                         const vec4_t color);
   void (*drawSides)(float x, float y, float w, float h, float size);
   void (*drawTopBottom)(float x, float y, float w, float h, float size);


### PR DESCRIPTION
Can be used to set the thickness used for the rectangle borders for `etj_drawSnapHUD 3`, similar to edge thickness on `etj_drawSnapHUD 2`.

Capped to `0.1 - 10.0` or `0.1 - (etj_snapHUDHeight * 2)` range.

This also changes `CG_DrawRect_FixedBorder` to allow for float values for the border thickness, this doesn't affect any existing code as it's only ever called with integer values everywhere.

refs #1430 