### PR TITLE
Fix autoload/deathcam skip load spawn position

### DIFF
--- a/src/game/etj_save_system.h
+++ b/src/game/etj_save_system.h
@@ -130,7 +130,9 @@ public:
   void loadPositionsFromDatabase(gentity_t *ent);
 
   void storeTeamQuickDeployPosition(gentity_t *ent, team_t team);
-  void loadOnceTeamQuickDeployPosition(gentity_t *ent, team_t team);
+  // true if valid position was loaded
+  bool loadOnceTeamQuickDeployPosition(gentity_t *ent, team_t team);
+  void invalidateTeamQuickDeployPosition(gentity_t *ent, team_t team);
 
 private:
   // Saves backup position

--- a/src/game/etj_savepos_command_handler.cpp
+++ b/src/game/etj_savepos_command_handler.cpp
@@ -41,6 +41,9 @@ void SavePosHandler::execSaveposCommand(gentity_t *ent,
 
   if (ent->client->ps.stats[STAT_HEALTH] <= GIB_HEALTH) {
     ent->client->respawnFromLoad = true;
+    // set origin from savepos before calling respawn, so we can grab
+    // the spawnpoint location from the savepos
+    G_SetOrigin(ent, data.pos.origin);
     respawn(ent);
     ent->client->respawnFromLoad = false;
   }

--- a/src/game/etj_savepos_command_handler.cpp
+++ b/src/game/etj_savepos_command_handler.cpp
@@ -40,7 +40,9 @@ void SavePosHandler::execSaveposCommand(gentity_t *ent,
   }
 
   if (ent->client->ps.stats[STAT_HEALTH] <= GIB_HEALTH) {
+    ent->client->respawnFromLoad = true;
     respawn(ent);
+    ent->client->respawnFromLoad = false;
   }
 
   game.timerunV2->interrupt(ClientNum(ent));

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1511,15 +1511,6 @@ void SpectatorClientEndFrame(gentity_t *ent) {
 
     if (do_respawn) {
       reinforce(ent);
-      if (ent->client->pers.autoLoad) {
-        // need to do this here as reinforce will override any value set in
-        // clientspawn (ClientSpawn gets called twice, and we only want to
-        // call this once --> first call sets the origin, second call resets
-        // the origin (since we're no longer setting the origin
-        // as we already set it))
-        ETJump::saveSystem->loadOnceTeamQuickDeployPosition(
-            ent, ent->client->sess.sessionTeam);
-      }
       return;
     }
 

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2339,7 +2339,8 @@ void ClientSpawn(gentity_t *ent, qboolean revived) {
         client->sess.sessionTeam != TEAM_ALLIES) {
       spawnPoint = SelectSpectatorSpawnPoint(spawn_origin, spawn_angles);
     } else {
-      // try to spawn in last load position if autoload is enabled
+      // try to spawn in last load position if autoload is enabled,
+      // or if we're forcing a respawn during death sequence with load/loadpos
       if ((ent->client->pers.autoLoad &&
            ETJump::saveSystem->loadOnceTeamQuickDeployPosition(
                ent, ent->client->sess.sessionTeam)) ||

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2309,7 +2309,7 @@ void ClientSpawn(gentity_t *ent, qboolean revived) {
   clientPersistant_t saved;
   clientSession_t savedSess;
   int persistant[MAX_PERSISTANT];
-  gentity_t *spawnPoint;
+  gentity_t *spawnPoint = nullptr;
   int flags;
   int savedPing;
   int savedTeam;
@@ -2334,40 +2334,29 @@ void ClientSpawn(gentity_t *ent, qboolean revived) {
   } else {
     // Arnout: let's just be sure it does the right thing at all
     // times. (well maybe not the right thing, but at least not
-    // the bad thing!) if( client->sess.sessionTeam ==
-    // TEAM_SPECTATOR || client->sess.sessionTeam == TEAM_FREE )
-    // {
+    // the bad thing!)
     if (client->sess.sessionTeam != TEAM_AXIS &&
         client->sess.sessionTeam != TEAM_ALLIES) {
       spawnPoint = SelectSpectatorSpawnPoint(spawn_origin, spawn_angles);
     } else {
-      // RF, if we have requested a specific spawn
-      // point, use it (fixme: what if this will place
-      // us inside another character?)
-      /*			spawnPoint = NULL;
-                  trap_GetUserinfo( ent->s.number,
-         userinfo, sizeof(userinfo) ); if( (str =
-         Info_ValueForKey( userinfo, "spawnPoint" )) !=
-         NULL
-         && str[0] ) { spawnPoint =
-         SelectSpawnPointFromList( str, spawn_origin,
-         spawn_angles ); if (!spawnPoint) { G_Printf(
-         "WARNING: unable to find spawn point \"%s\" for
-         bot \"%s\"\n", str, ent->aiName );
-                      }
-                  }
-                  //
-                  if( !spawnPoint ) {*/
-      auto spawnObjective = 0;
-      if (client->sess.spawnObjectiveIndex > 0) {
-        spawnObjective = client->sess.spawnObjectiveIndex;
-      } else if (client->sess.autoSpawnObjectiveIndex > 0) {
-        spawnObjective = client->sess.autoSpawnObjectiveIndex;
+      // try to spawn in last load position if autoload is enabled
+      if ((ent->client->pers.autoLoad &&
+           ETJump::saveSystem->loadOnceTeamQuickDeployPosition(
+               ent, ent->client->sess.sessionTeam)) ||
+          ent->client->respawnFromLoad) {
+        VectorCopy(ent->client->ps.origin, spawn_origin);
+        VectorCopy(ent->client->ps.viewangles, spawn_angles);
+      } else {
+        auto spawnObjective = 0;
+        if (client->sess.spawnObjectiveIndex > 0) {
+          spawnObjective = client->sess.spawnObjectiveIndex;
+        } else if (client->sess.autoSpawnObjectiveIndex > 0) {
+          spawnObjective = client->sess.autoSpawnObjectiveIndex;
+        }
+        spawnPoint = SelectCTFSpawnPoint(
+            client->sess.sessionTeam, client->pers.teamState.state,
+            spawn_origin, spawn_angles, spawnObjective);
       }
-      spawnPoint = SelectCTFSpawnPoint(
-          client->sess.sessionTeam, client->pers.teamState.state, spawn_origin,
-          spawn_angles, spawnObjective);
-      //			}
     }
   }
 
@@ -2613,7 +2602,8 @@ void ClientSpawn(gentity_t *ent, qboolean revived) {
     MoveClientToIntermission(ent);
   } else {
     // fire the targets of the spawn point
-    if (!revived) {
+    // this can be null if we're spawning into a save slot
+    if (!revived && spawnPoint != nullptr) {
       G_UseTargets(spawnPoint, ent);
     }
   }
@@ -2626,7 +2616,7 @@ void ClientSpawn(gentity_t *ent, qboolean revived) {
 
   // run a client frame to drop exactly to the floor,
   // initialize animations and other things
-  client->ps.commandTime = level.time - 100;
+  client->ps.commandTime = level.time - level.frameTime * 2;
   ent->client->pers.cmd.serverTime = level.time;
   ClientThink(ent - g_entities);
 

--- a/src/game/g_combat.cpp
+++ b/src/game/g_combat.cpp
@@ -11,6 +11,7 @@
 #include "etj_string_utilities.h"
 #include "etj_printer.h"
 #include "etj_missilepad.h"
+#include "etj_save_system.h"
 
 extern vec3_t muzzleTrace;
 
@@ -570,6 +571,11 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker,
   } else if ((meansOfDeath == MOD_SUICIDE &&
               g_gamestate.integer == GS_PLAYING)) {
     limbo(self, qtrue);
+  }
+
+  if (meansOfDeath != MOD_SWITCHTEAM) {
+    ETJump::saveSystem->invalidateTeamQuickDeployPosition(
+        self, self->client->sess.sessionTeam);
   }
 
   if (!self->client->sess.runSpawnflags ||

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1165,6 +1165,8 @@ struct gclient_s {
   bool forceRename;
 
   int lastRevivePushTime;
+
+  bool respawnFromLoad;
 };
 
 typedef struct {
@@ -1580,7 +1582,7 @@ void G_TouchTriggers(gentity_t *ent);
 
 void G_AddPredictableEvent(gentity_t *ent, int event, int eventParm);
 void G_AddEvent(gentity_t *ent, int event, int eventParm);
-void G_SetOrigin(gentity_t *ent, vec3_t origin);
+void G_SetOrigin(gentity_t *ent, const vec3_t origin);
 void AddRemap(const char *oldShader, const char *newShader, float timeOffset);
 const char *BuildShaderStateConfig();
 void G_SetAngle(gentity_t *ent, vec3_t angle);

--- a/src/game/g_utils.cpp
+++ b/src/game/g_utils.cpp
@@ -862,7 +862,7 @@ G_SetOrigin
 Sets the pos trajectory for a fixed position
 ================
 */
-void G_SetOrigin(gentity_t *ent, vec3_t origin) {
+void G_SetOrigin(gentity_t *ent, const vec3_t origin) {
   VectorCopy(origin, ent->s.pos.trBase);
   ent->s.pos.trType = TR_STATIONARY;
   ent->s.pos.trTime = 0;


### PR DESCRIPTION
Autoload and respawn performed during the death sequence would initially spawn the player at a normal spawnpoint, run `ClientThink` and only teleport player to the saved position at the end of the frame. This caused the player to for example touch any triggers that are directly on top of spawnpoint, before getting placed into the correct position, which could cause entities to fire unexpectedly when joining a team or forcing a respawn during death sequence.

refs #198, #961