### PR TITLE
Enable etj_smoothAngles by default & remove experimental label

### DIFF
--- a/assets/ui/etjump_settings_general_gameplay.menu
+++ b/assets/ui/etjump_settings_general_gameplay.menu
@@ -46,7 +46,7 @@ menuDef {
 
         YESNO               (SETTINGS_ITEM_POS(1), "Fixed physics:", 0.2, SETTINGS_ITEM_H, "pmove_fixed", "Enable fixed 125 FPS movement physics\npmove_fixed")
         YESNO               (SETTINGS_ITEM_POS(2), "Unlimited stamina:", 0.2, SETTINGS_ITEM_H, "etj_nofatigue", "Enable unlimited stamina\netj_nofatigue")
-        YESNO               (SETTINGS_ITEM_POS(3), "Smooth angles (EXPERIMENTAL):", 0.2, SETTINGS_ITEM_H, "etj_smoothAngles", "Update client view every frame with pmove_fixed 1\nThis is experimental and might break viewangles in some scenarios\netj_smoothAngles")
+        YESNO               (SETTINGS_ITEM_POS(3), "Smooth angles:", 0.2, SETTINGS_ITEM_H, "etj_smoothAngles", "Update client view every frame with 'pmove_fixed 1'\netj_smoothAngles")
         YESNO               (SETTINGS_ITEM_POS(4), "Load view angles:", 0.2, SETTINGS_ITEM_H, "etj_loadviewangles", "Load view angles when loading position\netj_loadviewangles")
         YESNO               (SETTINGS_ITEM_POS(5), "Auto sprint:", 0.2, SETTINGS_ITEM_H, "etj_autoSprint", "Automatically enables sprint without holding '+sprint'\nHolding '+sprint' enables running instead of sprinting\netj_autoSprint")
         YESNO               (SETTINGS_ITEM_POS(6), "Auto load:", 0.2, SETTINGS_ITEM_H, "etj_autoLoad", "Automatically load to latest saved position when joining team\netj_autoLoad")

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1268,7 +1268,7 @@ cvarTable_t cvarTable[] = {
     {&etj_recordingStatusX, "etj_recordingStatusX", "2", CVAR_ARCHIVE},
     {&etj_recordingStatusY, "etj_recordingStatusY", "9", CVAR_ARCHIVE},
 
-    {&etj_smoothAngles, "etj_smoothAngles", "0", CVAR_ARCHIVE},
+    {&etj_smoothAngles, "etj_smoothAngles", "1", CVAR_ARCHIVE},
     {&etj_autoSprint, "etj_autoSprint", "0", CVAR_ARCHIVE},
 };
 


### PR DESCRIPTION
This is pretty well tested at this point and realistically is pretty foolproof since the angles are forced to re-sync after pmove is ran, so I'm confident in enabling this by default for everyone.

refs #1495 