### PR TITLE
Add etj_ad_stopInSpec to automatically stop autodemo in spec

### DIFF
--- a/assets/ui/etjump_settings_demos_autodemo.menu
+++ b/assets/ui/etjump_settings_demos_autodemo.menu
@@ -45,9 +45,10 @@ menuDef {
 
         MULTI               (SETTINGS_ITEM_POS(1), "Enable autodemo:", 0.2, SETTINGS_ITEM_H, "etj_autoDemo", cvarFloatList { "No" 0 "Timeruns only" 1 "Always" 2 }, "Enable autodemo\netj_autoDemo")
         YESNO               (SETTINGS_ITEM_POS(2), "Save personal bests only:", 0.2, SETTINGS_ITEM_H, "etj_ad_savePBOnly", "Save only demos that beat or tie your personal best times\netj_ad_savePBOnly")
-        CVARINTLABEL        (SETTINGS_ITEM_POS(3), "etj_ad_stopDelay", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS(3), "Demo stop delay:", 0.2, SETTINGS_ITEM_H, etj_ad_stopDelay 2000 0 10000 100, "Delay in milliseconds to wait before stopping demo recording when timerun finishes\netj_ad_stopDelay")
-        EDITFIELD_EXT       (SETTINGS_EF_POS(4), "Autodemo path:", 0.2, SETTINGS_ITEM_H, "etj_ad_targetPath", SETTINGS_EF_MAXCHARS, SETTINGS_EF_MAXPAINTCHARS, "Path to store autodemo demos in (demos/...)\netj_ad_targetPath")
+        YESNO               (SETTINGS_ITEM_POS(3), "Stop in spec:", 0.2, SETTINGS_ITEM_H, "etj_ad_stopInSpec", "Automatically stop current autodemo recording when switching to spectators\netj_ad_stopInSpec")
+        CVARINTLABEL        (SETTINGS_ITEM_POS(4), "etj_ad_stopDelay", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(4), "Demo stop delay:", 0.2, SETTINGS_ITEM_H, etj_ad_stopDelay 2000 0 10000 100, "Delay in milliseconds to wait before stopping demo recording when timerun finishes\netj_ad_stopDelay")
+        EDITFIELD_EXT       (SETTINGS_EF_POS(5), "Autodemo path:", 0.2, SETTINGS_ITEM_H, "etj_ad_targetPath", SETTINGS_EF_MAXCHARS, SETTINGS_EF_MAXPAINTCHARS, "Path to store autodemo demos in (demos/...)\netj_ad_targetPath")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2681,6 +2681,7 @@ extern vmCvar_t etj_autoDemo;
 extern vmCvar_t etj_ad_savePBOnly;
 extern vmCvar_t etj_ad_stopDelay;
 extern vmCvar_t etj_ad_targetPath;
+extern vmCvar_t etj_ad_stopInSpec;
 
 extern vmCvar_t etj_chatScale;
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -571,6 +571,7 @@ vmCvar_t etj_autoDemo;
 vmCvar_t etj_ad_savePBOnly;
 vmCvar_t etj_ad_stopDelay;
 vmCvar_t etj_ad_targetPath;
+vmCvar_t etj_ad_stopInSpec;
 
 vmCvar_t etj_chatScale;
 
@@ -1141,6 +1142,8 @@ cvarTable_t cvarTable[] = {
     {&etj_ad_savePBOnly, "etj_ad_savePBOnly", "0", CVAR_ARCHIVE},
     {&etj_ad_stopDelay, "etj_ad_stopDelay", "2000", CVAR_ARCHIVE},
     {&etj_ad_targetPath, "etj_ad_targetPath", "autodemo", CVAR_ARCHIVE},
+    {&etj_ad_stopInSpec, "etj_ad_stopInSpec", "1", CVAR_ARCHIVE},
+
     {&etj_chatScale, "etj_chatScale", "1.0", CVAR_ARCHIVE},
     // Snaphud
     {&etj_drawSnapHUD, "etj_drawSnapHUD", "0", CVAR_ARCHIVE},

--- a/src/cgame/etj_demo_recorder.cpp
+++ b/src/cgame/etj_demo_recorder.cpp
@@ -54,6 +54,12 @@ void ETJump::DemoRecorder::stop() {
 
 void ETJump::DemoRecorder::restart(const std::string &name) {
   stop();
+
+  if (etj_ad_stopInSpec.integer &&
+      cgs.clientinfo[cg.clientNum].team == TEAM_SPECTATOR) {
+    return;
+  }
+
   start(name);
 }
 


### PR DESCRIPTION
Enabled by default, stops current autodemo recording automatically when player switches to spectators. If a timerun demo is being saved, waits normally until `etj_ad_stopDelay` has passed, but doesn't start a new demo afterwards.