### PR TITLE
Fix reveresed combo menu not drawing background

### DIFF
--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -5707,7 +5707,7 @@ static void comboPaint(itemDef_t *item) {
   const bool reversed = item->comboData.reversed;
 
   if (reversed) {
-    item->comboData.rect.y -= item->comboData.rect.h + item->comboData.height;
+    comboRect.y -= item->comboData.rect.h + item->comboData.height;
   }
 
   // we can't use forecolor here because if mouse is over an item,


### PR DESCRIPTION
The draw function was modifying the original combo rect data, which caused it to drift off screen constantly.

fixes #1624 
refs #1532 