### PR TITLE
Add backcolorAlt support for ITEM_TYPE_LISTBOX

### DIFF
--- a/assets/ui/etjump_changelog.menu
+++ b/assets/ui/etjump_changelog.menu
@@ -94,8 +94,10 @@ menuDef {
         style           WINDOW_STYLE_FILLED
 #ifdef FUI
         backcolor       0 0 0 .2
+        backcolorAlt    .1 .1 .1 .2
 #else
         backcolor       0 0 0 .6
+        backcolorAlt    .1 .1 .1 .6
 #endif
         visible         1
         notselectable

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -5958,11 +5958,18 @@ void Item_ListBox_Paint(itemDef_t *item) {
     } else {
       x = fillRect.x /*+ 1*/;
       y = fillRect.y /*+ 1*/;
+      const bool hasAltBackground = item->window.backColorAlt[3] > 0;
+
       for (i = listPtr->startPos; i < count; i++) {
         const char *text;
         // always draw at least one
         // which may overdraw the box if it is
         // too small for the element
+
+        if (static_cast<int>(i) % 2 == 0 && hasAltBackground) {
+          DC->fillRect(x, y, fillRect.w - SCROLLBAR_SIZE - 2,
+                       listPtr->elementHeight, item->window.backColorAlt);
+        }
 
         if (listPtr->numColumns > 0) {
           int j, k;
@@ -7234,6 +7241,18 @@ qboolean ItemParse_backcolor(itemDef_t *item, int handle) {
   return qtrue;
 }
 
+qboolean ItemParse_backcolorAlt(itemDef_t *item, int handle) {
+  float f = 0.0f;
+
+  for (int i = 0; i < 4; i++) {
+    if (!PC_Float_Parse(handle, &f)) {
+      return qfalse;
+    }
+    item->window.backColorAlt[i] = f;
+  }
+  return qtrue;
+}
+
 qboolean ItemParse_forecolor(itemDef_t *item, int handle) {
   int i;
   float f = 0.0f;
@@ -7829,6 +7848,7 @@ keywordHash_t itemParseKeywords[] = {
     {"asset_shader", ItemParse_asset_shader, nullptr},
     {"autowrapped", ItemParse_autowrapped, nullptr},
     {"backcolor", ItemParse_backcolor, nullptr},
+    {"backcolorAlt", ItemParse_backcolorAlt, nullptr},
     {"background", ItemParse_background, nullptr},
     {"border", ItemParse_border, nullptr},
     {"bordercolor", ItemParse_bordercolor, nullptr},

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -172,10 +172,12 @@ typedef struct {
   int offsetTime;         // time based value for various effects
   int nextTime;           // time next effect should cycle
   vec4_t foreColor;       // text color
-  vec4_t backColor;       // border color
-  vec4_t borderColor;     // border color
-  vec4_t outlineColor;    // border color
-  qhandle_t background;   // background asset
+  vec4_t backColor;       // background color
+  // alt background color, for alternating listbox entry background colors
+  vec4_t backColorAlt;
+  vec4_t borderColor;   // border color
+  vec4_t outlineColor;  // border color
+  qhandle_t background; // background asset
 } windowDef_t;
 
 typedef windowDef_t Window;


### PR DESCRIPTION
Allows specifying alternating background colors for every other row. Currently used for changelog drawing.

![image](https://github.com/user-attachments/assets/ac7d983c-e0a8-41eb-8728-9e6644b5ae12)
