### PR TITLE
Increase slick & NJD detector range

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -2673,7 +2673,7 @@ static void CG_DrawSlick(void) {
   ETJump_AdjustPosition(&x);
 
   VectorCopy(cg.refdef.vieworg, start);
-  VectorMA(start, 8192, cg.refdef.viewaxis[0], end);
+  VectorMA(start, MAX_MAP_SIZE * 2, cg.refdef.viewaxis[0], end);
 
   CG_Trace(&trace, start, NULL, NULL, end, ps->clientNum, traceContents);
 
@@ -2701,7 +2701,7 @@ static void CG_DrawJumpDelay(void) {
 
   ETJump_AdjustPosition(&x);
   VectorCopy(cg.refdef.vieworg, start);
-  VectorMA(start, 8192, cg.refdef.viewaxis[0], end);
+  VectorMA(start, MAX_MAP_SIZE * 2, cg.refdef.viewaxis[0], end);
 
   CG_Trace(&trace, start, nullptr, nullptr, end, ps->clientNum, traceContents);
 

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2637,7 +2637,7 @@ qboolean BG_LoadSpeakerScript(const char *filename);
 extern ammotable_t ammoTableMP[WP_NUM_WEAPONS];
 #define GetAmmoTableData(ammoIndex) ((ammotable_t *)(&ammoTableMP[ammoIndex]))
 
-#define MAX_MAP_SIZE 65536
+static constexpr int MAX_MAP_SIZE = 65536;
 
 qboolean BG_BBoxCollision(vec3_t min1, vec3_t max1, vec3_t min2, vec3_t max2);
 


### PR DESCRIPTION
Just trace for full map size, we can have quite large areas with long jumps that have slicks far up ahead.