### PR TITLE
Add spawnflags 1 to target_delay for per-client delay cycle

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -596,6 +596,8 @@ struct gentity_s {
   int triggerActivationTime[MAX_CLIENTS];
   // for tracking projectiles entering skybox
   int lastSurfaceFlag;
+
+  std::array<int, MAX_CLIENTS> targetDelayActivationTime;
 };
 
 // Ridah


### PR DESCRIPTION
When set, the delay time is unique for each client, and activations for other players are individually handled, and won't change the activator. A specific client re-triggering the entity will only reset the cycle for themselves, and not others.