### PR TITLE
Fix bullet impact particle effects working unreliably

### DIFF
--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -6387,20 +6387,16 @@ void CG_Bullet(vec3_t end, int sourceEntityNum, vec3_t normal, qboolean flesh,
                int fleshEntityNum, int otherEntNum2, float waterfraction,
                int seed) {
   trace_t trace, trace2;
-  int sourceContentType, destContentType;
   vec3_t dir;
   vec3_t start{};
-  vec3_t trend; // JPW
-  vec4_t projection;
   static int lastBloodSpat;
-  centity_t *cent;
 
   // shouldn't ever happen
   if (sourceEntityNum < 0 || sourceEntityNum >= MAX_GENTITIES) {
     return;
   }
 
-  cent = &cg_entities[fleshEntityNum];
+  centity_t *cent = &cg_entities[fleshEntityNum];
 
   // Hideme check to prevent tracers & impact sounds
   // FIXME: currently this works for players only
@@ -6418,7 +6414,6 @@ void CG_Bullet(vec3_t end, int sourceEntityNum, vec3_t normal, qboolean flesh,
   if (cgs.antilag && otherEntNum2 == cg.snap->ps.clientNum &&
       cg_entities[otherEntNum2].currentState.eFlags & EF_MG42_ACTIVE) {
     vec3_t muzzle, forward, right, up;
-    float r, u;
     trace_t tr;
 
     AngleVectors(cg.predictedPlayerState.viewangles, forward, right, up);
@@ -6429,8 +6424,8 @@ void CG_Bullet(vec3_t end, int sourceEntityNum, vec3_t normal, qboolean flesh,
       VectorMA(muzzle, 16, up, muzzle);
     }
 
-    r = Q_crandom(&seed) * MG42_SPREAD_MP;
-    u = Q_crandom(&seed) * MG42_SPREAD_MP;
+    const float r = Q_crandom(&seed) * MG42_SPREAD_MP;
+    const float u = Q_crandom(&seed) * MG42_SPREAD_MP;
 
     VectorMA(muzzle, 8192, forward, end);
     VectorMA(end, r, right, end);
@@ -6446,22 +6441,20 @@ void CG_Bullet(vec3_t end, int sourceEntityNum, vec3_t normal, qboolean flesh,
   // do trail effects
   if (cg_tracerChance.value > 0) {
     if (CG_CalcMuzzlePoint(sourceEntityNum, start)) {
-      sourceContentType = CG_PointContents(start, 0);
-      destContentType = CG_PointContents(end, 0);
+      const int sourceContentType = CG_PointContents(start, 0);
+      const int destContentType = CG_PointContents(end, 0);
 
       // do a complete bubble trail if necessary
-      if ((sourceContentType == destContentType) &&
-          (sourceContentType & CONTENTS_WATER)) {
+      if (sourceContentType == destContentType &&
+          sourceContentType & CONTENTS_WATER) {
         CG_BubbleTrail(start, end, .5, 8);
-      } else if ((sourceContentType &
-                  CONTENTS_WATER)) // bubble trail from water into air
-      {
+      } else if ((sourceContentType & CONTENTS_WATER)) {
+        // bubble trail from water into air
         trap_CM_BoxTrace(&trace, end, start, nullptr, nullptr, 0,
                          CONTENTS_WATER);
         CG_BubbleTrail(start, trace.endpos, .5, 8);
-      } else if ((destContentType &
-                  CONTENTS_WATER)) // bubble trail from air into water
-      {
+      } else if (destContentType & CONTENTS_WATER) {
+        // bubble trail from air into water
         // only add bubbles if effect is close to viewer
         if (Distance(cg.snap->ps.origin, end) < 1024) {
           trap_CM_BoxTrace(&trace, start, end, nullptr, nullptr, 0,
@@ -6474,8 +6467,7 @@ void CG_Bullet(vec3_t end, int sourceEntityNum, vec3_t normal, qboolean flesh,
       if (flesh && random() < cg_tracerChance.value) {
         // draw a tracer
         CG_Tracer(start, end, 0);
-      } else // (not flesh)
-      {
+      } else {
         if (otherEntNum2 >= 0 && otherEntNum2 != ENTITYNUM_NONE) {
           CG_SpawnTracer(otherEntNum2, start, end);
         } else {
@@ -6571,6 +6563,8 @@ void CG_Bullet(vec3_t end, int sourceEntityNum, vec3_t normal, qboolean flesh,
       vec4_t color;
 
       if (CG_CalcMuzzlePoint(sourceEntityNum, start)) {
+        vec4_t projection;
+        vec3_t trend;
         VectorSubtract(end, start, dir);
         VectorNormalize(dir);
         VectorMA(end, 128, dir, trend);
@@ -6607,19 +6601,10 @@ void CG_Bullet(vec3_t end, int sourceEntityNum, vec3_t normal, qboolean flesh,
       }
     }
 
-  } else // (not flesh)
-  {
+  } else { // (not flesh)
     // Gordon: all bullet weapons have the same fx,
     // and this stops pvs issues causing grenade explosions
-    int fromweap = WP_MP40; // cg_entities[sourceEntityNum].currentState.weapon;
-
-    if (!fromweap ||
-        cg_entities[sourceEntityNum].currentState.eFlags & EF_MG42_ACTIVE ||
-        cg_entities[sourceEntityNum].currentState.eFlags &
-            EF_MOUNTEDTANK) // mounted
-    {
-      fromweap = WP_MP40;
-    }
+    constexpr int fromweap = WP_MP40;
 
     if (CG_CalcMuzzlePoint(sourceEntityNum, start) ||
         cg.snap->ps.persistant[PERS_HWEAPON_USE]) {


### PR DESCRIPTION
This was caused by a div by 0 fix done earlier in #1355, but that overwrote valid trace results which caused impact particles to not generate properly. To be honest I am still not fully sure what is actually wrong here, but we now just skip the particle generation if the second trace didn't hit anything, when shooting at water.

refs #1355 