### PR TITLE
Force crouch stance when saving while dead

### DIFF
--- a/src/cgame/etj_savepos.cpp
+++ b/src/cgame/etj_savepos.cpp
@@ -313,10 +313,12 @@ std::vector<std::string> SavePos::getSaveposNames() {
 PlayerStance SavePos::getStance(const playerState_t *ps) {
   if (ps->eFlags & (EF_PRONE | EF_PRONE_MOVING)) {
     return PlayerStance::Prone;
-  } else if (ps->pm_flags & PMF_DUCKED) {
-    return PlayerStance::Crouch;
-  } else {
-    return PlayerStance::Stand;
   }
+
+  if (ps->eFlags & (EF_CROUCHING | EF_DEAD)) {
+    return PlayerStance::Crouch;
+  }
+
+  return PlayerStance::Stand;
 }
 } // namespace ETJump

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2884,7 +2884,6 @@ enum class ViewlockState {
   Medic = 7,   // look at nearest medic
 };
 
-// TODO: use this in save system/goto/call
 enum class PlayerStance {
   Stand = 0,
   Crouch = 1,

--- a/src/game/etj_save_system.h
+++ b/src/game/etj_save_system.h
@@ -40,17 +40,15 @@ public:
   static const int MAX_SAVED_POSITIONS = 3;
   static const int MAX_BACKUP_POSITIONS = 3;
 
-  enum SaveStance { Stand, Crouch, Prone };
-
   struct SavePosition {
     SavePosition()
         : isValid(false), isLatest(false), origin{0, 0, 0}, vangles{0, 0, 0},
-          stance(SaveStance::Stand), isTimerunSave(false) {}
+          stance(PlayerStance::Stand), isTimerunSave(false) {}
     bool isValid;
     bool isLatest;
     vec3_t origin;
     vec3_t vangles;
-    SaveStance stance;
+    PlayerStance stance;
     bool isTimerunSave;
   };
 
@@ -139,7 +137,7 @@ private:
   void saveBackupPosition(gentity_t *ent, SavePosition *pos);
 
   // copies player positional info to target position
-  static void storePosition(gclient_s *client, SavePosition *pos);
+  static void storePosition(const gclient_s *client, SavePosition *pos);
 
   // returns the latest save slot number that client used in their current team
   // -1 if no slots found (no saved positions in current team)
@@ -155,7 +153,7 @@ private:
 
   SavePosition *getValidTeamQuickDeploySave(gentity_t *ent, team_t team);
 
-  static void restoreStanceFromSave(gentity_t *ent, SavePosition *pos);
+  static void restoreStanceFromSave(gentity_t *ent, const SavePosition *pos);
 
   SavePosition *getValidTeamSaveForSlot(gentity_t *ent, team_t team, int slot);
 


### PR DESCRIPTION
Dead bbox height is equal to crouch bbox height, so it was possible to get into a wallbugged state when saving while dead and no room to stand up.

Also refactor the stance handling to use the enum in `bg_public.h`

fixes #1336 