### PR TITLE
Fix grouped popup counter formatting inconsistency

### DIFF
--- a/src/cgame/cg_popupmessages.cpp
+++ b/src/cgame/cg_popupmessages.cpp
@@ -428,7 +428,7 @@ void CG_DrawPMItems(void) {
 
   // show repeats counter
   if (cg_pmWaitingList->repeats > 1) {
-    msg = va("%s^9(x%d)", cg_pmWaitingList->message, cg_pmWaitingList->repeats);
+    msg = va("%s ^9(x%d)", cg_pmWaitingList->message, cg_pmWaitingList->repeats);
   } else {
     msg = (char *)&cg_pmWaitingList->message;
   }
@@ -468,7 +468,7 @@ void CG_DrawPMItems(void) {
     }
 
     if (listItem->repeats > 1) {
-      msg = va("%s (x%d)", listItem->message, listItem->repeats);
+      msg = va("%s ^9(x%d)", listItem->message, listItem->repeats);
     } else {
       msg = (char *)&listItem->message;
     }


### PR DESCRIPTION
The counter indicating the amount of grouped popups broke when a new, unique popup was drawn from the popup stack, since it was formatted differently depending on if it was the latest popup or not. Also adds back the whitespace before the counter.

refs #539 