### PR TITLE
Fix nametag interpolation not accounting for QP-encoding

### DIFF
--- a/src/game/g_utilities.cpp
+++ b/src/game/g_utilities.cpp
@@ -266,10 +266,13 @@ std::string interpolateNametags(std::string input, const int color) {
       }
     }
   }
+
   if (len % 2 != 0 || i == len) {
     interpolated += split[len - 1];
   }
 
+  // escape '=' for QP-encoding
+  ETJump::StringUtil::replaceAll(interpolated, "=", "\x19=");
   return interpolated;
 }
 


### PR DESCRIPTION
Escape `=` characters in the interpolated names to not break `enc_say` commands.

fixes #1551 