### PR TITLE
Tweak chat replay behavior for messages prior to connecting

### DIFF
--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -27,6 +27,7 @@
 #include "etj_chat_replay.h"
 #include "etj_string_utilities.h"
 #include "etj_time_utilities.h"
+#include "etj_session.h"
 
 namespace ETJump {
 
@@ -83,12 +84,11 @@ void ChatReplay::sendChatMessages(gentity_t *ent) {
 
   // if messages are set to expire, mark any chats that are too old
   if (g_chatReplayMaxMessageAge.integer > 0) {
-    time_t t;
-    t = std::time(&t);
+    int sessStartTime = session->getSessionStartTime(ClientNum(ent));
 
     // FIXME: 32-bit time
-    t -= g_chatReplayMaxMessageAge.integer * 60;
-    const Time maxAge = Time::fromInt(static_cast<int>(t));
+    sessStartTime -= g_chatReplayMaxMessageAge.integer * 60;
+    const Time maxAge = Time::fromInt(sessStartTime);
 
     bool allExpired = true;
 
@@ -96,6 +96,7 @@ void ChatReplay::sendChatMessages(gentity_t *ent) {
       if (maxAge > Time::fromInt(msg.timestamp)) {
         msg.expired = true;
       } else {
+        msg.expired = false;
         allExpired = false;
       }
     }

--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -84,7 +84,7 @@ void ChatReplay::sendChatMessages(gentity_t *ent) {
 
   // if messages are set to expire, mark any chats that are too old
   if (g_chatReplayMaxMessageAge.integer > 0) {
-    int sessStartTime = session->getSessionStartTime(ClientNum(ent));
+    int sessStartTime = session->getSessionStartTime(clientNum);
 
     // FIXME: 32-bit time
     sessStartTime -= g_chatReplayMaxMessageAge.integer * 60;

--- a/src/game/etj_session.cpp
+++ b/src/game/etj_session.cpp
@@ -108,14 +108,14 @@ std::string Session::Guid(gentity_t *ent) const {
 void Session::ReadSessionData(int clientNum) {
   G_DPrintf("Session::ReadSessionData called for %d\n", clientNum);
 
-  char sessionData[MAX_STRING_CHARS] = "\0";
+  char sessionData[MAX_CVAR_VALUE_STRING] = "\0";
 
   trap_Cvar_VariableStringBuffer(va("etjumpsession%i", clientNum), sessionData,
                                  sizeof(sessionData));
 
-  char guidBuf[MAX_TOKEN_CHARS] = "\0";
-  char hwidBuf[MAX_TOKEN_CHARS] = "\0";
-  char sessStartTimeBuf[MAX_TOKEN_CHARS] = "\0";
+  char guidBuf[MAX_CVAR_VALUE_STRING] = "\0";
+  char hwidBuf[MAX_CVAR_VALUE_STRING] = "\0";
+  char sessStartTimeBuf[MAX_CVAR_VALUE_STRING] = "\0";
 
   sscanf(sessionData, "%s %s %s", guidBuf, hwidBuf, sessStartTimeBuf);
 
@@ -135,8 +135,8 @@ void Session::ReadSessionData(int clientNum) {
 bool Session::GuidReceived(gentity_t *ent) {
   int argc = trap_Argc();
   int clientNum = ClientNum(ent);
-  char guidBuf[MAX_TOKEN_CHARS];
-  char hwidBuf[MAX_TOKEN_CHARS];
+  char guidBuf[MAX_CVAR_VALUE_STRING];
+  char hwidBuf[MAX_CVAR_VALUE_STRING];
 
   // Client sends 'AUTHENTICATE guid hwid'
   constexpr int ARGC = 3;

--- a/src/game/etj_session.cpp
+++ b/src/game/etj_session.cpp
@@ -22,12 +22,14 @@
  * SOFTWARE.
  */
 
+#include <iostream>
+#include <ctime>
+
 #include "etj_session.h"
 #include "utilities.hpp"
 #include "etj_printer.h"
 #include "etj_string_utilities.h"
 #include "etj_levels.h"
-#include <iostream>
 
 Session::Session(std::shared_ptr<IAuthentication> database)
     : database_(database) {
@@ -43,6 +45,7 @@ void Session::ResetClient(int clientNum) {
   clients_[clientNum].hwid = "";
   clients_[clientNum].user = NULL;
   clients_[clientNum].level = NULL;
+  clients_[clientNum].sessionStartTime = 0;
   clients_[clientNum].permissions.reset();
 }
 
@@ -52,13 +55,17 @@ void Session::Init(int clientNum) {
   clients_[clientNum].hwid = "";
   clients_[clientNum].user = NULL;
   clients_[clientNum].level = NULL;
+  clients_[clientNum].sessionStartTime = 0;
   clients_[clientNum].permissions.reset();
 
   std::string ip = ValueForKey(clientNum, "ip");
-  std::string::size_type pos = ip.find(":");
+  const size_t pos = ip.find(':');
   clients_[clientNum].ip = ip.substr(0, pos);
 
-  WriteSessionData(clientNum);
+  // FIXME: 32-bit time
+  time_t t;
+  t = std::time(&t);
+  clients_[clientNum].sessionStartTime = static_cast<int>(t);
 }
 
 void Session::UpdateLastSeen(int clientNum) {
@@ -87,8 +94,9 @@ void Session::UpdateLastSeen(int clientNum) {
 void Session::WriteSessionData(int clientNum) {
   G_DPrintf("DEBUG: Writing client %d etjump session data\n", clientNum);
 
-  const char *sessionData = va("%s %s", clients_[clientNum].guid.c_str(),
-                               clients_[clientNum].hwid.c_str());
+  const char *sessionData = va("%s %s %i", clients_[clientNum].guid.c_str(),
+                               clients_[clientNum].hwid.c_str(),
+                               clients_[clientNum].sessionStartTime);
 
   trap_Cvar_Set(va("etjumpsession%i", clientNum), sessionData);
 }
@@ -107,11 +115,13 @@ void Session::ReadSessionData(int clientNum) {
 
   char guidBuf[MAX_TOKEN_CHARS] = "\0";
   char hwidBuf[MAX_TOKEN_CHARS] = "\0";
+  char sessStartTimeBuf[MAX_TOKEN_CHARS] = "\0";
 
-  sscanf(sessionData, "%s %s", guidBuf, hwidBuf);
+  sscanf(sessionData, "%s %s %s", guidBuf, hwidBuf, sessStartTimeBuf);
 
   clients_[clientNum].guid = guidBuf;
   clients_[clientNum].hwid = hwidBuf;
+  clients_[clientNum].sessionStartTime = Q_atoi(sessStartTimeBuf);
 
   GetUserAndLevelData(clientNum);
 
@@ -128,8 +138,8 @@ bool Session::GuidReceived(gentity_t *ent) {
   char guidBuf[MAX_TOKEN_CHARS];
   char hwidBuf[MAX_TOKEN_CHARS];
 
-  // Client sends "AUTHENTICATE guid hwid
-  const int ARGC = 3;
+  // Client sends 'AUTHENTICATE guid hwid'
+  constexpr int ARGC = 3;
   if (argc != ARGC) {
     G_LogPrintf("Possible guid/hwid spoof attempt by %s (%s).\n",
                 ent->client->pers.netname, ClientIPAddr(ent));
@@ -164,6 +174,8 @@ bool Session::GuidReceived(gentity_t *ent) {
     trap_DropClient(clientNum, "You are banned.", 0);
     return false;
   }
+
+  WriteSessionData(clientNum);
 
   ClientNameChanged(ent);
 
@@ -278,6 +290,7 @@ void Session::OnClientDisconnect(int clientNum) {
 
   clients_[clientNum].user = NULL;
   clients_[clientNum].level = NULL;
+  clients_[clientNum].sessionStartTime = 0;
   clients_[clientNum].permissions.reset();
 }
 
@@ -513,4 +526,8 @@ void Session::NewName(gentity_t *ent) {
 
 bool Session::HasPermission(gentity_t *ent, char flag) {
   return clients_[ClientNum(ent)].permissions[flag];
+}
+
+int Session::getSessionStartTime(const int clientNum) const {
+  return clients_[clientNum].sessionStartTime;
 }

--- a/src/game/etj_session.h
+++ b/src/game/etj_session.h
@@ -22,8 +22,7 @@
  * SOFTWARE.
  */
 
-#ifndef SESSION_HPP
-#define SESSION_HPP
+#pragma once
 
 #include <string>
 #include <vector>
@@ -46,6 +45,7 @@ public:
     std::string hwid;
     std::bitset<MAX_COMMANDS> permissions;
     std::string ip;
+    int sessionStartTime; // FIXME: 32-bit time
     const User_s *user;
     const Levels::Level *level;
   };
@@ -79,6 +79,7 @@ public:
   // Returns the amount of users with that level
   int LevelDeleted(int level);
   std::vector<Session::Client *> FindUsersByLevel(int level);
+  int getSessionStartTime(int clientNum) const;
 
 private:
   std::shared_ptr<IAuthentication> database_;
@@ -87,5 +88,3 @@ private:
   Client clients_[MAX_CLIENTS];
   std::string message_;
 };
-
-#endif

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -517,7 +517,7 @@ cvarTable_t gameCvarTable[] = {
     {&g_adminChat, "g_adminChat", "1", CVAR_ARCHIVE},
 
     {&g_chatReplay, "g_chatReplay", "1", CVAR_ARCHIVE},
-    {&g_chatReplayMaxMessageAge, "g_chatReplayMaxMessageAge", "0",
+    {&g_chatReplayMaxMessageAge, "g_chatReplayMaxMessageAge", "5",
      CVAR_ARCHIVE | CVAR_LATCH},
 };
 


### PR DESCRIPTION
`g_chatReplayMaxMessageAge` now only applies to messages that were sent prior to your session starting. Any messages that were sent during your session will always be replayed, regardless of the value of this cvar. The default value is now 5 minutes.

This also fixes client session data (GUID + HWID) getting written prematurely before the authentication response is received, which resulted in GUID/HWID not getting stored on initial connect, but only after a map was changed once.

refs #1335 