### PR TITLE
Add support for cursorhints in set/delete script actions

### DIFF
--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -1891,6 +1891,33 @@ typedef enum {
   HINT_NUM_HINTS
 } hintType_t;
 
+static constexpr std::array<const char *, HINT_NUM_HINTS + 1> hintStrings = {
+    "",          // HINT_NONE
+    "HINT_NONE", // actually HINT_FORCENONE, but since this is being specified
+                 // in the ent, the designer actually means HINT_FORCENONE
+    "HINT_PLAYER", "HINT_ACTIVATE", "HINT_DOOR", "HINT_DOOR_ROTATING",
+    "HINT_DOOR_LOCKED", "HINT_DOOR_ROTATING_LOCKED", "HINT_MG42",
+    "HINT_BREAKABLE", "HINT_BREAKABLE_BIG", "HINT_CHAIR", "HINT_ALARM",
+    "HINT_HEALTH", "HINT_TREASURE", "HINT_KNIFE", "HINT_LADDER", "HINT_BUTTON",
+    "HINT_WATER", "HINT_CAUTION", "HINT_DANGER", "HINT_SECRET", "HINT_QUESTION",
+    "HINT_EXCLAMATION", "HINT_CLIPBOARD", "HINT_WEAPON", "HINT_AMMO",
+    "HINT_ARMOR", "HINT_POWERUP", "HINT_HOLDABLE", "HINT_INVENTORY",
+    "HINT_SCENARIC", "HINT_EXIT", "HINT_NOEXIT", "HINT_PLYR_FRIEND",
+    "HINT_PLYR_NEUTRAL", "HINT_PLYR_ENEMY", "HINT_PLYR_UNKNOWN",
+    "HINT_BUILD",    // DHM - Nerve
+    "HINT_DISARM",   // DHM - Nerve
+    "HINT_REVIVE",   // DHM - Nerve
+    "HINT_DYNAMITE", // DHM - Nerve
+
+    "HINT_CONSTRUCTIBLE", "HINT_UNIFORM", "HINT_LANDMINE", "HINT_TANK",
+    "HINT_SATCHELCHARGE",
+    // START Mad Doc - TDF
+    "HINT_LOCKPICK",
+    // END Mad Doc - TDF
+
+    "", // HINT_BAD_USER
+};
+
 void BG_EvaluateTrajectory(const trajectory_t *tr, int atTime, vec3_t result,
                            qboolean isAngle, int splinePath);
 void BG_EvaluateTrajectoryDelta(const trajectory_t *tr, int atTime,

--- a/src/game/etj_entity_utilities.cpp
+++ b/src/game/etj_entity_utilities.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "etj_entity_utilities.h"
+#include "etj_string_utilities.h"
 
 namespace ETJump {
 bool EntityUtilities::isPlayer(gentity_t *ent) {
@@ -124,4 +125,14 @@ bool EntityUtilities::entitiesFree(const int threshold) {
 
   return free > threshold;
 }
+
+void EntityUtilities::setCursorhintFromString(int &value,
+                                              const std::string &hint) {
+  for (int i = 0; i < HINT_NUM_HINTS; i++) {
+    if (StringUtil::iEqual(hint, hintStrings[i])) {
+      value = i;
+    }
+  }
+}
+
 } // namespace ETJump

--- a/src/game/etj_entity_utilities.h
+++ b/src/game/etj_entity_utilities.h
@@ -37,5 +37,9 @@ public:
 
   // 'threshold' indicates the number of entities that must be free
   static bool entitiesFree(int threshold);
+
+  // sets 'value' to corresponding cursorhint from 'hint'
+  // if 'hint' isn't found in hintStrings, no modification is performed
+  static void setCursorhintFromString(int &value, const std::string &hint);
 };
 } // namespace ETJump

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -256,7 +256,8 @@ typedef enum {
   F_ENTITY, // index on disk, pointer in memory
   F_ITEM,   // index on disk, pointer in memory
   F_CLIENT, // index on disk, pointer in memory
-  F_IGNORE
+  F_IGNORE,
+  F_CURSORHINT, // maps cursorhint string to a correct int
 } fieldtype_t;
 
 typedef struct {

--- a/src/game/g_mover.cpp
+++ b/src/game/g_mover.cpp
@@ -10,33 +10,6 @@
 #include "etj_utilities.h"
 #include "etj_entity_utilities.h"
 
-static constexpr std::array<const char *, HINT_NUM_HINTS + 1> hintStrings = {
-    "",          // HINT_NONE
-    "HINT_NONE", // actually HINT_FORCENONE, but since this is being specified
-                 // in the ent, the designer actually means HINT_FORCENONE
-    "HINT_PLAYER", "HINT_ACTIVATE", "HINT_DOOR", "HINT_DOOR_ROTATING",
-    "HINT_DOOR_LOCKED", "HINT_DOOR_ROTATING_LOCKED", "HINT_MG42",
-    "HINT_BREAKABLE", "HINT_BREAKABLE_BIG", "HINT_CHAIR", "HINT_ALARM",
-    "HINT_HEALTH", "HINT_TREASURE", "HINT_KNIFE", "HINT_LADDER", "HINT_BUTTON",
-    "HINT_WATER", "HINT_CAUTION", "HINT_DANGER", "HINT_SECRET", "HINT_QUESTION",
-    "HINT_EXCLAMATION", "HINT_CLIPBOARD", "HINT_WEAPON", "HINT_AMMO",
-    "HINT_ARMOR", "HINT_POWERUP", "HINT_HOLDABLE", "HINT_INVENTORY",
-    "HINT_SCENARIC", "HINT_EXIT", "HINT_NOEXIT", "HINT_PLYR_FRIEND",
-    "HINT_PLYR_NEUTRAL", "HINT_PLYR_ENEMY", "HINT_PLYR_UNKNOWN",
-    "HINT_BUILD",    // DHM - Nerve
-    "HINT_DISARM",   // DHM - Nerve
-    "HINT_REVIVE",   // DHM - Nerve
-    "HINT_DYNAMITE", // DHM - Nerve
-
-    "HINT_CONSTRUCTIBLE", "HINT_UNIFORM", "HINT_LANDMINE", "HINT_TANK",
-    "HINT_SATCHELCHARGE",
-    // START Mad Doc - TDF
-    "HINT_LOCKPICK",
-    // END Mad Doc - TDF
-
-    "", // HINT_BAD_USER
-};
-
 /*
 ===============================================================================
 
@@ -2699,11 +2672,8 @@ void SP_func_button(gentity_t *ent) {
   ent->s.dmgFlags = HINT_BUTTON;
 
   if (G_SpawnString("cursorhint", "0", &cursorhint)) {
-    for (int i = 0; i < HINT_NUM_HINTS; i++) {
-      if (!Q_stricmp(cursorhint, hintStrings[i])) {
-        ent->s.dmgFlags = i;
-      }
-    }
+    ETJump::EntityUtilities::setCursorhintFromString(ent->s.dmgFlags,
+                                                     cursorhint);
   }
 
   // first position
@@ -4346,22 +4316,12 @@ void SP_func_explosive(gentity_t *ent) {
     }
   }
 
-  //----(SA)	added
-
-  ent->s.dmgFlags = 0;
+  ent->s.dmgFlags = HINT_NONE;
 
   if (G_SpawnString("cursorhint", "0", &cursorhint)) {
-
-    for (i = 0; i < HINT_NUM_HINTS; i++) {
-      if (!Q_stricmp(cursorhint, hintStrings[i])) {
-        ent->s.dmgFlags = i;
-      }
-    }
+    ETJump::EntityUtilities::setCursorhintFromString(ent->s.dmgFlags,
+                                                     cursorhint);
   }
-  //----(SA)	end
-
-  // (SA) shouldn't need this
-  //	ent->s.density = ent->count;	// pass the "mass" to the client
 
   ent->die = func_explosive_explode;
 }
@@ -4506,16 +4466,10 @@ void SP_func_invisible_user(gentity_t *ent) {
 
   ent->use = use_invisible_user;
 
-  //----(SA)	added
   if (G_SpawnString("cursorhint", "0", &cursorhint)) {
-
-    for (i = 0; i < HINT_NUM_HINTS; i++) {
-      if (!Q_stricmp(cursorhint, hintStrings[i])) {
-        ent->s.dmgFlags = i;
-      }
-    }
+    ETJump::EntityUtilities::setCursorhintFromString(ent->s.dmgFlags,
+                                                     cursorhint);
   }
-  //----(SA)	end
 
   if (!(ent->spawnflags &
         static_cast<int>(ETJump::FuncInvisSpawnflags::NoOffNoise))) {

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -6,6 +6,7 @@
 // Tab Size:		4 (real tabs)
 //===========================================================================
 
+#include "etj_entity_utilities.h"
 #include "../game/g_local.h"
 #include "../game/q_shared.h"
 #include "etj_printer.h"
@@ -4780,6 +4781,24 @@ qboolean G_ScriptAction_Delete(gentity_t *ent, char *params) {
         }
 
         while ((found = G_FindVec(found, fields[i].ofs, valueVec)) != nullptr) {
+          pass[found->s.number].first++;
+          pass[found->s.number].second.emplace_back(
+              ETJump::stringFormat(R"(%s "%s")", key, value));
+        }
+
+        break;
+      case F_CURSORHINT:
+        if (args.size() != 1) {
+          invalidArgCount(1, args.size());
+          break;
+        }
+
+        // set to end cap initially, so we don't delete all entities
+        // with HINT_NONE if we don't find a match
+        valueInt = HINT_NUM_HINTS;
+        ETJump::EntityUtilities::setCursorhintFromString(valueInt, value);
+
+        while ((found = G_FindInt(found, fields[i].ofs, valueInt)) != nullptr) {
           pass[found->s.number].first++;
           pass[found->s.number].second.emplace_back(
               ETJump::stringFormat(R"(%s "%s")", key, value));


### PR DESCRIPTION
This required special handling as cursorhints are written as strings by mappers, but are internally mapped into an enum value.

refs #1583 