### PR TITLE
Fix timerun entity validation

### DIFF
--- a/src/game/etj_timerun_entities.h
+++ b/src/game/etj_timerun_entities.h
@@ -32,7 +32,6 @@
 namespace ETJump {
 class TimerunEntity {
 private:
-  static Log logger;
   static std::map<std::string, int> runIndices;
   static std::set<std::string> cleanNames;
   static std::set<std::string> names;


### PR DESCRIPTION
This was never functional because `ent->runName` wasn't set for start/stoptimers, and would fail most of the time anyway as the container search was done with a case sensitive string comparison, and radiant creates entity names with all lowercase letters. This also moves the prints from log to server console, as these warnings are mostly meant for mappers, so it makes sense to print them to console instead of log to make them easier to catch.

refs #995 