### PR TITLE
Fix target_init + timeruns not resetting player ammo correctly

### DIFF
--- a/src/game/bg_misc.cpp
+++ b/src/game/bg_misc.cpp
@@ -2795,28 +2795,7 @@ qboolean BG_WeaponInWolfMP(int weapon) {
   }
 }
 
-qboolean BG_WeaponIsExplosive(int weap) {
-  switch (weap) {
-    case WP_CARBINE:
-    case WP_KAR98:
-    case WP_M7:
-    case WP_GRENADE_LAUNCHER:
-    case WP_GRENADE_PINEAPPLE:
-    case WP_PANZERFAUST:
-    case WP_LANDMINE:
-    case WP_ARTY:
-    case WP_GPG40:
-    case WP_FLAMETHROWER:
-    case WP_MORTAR:
-    case WP_SATCHEL:
-    case WP_DYNAMITE:
-      return qtrue;
-    default:
-      return qfalse;
-  }
-}
-
-bool BG_WeaponDisallowedInTimeruns(int weap) {
+bool BG_WeaponDisallowedInTimeruns(const int weap) {
   switch (weap) {
     case WP_DYNAMITE:
     case WP_GRENADE_LAUNCHER:

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -1550,3 +1550,50 @@ const ETJump::Timerun::Season *ETJump::TimerunV2::getMostRelevantSeason() {
   }
   return mostRelevant;
 }
+
+void ETJump::TimerunV2::removeDisallowedWeapons(gentity_t *ent) {
+  for (int i = 0; i < WP_NUM_WEAPONS; i++) {
+    if (BG_WeaponDisallowedInTimeruns(i)) {
+      COM_BitClear(ent->client->ps.weapons, i);
+      ent->client->ps.ammo[i] = 0;
+      ent->client->ps.ammoclip[i] = 0;
+    }
+  }
+
+  // expire grenades
+  ent->client->ps.grenadeTimeLeft = 0;
+}
+
+void ETJump::TimerunV2::removePlayerProjectiles(gentity_t *ent) {
+  for (int i = MAX_CLIENTS + BODY_QUEUE_SIZE; i < level.num_entities; i++) {
+    if (ent->s.eType == ET_MISSILE) {
+      if (ent->parent && ent->parent->s.number == ClientNum(ent)) {
+        G_FreeEntity(ent);
+      }
+    }
+  }
+}
+
+bool ETJump::TimerunV2::weaponIsExplosivePickup(const int weapon) {
+  // FIXME: we should allow K43/Garand, but remove rifle nades on pickup
+  switch (weapon) {
+    case WP_GRENADE_LAUNCHER:
+    case WP_PANZERFAUST:
+    case WP_FLAMETHROWER:
+    case WP_GRENADE_PINEAPPLE:
+    case WP_DYNAMITE:
+    case WP_PLIERS:
+    case WP_KAR98:
+    case WP_CARBINE:
+    case WP_LANDMINE:
+    case WP_SATCHEL:
+    case WP_SATCHEL_DET:
+    case WP_MORTAR:
+    case WP_GPG40:
+    case WP_M7:
+    case WP_MORTAR_SET:
+      return true;
+    default:
+      return false;
+  }
+}

--- a/src/game/etj_timerun_v2.h
+++ b/src/game/etj_timerun_v2.h
@@ -115,6 +115,13 @@ public:
   void printSeasons(int clientNum);
   void deleteSeason(int clientNum, const std::string &name);
 
+  static void removeDisallowedWeapons(gentity_t *ent);
+  static void removePlayerProjectiles(gentity_t *ent);
+
+  // returns true if weapon is considered an explosive by the
+  // "No explosives" timerun spawnflag
+  static bool weaponIsExplosivePickup(int weapon);
+
 private:
   void startNotify(Player *player) const;
   static bool isDebugging(int clientNum);

--- a/src/game/etj_utilities.h
+++ b/src/game/etj_utilities.h
@@ -24,9 +24,8 @@
 
 #pragma once
 
-#include <algorithm>
-#include <iterator>
 #include <vector>
+
 #include "etj_levels.h"
 
 namespace Utilities {
@@ -81,7 +80,10 @@ std::string timestampToString(int timestamp,
                               const char *format = "%d/%m/%y %H:%M:%S",
                               const char *start = "never");
 
-void RemovePlayerWeapons(int clientNum);
+/**
+ * Sets a valid weapon as currently held weapon
+ */
+void selectValidWeapon(const gentity_t *ent);
 
 /**
  * Returns true if the player is inside a no-noclip area

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -741,12 +741,16 @@ Resets players ammo to default
 =================================
 */
 void ResetPlayerAmmo(gclient_t *client, gentity_t *ent) {
-  auto ammoMultiplier = 0;
-  auto nadeCount = 0;
+  // clear everything - AddWeaponToPlayer adds back the correct amount of ammo
+  memset(client->ps.ammo, 0, MAX_WEAPONS * sizeof(int));
+  memset(client->ps.ammoclip, 0, MAX_WEAPONS * sizeof(int));
 
-  // set default ammo multiplier for thompson/mp40/sten
+  // set default ammo multiplier for thompson/mp40/sten,
   // and grenade count per class, as these do not follow ammotable data
   // ammo from skill bonuses is handled in AddWeaponToPlayer
+  int ammoMultiplier = 0;
+  int nadeCount = 0;
+
   switch (client->sess.playerType) {
     case PC_SOLDIER:
       ammoMultiplier = 2;
@@ -777,26 +781,31 @@ void ResetPlayerAmmo(gclient_t *client, gentity_t *ent) {
   // grenades are cleared from ps.weapons when they run out of ammo so
   // they are handled seperately dynamite, pliers, satchel & satchel
   // detonator have 0 ammo in ammotable so they must be given manually
-  for (auto i = 0; i < WP_NUM_WEAPONS; i++) {
+  for (int i = WP_NONE; i < WP_NUM_WEAPONS; i++) {
     if (COM_BitCheck(client->ps.weapons, i)) {
       if (i == WP_GRENADE_LAUNCHER || i == WP_GRENADE_PINEAPPLE) {
         continue;
       }
+
       if (client->sess.timerunActive && BG_WeaponDisallowedInTimeruns(i)) {
         continue;
       }
+
       if ((i == WP_DYNAMITE || i == WP_PLIERS) && level.noExplosives != 2) {
         AddWeaponToPlayer(client, static_cast<weapon_t>(i), 0, 1, qfalse);
         continue;
       }
+
       if (i == WP_SATCHEL && !level.noExplosives) {
         AddWeaponToPlayer(client, WP_SATCHEL, 0, 1, qfalse);
         AddWeaponToPlayer(client, WP_SATCHEL_DET, 0, 0, qfalse);
         continue;
       }
-      if (BG_WeaponIsExplosive(i) && level.noExplosives) {
+
+      if (level.noExplosives && !ETJump::weaponAllowedWithNoExplosives(i)) {
         continue;
       }
+
       if (i == WP_MP40 || i == WP_THOMPSON || i == WP_STEN) {
         AddWeaponToPlayer(client, static_cast<weapon_t>(i),
                           GetAmmoTableData(i)->defaultStartingAmmo *

--- a/src/game/g_items.cpp
+++ b/src/game/g_items.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "g_local.h"
+#include "etj_timerun_v2.h"
 
 #define RESPAWN_SP -1
 #define RESPAWN_KEY 4
@@ -544,7 +545,8 @@ int Pickup_Weapon(gentity_t *ent, gentity_t *other) {
   // ent->delay carries secondary weapon ammo
   const int quantityAlt = static_cast<int>(ent->delay);
 
-  const weapon_t grenadeType = BG_GrenadeTypeForTeam(other->client->sess.sessionTeam);
+  const weapon_t grenadeType =
+      BG_GrenadeTypeForTeam(other->client->sess.sessionTeam);
 
   if (grenadeType != WP_NONE && ent->item->giTag == grenadeType) {
     if (quantity > 0) {
@@ -553,8 +555,8 @@ int Pickup_Weapon(gentity_t *ent, gentity_t *other) {
       other->client->ps.ammoclip[grenadeType] += quantity;
 
       const int maxGrenades =
-        BG_GrenadesForClass(other->client->ps.stats[STAT_PLAYER_CLASS],
-                            other->client->sess.skill);
+          BG_GrenadesForClass(other->client->ps.stats[STAT_PLAYER_CLASS],
+                              other->client->sess.skill);
 
       if (other->client->ps.ammoclip[grenadeType] > maxGrenades) {
         other->client->ps.ammoclip[grenadeType] = maxGrenades;
@@ -562,7 +564,6 @@ int Pickup_Weapon(gentity_t *ent, gentity_t *other) {
       return -1;
     }
   }
-
 
   // JPW NERVE -- magic ammo for any two-handed weapon
   if (ent->item->giTag == WP_AMMO) {
@@ -746,13 +747,12 @@ void RespawnItem(gentity_t *ent) {
     }
     master = ent->teammaster;
 
-    for (count = 0, ent = master; ent; ent = ent->teamchain, count++)
-      ;
+    for (count = 0, ent = master; ent; ent = ent->teamchain, count++);
 
     choice = rand() % count;
 
-    for (count = 0, ent = master; count < choice; ent = ent->teamchain, count++)
-      ;
+    for (count = 0, ent = master; count < choice;
+         ent = ent->teamchain, count++);
   }
 
   ent->r.contents = CONTENTS_TRIGGER;
@@ -855,10 +855,10 @@ void Touch_Item(gentity_t *ent, gentity_t *other, trace_t *trace) {
   }
 
   // ETJump: disable explosives pickup
-  if (BG_WeaponIsExplosive(ent->item->giTag) &&
+  if (ETJump::TimerunV2::weaponIsExplosivePickup(ent->item->giTag) &&
       other->client->sess.timerunActive &&
-      (other->client->sess.runSpawnflags &
-       static_cast<int>(ETJump::TimerunSpawnflags::NoExplosivesPickup))) {
+      other->client->sess.runSpawnflags &
+          static_cast<int>(ETJump::TimerunSpawnflags::NoExplosivesPickup)) {
     return;
   }
 
@@ -1268,7 +1268,7 @@ void G_SpawnItem(gentity_t *ent, gitem_t *item) {
   } else if (item->giTag == WP_GRENADE_PINEAPPLE ||
              item->giTag == WP_GRENADE_LAUNCHER) {
     G_SpawnInt("count", "1", &ent->count);
-    
+
     if (ent->count < 0) {
       ent->count = 0;
     }

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1709,6 +1709,10 @@ void teleportPlayer(gentity_t *self, gentity_t *other, const vec3_t origin,
 //
 // g_weapon.c
 //
+namespace ETJump {
+bool weaponAllowedWithNoExplosives(int weapon);
+}
+
 qboolean AccuracyHit(gentity_t *target, gentity_t *attacker);
 void CalcMuzzlePoint(gentity_t *ent, int weapon, vec3_t forward, vec3_t right,
                      vec3_t up, vec3_t muzzlePoint);

--- a/src/game/g_weapon.cpp
+++ b/src/game/g_weapon.cpp
@@ -23,7 +23,32 @@ qboolean Bullet_Fire_Extended(gentity_t *source, gentity_t *attacker,
                               vec3_t start, vec3_t end, float spread,
                               int damage, qboolean distance_falloff);
 
-int G_GetWeaponDamage(int weapon); // JPW
+namespace ETJump {
+bool weaponAllowedWithNoExplosives(const int weapon) {
+  switch (weapon) {
+    case WP_GRENADE_LAUNCHER:
+    case WP_PANZERFAUST:
+    case WP_GRENADE_PINEAPPLE:
+    case WP_LANDMINE:
+    case WP_SATCHEL:
+    case WP_SATCHEL_DET:
+    case WP_MORTAR:
+    case WP_GPG40:
+    case WP_M7:
+    case WP_MORTAR_SET:
+      return false;
+    case WP_DYNAMITE:
+    case WP_PLIERS:
+      if (level.noExplosives == 2) {
+        return false;
+      }
+
+      return true;
+    default:
+      return true;
+  }
+}
+} // namespace ETJump
 
 qboolean G_WeaponIsExplosive(meansOfDeath_t mod) {
   switch (mod) {


### PR DESCRIPTION
When players weapons were removed by `target_init` or timerun start, the ammo for the weapons wasn't cleared. This caused an issue with weapons that do no use clips, where picking up the weapon after it was removed would restore the ammo count the player had when the weapon was taken away, instead of having whatever ammo the picked up weapon had.