### PR TITLE
Add newline between season outputs on records command

### DIFF
--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -732,8 +732,13 @@ void ETJump::TimerunV2::printRecords(Timerun::PrintRecordsParams params) {
                 rank++;
               }
 
-              if (ownRecordString.length() > 0) {
+              if (!ownRecordString.empty()) {
                 message += "\n" + ownRecordString;
+              }
+
+              if (processedRecords.size() > 1 &&
+                  skvp.first != std::prev(processedRecords.end())->first) {
+                message += "\n";
               }
             }
           }


### PR DESCRIPTION
If printing records for multiple seasons, separate the seasons with a newline print.