### PR TITLE
Add CMake target to cleanup old mod pk3 files

### DIFF
--- a/assets/CMakeLists.txt
+++ b/assets/CMakeLists.txt
@@ -10,12 +10,12 @@ file(GENERATE OUTPUT "${BASE_DIR_PATH}/description.txt" CONTENT "${PK_NAME}")
 list(APPEND PK_ASSETS "description.txt")
 
 add_custom_target(mod_pk3
-	COMMAND ${CMAKE_COMMAND} 
+	COMMAND ${CMAKE_COMMAND}
 		-DINPUT="${PK_ASSETS};cgame*.so;cgame*.dll;cgame_mac;ui*.so;ui*.dll;ui_mac"
 		-DOUTPUT="${PK_PATH}"
 		-P ${CMAKE_SOURCE_DIR}/cmake/AssetsPackager.cmake
 	WORKING_DIRECTORY ${BASE_DIR_PATH}
-	# DEPENDS cgame ui
+	DEPENDS remove_old_pk3
 	COMMENT "Packing ${PK_NAME}.pk3"
 )
 
@@ -30,4 +30,12 @@ add_custom_target(mod_release
 	# DEPENDS qagame mod_pk3
 	DEPENDS mod_pk3
 	COMMENT "Packing ${RELEASE_NAME}.zip"
+)
+
+add_custom_target(remove_old_pk3
+		COMMAND ${CMAKE_COMMAND}
+		-DPK3_PATH="${BASE_DIR_PATH}"
+		-P ${CMAKE_SOURCE_DIR}/cmake/RemoveOldPK3.cmake
+		WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+		COMMENT "Cleaning old mod pk3 files"
 )

--- a/assets/CMakeLists.txt
+++ b/assets/CMakeLists.txt
@@ -1,41 +1,41 @@
-set(PK_NAME "${CMAKE_PROJECT_NAME}-${GAME_VERSION}")
-set(PK_PATH "${BASE_DIR_PATH}/${PK_NAME}.pk3")
+set(PK3_NAME "${CMAKE_PROJECT_NAME}-${GAME_VERSION}")
+set(PK3_PATH "${BASE_DIR_PATH}/${PK3_NAME}.pk3")
 
-file(GLOB_RECURSE PK_ASSETS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *)
-list(REMOVE_ITEM PK_ASSETS CMakeLists.txt)
+file(GLOB_RECURSE PK3_ASSETS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *)
+list(REMOVE_ITEM PK3_ASSETS CMakeLists.txt)
 
-message(STATUS "Coping assets/ to ${BASE_DIR_PATH}")
+message(STATUS "Copying assets/ to ${BASE_DIR_PATH}")
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/assets" "${BASE_DIR_PATH}")
-file(GENERATE OUTPUT "${BASE_DIR_PATH}/description.txt" CONTENT "${PK_NAME}")
-list(APPEND PK_ASSETS "description.txt")
+file(GENERATE OUTPUT "${BASE_DIR_PATH}/description.txt" CONTENT "${PK3_NAME}")
+list(APPEND PK3_ASSETS "description.txt")
 
 add_custom_target(mod_pk3
-	COMMAND ${CMAKE_COMMAND}
-		-DINPUT="${PK_ASSETS};cgame*.so;cgame*.dll;cgame_mac;ui*.so;ui*.dll;ui_mac"
-		-DOUTPUT="${PK_PATH}"
-		-P ${CMAKE_SOURCE_DIR}/cmake/AssetsPackager.cmake
-	WORKING_DIRECTORY ${BASE_DIR_PATH}
-	DEPENDS remove_old_pk3
-	COMMENT "Packing ${PK_NAME}.pk3"
+		COMMAND ${CMAKE_COMMAND}
+			-DINPUT="${PK3_ASSETS};cgame*.so;cgame*.dll;cgame_mac;ui*.so;ui*.dll;ui_mac"
+			-DOUTPUT="${PK3_PATH}"
+			-P ${CMAKE_SOURCE_DIR}/cmake/AssetsPackager.cmake
+		WORKING_DIRECTORY ${BASE_DIR_PATH}
+		DEPENDS remove_old_pk3
+		COMMENT "Packing ${PK3_NAME}.pk3"
 )
 
 set(RELEASE_NAME "${CMAKE_PROJECT_NAME}-${GAME_VERSION}")
 set(RELEASE_PATH "${CMAKE_BINARY_DIR}/${RELEASE_NAME}.zip")
+
 add_custom_target(mod_release
-	COMMAND ${CMAKE_COMMAND} 
-		-DINPUT="${BASE_DIR}/qagame*.so;${BASE_DIR}/qagame*.dll;${BASE_DIR}/qagame_mac;${BASE_DIR}/${PK_NAME}.pk3"
-		-DOUTPUT="${RELEASE_PATH}"
-		-P ${CMAKE_SOURCE_DIR}/cmake/AssetsPackager.cmake
-	WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
-	# DEPENDS qagame mod_pk3
-	DEPENDS mod_pk3
-	COMMENT "Packing ${RELEASE_NAME}.zip"
+		COMMAND ${CMAKE_COMMAND}
+			-DINPUT="${BASE_DIR}/qagame*.so;${BASE_DIR}/qagame*.dll;${BASE_DIR}/qagame_mac;${BASE_DIR}/${PK3_NAME}.pk3"
+			-DOUTPUT="${RELEASE_PATH}"
+			-P ${CMAKE_SOURCE_DIR}/cmake/AssetsPackager.cmake
+		WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+		DEPENDS mod_pk3
+		COMMENT "Packing ${RELEASE_NAME}.zip"
 )
 
 add_custom_target(remove_old_pk3
 		COMMAND ${CMAKE_COMMAND}
-		-DPK3_PATH="${BASE_DIR_PATH}"
-		-P ${CMAKE_SOURCE_DIR}/cmake/RemoveOldPK3.cmake
+			-DPK3_PATH="${BASE_DIR_PATH}"
+			-P ${CMAKE_SOURCE_DIR}/cmake/RemoveOldPK3.cmake
 		WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
 		COMMENT "Cleaning old mod pk3 files"
 )

--- a/cmake/RemoveOldPK3.cmake
+++ b/cmake/RemoveOldPK3.cmake
@@ -1,0 +1,16 @@
+if (NOT PK3_PATH)
+    message(FATAL_ERROR "PK3_PATH not specified")
+endif ()
+
+file(GLOB OLD_PK3_FILES "${PK3_PATH}/etjump-*.pk3")
+
+message("pk3 path: ${PK3_PATH}")
+
+if (NOT OLD_PK3_FILES)
+    message("No old PK3 files found.")
+else ()
+    foreach (PK3 IN LISTS OLD_PK3_FILES)
+        message("Removing file ${PK3}")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E rm -f ${PK3})
+    endforeach ()
+endif ()


### PR DESCRIPTION
Cleanup old mod pk3 files before building the mod_pk3 target, to ensure we aren't accidentally loading wrong files while debugging, and to not pile up old files to the directory for no reason.

Inspiration from ET: Legacy https://github.com/etlegacy/etlegacy/commit/30d8529a3ca9474950576e78d5d00c8a18af5247