### PR TITLE
Require JSON root to be an object or array

### DIFF
--- a/src/game/etj_json_utilities.cpp
+++ b/src/game/etj_json_utilities.cpp
@@ -65,9 +65,10 @@ bool JsonUtils::readFile(const std::string &file, Json::Value &root,
   }
 
   Json::CharReaderBuilder readerBuilder;
+  readerBuilder["strictRoot"] = true;
   std::string err;
 
-  if (!Json::parseFromStream(readerBuilder, fIn, &root, &err)) {
+  if (!parseFromStream(readerBuilder, fIn, &root, &err)) {
     if (errors) {
       *errors = stringFormat("Failed to parse JSON file '%s':\n%s", file, err);
     }


### PR DESCRIPTION
All the JSON files the mod handles are expected to be either an object or an array, but `CharReaderBuilder` does not force this by default, leading to unexpected errors with parsing.