### PR TITLE
Fix corpses producing water impacts

### DIFF
--- a/src/game/g_weapon.cpp
+++ b/src/game/g_weapon.cpp
@@ -3546,7 +3546,7 @@ qboolean Bullet_Fire_Extended(gentity_t *source, gentity_t *attacker,
     tent = G_TempEntity(tr.endpos, EV_BULLET_HIT_WALL);
 
     G_Trace(source, &tr2, start, nullptr, nullptr, end, source->s.number,
-            MASK_WATER | MASK_SOLID);
+            MASK_WATER | MASK_SHOT);
 
     if ((tr.entityNum != tr2.entityNum && tr2.fraction != 1)) {
       vec3_t v;


### PR DESCRIPTION
Bullet trace used when tracing missed shots was not ignoring corpses, which set incorrect params to entitystate for `EV_BULLET_HIT_WALL` event and caused cgame to think that the shot hit water surface.

This trace was adjusted in 2016 in #68, which made bullets pass through players. This worked until #1333 where solid players were made to block bullets again, but the trace was never adjusted.

refs #1333 