### PR TITLE
Disable new HWID stuff for now

### DIFF
--- a/src/cgame/etj_operating_system_linux.cpp
+++ b/src/cgame/etj_operating_system_linux.cpp
@@ -96,6 +96,9 @@ std::string ETJump::OperatingSystem::getHwid() {
                        mac_address[1], mac_address[2], mac_address[3],
                        mac_address[4], mac_address[5]);
 
+  // TODO: include this in HWID, when user database has been refactored
+  //  to store HWIDs of individual components
+  /*
   std::ifstream machineID("/etc/machine-id");
 
   if (!machineID) {
@@ -110,6 +113,8 @@ std::string ETJump::OperatingSystem::getHwid() {
   }
 
   hwid += id;
+  */
+
   return G_SHA1(hwid.c_str());
 }
 

--- a/src/cgame/etj_operating_system_windows.cpp
+++ b/src/cgame/etj_operating_system_windows.cpp
@@ -113,9 +113,13 @@ std::string ETJump::OperatingSystem::getHwid() {
   std::string rootDrive;
   DWORD vsn = 0;
 
+  // TODO: include once user database is refactored
+  //  to store individual components of HWID
+  /*
   // Get user SID
   const std::string userSid = getCurrentUserSID();
   hardwareId += userSid;
+  */
 
   SYSTEM_INFO systemInfo;
   GetSystemInfo(&systemInfo);
@@ -139,7 +143,9 @@ std::string ETJump::OperatingSystem::getHwid() {
     rootDrive += "failed";
   }
 
-  hardwareId += rootDrive;
+  // TODO: include once user database is refactored
+  //  to store individual components of HWID
+  // hardwareId += rootDrive;
 
   _ultoa(vsn, buffer, 10);
   hardwareId += buffer;


### PR DESCRIPTION
Because we send the entire HWID as a single hash, this doesn't actually benefit anything and just changes everyone's HWIDs for no real reason. We should refactor the user database to store individual components of HWID for users for this to make sense (#1559).