### PR TITLE
Increase max brush entity limit

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2013,8 +2013,8 @@ typedef struct {
   sfxHandle_t gameSounds[MAX_SOUNDS];
 
   int numInlineModels;
-  qhandle_t inlineDrawModel[MAX_MODELS];
-  vec3_t inlineModelMidpoints[MAX_MODELS];
+  qhandle_t inlineDrawModel[MAX_SUBMODELS];
+  vec3_t inlineModelMidpoints[MAX_SUBMODELS];
 
   clientInfo_t clientinfo[MAX_CLIENTS];
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -2897,16 +2897,10 @@ static void CG_RegisterGraphics(void) {
   CG_LoadingString(" - inline models");
 
   // register the inline models
+  // since we now support 512 inline models like engine does,
+  // we don't need to check the limits here as engine fails to load the map
+  // if we go over MAX_SUBMODELS
   cgs.numInlineModels = trap_CM_NumInlineModels();
-  // TAT 12/23/2002 - as a safety check, let's not let the number of
-  // models exceed MAX_MODELS
-  if (cgs.numInlineModels > MAX_MODELS) {
-    CG_Error("CG_RegisterGraphics: Too many inline models: %i\n",
-             cgs.numInlineModels);
-    // CG_Printf( S_COLOR_RED "WARNING: CG_RegisterGraphics: Too
-    // many inline models: %i\n", cgs.numInlineModels );
-    // cgs.numInlineModels = MAX_MODELS;
-  }
 
   for (i = 1; i < cgs.numInlineModels; i++) {
     char name[10];

--- a/src/game/g_svcmds.cpp
+++ b/src/game/g_svcmds.cpp
@@ -376,8 +376,8 @@ static void Svcmd_EntityList_f() {
   G_Printf("-------------------------------------------------------------------"
            "---------------------------------\n");
   G_Printf("%4i / %4i total entities\n", level.num_entities, MAX_GENTITIES);
-  // bmodels are 1-indexed so the limit is actually MAX_MODELS - 1
-  G_Printf("%4i / %4i brush entities\n", numBrushEnts, MAX_MODELS - 1);
+  // bmodels are 1-indexed so the limit is actually MAX_SUBMODELS - 1
+  G_Printf("%4i / %4i brush entities\n", numBrushEnts, MAX_SUBMODELS - 1);
   G_Printf("%4i / %4i entities inactive\n", not_inuse, level.num_entities);
 }
 

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -1101,6 +1101,9 @@ typedef enum {
 #define MAX_SERVER_TAGS 256
 #define MAX_TAG_FILES 64
 
+// cm_local.h in engine
+static constexpr int MAX_SUBMODELS = 512;
+
 #define MAX_MULTI_SPAWNTARGETS 16 // JPW NERVE
 
 #define MAX_CONFIGSTRINGS 1024


### PR DESCRIPTION
The engine supports 512, and since bmodels aren't actually stored/communicated in CS even though the limit was checked against a CS limit, there should be no issues in increasing this to the same value as engine uses.

~~I will still need to test how this behaves if someone tries to for example add 500 brush entities with a `model2` key set, because registering models is still limited by CS.~~ Should be okay, see comment below.