### PR TITLE
Fix trigger_teleport_client for spectators

### DIFF
--- a/src/game/etj_entity_utilities_shared.cpp
+++ b/src/game/etj_entity_utilities_shared.cpp
@@ -93,11 +93,6 @@ void EntityUtilsShared::teleportPlayer(playerState_t *ps, entityState_t *player,
                                        entityState_t *teleporter,
                                        usercmd_t *cmd, const vec3_t origin,
                                        vec3_t angles) {
-  // do not trigger while noclipping or spectating, prediction doesn't work
-  if (ps->pm_type != PM_NORMAL) {
-    return;
-  }
-
   // bits 8-31 contain the spawnflags
   const int spawnflags = (teleporter->constantLight >> 8) & 0xffffff;
 

--- a/src/game/etj_entity_utilities_shared.cpp
+++ b/src/game/etj_entity_utilities_shared.cpp
@@ -93,6 +93,11 @@ void EntityUtilsShared::teleportPlayer(playerState_t *ps, entityState_t *player,
                                        entityState_t *teleporter,
                                        usercmd_t *cmd, const vec3_t origin,
                                        vec3_t angles) {
+  // do not trigger while noclipping or spectating, prediction doesn't work
+  if (ps->pm_type != PM_NORMAL) {
+    return;
+  }
+
   // bits 8-31 contain the spawnflags
   const int spawnflags = (teleporter->constantLight >> 8) & 0xffffff;
 

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -378,7 +378,8 @@ void G_TouchTriggers(gentity_t *ent) {
 
     // ignore most entities if a spectator
     if (ent->client->sess.sessionTeam == TEAM_SPECTATOR) {
-      if (hit->s.eType != ET_TELEPORT_TRIGGER) {
+      if (hit->s.eType != ET_TELEPORT_TRIGGER &&
+          hit->s.eType != ET_TELEPORT_TRIGGER_CLIENT) {
         continue;
       }
     }


### PR DESCRIPTION
~~This breaks prediction as noclipped players aren't predicted, and spectators don't get linked so setting origin breaks.~~ `ET_TELEPORT_TRIGGER_CLIENT` wasn't handled in `G_TouchTriggers`.

refs #1332 