### PR TITLE
Fix CG_FillAngleYawExt drawing things off-screen

### DIFF
--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -87,6 +87,13 @@ void CG_FillAngleYawExt(float start, float end, float yaw, float y, float h,
 
   const range_t range = AnglesToRange(start, end, yaw, fov);
 
+  // don't try to draw things off-screen
+  if ((range.x1 == 0 && range.x2 == 0) ||
+      (range.x1 == SCREEN_WIDTH && range.x2 == SCREEN_WIDTH) ||
+      (range.x1 == 0 && range.x2 == SCREEN_WIDTH)) {
+    return;
+  }
+
   if (!range.split) {
     if (borderOnly) {
       CG_DrawRect_FixedBorder(range.x1, y, range.x2 - range.x1, h,

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -90,7 +90,7 @@ void CG_FillAngleYawExt(float start, float end, float yaw, float y, float h,
   // don't try to draw things off-screen
   if ((range.x1 == 0 && range.x2 == 0) ||
       (range.x1 == SCREEN_WIDTH && range.x2 == SCREEN_WIDTH) ||
-      (range.x1 == 0 && range.x2 == SCREEN_WIDTH)) {
+      (range.x1 == 0 && range.x2 == SCREEN_WIDTH && range.split)) {
     return;
   }
 


### PR DESCRIPTION
Not only it's wasteful, but it causes `etj_drawSnapHUD 3` to draw borders of snapzones at the screen edges, if the snapzone is off-screen