### PR TITLE
Fix etj_autoSprint not working < 125FPS with pmove_fixed 1

### DIFF
--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -436,6 +436,11 @@ static void CG_InterpolatePlayerState(qboolean grabAngles) {
     cmdNum = trap_GetCurrentCmdNumber();
     trap_GetUserCmd(cmdNum, &cmd);
 
+    // use cg.pmext here as we haven't setup cg_pmove for interpolation
+    if (cg.pmext.autoSprint) {
+      cmd.buttons ^= BUTTON_SPRINT;
+    }
+
     // rain - added tracemask
     PM_UpdateViewAngles(out, &cg.pmext, &cmd, CG_Trace, MASK_PLAYERSOLID);
   }
@@ -1287,6 +1292,10 @@ void CG_PredictPlayerState() {
     // ETJump: client side no activate lean
     cg_pmove.noActivateLean = etj_noActivateLean.integer ? qtrue : qfalse;
     cg_pmove.noPanzerAutoswitch = etj_noPanzerAutoswitch.integer;
+
+    if (cg_pmove.pmext->autoSprint) {
+      cg_pmove.cmd.buttons ^= BUTTON_SPRINT;
+    }
 
     // grab data, we only want the final result
     // rain - copy the pmext as it was just before we

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -5896,11 +5896,6 @@ void PmoveSingle(pmove_t *pmove) {
     }
   }
 
-  // flip sprint button bit if autosprint is enabled
-  if (pm->pmext->autoSprint) {
-    pm->cmd.buttons ^= BUTTON_SPRINT;
-  }
-
   // ETJump: no activate lean
   if (pm->noActivateLean) {
     if (pm->cmd.wbuttons & WBUTTON_LEANLEFT &&

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -482,6 +482,10 @@ void SpectatorThink(gentity_t *ent, usercmd_t *ucmd) {
     pm.noActivateLean = client->pers.noActivateLean;
     pm.noPanzerAutoswitch = client->pers.noPanzerAutoswitch;
 
+    if (client->pmext.autoSprint) {
+      pm.cmd.buttons ^= BUTTON_SPRINT;
+    }
+
     Pmove(&pm); // JPW NERVE
 
     // Rafael - Activate
@@ -1200,24 +1204,12 @@ void ClientThink_real(gentity_t *ent) {
   pm.covertopsChargeTime =
       level.covertopsChargeTime[client->sess.sessionTeam - 1];
 
+  if (client->pmext.autoSprint) {
+    pm.cmd.buttons ^= BUTTON_SPRINT;
+  }
+
   if (client->ps.pm_type != PM_DEAD &&
       level.timeCurrent - client->pers.lastBattleSenseBonusTime > 45000) {
-    /*switch( client->combatState )
-    {
-    case COMBATSTATE_COLD:	G_AddSkillPoints( ent,
-    SK_BATTLE_SENSE, 0.f ); G_DebugAddSkillPoints( ent,
-    SK_BATTLE_SENSE, 0.f, "combatstate cold" ); break; case
-    COMBATSTATE_WARM:	G_AddSkillPoints( ent,
-    SK_BATTLE_SENSE, 2.f ); G_DebugAddSkillPoints( ent,
-    SK_BATTLE_SENSE, 2.f, "combatstate warm" ); break; case
-    COMBATSTATE_HOT:	G_AddSkillPoints( ent,
-    SK_BATTLE_SENSE, 5.f ); G_DebugAddSkillPoints( ent,
-    SK_BATTLE_SENSE, 5.f, "combatstate hot" ); break; case
-    COMBATSTATE_SUPERHOT: G_AddSkillPoints( ent,
-    SK_BATTLE_SENSE, 8.f ); G_DebugAddSkillPoints( ent,
-    SK_BATTLE_SENSE, 8.f, "combatstate super-hot" ); break;
-    }*/
-
     if (client->combatState != COMBATSTATE_COLD) {
       if (client->combatState & (1 << COMBATSTATE_KILLEDPLAYER) &&
           client->combatState & (1 << COMBATSTATE_DAMAGERECEIVED)) {


### PR DESCRIPTION
Because `pmove_fixed 1` forces 8ms command times (with `pmove_msec 8`), running at < 125FPS results in the same usercmd being used for multiple calls to `Pmove`. Because we flipped the bit inside `PmoveSingle`, this would result in the bit getting flipped potentially multiple times within a single physics frame, which caused the state to not reflect the users actual inputs. Do the bit flipping before we call `Pmove`, on both client and server, in order to not flip the bit multiple times for a single usercmd.

fixes #1548 
refs #1519 