### PR TITLE
Add support for engine extensions + flash window on chat mention/pm

### DIFF
--- a/assets/ui/etjump_settings_hud1_chat.menu
+++ b/assets/ui/etjump_settings_hud1_chat.menu
@@ -69,7 +69,11 @@ menuDef {
         SLIDER              (SETTINGS_ITEM_POS(8), "Chat scale:", 0.2, SETTINGS_ITEM_H, etj_chatScale 1 0.1 5 0.1, "Sets chat size scale\netj_chatScale")
         CVARINTLABEL        (SETTINGS_ITEM_POS(9), "etj_chatLineWidth", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(9), "Chat line width:", 0.2, SETTINGS_ITEM_H, etj_chatLineWidth 62 15 100 1, "Maximum number of characters on one line before chat wraps to a new line\netj_chatLineWidth")
+#ifdef ETLEGACY
+        COMBO_BIT           (SETTINGS_COMBO_POS(10), "Chat mentions:", 0.2, SETTINGS_ITEM_H, "etj_highlight", cvarFloatList { "Beeper" 1 "Flash window" 2 }, none, "Highlight chat messages if you are mentioned\netj_highlight")
+#else
         YESNO               (SETTINGS_ITEM_POS(10), "Chat mentions:", 0.2, SETTINGS_ITEM_H, "etj_highlight", "Highlight chat messages if you are mentioned\netj_highlight")
+#endif
         EDITFIELD_EXT       (SETTINGS_EF_POS(11), "Highlight text:", 0.2, SETTINGS_ITEM_H, "etj_highlightText", SETTINGS_EF_MAXCHARS, SETTINGS_EF_MAXPAINTCHARS, "Prefix of chat message where you are highlighted\netj_highlightText")
         EDITFIELD_EXT       (SETTINGS_EF_POS(12), "Highlight sound:", 0.2, SETTINGS_ITEM_H, "etj_highlightSound", SETTINGS_EF_MAXCHARS, SETTINGS_EF_MAXPAINTCHARS, "Sound to play when you are highlighted in chat\netj_highlightSound")
         YESNO               (SETTINGS_ITEM_POS(13), "Chat replay:", 0.2, SETTINGS_ITEM_H, "etj_chatReplay", "Replay latest chat messages from server when connecting to server or after vid_restart\netj_chatReplay")

--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -114,6 +114,7 @@ add_library(cgame MODULE
 	"../game/etj_string_utilities.cpp"
 	"../game/etj_time_utilities.cpp"
 	"../game/etj_timerun_shared.cpp"
+	"../game/etj_syscall_ext_shared.cpp"
 	"../ui/ui_shared.cpp"
 	${CGAME_HEADERS}
 )

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4223,6 +4223,7 @@ class DemoCompatibility;
 class AccelColor;
 class PlayerBBox;
 class SavePos;
+class SyscallExt;
 
 extern std::shared_ptr<ClientCommandsHandler> serverCommandsHandler;
 extern std::shared_ptr<ClientCommandsHandler> consoleCommandsHandler;
@@ -4238,6 +4239,7 @@ extern std::unique_ptr<DemoCompatibility> demoCompatibility;
 extern std::array<bool, MAX_CLIENTS> tempTraceIgnoredClients;
 extern std::shared_ptr<PlayerBBox> playerBBox;
 extern std::unique_ptr<SavePos> savePos;
+extern std::unique_ptr<SyscallExt> syscallExt;
 
 void addRealLoopingSound(const vec3_t origin, const vec3_t velocity,
                          sfxHandle_t sfx, int range, int volume, int soundTime);

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4264,6 +4264,11 @@ enum extraTraceOptions {
   CHS_16,
   CHS_53,
 };
+
+enum class ChatHighlightFlags {
+  HIGHLIGHT_BEEPER = 1,
+  HIGHLIGHT_FLASH = 2,
+};
 } // namespace ETJump
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -2213,7 +2213,7 @@ static const char *addChatModifications(char *text, const int clientNum,
     if (etj_highlight.integer &
         static_cast<int>(ChatHighlightFlags::HIGHLIGHT_FLASH)) {
       SyscallExt::trap_SysFlashWindowETLegacy(
-          SyscallExt::FlashWindowState::FLASH_UNTIL_FOCUS);
+          SyscallExt::FlashWindowState::SDL_FLASH_UNTIL_FOCUSED);
     }
   }
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -2208,7 +2208,7 @@ static const char *addChatModifications(char *text, const int clientNum,
         trap_S_RegisterSound(etj_highlightSound.string, qfalse), CHAN_LOCAL);
 
     SyscallExt::trap_SysFlashWindowETLegacy(
-        SyscallExt::FlashWindowState::FLASH_UNTIL_FOCUS);
+        SyscallExt::FlashWindowState::SDL_FLASH_UNTIL_FOCUSED);
   }
 
   if (etj_drawMessageTime.integer) {

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -13,6 +13,7 @@
 
 #include "../game/etj_numeric_utilities.h"
 #include "../game/etj_string_utilities.h"
+#include "../game/etj_syscall_ext_shared.h"
 
 #define SCOREPARSE_COUNT 9
 
@@ -2205,6 +2206,9 @@ static const char *addChatModifications(char *text, const int clientNum,
 
     trap_S_StartLocalSound(
         trap_S_RegisterSound(etj_highlightSound.string, qfalse), CHAN_LOCAL);
+
+    SyscallExt::trap_SysFlashWindowETLegacy(
+        SyscallExt::FlashWindowState::FLASH_UNTIL_FOCUS);
   }
 
   if (etj_drawMessageTime.integer) {

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -2201,14 +2201,20 @@ static const char *addChatModifications(char *text, const int clientNum,
   if (etj_highlight.integer && (serverSay || cg.clientNum != clientNum) &&
       strstr(text + strlen(cgs.clientinfo[clientNum].name),
              cgs.clientinfo[cg.clientNum].name) != nullptr) {
-    Q_strcat(message, sizeof(message), etj_highlightText.string);
-    Q_strcat(message, sizeof(message), "^7");
+    if (etj_highlight.integer &
+        static_cast<int>(ChatHighlightFlags::HIGHLIGHT_BEEPER)) {
+      Q_strcat(message, sizeof(message), etj_highlightText.string);
+      Q_strcat(message, sizeof(message), "^7");
 
-    trap_S_StartLocalSound(
-        trap_S_RegisterSound(etj_highlightSound.string, qfalse), CHAN_LOCAL);
+      trap_S_StartLocalSound(
+          trap_S_RegisterSound(etj_highlightSound.string, qfalse), CHAN_LOCAL);
+    }
 
-    SyscallExt::trap_SysFlashWindowETLegacy(
-        SyscallExt::FlashWindowState::SDL_FLASH_UNTIL_FOCUSED);
+    if (etj_highlight.integer &
+        static_cast<int>(ChatHighlightFlags::HIGHLIGHT_FLASH)) {
+      SyscallExt::trap_SysFlashWindowETLegacy(
+          SyscallExt::FlashWindowState::FLASH_UNTIL_FOCUS);
+    }
   }
 
   if (etj_drawMessageTime.integer) {

--- a/src/cgame/cg_syscalls.cpp
+++ b/src/cgame/cg_syscalls.cpp
@@ -1,6 +1,7 @@
 // cg_syscalls.c -- this file is only included when building a dll
 // cg_syscalls.asm is included instead when building a qvm
 #include "cg_local.h"
+#include "../game/etj_syscall_ext_shared.h"
 
 static intptr_t(QDECL *syscall)(intptr_t arg,
                                 ...) = (intptr_t(QDECL *)(intptr_t, ...)) - 1;
@@ -932,3 +933,19 @@ int trap_R_GetTextureId(const char *name) {
 
 // bani - sync rendering
 void trap_R_Finish(void) { SystemCall(CG_R_FINISH); }
+
+// ETJump: syscall extensions
+namespace ETJump {
+// entry point for additional system calls for other engines (ETe, ET: Legacy)
+bool SyscallExt::trap_GetValue(char *value, const int size, const char *key) {
+  return SystemCall(syscallExt->dll_com_trapGetValue, value, size, key);
+}
+
+// ET: Legacy - flash client window
+void SyscallExt::trap_SysFlashWindowETLegacy(const FlashWindowState state) {
+  if (syscallExt->cgameExtensions[syscallExt->flashWindowETLegacy]) {
+    SystemCall(syscallExt->cgameExtensions[syscallExt->flashWindowETLegacy],
+               static_cast<int>(state));
+  }
+}
+} // namespace ETJump

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -496,7 +496,7 @@ qboolean CG_ServerCommandExt(const char *cmd) {
 
   if (command == "pmFlashWindow") {
     ETJump::SyscallExt::trap_SysFlashWindowETLegacy(
-        ETJump::SyscallExt::FlashWindowState::FLASH_UNTIL_FOCUS);
+        ETJump::SyscallExt::FlashWindowState::SDL_FLASH_UNTIL_FOCUSED);
     return qtrue;
   }
 

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -498,7 +498,7 @@ qboolean CG_ServerCommandExt(const char *cmd) {
     if (etj_highlight.integer &
         static_cast<int>(ETJump::ChatHighlightFlags::HIGHLIGHT_FLASH)) {
       ETJump::SyscallExt::trap_SysFlashWindowETLegacy(
-          ETJump::SyscallExt::FlashWindowState::FLASH_UNTIL_FOCUS);
+          ETJump::SyscallExt::FlashWindowState::SDL_FLASH_UNTIL_FOCUSED);
     }
 
     return qtrue;

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -495,8 +495,12 @@ qboolean CG_ServerCommandExt(const char *cmd) {
   }
 
   if (command == "pmFlashWindow") {
-    ETJump::SyscallExt::trap_SysFlashWindowETLegacy(
-        ETJump::SyscallExt::FlashWindowState::SDL_FLASH_UNTIL_FOCUSED);
+    if (etj_highlight.integer &
+        static_cast<int>(ETJump::ChatHighlightFlags::HIGHLIGHT_FLASH)) {
+      ETJump::SyscallExt::trap_SysFlashWindowETLegacy(
+          ETJump::SyscallExt::FlashWindowState::FLASH_UNTIL_FOCUS);
+    }
+
     return qtrue;
   }
 

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -65,6 +65,7 @@
 #include "etj_player_bbox.h"
 #include "etj_pmove_utils.h"
 #include "etj_savepos.h"
+#include "../game/etj_syscall_ext_shared.h"
 
 namespace ETJump {
 std::shared_ptr<ClientCommandsHandler> serverCommandsHandler;
@@ -91,6 +92,7 @@ std::shared_ptr<AccelColor> accelColor;
 std::array<bool, MAX_CLIENTS> tempTraceIgnoredClients;
 std::shared_ptr<PlayerBBox> playerBBox;
 std::unique_ptr<SavePos> savePos;
+std::unique_ptr<SyscallExt> syscallExt;
 } // namespace ETJump
 
 static bool isInitialized{false};
@@ -330,6 +332,9 @@ void init() {
 
   std::fill_n(tempTraceIgnoredClients.begin(), MAX_CLIENTS, false);
 
+  syscallExt = std::make_unique<SyscallExt>();
+  syscallExt->setupExtensions();
+
   trickjumpLines = std::make_shared<TrickjumpLines>();
 
   // Check if load TJL on connection is enable
@@ -387,6 +392,8 @@ void shutdown() {
   ETJump::entityEventsHandler = nullptr;
 
   ETJump::savePos = nullptr;
+
+  syscallExt = nullptr;
 
   isInitialized = false;
 
@@ -484,6 +491,12 @@ qboolean CG_ServerCommandExt(const char *cmd) {
     uiCommand += '\n';
 
     trap_SendConsoleCommand(uiCommand.c_str());
+    return qtrue;
+  }
+
+  if (command == "pmFlashWindow") {
+    ETJump::SyscallExt::trap_SysFlashWindowETLegacy(
+        ETJump::SyscallExt::FlashWindowState::FLASH_UNTIL_FOCUS);
     return qtrue;
   }
 

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(qagame MODULE
 	"etj_savepos_command_handler.cpp"
 	"etj_savepos_shared.cpp"
 	"etj_session.cpp"
+	"etj_syscall_ext_shared.cpp"
 	"etj_synchronization_context.cpp"
 	"etj_string_utilities.cpp"
 	"etj_target_init.cpp"

--- a/src/game/etj_syscall_ext_shared.cpp
+++ b/src/game/etj_syscall_ext_shared.cpp
@@ -36,7 +36,6 @@ void SyscallExt::setupExtensions() {
   dll_com_trapGetValue = Q_atoi(value);
 
 #ifdef CGAMEDLL
-  Com_Printf("cgame extensions...\n");
   for (auto &ext : cgameExtensions) {
     setupExtensionTrap(value, ext.first, ext.second);
   }

--- a/src/game/etj_syscall_ext_shared.cpp
+++ b/src/game/etj_syscall_ext_shared.cpp
@@ -1,0 +1,52 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_syscall_ext_shared.h"
+
+namespace ETJump {
+void SyscallExt::setupExtensions() {
+  trap_Cvar_VariableStringBuffer(entryPointCvar, value, sizeof(value));
+
+  // extension system not supported by the engine
+  if (value[0] == '\0') {
+    return;
+  }
+
+  dll_com_trapGetValue = Q_atoi(value);
+
+#ifdef CGAMEDLL
+  Com_Printf("cgame extensions...\n");
+  for (auto &ext : cgameExtensions) {
+    setupExtensionTrap(value, ext.first, ext.second);
+  }
+#endif
+}
+
+void SyscallExt::setupExtensionTrap(char *value, const std::string &name,
+                                    int &trap) {
+  if (trap_GetValue(value, MAX_CVAR_VALUE_STRING, name.c_str())) {
+    trap = Q_atoi(value);
+  }
+}
+} // namespace ETJump

--- a/src/game/etj_syscall_ext_shared.h
+++ b/src/game/etj_syscall_ext_shared.h
@@ -35,7 +35,6 @@
 #include <unordered_map>
 
 namespace ETJump {
-
 class SyscallExt {
 public:
 #ifdef CGAMEDLL

--- a/src/game/etj_syscall_ext_shared.h
+++ b/src/game/etj_syscall_ext_shared.h
@@ -1,0 +1,77 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#if defined(GAMEDLL)
+  #include "g_local.h"
+#elif defined(CGAMEDLL)
+  #include "../cgame/cg_local.h"
+#elif defined(UIDLL)
+  #include "../ui/ui_local.h"
+#endif
+
+#include <unordered_map>
+
+namespace ETJump {
+
+class SyscallExt {
+public:
+#ifdef CGAMEDLL
+  const char *flashWindowETLegacy = "trap_SysFlashWindow_Legacy";
+
+  std::unordered_map<const char *, int> cgameExtensions = {
+      {flashWindowETLegacy, 0},
+  };
+
+  // defined by SDL2
+  enum class FlashWindowState {
+    FLASH_OFF = 0,
+    FLASH_BRIEF = 1,
+    FLASH_UNTIL_FOCUS = 2,
+  };
+
+  static void trap_SysFlashWindowETLegacy(FlashWindowState state);
+#endif
+
+  // entry point for extensions
+  int dll_com_trapGetValue{};
+
+  // the implementations are in module-specific *_syscalls.cpp files
+  // due to SystemCall macro expansion
+  static bool trap_GetValue(char *value, int size, const char *key);
+
+  SyscallExt() = default;
+  ~SyscallExt() = default;
+  void setupExtensions();
+
+private:
+  static void setupExtensionTrap(char *value, const std::string &name,
+                                 int &trap);
+
+  // the entry point cvar into the extension system in engine
+  const char *entryPointCvar = "//trap_GetValue";
+  char value[MAX_CVAR_VALUE_STRING]{};
+};
+} // namespace ETJump

--- a/src/game/etj_syscall_ext_shared.h
+++ b/src/game/etj_syscall_ext_shared.h
@@ -46,9 +46,9 @@ public:
 
   // defined by SDL2
   enum class FlashWindowState {
-    FLASH_OFF = 0,
-    FLASH_BRIEF = 1,
-    FLASH_UNTIL_FOCUS = 2,
+    SDL_FLASH_CANCEL = 0,
+    SDL_FLASH_BRIEFLY = 1,
+    SDL_FLASH_UNTIL_FOCUSED = 2,
   };
 
   static void trap_SysFlashWindowETLegacy(FlashWindowState state);

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -4472,11 +4472,14 @@ void Cmd_PrivateMessage_f(gentity_t *ent) {
   }
 
   other = g_entities + clientNum;
+  const int otherNum = ClientNum(other);
 
   if (!ent) {
     msg = ConcatArgs(2);
     Printer::chat(ClientNum(other),
                   va("^7Private message from server console: ^3%s", msg));
+    trap_SendServerCommand(otherNum, "pmFlashWindow");
+
     G_Printf("Private message to %s^7: ^3%s\n", other->client->pers.netname,
              msg);
     return;
@@ -4484,8 +4487,10 @@ void Cmd_PrivateMessage_f(gentity_t *ent) {
 
   if (!COM_BitCheck(other->client->sess.ignoreClients, ClientNum(ent))) {
     msg = ConcatArgs(2);
-    Printer::chat(ClientNum(other), va("^7Private message from %s^7: ^3%s",
-                                       ent->client->pers.netname, msg));
+    Printer::chat(otherNum, va("^7Private message from %s^7: ^3%s",
+                               ent->client->pers.netname, msg));
+    trap_SendServerCommand(otherNum, "pmFlashWindow");
+
     if (ent) {
       Printer::chat(selfNum, va("^7Private message to %s^7: ^3%s",
                                 other->client->pers.netname, msg));

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2919,6 +2919,9 @@ extern std::shared_ptr<Database> database;
 class ProgressionTrackers;
 extern std::shared_ptr<ProgressionTrackers> progressionTrackers;
 
+class SyscallExt;
+extern std::unique_ptr<SyscallExt> syscallExt;
+
 struct GameLogicException : public std::exception {
 private:
   std::string message;

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -12,6 +12,7 @@
 #include "etj_entity_utilities.h"
 #include "etj_numeric_utilities.h"
 #include "etj_rtv.h"
+#include "etj_syscall_ext_shared.h"
 
 level_locals_t level;
 
@@ -37,6 +38,7 @@ std::shared_ptr<SaveSystem> saveSystem;
 std::shared_ptr<Database> database;
 std::shared_ptr<Session> session;
 std::shared_ptr<ProgressionTrackers> progressionTrackers;
+std::unique_ptr<SyscallExt> syscallExt;
 } // namespace ETJump
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -49,6 +51,9 @@ static void initializeETJump() {
   ETJump::session = std::make_shared<Session>(ETJump::database);
   ETJump::saveSystem = std::make_shared<ETJump::SaveSystem>(ETJump::session);
   ETJump::progressionTrackers = std::make_shared<ETJump::ProgressionTrackers>();
+
+  ETJump::syscallExt = std::make_unique<ETJump::SyscallExt>();
+  ETJump::syscallExt->setupExtensions();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -61,6 +66,7 @@ static void shutdownETJump() {
   ETJump::session = nullptr;
   ETJump::saveSystem = nullptr;
   ETJump::progressionTrackers = nullptr;
+  ETJump::syscallExt = nullptr;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/game/g_syscalls.cpp
+++ b/src/game/g_syscalls.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 1999-2000 Id Software, Inc.
 //
 #include "g_local.h"
+#include "etj_syscall_ext_shared.h"
 
 // this file is only included when building a dll
 // g_syscalls.asm is included instead when building a qvm
@@ -1010,3 +1011,11 @@ void trap_SendMessage(int clientNum, char *buf, int buflen) {
 messageStatus_t trap_MessageStatus(int clientNum) {
   return static_cast<messageStatus_t>(SystemCall(G_MESSAGESTATUS, clientNum));
 }
+
+// ETJump: syscall extensions
+namespace ETJump {
+// entry point for additional system calls for other engines (ETe, ET: Legacy)
+bool SyscallExt::trap_GetValue(char *value, const int size, const char *key) {
+  return SystemCall(syscallExt->dll_com_trapGetValue, value, size, key);
+}
+} // namespace ETJump

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(ui MODULE
 	"../game/etj_file.cpp"
 	"../game/etj_filesystem.cpp"
 	"../game/etj_string_utilities.cpp"
+	"../game/etj_syscall_ext_shared.cpp"
 	${UI_HEADERS}
 )
 target_compile_definitions(ui PRIVATE UIDLL)

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -1115,6 +1115,9 @@ char *trap_TranslateString(const char *string); // NERVE - SMF - localization
 void ETJump_DrawMapDetails();
 
 namespace ETJump {
+class SyscallExt;
+extern std::unique_ptr<SyscallExt> syscallExt;
+
 void parseMaplist();
 void parseNumCustomvotes();
 void parseCustomvote();

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -18,6 +18,7 @@ USER INTERFACE MAIN
 #include "../cgame/etj_utilities.h"
 #include "../game/etj_numeric_utilities.h"
 #include "../game/etj_filesystem.h"
+#include "../game/etj_syscall_ext_shared.h"
 
 // NERVE - SMF
 #define AXIS_TEAM 0
@@ -808,6 +809,7 @@ void UI_ShowPostGame(qboolean newHigh) {
 
 namespace ETJump {
 std::unique_ptr<ColorPicker> colorPicker;
+std::unique_ptr<SyscallExt> syscallExt;
 
 static void initColorPicker() {
   colorPicker = std::make_unique<ColorPicker>();
@@ -843,6 +845,11 @@ static void initColorPicker() {
   uiInfo.uiDC.setColorSliderType = &ColorPicker::setColorSliderType;
   uiInfo.uiDC.getColorSliderValue = &ColorPicker::getColorSliderValue;
   uiInfo.uiDC.setColorSliderValue = &ColorPicker::setColorSliderValue;
+}
+
+static void initExtensionSystem() {
+  syscallExt = std::make_unique<SyscallExt>();
+  syscallExt->setupExtensions();
 }
 
 static void drawLevelshotPreview(rectDef_t &rect) {
@@ -7048,6 +7055,7 @@ void _UI_Init(int legacyClient, int clientVersion) {
   uiInfo.uiDC.getActiveFont = &GetActiveFont;
 
   ETJump::initColorPicker();
+  ETJump::initExtensionSystem();
 
   Init_Display(&uiInfo.uiDC);
 

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -995,6 +995,7 @@ void _UI_Shutdown(void) {
   trap_LAN_SaveCachedServers();
 
   ETJump::colorPicker = nullptr;
+  ETJump::syscallExt = nullptr;
 
   Shutdown_Display();
 }

--- a/src/ui/ui_syscalls.cpp
+++ b/src/ui/ui_syscalls.cpp
@@ -1,4 +1,5 @@
 #include "ui_local.h"
+#include "../game/etj_syscall_ext_shared.h"
 
 // this file is only included when building a dll
 // syscalls.asm is included instead when building a qvm
@@ -499,3 +500,11 @@ void trap_openURL(const char *s) { SystemCall(UI_OPENURL, s); }
 void trap_GetHunkData(int *hunkused, int *hunkexpected) {
   SystemCall(UI_GETHUNKDATA, hunkused, hunkexpected);
 }
+
+// ETJump: syscall extensions
+namespace ETJump {
+// entry point for additional system calls for other engines (ETe, ET: Legacy)
+bool SyscallExt::trap_GetValue(char *value, const int size, const char *key) {
+  return SystemCall(syscallExt->dll_com_trapGetValue, value, size, key);
+}
+} // namespace ETJump


### PR DESCRIPTION
Initial implementation of engine extension system. Wired to each module, currently only used in cgame for flashing the game window on chat mentions and incoming private messages.