### PR TITLE
Add cvar size/scale parser for non-uniform scaling

### DIFF
--- a/assets/ui/etjump_settings_hud1_crosshair.menu
+++ b/assets/ui/etjump_settings_hud1_crosshair.menu
@@ -7,7 +7,7 @@
 #define GROUP_NAME "group_etjump_settings_hud1"
 
 #define NUM_SUBMENUS 13
-#define NUM_SETTINGS 12 // required for bottom-up settings drawing
+#define NUM_SETTINGS 10 // required for bottom-up settings drawing
 #define SIDEBAR_BTN_Y (SIDEBAR_Y + (SIDEBAR_H * 0.5) - (((NUM_SUBMENUS * SIDEBAR_BTN_H) + (MAIN_ELEMENT_MARGIN * (NUM_SUBMENUS - 1))) * 0.5))
 
 menuDef {
@@ -79,22 +79,18 @@ menuDef {
 
         CVARINTLABEL        (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 1), "cg_crosshairSize", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 1), "Crosshair size:", 0.2, SETTINGS_ITEM_H, cg_crosshairSize 48 0 96 1, "Sets the size of the crosshair\ncg_crosshairSize")
-        CVARFLOATLABEL      (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 2), "etj_crosshairScaleX", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 2), "Crosshair scale X:", 0.2, SETTINGS_ITEM_H, etj_crosshairScaleX 1.0 -5.0 5.0 0.1, "Horizontal scale of crosshair, negative values will flip the crosshair\netj_crosshairScaleX")
-        CVARFLOATLABEL      (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 3), "etj_crosshairScaleY", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 3), "Crosshair scale Y:", 0.2, SETTINGS_ITEM_H, etj_crosshairScaleY 1.0 -5.0 5.0 0.1, "Vertical scale of crosshair, negative values will flip the crosshair\netj_crosshairScaleY")
-        YESNO               (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 4), "Crosshair pulsing:", 0.2, SETTINGS_ITEM_H, "cg_crosshairPulse", "Toggles crosshair spread sizing while moving/firing\ncg_crosshairPulse")
-        YESNO               (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 5), "Crosshair health info:", 0.2, SETTINGS_ITEM_H, "cg_crosshairHealth", "Colors the crosshair based on current health (overrides crosshair color settings)\ncg_crosshairHealth")
-        YESNO               (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 6), "Crosshair name drawing:", 0.2, SETTINGS_ITEM_H, "cg_drawCrosshairNames", "Displays player info when the crosshair is over a teammate\ncg_drawCrosshairNames")
-        COMBO               (SETTINGS_COMBO_POS_REVERSE(NUM_SETTINGS - 7), "Primary color:", 0.2, SETTINGS_ITEM_H, "cg_crosshairColor", COLOR_LIST, uiScript uiPreviousMenu MENU_NAME, "Set the color for the primary crosshair element\ncg_crosshairColor")
-        CVARFLOATLABEL      (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 8), "cg_crosshairAlpha", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 8), "Primary alpha:", 0.2, SETTINGS_ITEM_H, "cg_crosshairAlpha" 1 0 1, "Set the transparency level for the primary crosshair\ncg_crosshairAlpha")
-        COMBO               (SETTINGS_COMBO_POS_REVERSE(NUM_SETTINGS - 9), "Secondary color:", 0.2, SETTINGS_ITEM_H, "cg_crosshairColorAlt", COLOR_LIST, uiScript uiPreviousMenu MENU_NAME, "Set the color for the secondary crosshair\ncg_crosshairColorAlt")
-        CVARFLOATLABEL      (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 10), "cg_crosshairAlphaAlt", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 10), "Secondary alpha:", 0.2, SETTINGS_ITEM_H, "cg_crosshairAlphaAlt" 1 0 1, "Set the transparency level for the secondary crosshair\ncg_crosshairAlphaAlt")
-        CVARFLOATLABEL      (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 11), "etj_crosshairThickness", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 11), "Line thickness:", 0.2, SETTINGS_ITEM_H, etj_crosshairThickness 1.0 0.0 5.0 0.1, "Line thickness of ETJump crosshairs\netj_crosshairThickness")
-        YESNO               (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 12), "Crosshair outline:", 0.2, SETTINGS_ITEM_H, "etj_crosshairOutline", "Draw outline on ETJump crosshairs\netj_crosshairOutline")
+        YESNO               (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 2), "Crosshair pulsing:", 0.2, SETTINGS_ITEM_H, "cg_crosshairPulse", "Toggles crosshair spread sizing while moving/firing\ncg_crosshairPulse")
+        YESNO               (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 3), "Crosshair health info:", 0.2, SETTINGS_ITEM_H, "cg_crosshairHealth", "Colors the crosshair based on current health (overrides crosshair color settings)\ncg_crosshairHealth")
+        YESNO               (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 4), "Crosshair name drawing:", 0.2, SETTINGS_ITEM_H, "cg_drawCrosshairNames", "Displays player info when the crosshair is over a teammate\ncg_drawCrosshairNames")
+        COMBO               (SETTINGS_COMBO_POS_REVERSE(NUM_SETTINGS - 5), "Primary color:", 0.2, SETTINGS_ITEM_H, "cg_crosshairColor", COLOR_LIST, uiScript uiPreviousMenu MENU_NAME, "Set the color for the primary crosshair element\ncg_crosshairColor")
+        CVARFLOATLABEL      (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 6), "cg_crosshairAlpha", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 6), "Primary alpha:", 0.2, SETTINGS_ITEM_H, "cg_crosshairAlpha" 1 0 1, "Set the transparency level for the primary crosshair\ncg_crosshairAlpha")
+        COMBO               (SETTINGS_COMBO_POS_REVERSE(NUM_SETTINGS - 7), "Secondary color:", 0.2, SETTINGS_ITEM_H, "cg_crosshairColorAlt", COLOR_LIST, uiScript uiPreviousMenu MENU_NAME, "Set the color for the secondary crosshair\ncg_crosshairColorAlt")
+        CVARFLOATLABEL      (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 8), "cg_crosshairAlphaAlt", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 8), "Secondary alpha:", 0.2, SETTINGS_ITEM_H, "cg_crosshairAlphaAlt" 1 0 1, "Set the transparency level for the secondary crosshair\ncg_crosshairAlphaAlt")
+        CVARFLOATLABEL      (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 9), "etj_crosshairThickness", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 9), "Line thickness:", 0.2, SETTINGS_ITEM_H, etj_crosshairThickness 1.0 0.0 5.0 0.1, "Line thickness of ETJump crosshairs\netj_crosshairThickness")
+        YESNO               (SETTINGS_ITEM_POS_REVERSE(NUM_SETTINGS - 10), "Crosshair outline:", 0.2, SETTINGS_ITEM_H, "etj_crosshairOutline", "Draw outline on ETJump crosshairs\netj_crosshairOutline")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/assets/ui/etjump_settings_hud1_specinfo.menu
+++ b/assets/ui/etjump_settings_hud1_specinfo.menu
@@ -61,8 +61,8 @@ menuDef {
         CVARINTLABEL        (SETTINGS_ITEM_POS(3), "etj_spectatorInfoY", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(3), "Spec list Y:", 0.2, SETTINGS_ITEM_H, etj_spectatorInfoY 30 0 480 10, "Sets Y position of spectator list\netj_spectatorInfoY")
         YESNO               (SETTINGS_ITEM_POS(4), "Spec list shadow:", 0.2, SETTINGS_ITEM_H, "etj_spectatorInfoShadow", "Draw shadow on spectator list\netj_spectatorInfoShadow")
-        CVARFLOATLABEL      (SETTINGS_ITEM_POS(5), "etj_spectatorInfoSize", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS(5), "Spec list size:", 0.2, SETTINGS_ITEM_H, etj_spectatorInfoSize 2.3 0 10 0.1, "Size of spectator list\netj_spectatorInfoSize")
+        CVARFLOATLABEL      (SETTINGS_ITEM_POS(5), "etj_spectatorInfoScale", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(5), "Spec list scale:", 0.2, SETTINGS_ITEM_H, etj_spectatorInfoScale 1.0 0 5 0.1, "Scale of spectator list\netj_spectatorInfoSize")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2554,7 +2554,7 @@ extern vmCvar_t etj_altScoreboard;
 extern vmCvar_t etj_drawSpectatorInfo;
 extern vmCvar_t etj_spectatorInfoX;
 extern vmCvar_t etj_spectatorInfoY;
-extern vmCvar_t etj_spectatorInfoSize;
+extern vmCvar_t etj_spectatorInfoScale;
 extern vmCvar_t etj_spectatorInfoShadow;
 
 extern vmCvar_t etj_drawRunTimer;
@@ -2764,8 +2764,6 @@ extern vmCvar_t etj_optimizePrediction;
 
 extern vmCvar_t etj_menuSensitivity;
 
-extern vmCvar_t etj_crosshairScaleX;
-extern vmCvar_t etj_crosshairScaleY;
 extern vmCvar_t etj_crosshairThickness;
 extern vmCvar_t etj_crosshairOutline;
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -437,7 +437,7 @@ vmCvar_t etj_altScoreboard;
 vmCvar_t etj_drawSpectatorInfo;
 vmCvar_t etj_spectatorInfoX;
 vmCvar_t etj_spectatorInfoY;
-vmCvar_t etj_spectatorInfoSize;
+vmCvar_t etj_spectatorInfoScale;
 vmCvar_t etj_spectatorInfoShadow;
 
 vmCvar_t etj_drawRunTimer;
@@ -647,8 +647,6 @@ vmCvar_t etj_optimizePrediction;
 
 vmCvar_t etj_menuSensitivity;
 
-vmCvar_t etj_crosshairScaleX;
-vmCvar_t etj_crosshairScaleY;
 vmCvar_t etj_crosshairThickness;
 vmCvar_t etj_crosshairOutline;
 
@@ -1008,7 +1006,7 @@ cvarTable_t cvarTable[] = {
     {&etj_drawSpectatorInfo, "etj_drawSpectatorInfo", "0", CVAR_ARCHIVE},
     {&etj_spectatorInfoX, "etj_spectatorInfoX", "320", CVAR_ARCHIVE},
     {&etj_spectatorInfoY, "etj_spectatorInfoY", "30", CVAR_ARCHIVE},
-    {&etj_spectatorInfoSize, "etj_spectatorInfoSize", "2.3", CVAR_ARCHIVE},
+    {&etj_spectatorInfoScale, "etj_spectatorInfoScale", "1.0", CVAR_ARCHIVE},
     {&etj_spectatorInfoShadow, "etj_spectatorInfoShadow", "1", CVAR_ARCHIVE},
     {&etj_drawRunTimer, "etj_drawRunTimer", "1", CVAR_ARCHIVE},
     {&etj_runTimerX, "etj_runTimerX", "320", CVAR_ARCHIVE},
@@ -1235,8 +1233,6 @@ cvarTable_t cvarTable[] = {
 
     {&etj_menuSensitivity, "etj_menuSensitivity", "1.0", CVAR_ARCHIVE},
 
-    {&etj_crosshairScaleX, "etj_crosshairScaleX", "1.0", CVAR_ARCHIVE},
-    {&etj_crosshairScaleY, "etj_crosshairScaleY", "1.0", CVAR_ARCHIVE},
     {&etj_crosshairThickness, "etj_crosshairThickness", "1.0", CVAR_ARCHIVE},
     {&etj_crosshairOutline, "etj_crosshairOutline", "1", CVAR_ARCHIVE},
 

--- a/src/cgame/etj_accelmeter_drawable.cpp
+++ b/src/cgame/etj_accelmeter_drawable.cpp
@@ -26,6 +26,7 @@
 #include "etj_cvar_update_handler.h"
 #include "etj_pmove_utils.h"
 #include "etj_utilities.h"
+
 #include "../game/etj_string_utilities.h"
 
 namespace ETJump {
@@ -73,9 +74,12 @@ void AccelMeter::setTextStyle() {
 }
 
 void AccelMeter::setSize() {
-  size = 0.1f * etj_accelSize.value;
+  size = CvarValueParser::parse<CvarValue::Size>(etj_accelSize, 1, 10);
+  size.x *= 0.1f;
+  size.y *= 0.1f;
+
   halfW = static_cast<float>(
-              CG_Text_Width_Ext("-88  -88", size, 0, &cgs.media.limboFont1)) *
+              CG_Text_Width_Ext("-88  -88", size.x, 0, &cgs.media.limboFont1)) *
           0.5f;
 }
 
@@ -155,25 +159,26 @@ void AccelMeter::render() const {
   Vector4Copy(accelColor, color);
 
   switch (etj_accelAlign.integer) {
-    case Alignment::Left:
-      CG_Text_Paint_Ext(accelX, y, size, size, color, accelStr[0], 0, 0,
+    case Left:
+      CG_Text_Paint_Ext(accelX, y, size.x, size.y, color, accelStr[0], 0, 0,
                         textStyle, &cgs.media.limboFont1);
-      CG_Text_Paint_Ext(accelX + halfW, y, size, size, color, accelStr[1], 0, 0,
-                        textStyle, &cgs.media.limboFont1);
+      CG_Text_Paint_Ext(accelX + halfW, y, size.x, size.y, color, accelStr[1],
+                        0, 0, textStyle, &cgs.media.limboFont1);
       break;
-    case Alignment::Right:
-      CG_Text_Paint_RightAligned_Ext(accelX, y, size, size, color, accelStr[0],
-                                     0, 0, textStyle, &cgs.media.limboFont1);
-      CG_Text_Paint_RightAligned_Ext(accelX - halfW, y, size, size, color,
+    case Right:
+      CG_Text_Paint_RightAligned_Ext(accelX, y, size.x, size.y, color,
+                                     accelStr[0], 0, 0, textStyle,
+                                     &cgs.media.limboFont1);
+      CG_Text_Paint_RightAligned_Ext(accelX - halfW, y, size.x, size.y, color,
                                      accelStr[1], 0, 0, textStyle,
                                      &cgs.media.limboFont1);
       break;
     default: // center align
-      CG_Text_Paint_Centred_Ext(accelX - (halfW * 0.5f), y, size, size, color,
-                                accelStr[0], 0, 0, textStyle,
+      CG_Text_Paint_Centred_Ext(accelX - (halfW * 0.5f), y, size.x, size.y,
+                                color, accelStr[0], 0, 0, textStyle,
                                 &cgs.media.limboFont1);
-      CG_Text_Paint_Centred_Ext(accelX + (halfW * 0.5f), y, size, size, color,
-                                accelStr[1], 0, 0, textStyle,
+      CG_Text_Paint_Centred_Ext(accelX + (halfW * 0.5f), y, size.x, size.y,
+                                color, accelStr[1], 0, 0, textStyle,
                                 &cgs.media.limboFont1);
       break;
   }

--- a/src/cgame/etj_accelmeter_drawable.h
+++ b/src/cgame/etj_accelmeter_drawable.h
@@ -24,17 +24,19 @@
 
 #pragma once
 
+#include <list>
+
 #include "etj_irenderable.h"
 #include "cg_local.h"
 #include "etj_accel_color.h"
-#include <list>
+#include "etj_cvar_parser.h"
 
 namespace ETJump {
 class AccelMeter : public IRenderable {
   int textStyle{};
   float y{};
   float halfW{};
-  float size{};
+  CvarValue::Size size{};
   int accelColorStyle{};
   std::vector<std::string> accelStr{};
   bool playing{};

--- a/src/cgame/etj_crosshair.cpp
+++ b/src/cgame/etj_crosshair.cpp
@@ -26,6 +26,8 @@
 #include "etj_crosshair_drawer.h"
 #include "etj_cvar_update_handler.h"
 #include "etj_utilities.h"
+#include "etj_cvar_parser.h"
+
 #include "../game/etj_numeric_utilities.h"
 
 namespace ETJump {
@@ -55,10 +57,10 @@ void Crosshair::parseColors() {
 }
 
 void Crosshair::adjustSize() {
-  const float scaleX = Numeric::clamp(etj_crosshairScaleX.value, -5, 5);
-  const float scaleY = Numeric::clamp(etj_crosshairScaleY.value, -5, 5);
-  crosshair.w = cg_crosshairSize.value * scaleX;
-  crosshair.h = cg_crosshairSize.value * scaleY;
+  const auto size =
+      CvarValueParser::parse<CvarValue::Size>(cg_crosshairSize, -256, 256);
+  crosshair.w = size.x;
+  crosshair.h = size.y;
   crosshair.f = 0.0f;
   crosshair.t = Numeric::clamp(etj_crosshairThickness.value, 0.0f, 5.0f);
 

--- a/src/cgame/etj_cvar_parser.h
+++ b/src/cgame/etj_cvar_parser.h
@@ -1,0 +1,92 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#if defined(CGAMEDLL)
+  #include "cg_local.h"
+#elif defined(UIDLL)
+  #include "../ui/ui_local.h"
+#endif
+
+#include "../game/etj_numeric_utilities.h"
+#include "../game/etj_string_utilities.h"
+#include "../game/etj_shared.h"
+
+namespace ETJump {
+class CvarValue {
+public:
+  struct Size {
+    float x;
+    float y;
+  };
+
+  struct Scale {
+    float x;
+    float y;
+  };
+};
+
+class CvarValueParser {
+public:
+  template <typename T>
+  static T parse(const vmCvar_t &cvar, opt<float> min = opt<float>(),
+                 opt<float> max = opt<float>()) {
+    const bool clamp = min.hasValue() && max.hasValue();
+
+    // user set the string empty, return sane default values
+    // we can't unfortunately get the real default value for a vmCvar_t easily
+    if (std::strlen(cvar.string) == 0) {
+      if (clamp) {
+        return T{min.value(), min.value()};
+      }
+
+      return T{1.0f, 1.0f};
+    }
+
+    const auto scaleComponents = StringUtil::split(cvar.string, " ");
+
+    // single component = uniform scaling
+    if (scaleComponents.size() == 1) {
+      float ufScale = Q_atof(scaleComponents[0].c_str());
+
+      if (clamp) {
+        ufScale = Numeric::clamp(ufScale, min.value(), max.value());
+      }
+
+      return T{ufScale, ufScale};
+    }
+
+    float scaleX = Q_atof(scaleComponents[0].c_str());
+    float scaleY = Q_atof(scaleComponents[1].c_str());
+
+    if (clamp) {
+      scaleX = Numeric::clamp(scaleX, min.value(), max.value());
+      scaleY = Numeric::clamp(scaleY, min.value(), max.value());
+    }
+
+    return T{scaleX, scaleY};
+  }
+};
+} // namespace ETJump

--- a/src/cgame/etj_keyset_drawer.cpp
+++ b/src/cgame/etj_keyset_drawer.cpp
@@ -37,9 +37,8 @@ void ETJump::KeySetDrawer::initListeners() {
   cvarUpdateHandler->subscribe(&etj_keysColor, [&](const vmCvar_t *cvar) {
     updateKeysColor(etj_keysColor.string);
   });
-  cvarUpdateHandler->subscribe(&etj_keysSize, [&](const vmCvar_t *cvar) {
-    updateKeysSize(etj_keysSize.integer);
-  });
+  cvarUpdateHandler->subscribe(&etj_keysSize,
+                               [&](const vmCvar_t *cvar) { updateKeysSize(); });
   cvarUpdateHandler->subscribe(&etj_keysX, [&](const vmCvar_t *cvar) {
     updateKeysOrigin(etj_keysX.value, etj_keysY.value);
   });
@@ -53,7 +52,7 @@ void ETJump::KeySetDrawer::initListeners() {
 
 void ETJump::KeySetDrawer::initAttrs() {
   updateKeysColor(etj_keysColor.string);
-  updateKeysSize(etj_keysSize.value);
+  updateKeysSize();
   updateKeysOrigin(etj_keysX.value, etj_keysY.value);
   updateKeysShadow(etj_keysShadow.integer > 0);
   vec4_t shadowColor{0.0f, 0.0f, 0.0f, 1.0f};
@@ -64,8 +63,8 @@ void ETJump::KeySetDrawer::updateKeysColor(const char *str) {
   parseColorString(str, attrs.color);
 }
 
-void ETJump::KeySetDrawer::updateKeysSize(float size) {
-  attrs.size = Numeric::clamp(size, 0, 256);
+void ETJump::KeySetDrawer::updateKeysSize() {
+  attrs.size = CvarValueParser::parse<CvarValue::Size>(etj_keysSize, 0, 256);
 }
 
 void ETJump::KeySetDrawer::updateKeysOrigin(float x, float y) {
@@ -82,7 +81,7 @@ void ETJump::KeySetDrawer::updateKeysShadowColor(const vec4_t shadowColor) {
 }
 
 void ETJump::KeySetDrawer::render() const {
-  if (attrs.size <= 0) {
+  if (attrs.size.x == 0 || attrs.size.y == 0) {
     return;
   }
 
@@ -110,14 +109,18 @@ void ETJump::KeySetDrawer::drawShader(qhandle_t shader, int position) const {
   if (!shader) {
     return;
   }
-  auto size = attrs.size / 3;
-  auto centerOffset = attrs.size / 2;
-  auto pos = calcGridPosition<3>(size, position);
-  auto x = attrs.origin.x + pos.x - centerOffset;
-  auto y = attrs.origin.y + pos.y - centerOffset;
-  auto color = attrs.color;
-  auto shadowColor = attrs.shouldDrawShadow ? attrs.shadowColor : nullptr;
-  drawPic(x, y, size, size, shader, color, shadowColor);
+
+  const float sizeX = attrs.size.x / 3;
+  const float sizeY = attrs.size.y / 3;
+  const float centerOffset = attrs.size.x / 2;
+  const auto pos = calcGridPosition<3>(sizeX, sizeY, position);
+  const float x = attrs.origin.x + pos.x - centerOffset;
+  const float y = attrs.origin.y + pos.y - centerOffset;
+  const vec_t *color = attrs.color;
+  const vec_t *shadowColor =
+      attrs.shouldDrawShadow ? attrs.shadowColor : nullptr;
+
+  drawPic(x, y, sizeX, sizeY, shader, color, shadowColor);
 }
 
 int ETJump::KeySetDrawer::isKeyPressed(KeyNames key) {

--- a/src/cgame/etj_keyset_drawer.cpp
+++ b/src/cgame/etj_keyset_drawer.cpp
@@ -112,10 +112,11 @@ void ETJump::KeySetDrawer::drawShader(qhandle_t shader, int position) const {
 
   const float sizeX = attrs.size.x / 3;
   const float sizeY = attrs.size.y / 3;
-  const float centerOffset = attrs.size.x / 2;
+  const float centerOffsetX = attrs.size.x / 2;
+  const float centerOffsetY = attrs.size.y / 2;
   const auto pos = calcGridPosition<3>(sizeX, sizeY, position);
-  const float x = attrs.origin.x + pos.x - centerOffset;
-  const float y = attrs.origin.y + pos.y - centerOffset;
+  const float x = attrs.origin.x + pos.x - centerOffsetX;
+  const float y = attrs.origin.y + pos.y - centerOffsetY;
   const vec_t *color = attrs.color;
   const vec_t *shadowColor =
       attrs.shouldDrawShadow ? attrs.shadowColor : nullptr;

--- a/src/cgame/etj_keyset_drawer.h
+++ b/src/cgame/etj_keyset_drawer.h
@@ -23,17 +23,12 @@
  */
 
 #pragma once
-#include "cg_local.h"
 
-#ifdef min
-  #undef min
-#endif
-#ifdef max
-  #undef max
-#endif
-
-#include "etj_irenderable.h"
 #include <vector>
+
+#include "cg_local.h"
+#include "etj_irenderable.h"
+#include "etj_cvar_parser.h"
 
 namespace ETJump {
 class KeySetDrawer : public IRenderable {
@@ -66,7 +61,7 @@ public:
   };
 
   KeySetDrawer(const std::vector<KeyShader> &keyShaders);
-  virtual ~KeySetDrawer(){};
+  virtual ~KeySetDrawer() {};
   void render() const override;
   // FIXME: this should to be refactored, see etj_cvar_master_drawer.cpp/h,
   //  this whole system with keysets is more complex than it needs to be
@@ -82,7 +77,7 @@ protected:
   struct KeyAttrs {
     vec4_t color;
     vec4_t shadowColor;
-    float size;
+    CvarValue::Size size;
     Point2d origin;
     bool shouldDrawShadow;
   };
@@ -93,7 +88,7 @@ protected:
   void initListeners();
   void initAttrs();
   void updateKeysColor(const char *str);
-  void updateKeysSize(float size);
+  void updateKeysSize();
   void updateKeysOrigin(float x, float y);
   void updateKeysShadow(bool shouldDrawShadow);
   void updateKeysShadowColor(const vec4_t shadowColor);
@@ -104,9 +99,10 @@ protected:
   static int isKeyPressed(KeyNames key);
 
   template <int Cols>
-  static Point2d calcGridPosition(float cellSize, int cellIndex) {
-    return {cellSize * (cellIndex % Cols),
-            cellSize * static_cast<int>(cellIndex / Cols)};
+  static Point2d calcGridPosition(const float cellSizeX, const float cellSizeY,
+                                  const int cellIndex) {
+    return {cellSizeX * (cellIndex % Cols),
+            cellSizeY * static_cast<int>(cellIndex / Cols)};
   }
 };
 } // namespace ETJump

--- a/src/cgame/etj_keyset_keybind_drawer.cpp
+++ b/src/cgame/etj_keyset_keybind_drawer.cpp
@@ -42,10 +42,11 @@ void ETJump::KeySetKeyBindDrawer::drawPressShader(qhandle_t shader,
   // get command bind key name
   const float sizeX = attrs.size.x / 3;
   const float sizeY = attrs.size.y / 3;
-  const float centerOffset = attrs.size.x / 2;
+  const float centerOffsetX = attrs.size.x / 2;
+  const float centerOffsetY = attrs.size.y / 2;
   const auto pos = calcGridPosition<3>(sizeX, sizeY, position);
-  const float x = attrs.origin.x + pos.x - centerOffset;
-  const float y = attrs.origin.y + pos.y - centerOffset;
+  const float x = attrs.origin.x + pos.x - centerOffsetX;
+  const float y = attrs.origin.y + pos.y - centerOffsetY;
   const vec_t *color = attrs.color;
   const vec_t *shadowColor =
       attrs.shouldDrawShadow ? attrs.shadowColor : nullptr;

--- a/src/cgame/etj_keyset_keybind_drawer.cpp
+++ b/src/cgame/etj_keyset_keybind_drawer.cpp
@@ -38,35 +38,38 @@ void ETJump::KeySetKeyBindDrawer::drawPressShader(qhandle_t shader,
   if (!shader) {
     return;
   }
+
   // get command bind key name
-  auto size = attrs.size / 3;
-  auto centerOffset = attrs.size / 2;
-  auto pos = calcGridPosition<3>(size, position);
-  auto x = attrs.origin.x + pos.x - centerOffset;
-  auto y = attrs.origin.y + pos.y - centerOffset;
-  auto color = attrs.color;
-  auto shadowColor = attrs.shouldDrawShadow ? attrs.shadowColor : nullptr;
+  const float sizeX = attrs.size.x / 3;
+  const float sizeY = attrs.size.y / 3;
+  const float centerOffset = attrs.size.x / 2;
+  const auto pos = calcGridPosition<3>(sizeX, sizeY, position);
+  const float x = attrs.origin.x + pos.x - centerOffset;
+  const float y = attrs.origin.y + pos.y - centerOffset;
+  const vec_t *color = attrs.color;
+  const vec_t *shadowColor =
+      attrs.shouldDrawShadow ? attrs.shadowColor : nullptr;
 
   // key code handling
-  auto keyShader = keyShaders[position];
+  const auto keyShader = keyShaders[position];
   auto command = keyNameToCommand(keyShader.key);
   auto keyCode = getKeyCodeForName(command);
   keyCode = checkKeyCodeRemap(keyCode);
-  auto keyCodeShader = checkIfKeyCodeHasShader(keyCode);
+  const auto keyCodeShader = checkIfKeyCodeHasShader(keyCode);
 
   // background
-  drawPic(x, y, size, size, shader, color, shadowColor);
+  drawPic(x, y, sizeX, sizeY, shader, color, shadowColor);
 
   if (keyCodeShader) {
-    drawPic(x, y, size, size, keyCodeShader, color, shadowColor);
+    drawPic(x, y, sizeX, sizeY, keyCodeShader, color, shadowColor);
   } else {
     auto binding = ETJump::StringUtil::toUpperCase(getKeyCodeBinding(keyCode));
     // factor = 16 / ... = 0.20
     // size / factor;
     auto bindWidth = DrawStringWidth(binding.c_str(), 0.2f);
     auto bindHeight = DrawStringHeight(binding.c_str(), 0.2f);
-    auto charOffsetX = (size - bindWidth) / 2;
-    auto charOffsetY = (size + bindHeight + 1) / 2;
+    auto charOffsetX = (sizeX - bindWidth) / 2;
+    auto charOffsetY = (sizeY + bindHeight + 1) / 2;
     DrawString(x + charOffsetX, y + charOffsetY, 0.20f, 0.20f, color, qfalse,
                binding.c_str(), 0, 0);
   }

--- a/src/cgame/etj_overbounce_watcher.cpp
+++ b/src/cgame/etj_overbounce_watcher.cpp
@@ -101,6 +101,10 @@ OverbounceWatcher::OverbounceWatcher(
     parseColorString(etj_obWatcherColor.string, _color);
   });
 
+  cvarUpdateHandler->subscribe(&etj_obWatcherSize,
+                               [&](const vmCvar_t *) { setSize(); });
+
+  setSize();
   parseColorString(etj_obWatcherColor.string, _color);
 }
 
@@ -109,6 +113,12 @@ OverbounceWatcher::~OverbounceWatcher() {
   _clientCommandsHandler->unsubscribe("ob_load");
   _clientCommandsHandler->unsubscribe("ob_reset");
   _clientCommandsHandler->unsubscribe("ob_list");
+}
+
+void OverbounceWatcher::setSize() {
+  size = CvarValueParser::parse<CvarValue::Size>(etj_obWatcherSize, 0, 10);
+  size.x *= 0.1f;
+  size.y *= 0.1f;
 }
 
 bool OverbounceWatcher::beforeRender() {
@@ -135,10 +145,6 @@ bool OverbounceWatcher::beforeRender() {
 
   endHeight = (*_current)[2];
 
-  sizeX = sizeY = 0.1f;
-  sizeX *= etj_obWatcherSize.value;
-  sizeY *= etj_obWatcherSize.value;
-
   x = etj_obWatcherX.value;
   ETJump_AdjustPosition(&x);
 
@@ -163,7 +169,7 @@ bool OverbounceWatcher::beforeRender() {
 }
 
 void OverbounceWatcher::render() const {
-  DrawString(x, etj_obWatcherY.value, sizeX, sizeY, _color, qfalse, "OB", 0,
+  DrawString(x, etj_obWatcherY.value, size.x, size.y, _color, qfalse, "OB", 0,
              ITEM_TEXTSTYLE_SHADOWED);
 }
 

--- a/src/cgame/etj_overbounce_watcher.h
+++ b/src/cgame/etj_overbounce_watcher.h
@@ -27,6 +27,8 @@
 #include <map>
 
 #include "etj_irenderable.h"
+#include "etj_cvar_parser.h"
+
 #include "../game/q_shared.h"
 
 namespace ETJump {
@@ -59,6 +61,8 @@ private:
   // lists all available positions
   void list() const;
 
+  void setSize();
+
   bool overbounce = false;
 
   playerState_t *ps;
@@ -72,7 +76,7 @@ private:
 
   int gravity{};
 
-  float sizeX{}, sizeY{};
+  CvarValue::Size size;
   qhandle_t shader;
   vec4_t _color{};
 };

--- a/src/cgame/etj_spectatorinfo_drawable.cpp
+++ b/src/cgame/etj_spectatorinfo_drawable.cpp
@@ -23,8 +23,24 @@
  */
 
 #include "etj_spectatorinfo_drawable.h"
+#include "etj_cvar_update_handler.h"
 
 namespace ETJump {
+SpectatorInfo::SpectatorInfo() {
+  startListeners();
+  setScale();
+}
+
+void SpectatorInfo::startListeners() {
+  cvarUpdateHandler->subscribe(&etj_spectatorInfoScale,
+                               [&](const vmCvar_t *) { setScale(); });
+}
+
+void SpectatorInfo::setScale() {
+  scale =
+      CvarValueParser::parse<CvarValue::Scale>(etj_spectatorInfoScale, 0, 5);
+}
+
 bool SpectatorInfo::beforeRender() {
   // poll for updates every 3 seconds to refresh list
   // do this before checking if we should render, just to keep it up to date
@@ -41,22 +57,22 @@ bool SpectatorInfo::beforeRender() {
 }
 
 void SpectatorInfo::render() const {
-
   float x = etj_spectatorInfoX.value;
   float y = etj_spectatorInfoY.value;
-  const float size = 0.1f * etj_spectatorInfoSize.value;
+  const float sizeX = 0.23f * scale.x;
+  const float sizeY = 0.23f * scale.y;
 
   // for consistent line spacing, use pre-defined string
   // for height calculation instead of current spectators name
   const auto rowHeight = static_cast<float>(CG_Text_Height_Ext(
-                             "Yy", size, 0, &cgs.media.limboFont2)) *
+                             "Yy", sizeY, 0, &cgs.media.limboFont2)) *
                          1.75f;
   float w;
-  const char *spectator;
   const int textStyle = etj_spectatorInfoShadow.integer
                             ? ITEM_TEXTSTYLE_SHADOWED
                             : ITEM_TEXTSTYLE_NORMAL;
-  const vec4_t inactiveColor = {1.0f, 1.0f, 1.0f, 0.33f};
+
+  constexpr vec4_t inactiveColor = {1.0f, 1.0f, 1.0f, 0.33f};
 
   ETJump_AdjustPosition(&x);
 
@@ -68,19 +84,19 @@ void SpectatorInfo::render() const {
 
     if (cgs.clientinfo[cg.scores[i].client].team == TEAM_SPECTATOR) {
       if (cg.scores[i].followedClient == cg.snap->ps.clientNum) {
-        spectator = cgs.clientinfo[cg.scores[i].client].name;
+        const char *spectator = cgs.clientinfo[cg.scores[i].client].name;
         const bool inactive =
             cgs.clientinfo[cg.scores[i].client].clientIsInactive;
 
         switch (etj_drawSpectatorInfo.integer) {
           case 2: // center align
-            w = static_cast<float>(CG_Text_Width_Ext(spectator, size, 0,
+            w = static_cast<float>(CG_Text_Width_Ext(spectator, sizeX, 0,
                                                      &cgs.media.limboFont2)) *
                 0.5f;
             break;
           case 3: // right align
             w = static_cast<float>(
-                CG_Text_Width_Ext(spectator, size, 0, &cgs.media.limboFont2));
+                CG_Text_Width_Ext(spectator, sizeX, 0, &cgs.media.limboFont2));
             break;
           default: // left align
             w = 0.0f;
@@ -89,8 +105,9 @@ void SpectatorInfo::render() const {
 
         y += rowHeight;
 
-        DrawString(x - w, y, size, size, inactive ? inactiveColor : colorWhite,
-                   qfalse, spectator, 0, textStyle);
+        DrawString(x - w, y, sizeX, sizeY,
+                   inactive ? inactiveColor : colorWhite, qfalse, spectator, 0,
+                   textStyle);
       }
     }
   }

--- a/src/cgame/etj_spectatorinfo_drawable.h
+++ b/src/cgame/etj_spectatorinfo_drawable.h
@@ -25,13 +25,20 @@
 #pragma once
 
 #include "etj_irenderable.h"
-#include "cg_local.h"
+#include "etj_cvar_parser.h"
 
 namespace ETJump {
 class SpectatorInfo : public IRenderable {
+  CvarValue::Scale scale{};
+
   static bool canSkipDraw();
+  void startListeners();
+
+  void setScale();
 
 public:
+  SpectatorInfo();
+
   bool beforeRender() override;
   void render() const override;
 };

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -122,16 +122,16 @@ bool DrawSpeed::beforeRender() {
 
   // need to calculate this every frame because speed string changes
   switch (etj_speedAlign.integer) {
-    case Alignment::Left:
+    case Left:
       w = 0;
       break;
-    case Alignment::Right:
+    case Right:
       w = static_cast<float>(
-          CG_Text_Width_Ext(speedStr, size, 0, &cgs.media.limboFont2));
+          CG_Text_Width_Ext(speedStr, size.x, 0, &cgs.media.limboFont2));
       break;
     default: // center align
       w = static_cast<float>(
-              CG_Text_Width_Ext(speedStr, size, 0, &cgs.media.limboFont2)) *
+              CG_Text_Width_Ext(speedStr, size.x, 0, &cgs.media.limboFont2)) *
           0.5f;
       break;
   }
@@ -146,8 +146,8 @@ void DrawSpeed::render() const {
   vec4_t color;
   Vector4Copy(speedColor, color);
 
-  CG_Text_Paint_Ext(speedX - w, y, size, size, color, speedStr, 0, 0, textStyle,
-                    &cgs.media.limboFont1);
+  CG_Text_Paint_Ext(speedX - w, y, size.x, size.y, color, speedStr, 0, 0,
+                    textStyle, &cgs.media.limboFont1);
 }
 
 void DrawSpeed::resetMaxSpeed() {
@@ -168,7 +168,11 @@ void DrawSpeed::setAccelColorStyle() {
   accelColorStyle = etj_speedColorUsesAccel.integer;
 }
 
-void DrawSpeed::setSize() { size = 0.1f * etj_speedSize.value; }
+void DrawSpeed::setSize() {
+  size = CvarValueParser::parse<CvarValue::Size>(etj_speedSize, 1, 10);
+  size.x *= 0.1f;
+  size.y *= 0.1f;
+}
 
 std::string DrawSpeed::getSpeedString() const {
   switch (etj_drawSpeed2.integer) {

--- a/src/cgame/etj_speed_drawable.h
+++ b/src/cgame/etj_speed_drawable.h
@@ -24,10 +24,12 @@
 
 #pragma once
 
+#include <list>
+
 #include "etj_irenderable.h"
 #include "etj_accel_color.h"
 #include "cg_local.h"
-#include <list>
+#include "etj_cvar_parser.h"
 
 namespace ETJump {
 class DrawSpeed : public IRenderable {
@@ -38,7 +40,7 @@ class DrawSpeed : public IRenderable {
   std::string speedStr;
   float y{};
   float w{};
-  float size{};
+  CvarValue::Size size{};
 
   enum Alignment {
     Left = 1,

--- a/src/cgame/etj_strafe_quality_drawable.cpp
+++ b/src/cgame/etj_strafe_quality_drawable.cpp
@@ -34,6 +34,7 @@
 namespace ETJump {
 StrafeQuality::StrafeQuality() {
   parseColor();
+  setSize();
   startListeners();
 }
 
@@ -42,6 +43,9 @@ void StrafeQuality::startListeners() {
   // frame
   cvarUpdateHandler->subscribe(&etj_strafeQualityColor,
                                [&](const vmCvar_t *cvar) { parseColor(); });
+
+  cvarUpdateHandler->subscribe(&etj_strafeQualitySize,
+                               [&](const vmCvar_t *) { setSize(); });
 
   consoleCommandsHandler->subscribe(
       "resetStrafeQuality",
@@ -53,6 +57,12 @@ void StrafeQuality::startListeners() {
 
 void StrafeQuality::parseColor() {
   parseColorString(etj_strafeQualityColor.string, _color);
+}
+
+void StrafeQuality::setSize() {
+  size = CvarValueParser::parse<CvarValue::Size>(etj_strafeQualitySize, 0, 10);
+  size.x *= 0.1f;
+  size.y *= 0.1f;
 }
 
 void StrafeQuality::resetStrafeQuality() {
@@ -146,8 +156,7 @@ bool StrafeQuality::beforeRender() {
 void StrafeQuality::render() const {
   // get coordinates and size
   float x = _x + etj_strafeQualityX.value;
-  float y = _y + etj_strafeQualityY.value;
-  const float size = 0.1f * etj_strafeQualitySize.value;
+  const float y = _y + etj_strafeQualityY.value;
   ETJump_AdjustPosition(&x);
 
   // get hud text
@@ -175,7 +184,7 @@ void StrafeQuality::render() const {
                                             : ITEM_TEXTSTYLE_NORMAL);
 
   // draw quality on screen
-  CG_Text_Paint_Ext(x, y, size, size, _color, str, 0, 0, textStyle,
+  CG_Text_Paint_Ext(x, y, size.x, size.y, _color, str, 0, 0, textStyle,
                     &cgs.media.limboFont1);
 }
 

--- a/src/cgame/etj_strafe_quality_drawable.h
+++ b/src/cgame/etj_strafe_quality_drawable.h
@@ -23,8 +23,10 @@
  */
 
 #pragma once
+
 #include "etj_irenderable.h"
 #include "cg_local.h"
+#include "etj_cvar_parser.h"
 
 namespace ETJump {
 class StrafeQuality : public IRenderable {
@@ -35,7 +37,7 @@ class StrafeQuality : public IRenderable {
 
   float _oldSpeed{0};
   int _team{0};
-  mutable vec4_t _color;
+  mutable vec4_t _color{};
 
   // default absolute hud position
   static constexpr float _x = 100;
@@ -43,13 +45,16 @@ class StrafeQuality : public IRenderable {
   // amount of digits to show on hud
   static constexpr std::size_t _digits = 4;
 
+  CvarValue::Size size{};
+
   void startListeners();
   void parseColor();
+  void setSize();
   void resetStrafeQuality();
   bool canSkipDraw() const;
   bool canSkipUpdate(usercmd_t cmd);
 
-  pmove_t *pm;
+  pmove_t *pm{};
 
 public:
   StrafeQuality();

--- a/src/cgame/etj_timerun_view.h
+++ b/src/cgame/etj_timerun_view.h
@@ -27,6 +27,7 @@
 #include <string>
 #include "etj_drawable.h"
 #include "etj_timerun.h"
+#include "etj_cvar_parser.h"
 
 namespace ETJump {
 class TimerunView : public Drawable {
@@ -53,6 +54,9 @@ private:
   static float getTimerAlpha(bool running, bool autoHide, int fadeStart,
                              int duration);
 
+  void setCheckpointSize();
+  void setCheckpointPopupSize();
+
   vec4_t inactiveTimerColor{};
   std::shared_ptr<Timerun> _timerun;
 
@@ -62,6 +66,9 @@ private:
   static const int animationTime = 300;
   static const int fadeHold = 5000; // 5s pause before fade starts
   static const int fadeTime = 2000; // 2s fade
+
+  CvarValue::Size checkpointSize{};
+  CvarValue::Size popupSize{};
 
   static const int popupFadeTime = 100;
 

--- a/src/cgame/etj_upmove_meter_drawable.cpp
+++ b/src/cgame/etj_upmove_meter_drawable.cpp
@@ -32,6 +32,7 @@
 namespace ETJump {
 UpmoveMeter::UpmoveMeter() {
   parseAllColors();
+  setTextSize();
   startListeners();
 
   team_ = 0;
@@ -69,6 +70,9 @@ void UpmoveMeter::startListeners() {
         parseColorString(etj_upmoveMeterTextColor.string, jump_.text_rgba);
       });
 
+  cvarUpdateHandler->subscribe(&etj_upmoveMeterTextSize,
+                               [&](const vmCvar_t *) { setTextSize(); });
+
   consoleCommandsHandler->subscribe(
       "resetUpmoveMeter",
       [&](const std::vector<std::string> &args) { resetUpmoveMeter(); });
@@ -89,6 +93,12 @@ void UpmoveMeter::parseAllColors() {
   parseColorString(etj_upmoveMeterGraphOutlineColor.string,
                    jump_.graph_outline_rgba);
   parseColorString(etj_upmoveMeterTextColor.string, jump_.text_rgba);
+}
+
+void UpmoveMeter::setTextSize() {
+  textSize = CvarValueParser::parse<CvarValue::Size>(etj_upmoveMeterTextSize);
+  textSize.x *= 0.1f;
+  textSize.y *= 0.1f;
 }
 
 void UpmoveMeter::resetUpmoveMeter() {
@@ -230,9 +240,8 @@ void UpmoveMeter::render() const {
   const int textStyle =
       (etj_upmoveMeterTextShadow.integer != 0 ? ITEM_TEXTSTYLE_SHADOWED
                                               : ITEM_TEXTSTYLE_NORMAL);
-  const float textSize = 0.1f * etj_upmoveMeterTextSize.value;
   const float textHeightOffset =
-      0.5f * CG_Text_Height_Ext("0", textSize, 0, &cgs.media.limboFont1);
+      0.5f * CG_Text_Height_Ext("0", textSize.y, 0, &cgs.media.limboFont1);
 
   jump_.graph_xywh[0] = graphX_ + etj_upmoveMeterGraphX.value;
   ETJump_AdjustPosition(&jump_.graph_xywh[0]);
@@ -269,18 +278,18 @@ void UpmoveMeter::render() const {
   if (etj_drawUpmoveMeter.integer & 2) {
     CG_Text_Paint_Ext(jump_.graph_xywh[0] + jump_.graph_xywh[2] +
                           jump_.text_xh[0],
-                      graph_m - jump_.text_xh[1] + textHeightOffset, textSize,
-                      textSize, jump_.text_rgba, va("%i", jump_.postDelay), 0,
+                      graph_m - jump_.text_xh[1] + textHeightOffset, textSize.x,
+                      textSize.y, jump_.text_rgba, va("%i", jump_.postDelay), 0,
                       0, textStyle, &cgs.media.limboFont1);
     CG_Text_Paint_Ext(
         jump_.graph_xywh[0] + jump_.graph_xywh[2] + jump_.text_xh[0],
-        graph_m + textHeightOffset, textSize, textSize, jump_.text_rgba,
+        graph_m + textHeightOffset, textSize.x, textSize.y, jump_.text_rgba,
         va("%i", jump_.fullDelay), 0, 0, textStyle, &cgs.media.limboFont1);
     CG_Text_Paint_Ext(jump_.graph_xywh[0] + jump_.graph_xywh[2] +
                           jump_.text_xh[0],
-                      graph_m + jump_.text_xh[1] + textHeightOffset, textSize,
-                      textSize, jump_.text_rgba, va("%i", jump_.preDelay), 0, 0,
-                      textStyle, &cgs.media.limboFont1);
+                      graph_m + jump_.text_xh[1] + textHeightOffset, textSize.x,
+                      textSize.y, jump_.text_rgba, va("%i", jump_.preDelay), 0,
+                      0, textStyle, &cgs.media.limboFont1);
   }
 }
 

--- a/src/cgame/etj_upmove_meter_drawable.h
+++ b/src/cgame/etj_upmove_meter_drawable.h
@@ -23,8 +23,10 @@
  */
 
 #pragma once
+
 #include "etj_irenderable.h"
 #include "cg_local.h"
+#include "etj_cvar_parser.h"
 
 namespace ETJump {
 class UpmoveMeter : public IRenderable {
@@ -70,11 +72,14 @@ class UpmoveMeter : public IRenderable {
   static constexpr float graphX_ = 8.0f;
   static constexpr float graphY_ = 8.0f;
 
+  CvarValue::Size textSize;
+
   int lastUpdateTime{};
   pmove_t *pm{};
 
   void startListeners();
   void parseAllColors();
+  void setTextSize();
   void resetUpmoveMeter();
   bool canSkipDraw() const;
   bool canSkipUpdate() const;

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -2206,14 +2206,22 @@ static void UI_DrawCrosshair(const rectDef_t *rect) {
     auto size = ETJump::CvarValueParser::parse<ETJump::CvarValue::Size>(
         cg_crosshairSize, -256, 256);
 
-    // use abs for drawing these so they position correctly
-    size.x = Numeric::clamp(size.x, -96, 96);
-    size.x = rect->w / 96.0f * size.x;
-    size.x = std::abs(size.x);
+    if (size.x == 0 && size.y == 0) {
+      return;
+    }
 
-    size.y = Numeric::clamp(size.y, -96, 96);
-    size.y = rect->h / 96.0f * size.y;
-    size.y = std::abs(size.y);
+    // use abs for drawing these so they position correctly
+    if (size.x != 0) {
+      size.x = Numeric::clamp(size.x, -96, 96);
+      size.x = rect->w / 96.0f * size.x;
+      size.x = std::abs(size.x);
+    }
+
+    if (size.y != 0) {
+      size.y = Numeric::clamp(size.y, -96, 96);
+      size.y = rect->h / 96.0f * size.y;
+      size.y = std::abs(size.y);
+    }
 
     trap_R_SetColor(crosshairColor);
     UI_DrawHandlePic(


### PR DESCRIPTION
Adds a parser for cvars which control size/scale of various HUD elements. Each of these cvars can now take in a single argument like before to perform uniform scaling, or alternatively two values, for non-uniform scaling individually on X/Y axes.

### !!! BREAKING CHANGES !!!
* `etj_crosshairScaleX/Y` have been removed as non-uniform scaling can now be achieved with just `cg_crosshairSize`
* `etj_spectatorInfoSize` is now `etj_spectatorInfoScale` (`0 - 5` range)

Cvars supporting this:
* `cg_crosshairSize`
* `etj_keysSize`
* `etj_speedSize`
* `etj_accelSize`
* `etj_checkpointsSize`
* `etj_checkpointsPopupSize`
* `etj_obWatcherSize`
* `etj_strafeQualitySize`
* `etj_upmoveMeterTextSize`
* `etj_chatScale`
* `etj_spectatorInfoScale`

Additional changes:
* `etj_speedSize` is now clamped to `0 - 10`
* `etj_accelSize` is now clamped to `0 - 10`
* `etj_strafeQualitySize` is now clamped to `0 - 10`
* `cg_crosshairSize` is now clamped to `-256 - 256`

Menu entries do not support this new feature yet, they only adjust things with uniform scale. I'm not sure what's the best way to support this in the UI, will have to figure that out later.