### PR TITLE
Skip rank string display for tied records

### DIFF
--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -695,14 +695,46 @@ void ETJump::TimerunV2::printRecords(Timerun::PrintRecordsParams params) {
 
                 if (isOnVisiblePage || isOwnRecord) {
                   auto ownRecord = r->userId == params.userId;
-                  auto rankString = rankToString(rank);
+
+                  std::string rankString;
+
+                  // if the current record has the same time as previous record,
+                  // don't display rank string at all
+                  if (rank != 1 && r->time == std::prev(r)->time) {
+                    // ... unless this is our record,
+                    // and it's not visible on the current page, in which case
+                    // figure out the next faster time to get actual rank
+                    if (isOwnRecord && !isOnVisiblePage) {
+                      int tmpRank = rank;
+                      auto it = r;
+
+                      while (tmpRank > 1) {
+                        if (ownTime > std::prev(it)->time) {
+                          break;
+                        }
+
+                        --it;
+                        --tmpRank;
+                      }
+
+                      rankString = rankToString(tmpRank);
+                    } else {
+                      rankString = "";
+                    }
+                  } else {
+                    rankString = rankToString(rank);
+                  }
+
                   auto millisString = millisToString(r->time);
+
                   std::string diffString;
+
                   if (ownRecord || rank == 1 && ownTime == r->time) {
                     diffString = "";
                   } else {
                     diffString = diffToString(ownTime, r->time);
                   }
+
                   auto playerNameString =
                       ownRecord ? r->playerName + " ^g(You)" : r->playerName;
 


### PR DESCRIPTION
This makes it clearer which times are tied and are effectively the same rank.

![image](https://github.com/user-attachments/assets/aa79f5cc-4968-4626-b521-e1046c8cc76c)

![image](https://github.com/user-attachments/assets/96a2b4e9-bea5-4c63-a73c-e15869d87303)

![image](https://github.com/user-attachments/assets/f5686973-c629-4d2b-b6bb-dfa9874a6edb)
