### PR TITLE
Fix VERSION.txt parsing for CMAKE_PROJECT_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,10 @@ cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 file(READ "${CMAKE_SOURCE_DIR}/VERSION.txt" version_content)
 
 string(REGEX MATCH "VERSION_MAJOR ([0-9]+)" _major_match "${version_content}")
-string(REGEX MATCH "VERSION_MINOR ([0-9]+)" _minor_match "${version_content}")
-string(REGEX MATCH "VERSION_PATCH ([0-9]+)" _patch_match "${version_content}")
-
 set(VERSION_MAJOR "${CMAKE_MATCH_1}")
+string(REGEX MATCH "VERSION_MINOR ([0-9]+)" _minor_match "${version_content}")
 set(VERSION_MINOR "${CMAKE_MATCH_1}")
+string(REGEX MATCH "VERSION_PATCH ([0-9]+)" _patch_match "${version_content}")
 set(VERSION_PATCH "${CMAKE_MATCH_1}")
 
 project(etjump VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" HOMEPAGE_URL "etjump.com" LANGUAGES C CXX)


### PR DESCRIPTION
Apply version integer after each regex match so we don't constantly override the old value, and end up with `PATCH.PATCH.PATCH` version always.

This wasn't causing any issues as `CMAKE_PROJECT_VERSION` was only used in `VersionDescription.cmake` as a fallback if Git wasn't found, the actual versioning used everywhere came directly from the output of `git describe`.