### PR TITLE
Update macOS runner to macOS 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
 
   macOS:
     name: macOS ${{ matrix.arch }}
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
 
   macOS:
     name: macOS ${{ matrix.arch }}
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -39,7 +39,7 @@ function(create_compiler_opts target)
 
 	# Clang flags
 	set(CLANG_LINK_FLAGS
-		$<IF:$<PLATFORM_ID:Darwin>,-Wl$<COMMA>-undefined$<COMMA>error,-Wl$<COMMA>--no-undefined>
+		$<$<NOT:$<PLATFORM_ID:Darwin>>:-Wl,--no-undefined>
 		$<$<CONFIG:Release>:
 			-flto								# link time optimizations
 			-O3									# max optimization


### PR DESCRIPTION
Minimum supported macOS version should not change from this I believe, but I'm not 100% sure as Apples documentation is kinda convoluted. Realistically though it doesn't matter, as 10.10 is long EOL and shouldn't be used by anyone.

fixes #1490 