### PR TITLE
Fix size_t overflow in fitChangelogLinesToWidth

### DIFF
--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -956,7 +956,7 @@ fitChangelogLinesToWidth(std::vector<std::string> &lines, const int maxW,
     std::string tmp;
     tmp.reserve(line.length());
 
-    for (size_t i = 0; i < line.length(); i++) {
+    for (int i = 0; i < static_cast<int>(line.length()); i++) {
       tmp += line[i];
 
       if (std::isspace(line[i])) {
@@ -976,7 +976,6 @@ fitChangelogLinesToWidth(std::vector<std::string> &lines, const int maxW,
           line.erase(0, i);
         }
 
-        width = 0;
         i = -1; // so we start from 0 again after i++
 
         tmp.clear();


### PR DESCRIPTION
Use `int` instead of `size_t` for the loop iterator since we set it to `-1` when we start parsing again after a split.

Also remove unnecessary `width` value assignment which was always overwritten on the next iteration.

refs #1532 