### PR TITLE
Flamethrower fixes

### DIFF
--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -205,6 +205,10 @@ void ETJump::execFile(const std::string &filename) {
   trap_SendConsoleCommand(va("exec \"%s.cfg\"\n", filename.c_str()));
 }
 
+bool ETJump::isValidClientNum(const int clientNum) {
+  return clientNum >= 0 && clientNum < MAX_CLIENTS;
+}
+
 bool ETJump::isPlaying(const int clientNum) {
   return (cgs.clientinfo[clientNum].team == TEAM_ALLIES ||
           cgs.clientinfo[clientNum].team == TEAM_AXIS);

--- a/src/cgame/etj_utilities.h
+++ b/src/cgame/etj_utilities.h
@@ -63,6 +63,9 @@ bool configFileExists(const std::string &filename);
 // executes a cfg file with given name, omit .cfg extension
 void execFile(const std::string &filename);
 
+// returns true if clientNum is a valid number for client
+bool isValidClientNum(int clientNum);
+
 // returns true if client is currently playing (team axis/allies)
 bool isPlaying(int clientNum);
 

--- a/src/game/g_missile.cpp
+++ b/src/game/g_missile.cpp
@@ -975,11 +975,12 @@ int G_PredictMissile(gentity_t *ent, int duration, vec3_t endPos,
 //=============================================================================
 
 namespace ETJump {
-void flamechunkTrace(const gentity_t *ent, trace_t *tr, vec3_t start,
-                     vec3_t end, const int mask) {
+void flamechunkTrace(gentity_t *ent, trace_t *tr, vec3_t start, vec3_t end,
+                     const int mask) {
   trap_Trace(tr, start, ent->r.mins, ent->r.maxs, end, ent->r.ownerNum, mask);
 
-  if (g_ghostPlayers.integer != 1 || tr->entityNum >= MAX_CLIENTS) {
+  if (g_ghostPlayers.integer != 1 || !EntityUtilities::isPlayer(ent) ||
+      tr->entityNum >= MAX_CLIENTS) {
     return;
   }
 

--- a/src/game/g_missile.cpp
+++ b/src/game/g_missile.cpp
@@ -1017,8 +1017,20 @@ void G_BurnTarget(gentity_t *self, gentity_t *body, qboolean directhit) {
     return;
   }
 
-  // don't set other players on fire or entities in water
-  if (body->client || body->waterlevel >= 3) {
+  if (body->client) {
+    // don't set clients on fire if the shooter isn't us,
+    // or we're invulnerable
+    if (body->s.number != self->r.ownerNum ||
+        body->client->ps.powerups[PW_INVULNERABLE] >= level.time) {
+      body->flameQuota = 0;
+      body->s.onFireEnd = level.time - 1;
+    }
+
+    return;
+  }
+
+  // don't set underwater entities on fire
+  if (body->waterlevel >= 3) {
     body->flameQuota = 0;
     body->s.onFireEnd = level.time - 1;
     return;


### PR DESCRIPTION
* Fix not being able to set yourself on fire
* Fix flamechunks interacting with nonsolid players visually from the perspective of the player getting shot - even if the shooter was nonsolid, the chunks would visually spread around the players POV and block view
* Fix potential crash/oob read in `playerIsSolid` if a flamechunk was spawned by `props_flamethrower` entity

refs #1539, #1598 