### PR TITLE
Fix listbox & combo selection changing when dragging scrollbar

### DIFF
--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -6476,7 +6476,7 @@ void UI_FeederSelection(float feederID, int index) {
 }
 
 extern void Item_ListBox_MouseEnter(itemDef_t *item, float x, float y,
-                                    qboolean click);
+                                    bool click);
 qboolean UI_FeederSelectionClick(itemDef_t *item) {
   listBoxDef_t *listPtr = (listBoxDef_t *)item->typeData;
 

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -2444,10 +2444,10 @@ int Item_ListBox_OverLB(itemDef_t *item, float x, float y) {
   return 0;
 }
 
-void Item_ListBox_MouseEnter(itemDef_t *item, float x, float y,
-                             qboolean click) {
+void Item_ListBox_MouseEnter(itemDef_t *item, const float x, const float y,
+                             const bool click) {
   rectDef_t r;
-  listBoxDef_t *listPtr = (listBoxDef_t *)item->typeData;
+  auto *listPtr = static_cast<listBoxDef_t *>(item->typeData);
 
   item->window.flags &=
       ~(WINDOW_LB_LEFTARROW | WINDOW_LB_RIGHTARROW | WINDOW_LB_THUMB |
@@ -2456,46 +2456,43 @@ void Item_ListBox_MouseEnter(itemDef_t *item, float x, float y,
 
   // prevent listbox selection changing if we're dragging the scrollbar
   // and moving the cursor over the listbox
-  if (Menus_CaptureFuncActive()) {
+  if (Menus_CaptureFuncActive() || !click) {
     return;
   }
 
-  if (click) {
-    if (item->window.flags & WINDOW_HORIZONTAL) {
-      if (!(item->window.flags &
-            (WINDOW_LB_LEFTARROW | WINDOW_LB_RIGHTARROW | WINDOW_LB_THUMB |
-             WINDOW_LB_PGUP | WINDOW_LB_PGDN | WINDOW_LB_SOMEWHERE))) {
-        // check for selection hit as we have
-        // exausted buttons and thumb
-        if (listPtr->elementStyle == LISTBOX_IMAGE) {
-          r.x = item->window.rect.x;
-          r.y = item->window.rect.y;
-          r.h = item->window.rect.h - SCROLLBAR_SIZE;
-          r.w = item->window.rect.w - listPtr->drawPadding;
-          if (Rect_ContainsPoint(&r, x, y)) {
-            listPtr->cursorPos =
-                (int)((x - r.x) / listPtr->elementWidth) + listPtr->startPos;
-            if (listPtr->cursorPos >= listPtr->endPos) {
-              listPtr->cursorPos = listPtr->endPos;
-            }
+  if (item->window.flags & WINDOW_HORIZONTAL) {
+    if (!(item->window.flags &
+          (WINDOW_LB_LEFTARROW | WINDOW_LB_RIGHTARROW | WINDOW_LB_THUMB |
+           WINDOW_LB_PGUP | WINDOW_LB_PGDN | WINDOW_LB_SOMEWHERE))) {
+      // check for selection hit as we have exausted buttons and thumb
+      if (listPtr->elementStyle == LISTBOX_IMAGE) {
+        r.x = item->window.rect.x;
+        r.y = item->window.rect.y;
+        r.h = item->window.rect.h - SCROLLBAR_SIZE;
+        r.w = item->window.rect.w - static_cast<float>(listPtr->drawPadding);
+        if (Rect_ContainsPoint(&r, x, y)) {
+          listPtr->cursorPos =
+              static_cast<int>((x - r.x) / listPtr->elementWidth) +
+              listPtr->startPos;
+          if (listPtr->cursorPos >= listPtr->endPos) {
+            listPtr->cursorPos = listPtr->endPos;
           }
-        } else {
-          // text hit..
         }
       }
-    } else if (!(item->window.flags &
-                 (WINDOW_LB_LEFTARROW | WINDOW_LB_RIGHTARROW | WINDOW_LB_THUMB |
-                  WINDOW_LB_PGUP | WINDOW_LB_PGDN | WINDOW_LB_SOMEWHERE))) {
-      r.x = item->window.rect.x;
-      r.y = item->window.rect.y;
-      r.w = item->window.rect.w - SCROLLBAR_SIZE;
-      r.h = item->window.rect.h - listPtr->drawPadding;
-      if (Rect_ContainsPoint(&r, x, y)) {
-        listPtr->cursorPos =
-            (int)((y - 2 - r.y) / listPtr->elementHeight) + listPtr->startPos;
-        if (listPtr->cursorPos > listPtr->endPos) {
-          listPtr->cursorPos = listPtr->endPos;
-        }
+    }
+  } else if (!(item->window.flags &
+               (WINDOW_LB_LEFTARROW | WINDOW_LB_RIGHTARROW | WINDOW_LB_THUMB |
+                WINDOW_LB_PGUP | WINDOW_LB_PGDN | WINDOW_LB_SOMEWHERE))) {
+    r.x = item->window.rect.x;
+    r.y = item->window.rect.y;
+    r.w = item->window.rect.w - SCROLLBAR_SIZE;
+    r.h = item->window.rect.h - static_cast<float>(listPtr->drawPadding);
+    if (Rect_ContainsPoint(&r, x, y)) {
+      listPtr->cursorPos =
+          static_cast<int>((y - 2 - r.y) / listPtr->elementHeight) +
+          listPtr->startPos;
+      if (listPtr->cursorPos > listPtr->endPos) {
+        listPtr->cursorPos = listPtr->endPos;
       }
     }
   }

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -2454,6 +2454,12 @@ void Item_ListBox_MouseEnter(itemDef_t *item, float x, float y,
         WINDOW_LB_PGUP | WINDOW_LB_PGDN | WINDOW_LB_SOMEWHERE);
   item->window.flags |= Item_ListBox_OverLB(item, x, y);
 
+  // prevent listbox selection changing if we're dragging the scrollbar
+  // and moving the cursor over the listbox
+  if (Menus_CaptureFuncActive()) {
+    return;
+  }
+
   if (click) {
     if (item->window.flags & WINDOW_HORIZONTAL) {
       if (!(item->window.flags &

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -5748,7 +5748,8 @@ static void comboPaint(itemDef_t *item) {
           item->textRect.y + static_cast<float>(i) * comboRect.h + borderOfs;
     }
 
-    if (Rect_ContainsPoint(&textRect, static_cast<float>(DC->cursorx),
+    if (!Menus_CaptureFuncActive() &&
+        Rect_ContainsPoint(&textRect, static_cast<float>(DC->cursorx),
                            static_cast<float>(DC->cursory))) {
       Vector4Copy(item->window.foreColor, color);
       item->cursorPos = i + startPos;


### PR DESCRIPTION
Ignore mouse enter/hover events on the item if we're dragging the thumb, so we don't change the selected entry.

refs #1424 