### PR TITLE
Fixes to fireteam joining while collision is enabled

### DIFF
--- a/src/game/g_fireteams.cpp
+++ b/src/game/g_fireteams.cpp
@@ -296,11 +296,23 @@ void G_AddClientToFireteam(int entityNum, int leaderNum) {
 
       otherEnt->client->sess.saveLimitFt = ft->saveLimit;
 
-      if (otherEnt->client->pers.hideMe) {
-        otherEnt->client->pers.hideMe = false;
-        Printer::popup(
-            otherEnt,
-            "Fireteam ^3noghost ^7is enabled, disabling ^3etj_hideMe\n");
+      if (ft->noGhost) {
+        if (otherEnt->client->pers.hideMe) {
+          otherEnt->client->pers.hideMe = false;
+          Printer::popup(
+              otherEnt,
+              "Fireteam ^3noghost ^7is enabled, disabling ^3etj_hideMe\n");
+        }
+
+        otherEnt->client->ftNoGhostThisLife = true;
+
+        if (otherEnt->client->sess.timerunActive &&
+            !(otherEnt->client->sess.runSpawnflags &
+              static_cast<int>(ETJump::TimerunSpawnflags::AllowFTNoGhost))) {
+          Printer::popup(otherEnt, "Fireteam ^3noghost ^7is not allowed in "
+                                   "this timerun, interrupting!\n");
+          InterruptRun(otherEnt);
+        }
       }
 
       G_UpdateFireteamConfigString(ft);


### PR DESCRIPTION
* Only force hideme off if `noghost` is enabled
* Mark joined clients to have enabled `noghost` upon joining, if `noghost` is enabled
* Interrupt ongoing timeruns while joining to fireteam if `noghost` is enabled and run does not allow it.

refs #1333 