### PR TITLE
Add timestamps to chat replay messages

### DIFF
--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -128,9 +128,9 @@ void ChatReplay::sendChatMessages(gentity_t *ent) {
 
 std::string ChatReplay::parseChatMessage(const ChatMessage &msg) {
   const char *cmd = msg.encoded ? "enc_chat" : "chat";
-  return stringFormat("%s \"^g[REPLAY] ^7%s%c%c%s\" %i %i 1", cmd, msg.name,
+  return stringFormat("%s \"^7%s%c%c%s\" %i %i 1 %i", cmd, msg.name,
                       Q_COLOR_ESCAPE, COLOR_LTGREY, msg.message, msg.clientNum,
-                      msg.localize);
+                      msg.localize, msg.timestamp);
 }
 
 void ChatReplay::readChatsFromFile() {

--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -108,8 +108,10 @@ void ChatReplay::sendChatMessages(gentity_t *ent) {
 
   // send this with raw trap_SendServerCommand instead of Printer,
   // so we can omit team flags easily on client side
+  // timestamp is set to -1 to identify this from other chat replays
   trap_SendServerCommand(
-      clientNum, "chat \"^gServer: replaying latest chat messages:\" -1 0 1");
+      clientNum,
+      "chat \"^gServer: replaying latest chat messages:\" -1 0 1 -1");
 
   for (const auto &msg : chatReplayBuffer) {
     // skip messages from ignored clients


### PR DESCRIPTION
Adds relative timestamps to chat replays (1h ago, 30min ago, 10s ago etc.). Goes up to 12h, older messages are displayed as `12h+ ago`.

refs #1335 