### PR TITLE
Add bmodel number to entitylist

### DIFF
--- a/src/game/g_svcmds.cpp
+++ b/src/game/g_svcmds.cpp
@@ -338,38 +338,44 @@ static void Svcmd_EntityList_f() {
   }
 
   check = g_entities;
-  G_Printf("%-4s  %-*s %-28s %-32s\n", " Num", max_type_length, "Entity Type",
-           "Class", "Scriptname");
+  G_Printf("%-4s  %-*s %-28s %-32s %s\n", " Num", max_type_length,
+           "Entity Type", "Class", "Scriptname", "Model");
   G_Printf("-------------------------------------------------------------------"
-           "--------\n");
+           "---------------------------------\n");
   for (e = 0; e < level.num_entities; e++, check++) {
     if (!check->inuse) {
       ++not_inuse;
       continue;
     }
 
+    bool bmodel = false;
+
     if (check->model && check->model[0] == '*') {
       ++numBrushEnts;
+      bmodel = true;
     }
 
     if (check->s.eType < ET_EVENTS) {
-      G_Printf("^7%4i: %-*s %-28s ^9%-32s\n", e, max_type_length,
+      G_Printf("^7%4i: %-*s %-28s ^9%-32s ^7%s\n", e, max_type_length,
                entityTypeNames[check->s.eType],
                check->classname && check->classname[0] ? check->classname
                                                        : "noclass",
                check->scriptName && check->scriptName[0] ? check->scriptName
-                                                         : "");
+                                                         : "",
+               bmodel ? check->model : "");
     } else {
-      G_Printf("^7%4i: %-*s %-28s ^9%-32s\n", e, max_type_length,
+      G_Printf("^7%4i: %-*s %-28s ^9%-32s ^7%s\n", e, max_type_length,
                eventnames[check->s.eType - ET_EVENTS],
                check->classname && check->classname[0] ? check->classname
                                                        : "noclass",
                check->scriptName && check->scriptName[0] ? check->scriptName
-                                                         : "");
+                                                         : "",
+               bmodel ? check->model : "");
     }
   }
+
   G_Printf("-------------------------------------------------------------------"
-           "--------\n");
+           "---------------------------------\n");
   G_Printf("%4i / %4i total entities\n", level.num_entities, MAX_GENTITIES);
   G_Printf("%4i / %4i brush entities\n", numBrushEnts, MAX_MODELS);
   G_Printf("%4i / %4i entities inactive\n", not_inuse, level.num_entities);

--- a/src/game/g_svcmds.cpp
+++ b/src/game/g_svcmds.cpp
@@ -312,15 +312,14 @@ Svcmd_EntityList_f
 */
 static void Svcmd_EntityList_f() {
   int e;
-  const gentity_t *check;
   int not_inuse = 0;
-  int numBrushEnts = 1;     // bmodel count is 1-indexed for some reason
+  int numBrushEnts = 0;
   int max_type_length = 20; // starting point, no less than 11
 
   // add removed bmodels since these are still part of bmodel limit
   numBrushEnts += level.numRemovedBModels;
 
-  check = g_entities;
+  const gentity_t *check = g_entities;
   for (e = 0; e < level.num_entities; e++, check++) {
     if (!check->inuse) {
       continue;
@@ -377,7 +376,8 @@ static void Svcmd_EntityList_f() {
   G_Printf("-------------------------------------------------------------------"
            "---------------------------------\n");
   G_Printf("%4i / %4i total entities\n", level.num_entities, MAX_GENTITIES);
-  G_Printf("%4i / %4i brush entities\n", numBrushEnts, MAX_MODELS);
+  // bmodels are 1-indexed so the limit is actually MAX_MODELS - 1
+  G_Printf("%4i / %4i brush entities\n", numBrushEnts, MAX_MODELS - 1);
   G_Printf("%4i / %4i entities inactive\n", not_inuse, level.num_entities);
 }
 


### PR DESCRIPTION
Display the bmodel number for bmodels in entitylist output, so it's easier to grab model numbers for mapscripting purposes. This also makes it more clear which entities are brush entities and count towards the brush entity limit.

![image](https://github.com/user-attachments/assets/38d26097-efbe-4c0c-a60f-c018f91c64e9)
