### PR TITLE
Disallow etj_hideMe if fireteam collision is enabled

### DIFF
--- a/src/cgame/cg_fireteamoverlay.cpp
+++ b/src/cgame/cg_fireteamoverlay.cpp
@@ -130,8 +130,7 @@ void CG_ParseFireteams() {
         cg.fireTeams[i].joinOrder[j] = qtrue;
         cgs.clientinfo[j].fireteamData = &cg.fireTeams[i];
 
-        if (CG_IsOnFireteam(cg.clientNum) &&
-            cgs.clientinfo[j].fireteamData->noGhost && etj_hideMe.integer) {
+        if (cgs.clientinfo[j].fireteamData->noGhost && etj_hideMe.integer) {
           trap_Cvar_Set("etj_hideMe", "0");
         }
       } else {

--- a/src/cgame/cg_fireteamoverlay.cpp
+++ b/src/cgame/cg_fireteamoverlay.cpp
@@ -130,7 +130,8 @@ void CG_ParseFireteams() {
         cg.fireTeams[i].joinOrder[j] = qtrue;
         cgs.clientinfo[j].fireteamData = &cg.fireTeams[i];
 
-        if (cgs.clientinfo[j].fireteamData->noGhost && etj_hideMe.integer) {
+        if (cgs.clientinfo[j].fireteamData->noGhost &&
+            cgs.clientinfo[j].hideMe) {
           trap_Cvar_Set("etj_hideMe", "0");
         }
       } else {

--- a/src/cgame/cg_fireteamoverlay.cpp
+++ b/src/cgame/cg_fireteamoverlay.cpp
@@ -129,6 +129,11 @@ void CG_ParseFireteams() {
       if (COM_BitCheck(clnts, j)) {
         cg.fireTeams[i].joinOrder[j] = qtrue;
         cgs.clientinfo[j].fireteamData = &cg.fireTeams[i];
+
+        if (CG_IsOnFireteam(cg.clientNum) &&
+            cgs.clientinfo[i].fireteamData->noGhost && etj_hideMe.integer) {
+          trap_Cvar_Set("etj_hideMe", "0");
+        }
       } else {
         cg.fireTeams[i].joinOrder[j] = qfalse;
       }

--- a/src/cgame/cg_fireteamoverlay.cpp
+++ b/src/cgame/cg_fireteamoverlay.cpp
@@ -131,7 +131,7 @@ void CG_ParseFireteams() {
         cgs.clientinfo[j].fireteamData = &cg.fireTeams[i];
 
         if (CG_IsOnFireteam(cg.clientNum) &&
-            cgs.clientinfo[i].fireteamData->noGhost && etj_hideMe.integer) {
+            cgs.clientinfo[j].fireteamData->noGhost && etj_hideMe.integer) {
           trap_Cvar_Set("etj_hideMe", "0");
         }
       } else {

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1379,9 +1379,18 @@ void CG_UpdateCvars(void) {
   }
 }
 
-void CG_setClientFlags(void) {
+void CG_setClientFlags() {
   if (cg.demoPlayback) {
     return;
+  }
+
+  const fireteamData_t *ft = CG_IsOnFireteam(cg.clientNum);
+
+  if (ft && ft->noGhost && etj_hideMe.integer) {
+    CG_AddPMItem(PM_MESSAGE,
+                 "Fireteam ^3noghost ^7is enabled, cannot set ^3etj_hideMe\n",
+                 cgs.media.voiceChatShader);
+    trap_Cvar_Set("etj_hideMe", "0");
   }
 
   cg.pmext.bAutoReload = (cg_autoReload.integer > 0) ? qtrue : qfalse;

--- a/src/game/g_fireteams.cpp
+++ b/src/game/g_fireteams.cpp
@@ -296,6 +296,13 @@ void G_AddClientToFireteam(int entityNum, int leaderNum) {
 
       otherEnt->client->sess.saveLimitFt = ft->saveLimit;
 
+      if (otherEnt->client->pers.hideMe) {
+        otherEnt->client->pers.hideMe = false;
+        Printer::popup(
+            otherEnt,
+            "Fireteam ^3noghost ^7is enabled, disabling ^3etj_hideMe\n");
+      }
+
       G_UpdateFireteamConfigString(ft);
 
       return;
@@ -695,6 +702,12 @@ static void setFireTeamGhosting(fireteamData_t *ft, bool noGhost) {
 
     if (noGhost) {
       ent->client->ftNoGhostThisLife = true;
+
+      if (ent->client->pers.hideMe) {
+        ent->client->pers.hideMe = false;
+        Printer::popup(ent,
+                       "fireteam: disabling ^3etj_hideMe ^7due to ^3noghost\n");
+      }
     }
 
     Printer::popup(ent, msg);


### PR DESCRIPTION
Because hidden players aren't added as solid entities on client, having hideme enabled while fireteam collision is enabled breaks collision and freezes the hidden players playermodel in place.

refs #1333 