### PR TITLE
Fix demo directory loading on Windows

### DIFF
--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -3339,8 +3339,11 @@ static void UI_LoadDemos() {
       "dm_" +
       std::to_string(static_cast<int>(trap_Cvar_VariableValue("protocol")));
 
+  // trap_FS_GetFileList doesn't understand backslashes as a file "extension",
+  // so we must always send a forward slash here as the extension,
+  // instead of platform-specific path separator
   const std::vector<std::string> demoDirs =
-      ETJump::FileSystem::getFileList(path, PATH_SEP_STRING, true);
+      ETJump::FileSystem::getFileList(path, "/", true);
   std::vector<FileSystemObjectInfo> directories;
 
   for (const auto &dir : demoDirs) {


### PR DESCRIPTION
`trap_FS_GetFileList` does not understand backslashes as a file extension, so we must always send a forward slash, instead of OS-specific path separator.

refs #1437 