### PR TITLE
Validate custom vote names on read

### DIFF
--- a/src/game/etj_custom_map_votes.cpp
+++ b/src/game/etj_custom_map_votes.cpp
@@ -93,6 +93,12 @@ void CustomMapVotes::loadCustomvotes(const bool init) {
 
     customMapVotes_[curr].type = sanitize(customMapVotes_[curr].type, true);
 
+    if (customMapVotes_[curr].type.empty()) {
+      customMapVotes_.pop_back();
+      logger->error("Failed to parse custom vote - 'name' is empty");
+      continue;
+    }
+
     if (!JsonUtils::parseValue(customMapVotes_[curr].callvoteText,
                                list["callvote_text"], &errors,
                                "callvote_text")) {
@@ -102,6 +108,12 @@ void CustomMapVotes::loadCustomvotes(const bool init) {
 
     customMapVotes_[curr].callvoteText =
         sanitize(customMapVotes_[curr].callvoteText);
+
+    if (customMapVotes_[curr].callvoteText.empty()) {
+      customMapVotes_.pop_back();
+      logger->error("Failed to parse custom vote - 'callvote_text' is empty");
+      continue;
+    }
 
     std::set<std::string> uniqueMapsOnServer{};
     std::set<std::string> uniqueMapsOther{};


### PR DESCRIPTION
We already did validation for editing via custom vote admin commands, but it was still possible to insert an empty name as a list name or callvote text, which not only would be stupid, but would cause a crash in UI when custom votes are parsed.