### PR TITLE
Fix mounted MG42 heat event prediction

### DIFF
--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -1025,12 +1025,6 @@ void CG_PredictPlayerState() {
     cg.pmext.noclipScale = etj_noclipScale.value;
   }
 
-  // let server handle mounted MG42 cooldown since client doesn't know
-  // the heat values of each individual mounted gun in the map
-  // otherwise we fire excess overheat events when client exits and re-enters
-  // the gun, as the correct heat value is never assigned client side
-  cg.pmext.weapHeat[WP_DUMMY_MG42] = 0.0f;
-
   memcpy(&oldpmext[current & cg.cmdMask], &cg.pmext, sizeof(pmoveExt_t));
 
   // if we don't have the commands right after the snapshot, we

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -3367,8 +3367,8 @@ PM_CoolWeapons
 */
 void PM_CoolWeapons() {
   pm->pmext->weapHeat[WP_DUMMY_MG42] =
-      static_cast<float>(pm->ps->ammo[WP_DUMMY_MG42]) +
-      std::fmodf(pm->pmext->weapHeat[WP_DUMMY_MG42], 1);
+      static_cast<float>(pm->ps->ammo[WP_DUMMY_MG42] +
+                         std::fmod(pm->pmext->weapHeat[WP_DUMMY_MG42], 1));
 
   for (int wp = 0; wp < WP_NUM_WEAPONS; wp++) {
     // if you have the weapon, and it can overheat (or using mounted MG42)

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -3366,8 +3366,11 @@ PM_CoolWeapons
 ==============
 */
 void PM_CoolWeapons() {
-  for (int wp = 0; wp < WP_NUM_WEAPONS; wp++) {
+  pm->pmext->weapHeat[WP_DUMMY_MG42] =
+      static_cast<float>(pm->ps->ammo[WP_DUMMY_MG42]) +
+      std::fmodf(pm->pmext->weapHeat[WP_DUMMY_MG42], 1);
 
+  for (int wp = 0; wp < WP_NUM_WEAPONS; wp++) {
     // if you have the weapon, and it can overheat (or using mounted MG42)
     if ((GetAmmoTableData(wp)->maxHeat && COM_BitCheck(pm->ps->weapons, wp)) ||
         wp == WP_DUMMY_MG42) {
@@ -6286,6 +6289,8 @@ void PmoveSingle(pmove_t *pmove) {
 
   // weapons
   PM_Weapon();
+  pm->ps->ammo[WP_DUMMY_MG42] =
+      static_cast<int>(pm->pmext->weapHeat[WP_DUMMY_MG42]);
 
   // footstep events / legs animations
   PM_Footsteps();

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -3412,6 +3412,7 @@ qboolean Do_Activate_f(gentity_t *ent, gentity_t *traceEnt) {
       ent->client->ps.weaponTime = traceEnt->backupWeaponTime;
       ent->client->pmext.weapHeat[WP_DUMMY_MG42] =
           static_cast<float>(traceEnt->mg42weapHeat);
+      ent->client->ps.ammo[WP_DUMMY_MG42] = traceEnt->mg42weapHeat;
 
       ent->tankLink = traceEnt;
       traceEnt->tankLink = ent;
@@ -3453,6 +3454,7 @@ qboolean Do_Activate_f(gentity_t *ent, gentity_t *traceEnt) {
       ent->client->ps.weaponTime = traceEnt->backupWeaponTime;
       ent->client->pmext.weapHeat[WP_DUMMY_MG42] =
           static_cast<float>(traceEnt->mg42weapHeat);
+      ent->client->ps.ammo[WP_DUMMY_MG42] = traceEnt->mg42weapHeat;
 
       G_UseTargets(traceEnt,
                    ent); //----(SA)	added for Mike so

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -2242,6 +2242,7 @@ void mg42_use(gentity_t *ent, gentity_t *other, gentity_t *activator) {
     // owner->client->ps.gunfx = 0;
     other->client->pmext.weapHeat[WP_DUMMY_MG42] =
         static_cast<float>(ent->mg42weapHeat);
+    other->client->ps.ammo[WP_DUMMY_MG42] = ent->mg42weapHeat;
     ent->backupWeaponTime = owner->client->ps.weaponTime;
     owner->backupWeaponTime = owner->client->ps.weaponTime;
   }


### PR DESCRIPTION
By reusing `ps.ammo[WP_DUMMY_MG42]` for storing the heat value of a mounted MG42, we can keep it framerate independent while still correctly predicting it on client. The ammo field is not used for anything on mounted MG42s as they don't use ammo.

refs #894 