### PR TITLE
Enable buggy nojumpdelay behavior on solstice & stonehalls2

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1286,6 +1286,8 @@ typedef struct {
   int weapAltB2;
 
   bool showRtvMenu;
+
+  bool jumpDelayBug;
 } cg_t;
 
 #define NUM_FUNNEL_SPRITES 21

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -4091,6 +4091,11 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum,
     ETJump::execFile("autoexec_default");
   }
 
+  if (!Q_stricmp(cgs.rawmapname, "solstice") ||
+      !Q_stricmp(cgs.rawmapname, "stonehalls2")) {
+    cg.jumpDelayBug = true;
+  }
+
   Com_Printf("CG_Init... DONE\n");
 
   if (cg.demoPlayback) {

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -1031,6 +1031,8 @@ void CG_PredictPlayerState() {
   // the gun, as the correct heat value is never assigned client side
   cg.pmext.weapHeat[WP_DUMMY_MG42] = 0.0f;
 
+  cg.pmext.jumpDelayBug = cg.jumpDelayBug;
+
   memcpy(&oldpmext[current & cg.cmdMask], &cg.pmext, sizeof(pmoveExt_t));
 
   // if we don't have the commands right after the snapshot, we

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -1536,9 +1536,15 @@ static void PM_WalkMove(void) {
       if (pm->pmext->sprintTime < 0) {
         pm->pmext->sprintTime = 0;
       }
+
+      if (pm->pmext->jumpDelayBug) {
+        pm->pmext->jumpTime = pm->cmd.serverTime;
+      }
     }
 
-    pm->pmext->jumpTime = pm->cmd.serverTime;
+    if (!pm->pmext->jumpDelayBug) {
+      pm->pmext->jumpTime = pm->cmd.serverTime;
+    }
 
     // JPW NERVE
     pm->ps->jumpTime = pm->cmd.serverTime; // Arnout: NOTE : TEMP DEBUG

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -526,6 +526,10 @@ typedef struct {
   float bobCycle;              // for fps-independent bobCycle
 
   bool autoSprint;
+
+  // enable buggy nojumpdelay behavior on solstice and stonehalls2,
+  // where jump time does not get updated when a player jumps on a NJD surface
+  bool jumpDelayBug;
 } pmoveExt_t; // data used both in client and server - store it here
               // instead of playerstate to prevent different engine versions of
               // playerstate between XP and MP

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1105,6 +1105,8 @@ void ClientThink_real(gentity_t *ent) {
     client->pmext.noclipScale = client->pers.noclipScale;
   }
 
+  client->pmext.jumpDelayBug = client->pers.jumpDelayBug;
+
   if (client->speedScale) // Goalitem speed scale
   {
     client->ps.speed *= (client->speedScale * 0.01);

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2231,6 +2231,11 @@ void ClientBegin(int clientNum) {
 
   // clear out last jump speed
   client->ps.persistant[PERS_JUMP_SPEED] = 0;
+
+  if (!Q_stricmp(level.rawmapname, "solstice") ||
+      !Q_stricmp(level.rawmapname, "stonehalls2")) {
+    client->pers.jumpDelayBug = true;
+  }
 }
 
 gentity_t *SelectSpawnPointFromList(const char *list, vec3_t spawn_origin,

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -979,6 +979,8 @@ typedef struct {
 
   // auxiliary storage for pmext.autoSprint
   bool autoSprintAux;
+
+  bool jumpDelayBug;
 } clientPersistant_t;
 
 typedef struct {


### PR DESCRIPTION
These maps rely on a bug that was in the mod from 2.3.0 to 2.5.0, where jump time didn't get updated when a player jumped on a NJD surface, and fixing the bug broke some jumps on these maps.

refs #622 