### PR TITLE
Add target_ft_setrules entity + supplementary ws keys

### DIFF
--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library(qagame MODULE
 	"etj_syscall_ext_shared.cpp"
 	"etj_synchronization_context.cpp"
 	"etj_string_utilities.cpp"
+	"etj_target_ft_setrules.cpp"
 	"etj_target_init.cpp"
 	"etj_time_utilities.cpp"
 	"etj_timerun_repository.cpp"

--- a/src/game/etj_target_ft_setrules.cpp
+++ b/src/game/etj_target_ft_setrules.cpp
@@ -36,7 +36,7 @@ void TargetFtSetRules::spawn(gentity_t *ent) {
 
   // this must be a string so we can support 'savelimit reset'
   G_SpawnString("savelimit", "", &s);
-  Q_strncpyz(ent->ftSavelimit, s, sizeof(ent->ftSavelimit));
+  ent->ftSavelimit = G_NewString(s);
 
   // this is a boolean but there's no G_SpawnBoolean so bleh
   ent->damage = KEY_NOT_SET;
@@ -50,7 +50,7 @@ void TargetFtSetRules::spawn(gentity_t *ent) {
   }
 
   G_SpawnString("leader_only_message", "", &s);
-  Q_strncpyz(ent->ftLeaderOnlyMsg, s, sizeof(ent->ftLeaderOnlyMsg));
+  ent->message = G_NewString(s);
 
   ent->use = [](gentity_t *self, gentity_t *other, gentity_t *activator) {
     use(self, activator);
@@ -70,8 +70,8 @@ void TargetFtSetRules::use(const gentity_t *self, gentity_t *activator) {
   }
 
   if (self->spawnflags & LEADER_ONLY && !G_IsFireteamLeader(clientNum, &ft)) {
-    if (self->ftLeaderOnlyMsg[0] != '\0') {
-      std::string msg = self->ftLeaderOnlyMsg;
+    if (self->message[0] != '\0') {
+      std::string msg = self->message;
 
       // this will never be nullptr, otherwise we wouldn't have gotten this far
       const gentity_t *leader = getFireteamLeader(clientNum);

--- a/src/game/etj_target_ft_setrules.cpp
+++ b/src/game/etj_target_ft_setrules.cpp
@@ -1,0 +1,122 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_target_ft_setrules.h"
+#include "etj_numeric_utilities.h"
+#include "etj_printer.h"
+#include "etj_string_utilities.h"
+
+namespace ETJump {
+void TargetFtSetRules::spawn(gentity_t *ent) {
+  char keyNotSet[5]{};
+  Com_sprintf(keyNotSet, sizeof(keyNotSet), "%i", KEY_NOT_SET);
+
+  char *s;
+
+  // this must be a string so we can support 'savelimit reset'
+  G_SpawnString("savelimit", "", &s);
+  Q_strncpyz(ent->ftSavelimit, s, sizeof(ent->ftSavelimit));
+
+  // this is a boolean but there's no G_SpawnBoolean so bleh
+  ent->damage = KEY_NOT_SET;
+  if (G_SpawnInt("noghost", keyNotSet, &ent->damage)) {
+    ent->damage = Numeric::clamp(ent->damage, 0, 1);
+  }
+
+  ent->health = KEY_NOT_SET;
+  if (G_SpawnInt("teamjumpmode", keyNotSet, &ent->health)) {
+    ent->health = Numeric::clamp(ent->health, 0, 1);
+  }
+
+  G_SpawnString("leader_only_message", "", &s);
+  Q_strncpyz(ent->ftLeaderOnlyMsg, s, sizeof(ent->ftLeaderOnlyMsg));
+
+  ent->use = [](gentity_t *self, gentity_t *other, gentity_t *activator) {
+    use(self, activator);
+  };
+}
+
+void TargetFtSetRules::use(const gentity_t *self, gentity_t *activator) {
+  if (!activator || !activator->client) {
+    return;
+  }
+
+  fireteamData_t *ft = nullptr;
+  const int clientNum = ClientNum(activator);
+
+  if (!G_IsOnFireteam(clientNum, &ft)) {
+    return;
+  }
+
+  if (self->spawnflags & LEADER_ONLY && !G_IsFireteamLeader(clientNum, &ft)) {
+    if (self->ftLeaderOnlyMsg[0] != '\0') {
+      std::string msg = self->ftLeaderOnlyMsg;
+
+      // this will never be nullptr, otherwise we wouldn't have gotten this far
+      const gentity_t *leader = getFireteamLeader(clientNum);
+      StringUtil::replaceAll(msg, "%s",
+                             std::string(leader->client->pers.netname) + "^7");
+      Printer::center(activator, msg);
+    }
+
+    return;
+  }
+
+  // from here on, ft pointer will always be valid,
+  // so we can dereference it safely to check current ft state
+
+  bool rulesChanged = false;
+
+  if (self->ftSavelimit[0] != '\0' && canSetFtSavelimit(clientNum, self)) {
+    if (!Q_stricmp(self->ftSavelimit, "reset")) {
+      // no need to set rulesChanged to true here as we don't have to update
+      // configstrings for 'reset', see g_fireteams.cpp -> setFireTeamRules
+      setSaveLimitForFTMembers(ft, ft->saveLimit);
+    } else {
+      const int limit = Numeric::clamp(Q_atoi(self->ftSavelimit), -1, 100);
+      setSaveLimitForFTMembers(ft, limit);
+      rulesChanged = true;
+    }
+  }
+
+  if (self->damage != KEY_NOT_SET && ft->noGhost != self->damage &&
+      canEnableFtNoGhost(clientNum, ft, self)) {
+    setFireTeamGhosting(ft, self->damage);
+    rulesChanged = true;
+  }
+
+  // this 'canSetFtTeamjumpMode' is redundant here as it will always
+  // succeed for non-player entities, but better to have it here
+  // if other restrictions are added in the future
+  if (self->health != KEY_NOT_SET && ft->teamJumpMode != self->health &&
+      canSetFtTeamjumpMode(clientNum, self)) {
+    setFireteamTeamjumpMode(ft, self->health);
+    rulesChanged = true;
+  }
+
+  if (rulesChanged) {
+    G_UpdateFireteamConfigString(ft);
+  }
+}
+} // namespace ETJump

--- a/src/game/etj_target_ft_setrules.h
+++ b/src/game/etj_target_ft_setrules.h
@@ -1,0 +1,46 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "g_local.h"
+
+namespace ETJump {
+class TargetFtSetRules {
+public:
+  static void spawn(gentity_t *ent);
+
+private:
+  enum Spawnflags {
+    LEADER_ONLY = 1,
+  };
+
+  // default value for unset keys, we can't leave them 0 initialized because
+  // triggering this entity would then set any key to default value,
+  // and 0 is a valid value for all the keys this supports
+  static constexpr int KEY_NOT_SET = -999;
+
+  static void use(const gentity_t *self, gentity_t *activator);
+};
+} // namespace ETJump

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -600,7 +600,7 @@ struct gentity_s {
 
   std::array<int, MAX_CLIENTS> targetDelayActivationTime;
 
-  // target_ft_setrules, just big enough to hold -1 - 100 or 'reset'
+  // target_ft_setrules
   char *ftSavelimit;
 };
 

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -601,8 +601,7 @@ struct gentity_s {
   std::array<int, MAX_CLIENTS> targetDelayActivationTime;
 
   // target_ft_setrules, just big enough to hold -1 - 100 or 'reset'
-  char ftSavelimit[6];
-  char ftLeaderOnlyMsg[MAX_STRING_CHARS];
+  char *ftSavelimit;
 };
 
 // Ridah

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -599,6 +599,10 @@ struct gentity_s {
   int lastSurfaceFlag;
 
   std::array<int, MAX_CLIENTS> targetDelayActivationTime;
+
+  // target_ft_setrules, just big enough to hold -1 - 100 or 'reset'
+  char ftSavelimit[6];
+  char ftLeaderOnlyMsg[MAX_STRING_CHARS];
 };
 
 // Ridah
@@ -1435,6 +1439,8 @@ typedef struct {
   bool noDrop;
   bool noWallbug;
   bool noFTNoGhost;
+  bool noFTSaveLimit;
+  bool noFTTeamjumpMode;
 
   int portalEnabled; // Feen: PGM - Enabled/Disabled by map key
   qboolean portalSurfaces;
@@ -2560,6 +2566,17 @@ void G_InviteToFireTeam(int entityNum, int otherEntityNum);
 void G_UpdateFireteamConfigString(fireteamData_t *ft);
 void G_RemoveClientFromFireteams(int entityNum, qboolean update,
                                  qboolean print);
+
+namespace ETJump {
+gentity_t *getFireteamLeader(int clientNum);
+void setSaveLimitForFTMembers(fireteamData_t *ft, int limit);
+void setFireTeamGhosting(fireteamData_t *ft, bool noGhost);
+bool canEnableFtNoGhost(int clientNum, fireteamData_t *ft,
+                        const gentity_t *ent);
+bool canSetFtSavelimit(int clientNum, const gentity_t *ent);
+bool canSetFtTeamjumpMode(int clientNum, const gentity_t *ent);
+void setFireteamTeamjumpMode(fireteamData_t *ft, bool teamjumpMode);
+} // namespace ETJump
 
 void G_PrintClientSpammyCenterPrint(int entityNum, const char *text);
 

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -17,6 +17,7 @@
 #include "etj_missilepad.h"
 #include "etj_target_init.h"
 #include "etj_trigger_teleport_client.h"
+#include "etj_target_ft_setrules.h"
 
 qboolean G_SpawnStringExt(const char *key, const char *defaultString,
                           char **out, const char *file, int line) {
@@ -175,6 +176,11 @@ field_t fields[] = {
     {"targetShaderNewName", FOFS(targetShaderNewName), F_LSTRING},
 
     {"cursorhint", FOFS(s.dmgFlags), F_CURSORHINT},
+
+    {"savelimit", FOFS(ftSavelimit), F_LSTRING},
+    {"noghost", FOFS(damage), F_INT},
+    {"teamjumpmode", FOFS(health), F_INT},
+    {"leader_only_message", FOFS(ftLeaderOnlyMsg), F_LSTRING},
 
     {nullptr}};
 
@@ -460,8 +466,6 @@ void SP_target_deathrun_checkpoint(gentity_t *self);
 void SP_target_tjlclear(gentity_t *self);
 void SP_target_tjldisplay(gentity_t *self);
 
-void SP_target_init(gentity_t *self);
-
 spawn_t spawns[] = {
     // info entities don't do anything at all, but provide positional
     // information for things controlled by other processes
@@ -717,6 +721,7 @@ spawn_t spawns[] = {
     {"target_init", ETJump::TargetInit::spawn},
     {"func_missilepad", ETJump::Missilepad::spawn},
     {"trigger_teleport_client", ETJump::TriggerTeleportClient::spawn},
+    {"target_ft_setrules", ETJump::TargetFtSetRules::spawn},
     {nullptr, nullptr},
 };
 
@@ -1126,8 +1131,26 @@ static void initNoFTNoGhost() {
   G_SpawnInt("noftnoghost", "0", &value);
 
   level.noFTNoGhost = value;
-  G_Printf("Fireteam noghost is %s.\n",
-           level.noFTNoGhost ? "disabled" : "enabled");
+  G_Printf("Fireteam noghost %s be toggled by players.\n",
+           level.noFTNoGhost ? "cannot" : "can");
+}
+
+static void initNoFTSaveLimit() {
+  int value;
+  G_SpawnInt("noftsavelimit", "0", &value);
+
+  level.noFTSaveLimit = value;
+  G_Printf("Fireteam savelimit %s be set by players.\n",
+           level.noFTSaveLimit ? "cannot" : "can");
+}
+
+static void initNoFTTeamjumpMode() {
+  int value;
+  G_SpawnInt("noftteamjumpmode", "0", &value);
+
+  level.noFTTeamjumpMode = value;
+  G_Printf("Fireteam teamjump mode %s be toggled by players.\n",
+           level.noFTTeamjumpMode ? "cannot" : "can");
 }
 } // namespace ETJump
 
@@ -1274,6 +1297,8 @@ void SP_worldspawn(void) {
   ETJump::initNoWallbug();
   ETJump::initNoNoclip();
   ETJump::initNoFTNoGhost();
+  ETJump::initNoFTSaveLimit();
+  ETJump::initNoFTTeamjumpMode();
 
   level.mapcoordsValid = qfalse;
   if (G_SpawnVector2D("mapcoordsmins", "-128 128",

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -180,7 +180,7 @@ field_t fields[] = {
     {"savelimit", FOFS(ftSavelimit), F_LSTRING},
     {"noghost", FOFS(damage), F_INT},
     {"teamjumpmode", FOFS(health), F_INT},
-    {"leader_only_message", FOFS(ftLeaderOnlyMsg), F_LSTRING},
+    {"leader_only_message", FOFS(message), F_LSTRING},
 
     {nullptr}};
 


### PR DESCRIPTION
Allows setting fireteam rules for the activcators fireteam. Bypasses `noftnoghost` and new `noftsavelimit` & `noftteamjumpmode` worldspawn keys, so mappers have precise control over when these rules are set. Spawnflag 1 makes it so that only the leader of the fireteam is able to activate the entity.

Supported keys:
* `savelimit (-1 - 100 or reset)` - sets savelimit
* `noghost 0/1` - disable/enable fireteam noghost
* `teamjumpmode 0/1` - disable/enable teamjump mode
* `leader_only_message` - message to print to activator if `spawnflag 1` is set and the activator is not the fireteam leader, `%s` will be substituted with the fireteam leaders name

flxes #1588 