### PR TITLE
Slightly increase changelog font size

### DIFF
--- a/assets/ui/etjump_changelog.menu
+++ b/assets/ui/etjump_changelog.menu
@@ -45,7 +45,7 @@ menuDef {
         rect            6 $evalfloat(WINDOW_Y + 14) $evalfloat(WINDOW_WIDTH - 12) $evalfloat(WINDOW_HEIGHT - 12 - 18 - 6 - 24)
         type            ITEM_TYPE_LISTBOX
         textfont        UI_FONT_COURBD_21
-        textscale       .2
+        textscale       .25
         textaligny      -3
         forecolor       .6 .6 .6 1
         outlinecolor    .5 .5 .5 0
@@ -54,7 +54,7 @@ menuDef {
         feeder          FEEDER_CHANGELOG
         elementtype     LISTBOX_TEXT
         elementwidth    $evalfloat(WINDOW_WIDTH - 12)
-        elementheight   12
+        elementheight   16
         columns         1 0 $evalfloat(WINDOW_WIDTH - 12) 0
         style           WINDOW_STYLE_FILLED
 #ifdef FUI


### PR DESCRIPTION
This is a workaround for 2.60b hitting `MAX_RENDERER_COMMANDS` while viewing the changelog, realistically I should probably make the changelog a bit smaller window but the way the UI widescreen handling is done does not allow centered windows that are smaller than this, and would need refactoring which is likely to break other menus, so I will leave that to the future.

refs #1532 