### PR TITLE
Tweak timerun high ping interrupt logic

### DIFF
--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1109,10 +1109,19 @@ void ClientThink_real(gentity_t *ent) {
   // Stop lagging through triggers in timeruns
   if (client->sess.timerunActive) {
     if (client->ps.ping > 400) {
-      Printer::center(clientNum,
-                      "^3WARNING: ^7Timerun stopped due to high ping!");
-      InterruptRun(ent);
+      client->numLagFrames++;
+
+      // allow 100ms of sustained lag
+      if (client->numLagFrames * level.frameTime >= FRAMETIME) {
+        Printer::center(clientNum,
+                        "^3WARNING: ^7Timerun stopped due to high ping!");
+        InterruptRun(ent);
+        client->numLagFrames = 0;
+      }
+    } else {
+      client->numLagFrames = 0;
     }
+
     if (client->pers.maxFPS > 0 && client->pers.maxFPS < 25) {
       Printer::center(clientNum,
                       "^3WARNING: ^7Timerun stopped due to low FPS!");

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1170,6 +1170,8 @@ struct gclient_s {
   int lastRevivePushTime;
 
   bool respawnFromLoad;
+
+  int numLagFrames; // for tracking high ping on timeruns to counter lag abuse
 };
 
 typedef struct {


### PR DESCRIPTION
Require 100ms of sustained lag for timeruns to interrupt. With `sv_fps 125`, it's much more likely that you get few frames with > 400 ping just from regular network lag spikes, which causes issues especially for high ping players. Trigger abuse requires sustained lag to exploit, so this will still catch that, but is less likely to negatively impact regular lag spikes.