### PR TITLE
Fix ui_netGameType != 2 breaking UI map list

### DIFF
--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -5024,13 +5024,11 @@ UI_MapCountByGameType
 ==================
 */
 static int UI_MapCountByGameType() {
-  int i, c, game;
-  c = 0;
-  game = ui_netGameType.integer;
+  int c = 0;
 
-  for (i = 0; i < uiInfo.mapCount; i++) {
+  for (int i = 0; i < uiInfo.mapCount; i++) {
     uiInfo.mapList[i].active = qfalse;
-    if (uiInfo.mapList[i].typeBits & (1 << game)) {
+    if (uiInfo.mapList[i].typeBits & 1 << ETJUMP_GAMETYPE) {
       c++;
       uiInfo.mapList[i].active = qtrue;
     }


### PR DESCRIPTION
This whole cvar along with the `typeBits` field should just be nuked but it's a rather complex job since this stuff is used in the server browser and host game menus, so this will do for now.

refs #1431 