### PR TITLE
Log admin-related events to g_adminLog

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -2751,21 +2751,16 @@ bool Commands::AdminCommand(gentity_t *ent) {
     if (std::find(std::begin(CommandFlags::loggedCommandFlags),
                   std::end(CommandFlags::loggedCommandFlags),
                   flag) != std::end(CommandFlags::loggedCommandFlags)) {
-      char nameBuf[MAX_NETNAME];
 
-      if (ent) {
-        Q_strncpyz(nameBuf, ent->client->pers.netname, sizeof(nameBuf));
-        Q_CleanStr(nameBuf);
-      } else {
-        Q_strncpyz(nameBuf, "Console", sizeof(nameBuf));
-      }
+      const std::string name =
+          ent ? ETJump::sanitize(ent->client->pers.netname) : "Console";
 
       // skip the first arg because we might have partially matched the command
       const std::string cmdArgs = ETJump::StringUtil::join(
           ETJump::Container::skipFirstN(*argv, 1), " ");
       Printer::logAdminLn(ETJump::stringFormat(
           "admincommand: %s%s used '%s%s'",
-          ent ? std::to_string(ent->s.number) + " " : "", nameBuf,
+          ent ? std::to_string(ent->s.number) + " " : "", name,
           foundCommands[0]->first, cmdArgs.empty() ? "" : " " + cmdArgs));
     }
 

--- a/src/game/etj_commands.h
+++ b/src/game/etj_commands.h
@@ -54,30 +54,37 @@ namespace CommandFlags {
 // Silent command execution via '/' flag
 // Not listed here because it's not a command in itself
 
-const char BAN = 'b';
+constexpr char BAN = 'b';
 // For everyone
-const char BASIC = 'a';
-const char CANCELVOTE = 'C';
+constexpr char BASIC = 'a';
+constexpr char CANCELVOTE = 'C';
 // const char EBALL       = '8';
-const char EDIT = 'A';
-const char FINGER = 'f';
+constexpr char EDIT = 'A';
+constexpr char FINGER = 'f';
 // const char HELP        = 'h';
-const char KICK = 'k';
-const char LISTBANS = 'L';
-const char LISTPLAYERS = 'l';
-const char MAP = 'M';
-const char MUTE = 'm';
-const char NOCLIP = 'N';
-const char PASSVOTE = 'P';
+constexpr char KICK = 'k';
+constexpr char LISTBANS = 'L';
+constexpr char LISTPLAYERS = 'l';
+constexpr char MAP = 'M';
+constexpr char MUTE = 'm';
+constexpr char NOCLIP = 'N';
+constexpr char PASSVOTE = 'P';
 // const char READCONFIG  = 'G';
-const char RENAME = 'R';
-const char RESTART = 'r';
-const char TOKENS = 'V';
-const char SETLEVEL = 's';
-const char MOVERSCALE = 'v';
-const char TIMERUN_MANAGEMENT = 'T';
-const char CUSTOMVOTES = 'c';
-const char ADMINCHAT = 'S';
+constexpr char RENAME = 'R';
+constexpr char RESTART = 'r';
+constexpr char TOKENS = 'V';
+constexpr char SETLEVEL = 's';
+constexpr char MOVERSCALE = 'v';
+constexpr char TIMERUN_MANAGEMENT = 'T';
+constexpr char CUSTOMVOTES = 'c';
+constexpr char ADMINCHAT = 'S';
+
+// usage of admin commmands with these flags gets logged to g_adminLog
+constexpr char loggedCommandFlags[] = {
+    BAN,      CANCELVOTE,         EDIT,        KICK, MUTE, PASSVOTE, RENAME,
+    SETLEVEL, TIMERUN_MANAGEMENT, CUSTOMVOTES,
+};
+
 } // namespace CommandFlags
 
 #endif

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -62,7 +62,9 @@ void OnClientConnect(int clientNum, qboolean firstTime, qboolean isBot) {
   }
 
   if (ETJump::session->IsIpBanned(clientNum)) {
-    G_LogPrintf("Kicked banned client: %d\n", clientNum);
+    Printer::logAdminLn(
+        "authentication: Rejected connection from IP banned client " +
+        std::to_string(clientNum));
     trap_DropClient(clientNum, "You are banned.", 0);
   }
 }

--- a/src/game/etj_printer.cpp
+++ b/src/game/etj_printer.cpp
@@ -23,7 +23,6 @@
  */
 
 #include <utility>
-#include <ctime>
 
 #include "etj_printer.h"
 #include "etj_string_utilities.h"

--- a/src/game/etj_printer.cpp
+++ b/src/game/etj_printer.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <utility>
+#include <ctime>
 
 #include "etj_printer.h"
 #include "etj_string_utilities.h"
@@ -37,6 +38,23 @@ void Printer::log(const std::string &message) {
 }
 
 void Printer::logLn(const std::string &message) { log(message + "\n"); }
+
+void Printer::logAdmin(const std::string &message) {
+  if (!level.adminLogFile) {
+    return;
+  }
+
+  qtime_t tm;
+  trap_RealTime(&tm);
+
+  const char *msg = va("%02i:%02i:%02i %s", tm.tm_hour, tm.tm_min, tm.tm_sec,
+                       message.c_str());
+  trap_FS_Write(msg, static_cast<int>(std::strlen(msg)), level.adminLogFile);
+}
+
+void Printer::logAdminLn(const std::string &message) {
+  logAdmin(message + "\n");
+}
 
 void Printer::console(int clientNum, const std::string &message) {
   const auto splits = ETJump::wrapWords(message, '\n', BYTES_PER_PACKET);

--- a/src/game/etj_printer.h
+++ b/src/game/etj_printer.h
@@ -50,6 +50,18 @@ public:
   static void logLn(const std::string &message);
 
   /**
+   * Logs message to the admin log.
+   * @param message The message to be logged
+   */
+  static void logAdmin(const std::string &message);
+
+  /**
+   * Same functionality as logAdmin but adds a new line in the end
+   * @param message The message to be logged
+   */
+  static void logAdminLn(const std::string &message);
+
+  /**
    * Prints to client console.
    * Will send multiple messages if the message is longer than 998 bytes.
    * If client num is -1 sends to console.

--- a/src/game/etj_session.cpp
+++ b/src/game/etj_session.cpp
@@ -168,8 +168,8 @@ bool Session::GuidReceived(gentity_t *ent) {
 
   if (database_->IsBanned(clients_[clientNum].guid, clients_[clientNum].hwid)) {
     Printer::logAdminLn(ETJump::stringFormat(
-        "authentication: Banned player '%s' tried to connect with GUID '%s' "
-        "and HWID '%s'",
+        "authentication: Banned player %s tried to connect with GUID '%s' and "
+        "HWID '%s'",
         cleanName, clients_[clientNum].guid, clients_[clientNum].hwid));
     Printer::popupAll(
         va("Banned player %s ^7tried to connect.", ent->client->pers.netname));

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -2038,7 +2038,9 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
       color = COLOR_CYAN;
       break;
     case SAY_ADMIN:
-      G_LogPrintf("sayadmin: %s: %s\n", ent->client->pers.netname, chatText);
+      Printer::logAdminLn(ETJump::stringFormat(
+          "adminchat: %i %s: %s", ent->s.number,
+          ETJump::sanitize(ent->client->pers.netname), chatText));
       Com_sprintf(name, sizeof(name),
                   "^A> ^7%s^7: ", ent->client->pers.netname);
       color = COLOR_LTORANGE;


### PR DESCRIPTION
`g_adminLog` is now used to log admin-related events on the server.

* Certain admin commands are logged
  * Logs commands with flags `b`, `C`, `A`, `k`, `m`, `P`, `R`, `s`, `T` and `c`
* Admin chats are logged to admin log rather than regular log
* Authentication related events (potential GUID/HWID spoofs, rejected connections) are logged

fixes #1414 