### PR TITLE
Automate release process + CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,15 @@ on:
       - release.sh
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - docs/*
+      - .gitignore
+      - .gitattributes
+      - .clang-format
+      - changelog.md
+      - README.md
+      - VERSION.txt
+      - release.sh
   merge_group:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,20 @@
-name: etjump-CI
+name: ETJump CI/CD
 
 on:
   workflow_dispatch:
   push:
     branches: [ master ]
+    tags-ignore:
+      - '*'
+    paths-ignore:
+      - docs/*
+      - .gitignore
+      - .gitattributes
+      - .clang-format
+      - changelog.md
+      - README.md
+      - VERSION.txt
+      - release.sh
   pull_request:
     branches: [ master ]
   merge_group:
@@ -27,7 +38,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: '0'
+        fetch-depth: 0
 
     - name: Configure CMake
       run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.config }} -G "Visual Studio 16 2019" -A ${{ matrix.platform }}
@@ -63,7 +74,7 @@ jobs:
 
     - uses: actions/checkout@v4
       with:
-        fetch-depth: '0'
+        fetch-depth: 0
 
     - name: Configure CMake
       run: |
@@ -102,7 +113,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: '0'
+        fetch-depth: 0
 
     - name: Configure CMake
       run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_OSX_ARCHITECTURES=${{ matrix.platforms }} -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.osx-target }}
@@ -128,7 +139,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: '0'
+        fetch-depth: 0
 
     - name: Download artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
-name: etjump-release
+name: ETJump Release
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - '*'
 
 jobs:
   Windows:
@@ -22,7 +25,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: '0'
+        fetch-depth: 0
+        ref: master
 
     - name: Configure CMake
       run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.config }} -G "Visual Studio 16 2019" -A ${{ matrix.platform }}
@@ -58,7 +62,8 @@ jobs:
 
     - uses: actions/checkout@v4
       with:
-        fetch-depth: '0'
+        fetch-depth: 0
+        ref: master
 
     - name: Configure CMake
       run: |
@@ -97,7 +102,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: '0'
+        fetch-depth: 0
+        ref: master
 
     - name: Configure CMake
       run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_OSX_ARCHITECTURES=${{ matrix.platforms }} -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.osx-target }}
@@ -122,7 +128,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: '0'
+        fetch-depth: 0
+        ref: master
 
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -138,7 +145,9 @@ jobs:
         make mod_release
 
     - name: Upload release 
-      uses: actions/upload-artifact@v4
+      uses: softprops/action-gh-release@v2
       with:
-        name: etjump-stable-release
-        path: ${{ github.workspace }}/build/*.zip
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: ETJump ${{ github.ref_name }}
+        files: ${{ github.workspace }}/build/*.zip
+        draft: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,17 @@
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
-project(etjump VERSION 3.3.0 HOMEPAGE_URL "etjump.com" LANGUAGES C CXX)
+
+# read version from VERSION.txt
+file(READ "${CMAKE_SOURCE_DIR}/VERSION.txt" version_content)
+
+string(REGEX MATCH "VERSION_MAJOR ([0-9]+)" _major_match "${version_content}")
+string(REGEX MATCH "VERSION_MINOR ([0-9]+)" _minor_match "${version_content}")
+string(REGEX MATCH "VERSION_PATCH ([0-9]+)" _patch_match "${version_content}")
+
+set(VERSION_MAJOR "${CMAKE_MATCH_1}")
+set(VERSION_MINOR "${CMAKE_MATCH_1}")
+set(VERSION_PATCH "${CMAKE_MATCH_1}")
+
+project(etjump VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" HOMEPAGE_URL "etjump.com" LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 14)
 
 option(BUILD_TESTS "Enable tests building (ON by default)" ON)

--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,0 +1,4 @@
+# ETJump version information
+VERSION_MAJOR 3
+VERSION_MINOR 3
+VERSION_PATCH 0

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# encoding: utf-8
+
+# Creates a new release
+# Updates the VERSION.txt file and creates the tag
+# Kindly adapted from ET: Legacy team
+
+set -Eeuo pipefail
+
+# current Git branch
+branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+# Require master
+if [[ "$branch" != "master" ]]; then
+	echo "Not in master branch, exiting!"
+	exit 1
+fi
+
+# Require the current working directory to be clean
+if [[ -n "$(git status --porcelain)" ]]; then
+	echo "Git repository is not clean, exiting!"
+	exit 1
+fi
+
+# Parse the version file
+major=$(grep "VERSION_MAJOR" VERSION.txt | cut -d" " -f2)
+minor=$(grep "VERSION_MINOR" VERSION.txt | cut -d" " -f2)
+patch=$(grep "VERSION_PATCH" VERSION.txt | cut -d" " -f2)
+version_changed=
+version_message=
+gpg_sign=
+
+parse_params() {
+	while :; do
+		case "${1-}" in
+		-v | --verbose) set -x ;;
+		-h | --help)
+			printf 'Usage: \n./release.sh <--major|--minor|--patch> [--sign] [-m|--message] [-v|--verbose]\n\nOptions:\n  --major    Increment major version\n  --minor    Increment minor version\n  --patch    Increment patch version\n  --sign     Sign the release using GPG key\n  --message  Adjust commit message (default "ETJump MAJOR.MINOR.PATCH")\n  --verbose  Verbose output\n'
+			;;
+		--major)
+			major=$((major+1))
+			minor=0
+			patch=0
+			version_changed=true
+			;;
+		--minor)
+			minor=$((minor+1))
+			patch=0
+			version_changed=true
+			;;
+		--patch)
+			patch=$((patch+1))
+			version_changed=true
+			;;
+		--sign)
+			gpg_sign=true
+			;;
+		-m | --message)
+			version_message="${2-}"
+			shift
+			;;
+		-?*) die "Unknown option: $1" ;;
+		*) break ;;
+		esac
+		shift
+	done
+
+	return 0
+}
+
+parse_params "$@"
+
+# If nothing has changed then just exit
+if [[ -z $version_changed ]]; then
+	echo "Version not changed, exiting!"
+	exit 0
+fi
+
+# Sorry tag is already taken.
+if [[ "$(git tag -l "$major.$minor.$patch")" ]]; then
+	echo "Tag '$major.$minor.$patch' is already taken, exiting!"
+	exit 1
+fi
+
+if [[ "$patch" = 0 ]] && [[ "$(git tag -l "$major.$minor")" ]]; then
+	echo "Tag '$major.$minor' is already taken, exiting!"
+	exit 1
+fi
+
+if [[ -z "$version_message" ]]; then
+	version_message="ETJump $major.$minor.$patch"
+fi
+
+echo "Ready to commit and tag a new version: $major.$minor.$patch"
+echo "Version message will be: $version_message"
+read -p "Ready to commit? [Y/N]: " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+	# Update the version file.
+	perl -pi -e "s/(VERSION_MAJOR)\s+[0-9]+/\1 $major/g" VERSION.txt
+	perl -pi -e "s/(VERSION_MINOR)\s+[0-9]+/\1 $minor/g" VERSION.txt
+	perl -pi -e "s/(VERSION_PATCH)\s+[0-9]+/\1 $patch/g" VERSION.txt
+
+	if [[ -n $gpg_sign ]]; then
+		# no signing
+		# Create the release commit
+		git commit -am "$version_message"
+
+		# Tag it like a champ!
+		git tag -a "$major.$minor.$patch" -m "$version_message"
+	else
+		# Create the release commit
+		git commit -a -S -m "$version_message"
+
+		# sign the tag
+		git tag -s "$major.$minor.$patch" -m "$version_message"
+	fi
+
+	echo "Committed and tagged a new release"
+	read -p "Enter the name of the upstream remote (default: origin): " upstream
+	upstream=${upstream:-origin}
+
+	read -p "Push commit and tag to remote '$upstream'? [Y/N]: " -n 1 -r
+	echo
+	if [[ $REPLY =~ ^[Yy]$ ]]; then
+		git push "$upstream" HEAD
+		git push "$upstream" "$major.$minor.$patch"
+		echo "Pushed data to remote '$upstream'. Congrats!"
+	else
+		echo "You need to 'git push $upstream HEAD' and 'git push $upstream --tags' manually."
+	fi
+else
+  echo "Chicken!"
+fi


### PR DESCRIPTION
* Add `release.sh` script to automate the release process, adapted from ET: Legacy
* `release.yml` now automatically triggers on new tags, runs the release process and creates a new release as draft automatically
* Mod version is now pulled from `VERSION.txt`, which the release script modifies
* CI/CD no longer runs on tag pushes, changelog updates, docs updates etc.