### PR TITLE
Refactor centered UI window handling

### DIFF
--- a/assets/ui/credits_activision.menu
+++ b/assets/ui/credits_activision.menu
@@ -20,6 +20,7 @@ menuDef {
 	fullscreen	0
 	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
 	style		WINDOW_STYLE_FILLED
+	centered
 	
 	onESC {
 		close credits_activision ;

--- a/assets/ui/credits_additional.menu
+++ b/assets/ui/credits_additional.menu
@@ -20,6 +20,7 @@ menuDef {
 	fullscreen	0
 	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
 	style		WINDOW_STYLE_FILLED
+	centered
 	
 	onESC {
 		close credits_additional ;
@@ -185,7 +186,7 @@ menuDef {
 
 	LABELWHITE( 6, CREDITS_Y+52, .5*(WINDOW_WIDTH-24), 10, "Tony Ray", .2, ITEM_ALIGN_RIGHT, .5*(WINDOW_WIDTH-24), 8 )
 	LABELWHITE( 6+.5*(WINDOW_WIDTH-24)+12, CREDITS_Y+52, .5*(WINDOW_WIDTH-24), 10, "President", .2, ITEM_ALIGN_LEFT, 0, 8 )
-	LABELWHITE( 6, CREDITS_Y+64, .5*(WINDOW_WIDTH-24), 10, "Björn Christoph", .2, ITEM_ALIGN_RIGHT, .5*(WINDOW_WIDTH-24), 8 )
+	LABELWHITE( 6, CREDITS_Y+64, .5*(WINDOW_WIDTH-24), 10, "Bjï¿½rn Christoph", .2, ITEM_ALIGN_RIGHT, .5*(WINDOW_WIDTH-24), 8 )
 	LABELWHITE( 6+.5*(WINDOW_WIDTH-24)+12, CREDITS_Y+64, .5*(WINDOW_WIDTH-24), 10, "Senior Project Leader", .2, ITEM_ALIGN_LEFT, 0, 8 )
 
 // Voice Artists //

--- a/assets/ui/credits_et260.menu
+++ b/assets/ui/credits_et260.menu
@@ -26,6 +26,7 @@ menuDef {
 	fullscreen	0
 	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
 	style		WINDOW_STYLE_FILLED
+	centered
 	
 	onESC {
 		close credits_et260 ;

--- a/assets/ui/credits_idsoftware.menu
+++ b/assets/ui/credits_idsoftware.menu
@@ -20,6 +20,7 @@ menuDef {
 	fullscreen	0
 	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
 	style		WINDOW_STYLE_FILLED
+	centered
 	
 	onESC {
 		close credits_idsoftware ;

--- a/assets/ui/credits_quit.menu
+++ b/assets/ui/credits_quit.menu
@@ -20,6 +20,7 @@ menuDef {
 	fullscreen	0
 	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
 	style		WINDOW_STYLE_FILLED
+	centered
 	
 	onESC {
 		uiScript Quit;
@@ -194,7 +195,7 @@ menuDef {
 	
 // Copyright Notice //
 
-	LABEL( 6, CREDITS_Y+300, WINDOW_WIDTH-12, 10, "© 2003 Id Software, Inc. All rights reserved. Wolfenstein: Enemy Territory, Return to Castle Wolfenstein, the Return to Castle Wolfenstein logo, the id Software name, and the id logo are either registered trademarks or trademarks of Id Software, Inc. in the United States and/or other countries. All other trademarks and trade names are the properties of their respective owners.", .15, ITEM_ALIGN_LEFT, 0, 8 )
+	LABEL( 6, CREDITS_Y+300, WINDOW_WIDTH-12, 10, "ï¿½ 2003 Id Software, Inc. All rights reserved. Wolfenstein: Enemy Territory, Return to Castle Wolfenstein, the Return to Castle Wolfenstein logo, the id Software name, and the id logo are either registered trademarks or trademarks of Id Software, Inc. in the United States and/or other countries. All other trademarks and trade names are the properties of their respective owners.", .15, ITEM_ALIGN_LEFT, 0, 8 )
 
 // Buttons //
 

--- a/assets/ui/credits_splashdamage.menu
+++ b/assets/ui/credits_splashdamage.menu
@@ -20,6 +20,7 @@ menuDef {
 	fullscreen	0
 	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
 	style		WINDOW_STYLE_FILLED
+	centered
 	
 	onESC {
 		close credits_splashdamage ;
@@ -195,7 +196,7 @@ menuDef {
 	
 // Copyright Notice //
 
-//	LABEL( 6, CREDITS_Y+300, WINDOW_WIDTH-12, 10, "© 2003 Id Software, Inc. All rights reserved. Wolfenstein: Enemy Territory, Return to Castle Wolfenstein, the Return to Castle Wolfenstein logo, the id Software name, and the id logo are either registered trademarks or trademarks of Id Software, Inc. in the United States and/or other countries. All other trademarks and trade names are the properties of their respective owners.", .15, ITEM_ALIGN_LEFT, 0, 8 )
+//	LABEL( 6, CREDITS_Y+300, WINDOW_WIDTH-12, 10, "ï¿½ 2003 Id Software, Inc. All rights reserved. Wolfenstein: Enemy Territory, Return to Castle Wolfenstein, the Return to Castle Wolfenstein logo, the id Software name, and the id logo are either registered trademarks or trademarks of Id Software, Inc. in the United States and/or other countries. All other trademarks and trade names are the properties of their respective owners.", .15, ITEM_ALIGN_LEFT, 0, 8 )
 
 // Buttons //
 

--- a/assets/ui/etjump_changelog.menu
+++ b/assets/ui/etjump_changelog.menu
@@ -25,6 +25,7 @@ menuDef {
     fullscreen  0
     rect        WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style       WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         uiScript setActiveChangelog ITEM_NAME;

--- a/assets/ui/etjump_controls.menu
+++ b/assets/ui/etjump_controls.menu
@@ -36,6 +36,8 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
+
     onESC {
         close etjump_controls; open etjump;
     }

--- a/assets/ui/etjump_settings_audio.menu
+++ b/assets/ui/etjump_settings_audio.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_demos_autodemo.menu
+++ b/assets/ui/etjump_settings_demos_autodemo.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_demos_playback.menu
+++ b/assets/ui/etjump_settings_demos_playback.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_general_client.menu
+++ b/assets/ui/etjump_settings_general_client.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_general_console.menu
+++ b/assets/ui/etjump_settings_general_console.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_general_gameplay.menu
+++ b/assets/ui/etjump_settings_general_gameplay.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_graphics_gun.menu
+++ b/assets/ui/etjump_settings_graphics_gun.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_graphics_players.menu
+++ b/assets/ui/etjump_settings_graphics_players.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_graphics_visuals.menu
+++ b/assets/ui/etjump_settings_graphics_visuals.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud1_chat.menu
+++ b/assets/ui/etjump_settings_hud1_chat.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud1_crosshair.menu
+++ b/assets/ui/etjump_settings_hud1_crosshair.menu
@@ -16,6 +16,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud1_fireteam.menu
+++ b/assets/ui/etjump_settings_hud1_fireteam.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud1_indicators.menu
+++ b/assets/ui/etjump_settings_hud1_indicators.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud1_keys.menu
+++ b/assets/ui/etjump_settings_hud1_keys.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud1_lagometer.menu
+++ b/assets/ui/etjump_settings_hud1_lagometer.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud1_maxspeed.menu
+++ b/assets/ui/etjump_settings_hud1_maxspeed.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud1_misc.menu
+++ b/assets/ui/etjump_settings_hud1_misc.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud1_popups.menu
+++ b/assets/ui/etjump_settings_hud1_popups.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud1_scoreboard.menu
+++ b/assets/ui/etjump_settings_hud1_scoreboard.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud1_specinfo.menu
+++ b/assets/ui/etjump_settings_hud1_specinfo.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud1_speed1.menu
+++ b/assets/ui/etjump_settings_hud1_speed1.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud1_speed2.menu
+++ b/assets/ui/etjump_settings_hud1_speed2.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud2_accelspeed.menu
+++ b/assets/ui/etjump_settings_hud2_accelspeed.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud2_cgaz.menu
+++ b/assets/ui/etjump_settings_hud2_cgaz.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud2_chs.menu
+++ b/assets/ui/etjump_settings_hud2_chs.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud2_chs1.menu
+++ b/assets/ui/etjump_settings_hud2_chs1.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud2_chs2.menu
+++ b/assets/ui/etjump_settings_hud2_chs2.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud2_jumpspeeds.menu
+++ b/assets/ui/etjump_settings_hud2_jumpspeeds.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud2_snaphud.menu
+++ b/assets/ui/etjump_settings_hud2_snaphud.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud2_strafequality.menu
+++ b/assets/ui/etjump_settings_hud2_strafequality.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_hud2_upmove.menu
+++ b/assets/ui/etjump_settings_hud2_upmove.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_timeruns_checkpoints.menu
+++ b/assets/ui/etjump_settings_timeruns_checkpoints.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/etjump_settings_timeruns_runtimer.menu
+++ b/assets/ui/etjump_settings_timeruns_runtimer.menu
@@ -15,6 +15,7 @@ menuDef {
     fullscreen 0
     rect WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
     style WINDOW_STYLE_FILLED
+    centered
 
     onOpen {
         conditionalscript uiCheckBackground 2

--- a/assets/ui/hostgame.menu
+++ b/assets/ui/hostgame.menu
@@ -20,6 +20,7 @@ menuDef {
 	fullscreen	0
 	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
 	style		WINDOW_STYLE_FILLED
+	centered
 	
 	onOpen {
 		//uiScript loadArenas ;

--- a/assets/ui/hostgame_advanced.menu
+++ b/assets/ui/hostgame_advanced.menu
@@ -20,6 +20,7 @@ menuDef {
 	fullscreen	0
 	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
 	style		WINDOW_STYLE_FILLED
+	centered
 	
 	onESC {
 		close hostgame_advanced ;

--- a/assets/ui/ingame_ft_savelimit.menu
+++ b/assets/ui/ingame_ft_savelimit.menu
@@ -14,6 +14,7 @@ menuDef {
 	fullscreen	0
 	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
 	style		WINDOW_STYLE_FILLED
+	centered
 
 	onESC {
 		close ingame_ft_savelimit ;

--- a/assets/ui/mods.menu
+++ b/assets/ui/mods.menu
@@ -24,6 +24,7 @@ menuDef {
 	fullscreen	0
 	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
 	style		WINDOW_STYLE_FILLED
+	centered
 
 	onOpen {
 		uiScript LoadMods

--- a/assets/ui/options_controls.menu
+++ b/assets/ui/options_controls.menu
@@ -20,6 +20,7 @@ menuDef {
 	fullscreen	0
 	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
 	style		WINDOW_STYLE_FILLED
+	centered
 	
 	onESC {
 		close options_controls ;

--- a/assets/ui/options_system_gamma.menu
+++ b/assets/ui/options_system_gamma.menu
@@ -24,6 +24,7 @@ menuDef {
 	fullscreen	0
 	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
 	style		WINDOW_STYLE_FILLED
+	centered
 	
 	onESC {
 		close options_system_gamma ;

--- a/assets/ui/playonline.menu
+++ b/assets/ui/playonline.menu
@@ -20,6 +20,7 @@ menuDef {
 	fullscreen	0
 	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
 	style		WINDOW_STYLE_FILLED
+	centered
 	
 	onOpen {
 		conditionalScript cl_punkbuster 0

--- a/assets/ui/viewreplay.menu
+++ b/assets/ui/viewreplay.menu
@@ -21,6 +21,7 @@ menuDef {
 	fullscreen	0
 	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
 	style		WINDOW_STYLE_FILLED
+	centered
 
 	onOpen {
 		uiScript LoadDemos

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -24,47 +24,65 @@
 #define MAX_COLOR_RANGES 10
 #define MAX_MODAL_MENUS 16
 
-#define WINDOW_MOUSEOVER 0x00000001 // mouse is over it, non exclusive
-#define WINDOW_HASFOCUS 0x00000002  // has cursor focus, exclusive
-#define WINDOW_VISIBLE 0x00000004   // is visible
-#define WINDOW_GREY 0x00000008      // is visible but grey ( non-active )
-#define WINDOW_DECORATION                                                      \
-  0x00000010 // for decoration only, no mouse, keyboard, etc..
-#define WINDOW_FADINGOUT 0x00000020     // fading out, non-active
-#define WINDOW_FADINGIN 0x00000040      // fading in
-#define WINDOW_MOUSEOVERTEXT 0x00000080 // mouse is over it, non exclusive
-#define WINDOW_INTRANSITION 0x00000100  // window is in transition
-#define WINDOW_FORECOLORSET                                                    \
-  0x00000200 // forecolor was explicitly set ( used to color alpha
-             // images or not
-             // )
-#define WINDOW_HORIZONTAL                                                      \
-  0x00000400 // for list boxes and sliders, vertical is default this is
-             // set of horizontal
-#define WINDOW_LB_LEFTARROW 0x00000800  // mouse is over left/up arrow
-#define WINDOW_LB_RIGHTARROW 0x00001000 // mouse is over right/down arrow
-#define WINDOW_LB_THUMB 0x00002000      // mouse is over thumb
-#define WINDOW_LB_PGUP 0x00004000       // mouse is over page up
-#define WINDOW_LB_PGDN 0x00008000       // mouse is over page down
-#define WINDOW_ORBITING 0x00010000      // item is in orbit
-#define WINDOW_OOB_CLICK 0x00020000     // close on out of bounds click
-#define WINDOW_WRAPPED 0x00040000       // manually wrap text
-#define WINDOW_AUTOWRAPPED 0x00080000   // auto wrap text
-#define WINDOW_FORCED 0x00100000        // forced open
-#define WINDOW_POPUP 0x00200000         // popup
-#define WINDOW_BACKCOLORSET 0x00400000  // backcolor was explicitly set
-#define WINDOW_TIMEDVISIBLE 0x00800000  // visibility timing ( NOT implemented )
-#define WINDOW_IGNORE_HUDALPHA                                                 \
-  0x01000000 // window will apply cg_hudAlpha value to colors unless
-             // this flag is set
-#define WINDOW_DRAWALWAYSONTOP 0x02000000
-#define WINDOW_MODAL                                                           \
-  0x04000000 // window is modal, the window to go back to is stored in a
-             // stack
-#define WINDOW_FOCUSPULSE 0x08000000
-#define WINDOW_TEXTASINT 0x10000000
-#define WINDOW_TEXTASFLOAT 0x20000000
-#define WINDOW_LB_SOMEWHERE 0x40000000
+// mouse is over it, non-exclusive
+static constexpr uint32_t WINDOW_MOUSEOVER = 1 << 0;
+// has cursor focus, exclusive
+static constexpr uint32_t WINDOW_HASFOCUS = 1 << 1;
+// is visible
+static constexpr uint32_t WINDOW_VISIBLE = 1 << 2;
+// is visible but grey ( non-active )
+static constexpr uint32_t WINDOW_GREY = 1 << 3;
+// for decoration only, no mouse, keyboard, etc..
+static constexpr uint32_t WINDOW_DECORATION = 1 << 4;
+// fading out, non-active
+static constexpr uint32_t WINDOW_FADINGOUT = 1 << 5;
+// fading in
+static constexpr uint32_t WINDOW_FADINGIN = 1 << 6;
+// mouse is over it, non-exclusive
+static constexpr uint32_t WINDOW_MOUSEOVERTEXT = 1 << 7;
+// window is in transition
+static constexpr uint32_t WINDOW_INTRANSITION = 1 << 8;
+// forecolor was explicitly set ( used to color alpha images or not )
+static constexpr uint32_t WINDOW_FORECOLORSET = 1 << 9;
+// for list boxes and sliders, vertical is default this is set of horizontal
+static constexpr uint32_t WINDOW_HORIZONTAL = 1 << 10;
+// mouse is over left/up arrow
+static constexpr uint32_t WINDOW_LB_LEFTARROW = 1 << 11;
+// mouse is over right/down arrow
+static constexpr uint32_t WINDOW_LB_RIGHTARROW = 1 << 12;
+// mouse is over thumb
+static constexpr uint32_t WINDOW_LB_THUMB = 1 << 13;
+// mouse is over page up
+static constexpr uint32_t WINDOW_LB_PGUP = 1 << 14;
+// mouse is over page down
+static constexpr uint32_t WINDOW_LB_PGDN = 1 << 15;
+// item is in orbit
+static constexpr uint32_t WINDOW_ORBITING = 1 << 16;
+// close on out-of-bounds click
+static constexpr uint32_t WINDOW_OOB_CLICK = 1 << 17;
+// manually wrap text
+static constexpr uint32_t WINDOW_WRAPPED = 1 << 18;
+// auto wrap text
+static constexpr uint32_t WINDOW_AUTOWRAPPED = 1 << 19;
+// forced open
+static constexpr uint32_t WINDOW_FORCED = 1 << 20;
+// popup
+static constexpr uint32_t WINDOW_POPUP = 1 << 21;
+// backcolor was explicitly set
+static constexpr uint32_t WINDOW_BACKCOLORSET = 1 << 22;
+// visibility timing ( NOT implemented )
+static constexpr uint32_t WINDOW_TIMEDVISIBLE = 1 << 23;
+// window will apply cg_hudAlpha value to colors unless this flag is set
+static constexpr uint32_t WINDOW_IGNORE_HUDALPHA = 1 << 24;
+static constexpr uint32_t WINDOW_DRAWALWAYSONTOP = 1 << 25;
+// window is modal, the window to go back to is stored in a stack
+static constexpr uint32_t WINDOW_MODAL = 1 << 26;
+static constexpr uint32_t WINDOW_FOCUSPULSE = 1 << 27;
+static constexpr uint32_t WINDOW_TEXTASINT = 1 << 28;
+static constexpr uint32_t WINDOW_TEXTASFLOAT = 1 << 29;
+static constexpr uint32_t WINDOW_LB_SOMEWHERE = 1 << 30;
+// horizontally centered
+static constexpr uint32_t WINDOW_CENTERED = 1 << 31;
 
 // CGAME cursor type bits
 #define CURSOR_NONE 0x00000001
@@ -148,7 +166,7 @@ typedef struct {
   int ownerDrawFlags;        // show flags for ownerdraw items
   float borderSize;          //
   int borderFixedSize;
-  int flags;              // visible, focus, mouseover, cursor
+  uint32_t flags;         // visible, focus, mouseover, cursor
   rectDef_t rectEffects;  // for various effects
   rectDef_t rectEffects2; // for various effects
   int offsetTime;         // time based value for various effects


### PR DESCRIPTION
Rather than doing a weird `if (r->x == 16 && r->w == 608)`, require menus to explicitly set a `centered` flag in order to draw centered. This allows us to create centered windows, which do not necessarily fill up the whole screen.

Window flags are also now an `uint32_t`, as `WINDOW_CENTERED` was the last free one.