### PR TITLE
Fix flamethrower damage timestamps

### DIFF
--- a/src/game/g_weapon.cpp
+++ b/src/game/g_weapon.cpp
@@ -4284,8 +4284,8 @@ void G_BurnMeGood(gentity_t *self, gentity_t *body, const bool directhit) {
 
   // add the new damage
   body->flameQuota += 5;
-  body->flameQuotaTime = level.time;
-  body->lastBurnedFrametime = level.time;
+  body->flameQuotaTime = level.time - level.time % DEFAULT_SV_FRAMETIME;
+  body->lastBurnedFrametime = level.time - level.time % DEFAULT_SV_FRAMETIME;
 
   G_Damage(body, self->parent, self->parent, vec3_origin, self->r.currentOrigin,
            5, 0, MOD_FLAMETHROWER); // was 2 dmg in release ver, hit


### PR DESCRIPTION
Align damage timestamps always to 50ms intervals so damage is consistent, as flamechunks are spawned every 100ms. Otherwise we sometimes have 100ms intervals between taking damage, when `level.time` doesn't perfectly align to 50ms intervals.

refs #894 