### PR TITLE
Print func, file and line on Q_strncpyz/Q_strcat/Q_strnlen errors

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -81,6 +81,7 @@ function(create_compiler_opts target)
 			/Gy                # generate useful information for optimizer
 			/Ob2               # let compiler inline freely
 			/fp:fast>          # fast floating point math
+			/FC                # full path of source code file in diagnostics (/Zi in debug implies this)
 		$<$<CONFIG:Debug>:
 			/Ob0               # no inlining
 			/Od                # no optimizations
@@ -89,6 +90,10 @@ function(create_compiler_opts target)
 			/RTC1>)            # run-time checking
 
 	add_library(${target} INTERFACE)
+
+	# we use this to print out relative path to a source code file for __FILE__ macro replacement
+	string(LENGTH "${CMAKE_SOURCE_DIR}/" SOURCE_PATH_SIZE)
+	add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
 
 	if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 		target_compile_options(${target} INTERFACE ${MSVC_CXX_FLAGS})

--- a/src/game/q_shared.cpp
+++ b/src/game/q_shared.cpp
@@ -759,15 +759,17 @@ Q_strncpyz
 Safe strncpy that ensures a trailing zero
 =============
 */
-void Q_strncpyz(char *dest, const char *src, int destsize) {
+void Q_strncpyz_fn(char *dest, const char *src, const int destsize,
+                   const char *func, const char *file, const int line) {
   if (!dest) {
-    Com_Error(ERR_FATAL, "Q_strncpyz: NULL dest");
+    Com_Error(ERR_FATAL, "Q_strncpyz: NULL dest (%s, %s:%i)", func, file, line);
   }
   if (!src) {
-    Com_Error(ERR_FATAL, "Q_strncpyz: NULL src");
+    Com_Error(ERR_FATAL, "Q_strncpyz: NULL src (%s, %s:%i)", func, file, line);
   }
   if (destsize < 1) {
-    Com_Error(ERR_FATAL, "Q_strncpyz: destsize < 1");
+    Com_Error(ERR_FATAL, "Q_strncpyz: destsize < 1 (%s, %s:%i)", func, file,
+              line);
   }
 
   strncpy(dest, src, destsize - 1);
@@ -849,13 +851,15 @@ char *Q_strupr(char *s1) {
 }
 
 // never goes past bounds or leaves without a terminating 0
-void Q_strcat(char *dest, int size, const char *src) {
-  int l1;
+void Q_strcat_fn(char *dest, const int size, const char *src, const char *func,
+                 const char *file, const int line) {
+  const int l1 = static_cast<int>(strlen(dest));
 
-  l1 = strlen(dest);
   if (l1 >= size) {
-    Com_Error(ERR_FATAL, "Q_strcat: already overflowed");
+    Com_Error(ERR_FATAL, "Q_strcat: already overflowed (%s, %s:%i)", func, file,
+              line);
   }
+
   Q_strncpyz(dest + l1, src, size - l1);
 }
 
@@ -939,9 +943,10 @@ char *Q_CleanDirName(char *dirname) {
   return dirname;
 }
 
-size_t Q_strnlen(const char *str, size_t maxlen) {
+size_t Q_strnlen_fn(const char *str, const size_t maxlen, const char *func,
+                    const char *file, const int line) {
   if (!str) {
-    Com_Error(ERR_FATAL, "Q_strnlen: NULL str");
+    Com_Error(ERR_FATAL, "Q_strnlen: NULL str (%s, %s:%i)", func, file, line);
     return 0; // blah blah silence warning about str being null
   }
 

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -211,6 +211,9 @@ void Sys_PumpEvents(void);
 
 //=============================================================
 
+// relative path to a source file (src/foo/bar.cpp)
+#define SRC_FILENAME ((__FILE__) + (SOURCE_PATH_SIZE))
+
 typedef unsigned char byte;
 
 typedef enum { qfalse, qtrue } qboolean;
@@ -808,8 +811,15 @@ char *Q_strlwr(char *s1);
 char *Q_strupr(char *s1);
 
 // buffer size safe library replacements
-void Q_strncpyz(char *dest, const char *src, int destsize);
-void Q_strcat(char *dest, int size, const char *src);
+#define Q_strncpyz(dest, src, destsize)                                        \
+  Q_strncpyz_fn(dest, src, destsize, __func__, SRC_FILENAME, __LINE__)
+void Q_strncpyz_fn(char *dest, const char *src, int destsize, const char *func,
+                   const char *file, int line);
+
+#define Q_strcat(dest, size, src)                                              \
+  Q_strcat_fn(dest, size, src, __func__, SRC_FILENAME, __LINE__)
+void Q_strcat_fn(char *dest, int size, const char *src, const char *func,
+                 const char *file, int line);
 
 // strlen that discounts Quake color sequences
 int Q_PrintStrlen(const char *string);
@@ -818,7 +828,10 @@ char *Q_CleanStr(char *string);
 // removes whitespaces and other bad directory characters
 char *Q_CleanDirName(char *dirname);
 // safe strlen up to N chars
-size_t Q_strnlen(const char *str, size_t maxlen);
+#define Q_strnlen(str, maxlen)                                                 \
+  Q_strnlen_fn(str, maxlen, __func__, SRC_FILENAME, __LINE__)
+size_t Q_strnlen_fn(const char *str, size_t maxlen, const char *func,
+                    const char *file, int line);
 
 // #define _vsnprintf use_Q_vsnprintf
 // #define vsnprintf use_Q_vsnprintf


### PR DESCRIPTION
This eases debugging crashes in prod as we know precisely where the error comes from.

~~MSVC is untested still, need to make sure it works on that too, only tested GCC and Clang so far.~~ Works fine as long as `/FC` is used in release mode.