### PR TITLE
Properly fix changemodel script action

### DIFF
--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -269,7 +269,12 @@ qboolean G_ScriptAction_ChangeModel(gentity_t *ent, char *params) {
   Q_strcat(tagname, MAX_QPATH, ".tag");
   ent->tagNumber = trap_LoadTag(tagname);
 
-  ent->s.modelindex = G_ModelIndex(token);
+  // allow 'misc_gamemodel' models to be changed too
+  if (!Q_stricmp(ent->classname, "misc_gamemodel")) {
+    ent->s.modelindex = G_ModelIndex(token);
+  } else {
+    ent->s.modelindex2 = G_ModelIndex(token);
+  }
 
   return qtrue;
 }


### PR DESCRIPTION
The script action worked fine initially, but the intended use case was to change the models of brush entities using `model2` key. This is stored in `ent->s.modelindex2`, as opposed to `ent->s.modelindex`. Perform the swap in `ent->s.modelindex` for `misc_gamemodels`, but use `ent->s.modelindex2` for other entities.

refs #1522 