### PR TITLE
Fix playerbbox fireteam drawing logic while spectating

### DIFF
--- a/src/cgame/etj_player_bbox.cpp
+++ b/src/cgame/etj_player_bbox.cpp
@@ -61,7 +61,7 @@ void PlayerBBox::drawBBox(const clientInfo_t *ci, const centity_t *cent) const {
 
   const int drawFlags = etj_drawPlayerBBox.integer;
   const bool inFireteam =
-      CG_IsOnSameFireteam(cg.snap->ps.clientNum, cent->currentState.clientNum);
+      CG_IsOnSameFireteam(cg.clientNum, cent->currentState.clientNum);
 
   if (cent->currentState.clientNum == cg.snap->ps.clientNum) {
     if (!(drawFlags & static_cast<int>(DrawFlags::Self))) {


### PR DESCRIPTION
Check for `cg.clientNum` instead of `ps.clientNum`, so we don't potentially draw fireteam bboxes for players that are not part of our fireteam, but the spectated players FT instead.