### PR TITLE
Fix changelog dropdown sizing

### DIFF
--- a/assets/ui/etjump_changelog.menu
+++ b/assets/ui/etjump_changelog.menu
@@ -12,7 +12,7 @@
 
 // for now, increase if needed
 #define MAX_ITEMS        32
-#define POS              WINDOW_WIDTH - 140 - 8, 8, 140, 10, 140, MAX_ITEMS, 0
+#define POS              WINDOW_WIDTH - 140, 10, 140, 10, 140 - 6, MAX_ITEMS, 0
 
 // Macros //
 


### PR DESCRIPTION
The item width was defined too wide, which caused the border to be slightly misaligned. Also tweak the positioning a bit.

refs #1532 