### PR TITLE
Add command to toggle ETJump settings menu

### DIFF
--- a/assets/ui/etjump_controls.menu
+++ b/assets/ui/etjump_controls.menu
@@ -26,7 +26,7 @@
 // Right side menus
 #define SUBW_MISC_Y SUBW_Y
 #define SUBW_MISC_ITEM_Y SUBW_MISC_Y + SUBW_HEADER_HEIGHT
-#define SUBW_MISC_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 4)
+#define SUBW_MISC_HEIGHT SUBW_HEADER_HEIGHT + SUBW_ITEM_SPACING_Y + (SUBW_ITEM_SPACING_Y * 5)
 
 #define GROUP_NAME "groupETJumpControls"
 
@@ -86,6 +86,7 @@ menuDef {
         BIND                (SUBW_ITEM_RIGHT_X, SUBW_MISC_ITEM_Y + (SUBW_ITEM_SPACING_Y * 2), SUBW_ITEM_WIDTH, SUBW_BIND_HEIGHT, "Interrupt timerun:", .2, SUBW_ITEM_HEIGHT, "interruptrun", "Stops current timerun without setting a record\ninterruptRun")
         BIND                (SUBW_ITEM_RIGHT_X, SUBW_MISC_ITEM_Y + (SUBW_ITEM_SPACING_Y * 3), SUBW_ITEM_WIDTH, SUBW_BIND_HEIGHT, "No call:", .2, SUBW_ITEM_HEIGHT, "nocall", "Toggle allowing other players to target you with call\nnocall")
         BIND                (SUBW_ITEM_RIGHT_X, SUBW_MISC_ITEM_Y + (SUBW_ITEM_SPACING_Y * 4), SUBW_ITEM_WIDTH, SUBW_BIND_HEIGHT, "No goto:", .2, SUBW_ITEM_HEIGHT, "nogoto", "Toggle allowing other players to target you with goto\nnogoto")
+        BIND                (SUBW_ITEM_RIGHT_X, SUBW_MISC_ITEM_Y + (SUBW_ITEM_SPACING_Y * 5), SUBW_ITEM_WIDTH, SUBW_BIND_HEIGHT, "ETJump settings:", .2, SUBW_ITEM_HEIGHT, "toggleETJumpSettings", "Toggles ETJump settings menu\ntoggleETJumpSettings")
 
         BUTTON              (ETJ_BUTTON_X, ETJ_BUTTON_Y, WINDOW_WIDTH - 16, ETJ_BUTTON_HEIGHT, "BACK", .3, ETJ_BUTTON_ITEM_HEIGHT, close etjump_controls; open etjump)
 }

--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -1257,6 +1257,10 @@ static void listSavepos() {
 }
 
 static void readSavepos() { savePos->parseExistingPositions(true); }
+
+static void toggleETJumpSettings() {
+  trap_SendConsoleCommand("uiToggleETJumpSettings\n");
+}
 } // namespace ETJump
 
 typedef struct {
@@ -1347,6 +1351,8 @@ static const consoleCommand_t noDemoCommands[] = {
 
     {"openRtvMenu", ETJump::openRtvMenu},
     {"loadpos", ETJump::loadSavepos},
+
+    {"toggleETJumpSettings", ETJump::toggleETJumpSettings},
 };
 
 static const consoleCommand_t anyTimeCommands[] = {

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -4095,6 +4095,9 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum,
 
   if (cg.demoPlayback) {
     ETJump::demoCompatibility->printDemoInformation();
+
+    // notify UI that we're in demo playback
+    trap_SendConsoleCommand("uiDemoPlaybackEnabled");
   }
 }
 

--- a/src/ui/ui_atoms.cpp
+++ b/src/ui/ui_atoms.cpp
@@ -213,6 +213,24 @@ qboolean UI_ConsoleCommand(const int realTime) {
     return qtrue;
   }
 
+  if (!Q_stricmp(cmd, "uiDemoPlaybackEnabled")) {
+    uiInfo.demoPlayback = true;
+    return qtrue;
+  }
+
+  if (!Q_stricmp(cmd, "uiToggleETJumpSettings")) {
+    uiClientState_t cstate;
+    trap_GetClientState(&cstate);
+
+    // FIXME: this breaks if 'ui_restart' is performed while in demo playback,
+    //  but there's no nice way to make this work for now, it is what it is
+    if (cstate.connState == CA_ACTIVE && !uiInfo.demoPlayback) {
+      ETJump::toggleSettingsMenu();
+    }
+
+    return qtrue;
+  }
+
   return qfalse;
 }
 

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -911,6 +911,8 @@ typedef struct {
   std::map<std::string, std::string> changelogs;
   std::vector<std::string> formattedChangelog;
   int changelogLineIndex;
+
+  bool demoPlayback;
 } uiInfo_t;
 
 extern uiInfo_t uiInfo;
@@ -1128,5 +1130,7 @@ void parseMaplist();
 void parseNumCustomvotes();
 void parseCustomvote();
 void resetCustomvotes();
+
+void toggleSettingsMenu();
 } // namespace ETJump
 #endif

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -7312,11 +7312,18 @@ void _UI_KeyEvent(int key, qboolean down) {
           !Q_stricmp(bindBuf, "toggleETJumpSettings") &&
           ETJump::StringUtil::startsWith(menu->window.name,
                                          "etjump_settings_")) {
-        // this is a stupid hack, if we have the color picker or writeconfig
-        // menu open, it runs an exit script which restores the menu from
-        // which they were opened from, and we don't close both menus,
-        // so just close everything twice lol
-        Menus_CloseAll();
+        // color picker and writeconfig menus run an exit script that restores
+        // the previously opened menu, so if we have either of them open,
+        // we end up with a menu open after Menus_CloseAll call
+        // if either is open, close them manually first
+        if (!Q_stricmp(menu->window.name,
+                       "etjump_settings_popup_colorpicker")) {
+          Menus_CloseByName("etjump_settings_popup_colorpicker");
+        } else if (!Q_stricmp(menu->window.name,
+                              "etjump_settings_popup_writeconfig")) {
+          Menus_CloseByName("etjump_settings_popup_writeconfig");
+        }
+
         Menus_CloseAll();
         return;
       }

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -5114,6 +5114,7 @@ static bind_t g_bindings[] = {
     {"team b 1", -1, -1, -1, -1},
     {"team r 1", -1, -1, -1, -1},
     {"team s", -1, -1, -1, -1},
+    {"toggleETJumpSettings", -1, -1, -1, -1},
 };
 
 static const int g_bindCount = sizeof(g_bindings) / sizeof(bind_t);


### PR DESCRIPTION
Can be bound to a key to toggle the ETJump settings menu on/off. Unavailable in FUI and demo playback.