### PR TITLE
Let compilers know that trap_Error does not return

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2806,7 +2806,7 @@ void CG_printConsoleString(const char *str);
 void CG_LoadObjectiveData(void);
 
 void QDECL CG_Printf(const char *msg, ...);
-void QDECL CG_Error(const char *msg, ...);
+[[noreturn]] void QDECL CG_Error(const char *msg, ...);
 
 void CG_StartMusic(void);
 void CG_QueueMusic(void);
@@ -3550,7 +3550,7 @@ int trap_RealTime(qtime_t *qtime);
 void trap_Print(const char *fmt);
 
 // abort the game
-void trap_Error(const char *fmt);
+[[noreturn]] void trap_Error(const char *fmt);
 
 // console variable interaction
 void trap_Cvar_Register(vmCvar_t *vmCvar, const char *varName,

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1471,7 +1471,7 @@ void QDECL CG_Printf(const char *msg, ...) {
   trap_Print(text);
 }
 
-void QDECL CG_Error(const char *msg, ...) {
+[[noreturn]] void QDECL CG_Error(const char *msg, ...) {
   va_list argptr;
   char text[1024];
 
@@ -1485,7 +1485,7 @@ void QDECL CG_Error(const char *msg, ...) {
 #ifndef CGAME_HARD_LINKED
 // this is only here so the functions in q_shared.c and bg_*.c can link (FIXME)
 
-void QDECL Com_Error(int level, const char *error, ...) {
+[[noreturn]] void QDECL Com_Error(int level, const char *error, ...) {
   va_list argptr;
   char text[1024];
 

--- a/src/cgame/cg_syscalls.cpp
+++ b/src/cgame/cg_syscalls.cpp
@@ -4,7 +4,7 @@
 #include "../game/etj_syscall_ext_shared.h"
 
 static intptr_t(QDECL *syscall)(intptr_t arg,
-                                ...) = (intptr_t(QDECL *)(intptr_t, ...)) - 1;
+                                ...) = (intptr_t(QDECL *)(intptr_t, ...))-1;
 
 #if defined(__MACOS__)
   #ifndef __GNUC__
@@ -46,7 +46,10 @@ void trap_PumpEventLoop(void) {
 void trap_Print(const char *fmt) { SystemCall(CG_PRINT, fmt); }
 
 // coverity[+kill]
-void trap_Error(const char *fmt) { SystemCall(CG_ERROR, fmt); }
+void trap_Error(const char *fmt) {
+  SystemCall(CG_ERROR, fmt);
+  UNREACHABLE
+}
 
 int trap_Milliseconds(void) { return SystemCall(CG_MILLISECONDS); }
 

--- a/src/cgame/cg_syscalls.cpp
+++ b/src/cgame/cg_syscalls.cpp
@@ -46,7 +46,7 @@ void trap_PumpEventLoop(void) {
 void trap_Print(const char *fmt) { SystemCall(CG_PRINT, fmt); }
 
 // coverity[+kill]
-void trap_Error(const char *fmt) {
+[[noreturn]] void trap_Error(const char *fmt) {
   SystemCall(CG_ERROR, fmt);
   UNREACHABLE
 }

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1839,7 +1839,7 @@ void QDECL G_LogPrintf(const char *fmt, ...);
 void SendScoreboardMessageToAllClients(void);
 void QDECL G_Printf(const char *fmt, ...);
 void QDECL G_DPrintf(const char *fmt, ...);
-void QDECL G_Error(const char *fmt, ...);
+[[noreturn]] void QDECL G_Error(const char *fmt, ...);
 void resetVote();
 
 //
@@ -2123,7 +2123,7 @@ extern vmCvar_t g_chatReplay;
 extern vmCvar_t g_chatReplayMaxMessageAge;
 
 void trap_Printf(const char *fmt);
-void trap_Error(const char *fmt);
+[[noreturn]] void trap_Error(const char *fmt);
 int trap_Milliseconds(void);
 int trap_Argc(void);
 void trap_Argv(int n, char *buffer, int bufferLength);

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -615,8 +615,6 @@ void QDECL G_Printf(const char *fmt, ...) {
 
   trap_Printf(text);
 }
-// bani
-void QDECL G_Printf(const char *fmt, ...);
 
 void QDECL G_DPrintf(const char *fmt, ...) {
   va_list argptr;
@@ -632,10 +630,8 @@ void QDECL G_DPrintf(const char *fmt, ...) {
 
   trap_Printf(text);
 }
-// bani
-void QDECL G_DPrintf(const char *fmt, ...);
 
-void QDECL G_Error(const char *fmt, ...) {
+[[noreturn]] void QDECL G_Error(const char *fmt, ...) {
   va_list argptr;
   char text[1024];
 
@@ -645,8 +641,6 @@ void QDECL G_Error(const char *fmt, ...) {
 
   trap_Error(text);
 }
-// bani
-void QDECL G_Error(const char *fmt, ...);
 
 #define CH_KNIFE_DIST 48 // from g_weapon.c
 #define CH_LADDER_DIST 100
@@ -2055,7 +2049,7 @@ void G_ShutdownGame(int restart) {
 #ifndef GAME_HARD_LINKED
 // this is only here so the functions in q_shared.c and bg_*.c can link
 
-void QDECL Com_Error(int unused, const char *error, ...) {
+[[noreturn]] void QDECL Com_Error(int level, const char *error, ...) {
   va_list argptr;
   char text[1024];
 
@@ -2065,8 +2059,6 @@ void QDECL Com_Error(int unused, const char *error, ...) {
 
   G_Error("%s", text);
 }
-// bani
-void QDECL Com_Error(int level, const char *error, ...);
 
 void QDECL Com_Printf(const char *msg, ...) {
   va_list argptr;
@@ -2078,8 +2070,6 @@ void QDECL Com_Printf(const char *msg, ...) {
 
   G_Printf("%s", text);
 }
-// bani
-void QDECL Com_Printf(const char *msg, ...);
 
 #endif
 

--- a/src/game/g_syscalls.cpp
+++ b/src/game/g_syscalls.cpp
@@ -7,7 +7,7 @@
 // g_syscalls.asm is included instead when building a qvm
 
 static intptr_t(QDECL *syscall)(intptr_t arg,
-                                ...) = (intptr_t(QDECL *)(intptr_t, ...)) - 1;
+                                ...) = (intptr_t(QDECL *)(intptr_t, ...))-1;
 
 #if defined(__MACOS__)
   #ifndef __GNUC__
@@ -42,7 +42,10 @@ inline int PASSFLOAT(const float &f) noexcept {
 void trap_Printf(const char *fmt) { SystemCall(G_PRINT, fmt); }
 
 // coverity[+kill]
-void trap_Error(const char *fmt) { SystemCall(G_ERROR, fmt); }
+void trap_Error(const char *fmt) {
+  SystemCall(G_ERROR, fmt);
+  UNREACHABLE
+}
 
 int trap_Milliseconds(void) { return SystemCall(G_MILLISECONDS); }
 int trap_Argc(void) { return SystemCall(G_ARGC); }

--- a/src/game/g_syscalls.cpp
+++ b/src/game/g_syscalls.cpp
@@ -42,7 +42,7 @@ inline int PASSFLOAT(const float &f) noexcept {
 void trap_Printf(const char *fmt) { SystemCall(G_PRINT, fmt); }
 
 // coverity[+kill]
-void trap_Error(const char *fmt) {
+[[noreturn]] void trap_Error(const char *fmt) {
   SystemCall(G_ERROR, fmt);
   UNREACHABLE
 }

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -214,6 +214,13 @@ void Sys_PumpEvents(void);
 // relative path to a source file (src/foo/bar.cpp)
 #define SRC_FILENAME ((__FILE__) + (SOURCE_PATH_SIZE))
 
+// tell compilers that trap_Error syscalls abort execution
+#if defined(_MSC_VER) && !defined(__clang__) // MSVC
+  #define UNREACHABLE __assume(false);
+#else // GCC, Clang
+  #define UNREACHABLE __builtin_unreachable();
+#endif
+
 typedef unsigned char byte;
 
 typedef enum { qfalse, qtrue } qboolean;

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -896,7 +896,7 @@ void RemoveDuplicates(char *str);
 void SortString(char *src);
 
 // this is only here so the functions in q_shared.c and bg_*.c can link
-void QDECL Com_Error(int level, const char *error, ...);
+[[noreturn]] void QDECL Com_Error(int level, const char *error, ...);
 void QDECL Com_Printf(const char *msg, ...);
 void QDECL Com_LocalPrintf(const char *msg, ...);
 

--- a/src/ui/ui_atoms.cpp
+++ b/src/ui/ui_atoms.cpp
@@ -33,7 +33,7 @@ void QDECL Com_DPrintf(const char *fmt, ...) {
 }
 // jpw
 
-void QDECL Com_Error(int level, const char *error, ...) {
+[[noreturn]] void QDECL Com_Error(int level, const char *error, ...) {
   va_list argptr;
   char text[1024];
 

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -991,7 +991,7 @@ void UI_SPSkillMenu_Cache(void);
 // ui_syscalls.c
 //
 void trap_Print(const char *string);
-void trap_Error(const char *string);
+[[noreturn]] void trap_Error(const char *string);
 int trap_Milliseconds(void);
 void trap_Cvar_Register(vmCvar_t *vmCvar, const char *varName,
                         const char *defaultValue, int flags);

--- a/src/ui/ui_syscalls.cpp
+++ b/src/ui/ui_syscalls.cpp
@@ -5,7 +5,7 @@
 // syscalls.asm is included instead when building a qvm
 
 static intptr_t(QDECL *syscall)(intptr_t arg,
-                                ...) = (intptr_t(QDECL *)(intptr_t, ...)) - 1;
+                                ...) = (intptr_t(QDECL *)(intptr_t, ...))-1;
 
 #if defined(__MACOS__)
   #ifndef __GNUC__
@@ -40,7 +40,10 @@ inline int PASSFLOAT(const float &f) noexcept {
 void trap_Print(const char *string) { SystemCall(UI_PRINT, string); }
 
 // coverity[+kill]
-void trap_Error(const char *string) { SystemCall(UI_ERROR, string); }
+void trap_Error(const char *string) {
+  SystemCall(UI_ERROR, string);
+  UNREACHABLE
+}
 
 int trap_Milliseconds(void) { return SystemCall(UI_MILLISECONDS); }
 

--- a/src/ui/ui_syscalls.cpp
+++ b/src/ui/ui_syscalls.cpp
@@ -40,7 +40,7 @@ inline int PASSFLOAT(const float &f) noexcept {
 void trap_Print(const char *string) { SystemCall(UI_PRINT, string); }
 
 // coverity[+kill]
-void trap_Error(const char *string) {
+[[noreturn]] void trap_Error(const char *string) {
   SystemCall(UI_ERROR, string);
   UNREACHABLE
 }


### PR DESCRIPTION
This way they can perform optimizations with control flow on places where execution aborts. Static analysis should also deal with error calls better, because it should now see that the execution does not return.