### PR TITLE
Allow turning off chat replay on server with g_chatReplay

### DIFF
--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -69,6 +69,10 @@ void ChatReplay::sendChatMessages(gentity_t *ent) {
     return;
   }
 
+  if (!g_chatReplay.integer) {
+    return;
+  }
+
   // shouldn't ever happen but just in case,
   // so we don't print out the info when there's no messages
   if (chatReplayBuffer.empty()) {

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2097,6 +2097,7 @@ extern vmCvar_t vote_minRtvDuration;
 
 extern vmCvar_t g_adminChat;
 
+extern vmCvar_t g_chatReplay;
 extern vmCvar_t g_chatReplayMaxMessageAge;
 
 void trap_Printf(const char *fmt);

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -263,6 +263,7 @@ vmCvar_t vote_minRtvDuration;
 
 vmCvar_t g_adminChat;
 
+vmCvar_t g_chatReplay;
 vmCvar_t g_chatReplayMaxMessageAge;
 
 // ETLegacy server browser integration
@@ -515,6 +516,7 @@ cvarTable_t gameCvarTable[] = {
 
     {&g_adminChat, "g_adminChat", "1", CVAR_ARCHIVE},
 
+    {&g_chatReplay, "g_chatReplay", "1", CVAR_ARCHIVE},
     {&g_chatReplayMaxMessageAge, "g_chatReplayMaxMessageAge", "0",
      CVAR_ARCHIVE | CVAR_LATCH},
 };


### PR DESCRIPTION
Allow servers to turn off chat replay with `g_chatReplay 0`. The chat logging still works in the background while if the cvar is off, but chats are not sent to clients.

refs #1335 