### PR TITLE
Fix incorrect string copy size in CG_SetupDlightstyles

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1737,7 +1737,7 @@ void CG_SetupDlightstyles(void) {
     cent = &cg_entities[entnum];
 
     token = COM_Parse(&str); // stylestring
-    Q_strncpyz(cent->dl_stylestring, token, strlen(token));
+    Q_strncpyz(cent->dl_stylestring, token, sizeof(cent->dl_stylestring));
 
     token = COM_Parse(&str); // offset
     cent->dl_frame = Q_atoi(token);


### PR DESCRIPTION
Don't try to write more characters to the array than it can hold. ~~This was "fine" because `Q_strncpyz` doesn't overflow, but it's better to have this correctly done.~~ NO IT'S NOT FINE, this was a classic buffer overflow.