### PR TITLE
Fixes to customvote UI

### DIFF
--- a/assets/ui/ingame_customvote_details.menu
+++ b/assets/ui/ingame_customvote_details.menu
@@ -64,6 +64,7 @@ menuDef {
         elementheight   12
         columns         1 0 200 33
         visible         0
+        notselectable
     }
 
     itemDef {
@@ -84,5 +85,6 @@ menuDef {
         elementheight   12
         columns         1 0 200 33
         visible         0
+        notselectable
     }
 }

--- a/assets/ui/ingame_vote_customvote.menu
+++ b/assets/ui/ingame_vote_customvote.menu
@@ -57,6 +57,10 @@ menuDef {
         elementheight   12
         columns         1 0 200 33
         visible         1
+
+        action {
+            uiScript resetCustomvoteDetailsIndex ingame_customvote_details
+        }
     }
 
     YESNO   ( 6, WINDOW_HEIGHT-60, (WINDOW_WIDTH-12), 8, "Rock the Vote:", 0.2, 8, "ui_voteCustomRTV", "Call Rock the Vote with selected list\nui_voteCustomRTV")

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -5005,10 +5005,17 @@ void UI_RunMenuScript(const char **args) {
     }
 
     if (!Q_stricmp(name, "resetCustomvoteDetailsIndex")) {
+      uiInfo.customvoteMapsOnServerIndex = 0;
+      uiInfo.customvoteOtherMapsIndex = 0;
+
+      const char *menuName = nullptr;
+      String_Parse(args, &menuName);
+
+      // if menuName is nullptr (called without args), active menu name is used
       Menu_SetFeederSelection(nullptr, FEEDER_CUSTOMVOTES_MAPS_ONSERVER, 0,
-                              nullptr);
+                              menuName);
       Menu_SetFeederSelection(nullptr, FEEDER_CUSTOMVOTES_MAPS_UNAVAILABLE, 0,
-                              nullptr);
+                              menuName);
       return;
     }
 


### PR DESCRIPTION
* Make maplists `notselectable` to make scrolling behavior more natural
* Reset list maplist position to top when a new list is selected, otherwise we might end up with a seemingly empty list because the selected position could be at an index which is invalid for the newly selected list

refs #1447 