### PR TITLE
Sync smoothangles each Pmove frame

### DIFF
--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -1199,12 +1199,6 @@ void CG_PredictPlayerState() {
           CG_Printf("PredictionTeleport\n");
         }
 
-        // sync up refdef angles if etj_smoothAngles is enabled
-        if (etj_smoothAngles.integer && cg_pmove.pmove_fixed) {
-          VectorCopy(cg_pmove.ps->viewangles, cg.refdefViewAngles);
-          VectorCopy(cg_pmove.ps->delta_angles, cg.refdefDeltaAngles);
-        }
-
         cg.thisFrameTeleport = qfalse;
       } else if (!cg.showGameView) {
         vec3_t adjusted;
@@ -1345,6 +1339,13 @@ void CG_PredictPlayerState() {
     // END unlagged - optimized prediction
 
     moved = true;
+
+    // after Pmove is run, sync playerstate viewangles with refdef angles
+    // if etj_smoothAngles is enabled, to apply any changes done in Pmove
+    if (etj_smoothAngles.integer && cg_pmove.pmove_fixed) {
+      VectorCopy(cg_pmove.ps->viewangles, cg.refdefViewAngles);
+      VectorCopy(cg_pmove.ps->delta_angles, cg.refdefDeltaAngles);
+    }
 
     // add push trigger movement effects
     CG_TouchTriggerPrediction();


### PR DESCRIPTION
This should ensure they never start drifting and get desynced with real viewangles. We could now in theory enable this for things like mounted weapons or prone, but because the view isn't actually capped outside of `Pmove`, it causes quite severe screen jitter whenever angles get capped in some way.

This seems like an obvious solution, but intuitively this should cause some sort of stuttering on framerates such as 333, where the cgame frames don't align properly with `ps.commandTime`, hence I didn't initially do this. But in reality it doesn't seem cause any stuttering at least on my testing.