### PR TITLE
Add extended cmd backup extension

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -805,7 +805,7 @@ static void CG_DrawDisconnect(void) {
   }
 
   // draw the phone jack if we are completely past our buffers
-  cmdNum = trap_GetCurrentCmdNumber() - CMD_BACKUP + 1;
+  cmdNum = trap_GetCurrentCmdNumber() - cg.cmdBackup + 1;
   trap_GetUserCmd(cmdNum, &cmd);
   if (cmd.serverTime <= cg.snap->ps.commandTime ||
       cmd.serverTime > cg.time) // special check for map_restart // bk

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -777,7 +777,9 @@ typedef enum { SHOW_OFF, SHOW_SHUTDOWN, SHOW_ON } showView_t;
 
 void CG_ParseMapEntityInfo(int axis_number, int allied_number);
 
-#define MAX_BACKUP_STATES (CMD_BACKUP + 2)
+// we need to reserve the extended value for this, it doesn't matter
+// if the client doesn't actually support CMD_BACKUP_EXT
+static constexpr int MAX_BACKUP_STATES = CMD_BACKUP_EXT + 2;
 
 typedef struct {
   int clientFrame; // incremented each frame
@@ -1192,6 +1194,8 @@ typedef struct {
   int backupStateTail;
   int lastPredictedCommand;
   int lastPhysicsTime;
+  int cmdBackup;
+  int cmdMask;
 
   qboolean skyboxEnabled;
   vec3_t skyboxViewOrg;

--- a/src/cgame/cg_public.h
+++ b/src/cgame/cg_public.h
@@ -1,10 +1,13 @@
+#pragma once
 
-
-#define CMD_BACKUP 64
-#define CMD_MASK (CMD_BACKUP - 1)
 // allow a lot of command backups for very fast systems
 // multiple commands may be combined into a single packet, so this
 // needs to be larger than PACKET_BACKUP
+static constexpr int CMD_BACKUP = 64;
+static constexpr int CMD_MASK = CMD_BACKUP - 1;
+
+static constexpr int CMD_BACKUP_EXT = 128;
+static constexpr int CMD_MASK_EXT = CMD_BACKUP_EXT - 1;
 
 #define MAX_ENTITIES_IN_SNAPSHOT 512
 

--- a/src/cgame/cg_syscalls.cpp
+++ b/src/cgame/cg_syscalls.cpp
@@ -948,4 +948,16 @@ void SyscallExt::trap_SysFlashWindowETLegacy(const FlashWindowState state) {
                static_cast<int>(state));
   }
 }
+
+void SyscallExt::trap_CmdBackup_Ext() {
+  if (syscallExt->cgameExtensions[syscallExt->cmdBackupExt]) {
+    cg.cmdBackup = CMD_BACKUP_EXT;
+    cg.cmdMask = CMD_MASK_EXT;
+    SystemCall(syscallExt->cgameExtensions[syscallExt->cmdBackupExt]);
+  } else {
+    cg.cmdBackup = CMD_BACKUP;
+    cg.cmdMask = CMD_MASK;
+  }
+}
+
 } // namespace ETJump

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -334,6 +334,7 @@ void init() {
 
   syscallExt = std::make_unique<SyscallExt>();
   syscallExt->setupExtensions();
+  SyscallExt::trap_CmdBackup_Ext();
 
   trickjumpLines = std::make_shared<TrickjumpLines>();
 

--- a/src/game/etj_syscall_ext_shared.h
+++ b/src/game/etj_syscall_ext_shared.h
@@ -39,9 +39,11 @@ class SyscallExt {
 public:
 #ifdef CGAMEDLL
   const char *flashWindowETLegacy = "trap_SysFlashWindow_Legacy";
+  const char *cmdBackupExt = "trap_CmdBackup_Ext_Legacy";
 
   std::unordered_map<const char *, int> cgameExtensions = {
       {flashWindowETLegacy, 0},
+      {cmdBackupExt, 0},
   };
 
   // defined by SDL2
@@ -52,6 +54,7 @@ public:
   };
 
   static void trap_SysFlashWindowETLegacy(FlashWindowState state);
+  static void trap_CmdBackup_Ext();
 #endif
 
   // entry point for extensions


### PR DESCRIPTION
Adds support for ET: Legacys extended cmd backup extensions. This allows ET: Legacy clients to support higher usercmd backup buffer, which in turn allows for them to play at higher framerates at higher pings, without exceeding the command backup buffer.