### PR TITLE
Fix autodemo stopping manual demo recordings

### DIFF
--- a/src/cgame/etj_autodemo_recorder.h
+++ b/src/cgame/etj_autodemo_recorder.h
@@ -24,13 +24,6 @@
 
 #pragma once
 
-#ifdef min
-  #undef min
-#endif
-#ifdef max
-  #undef max
-#endif
-
 #include <string>
 #include <queue>
 #include "etj_demo_recorder.h"

--- a/src/cgame/etj_demo_recorder.cpp
+++ b/src/cgame/etj_demo_recorder.cpp
@@ -31,9 +31,10 @@ ETJump::DemoRecorder::DemoRecorder() {}
 ETJump::DemoRecorder::~DemoRecorder() {}
 
 void ETJump::DemoRecorder::start(const std::string &name) {
-  // if (cl_demorecording.integer) return;
-  if (_isLocked)
+  if (_isLocked) {
     return;
+  }
+
   _startTime = cg.time;
 
   trap_SendConsoleCommand("set cl_noprint 1\n");
@@ -42,9 +43,10 @@ void ETJump::DemoRecorder::start(const std::string &name) {
 }
 
 void ETJump::DemoRecorder::stop() {
-  // if (!cl_demorecording.integer) return;
-  if (_isLocked)
+  if (_isLocked) {
     return;
+  }
+
   _stopTime = cg.time;
 
   trap_SendConsoleCommand("set cl_noprint 1\n");
@@ -63,8 +65,8 @@ void ETJump::DemoRecorder::restart(const std::string &name) {
   start(name);
 }
 
-bool ETJump::DemoRecorder::isRecording() {
-  return cl_demorecording.integer == 1;
+bool ETJump::DemoRecorder::recordingAutoDemo() {
+  return StringUtil::startsWith(cl_demofilename.string, "demos/temp/temp_");
 }
 
 int ETJump::DemoRecorder::elapsed() {

--- a/src/cgame/etj_demo_recorder.h
+++ b/src/cgame/etj_demo_recorder.h
@@ -24,13 +24,6 @@
 
 #pragma once
 
-#ifdef min
-  #undef min
-#endif
-#ifdef max
-  #undef max
-#endif
-
 #include <string>
 
 namespace ETJump {
@@ -45,7 +38,7 @@ public:
   void start(const std::string &name);
   void stop();
   void restart(const std::string &name);
-  static bool isRecording();
+  static bool recordingAutoDemo();
   int elapsed();
   void lock();
   void unlock();


### PR DESCRIPTION
* `ad_save` can no longer be used if the player isn't currently recording a demo via autodemo
* `etj_ad_stopInSpec` no longer stops a manually recorded demo when joining spectators

refs #1510 