### PR TITLE
Add etj_logCenterPrint for center print logging

### DIFF
--- a/assets/ui/etjump_settings_general_console.menu
+++ b/assets/ui/etjump_settings_general_console.menu
@@ -55,8 +55,9 @@ menuDef {
         YESNO               (SETTINGS_ITEM_POS(3), "Console shader:", 0.2, SETTINGS_ITEM_H, "etj_consoleShader", "Draw console background shader (vid_restart required)\netj_consoleShader")
         COMBO               (SETTINGS_COMBO_POS(4), "Console color:", 0.2, SETTINGS_ITEM_H, "etj_consoleColor", COLOR_LIST, uiScript uiPreviousMenu MENU_NAME, "Sets console color when console shader is disabled (vid_restart required)\netj_consoleColor")
         YESNO               (SETTINGS_ITEM_POS(5), "Log banners:", 0.2, SETTINGS_ITEM_H, "etj_logBanner", "Log banners into console\netj_logBanner")
-        YESNO               (SETTINGS_ITEM_POS(6), "Notify messages:", 0.2, SETTINGS_ITEM_H, "etj_drawNotify", "Draw console output at top left\netj_drawNotify (con_drawnotify)")
-        COMBO               (SETTINGS_COMBO_POS(7), "Renderer speeds:", 0.2, SETTINGS_ITEM_H, "etj_speeds", cvarFloatList { "Off" 0 "Surfaces" 1 "Culling" 2 "Viewcluster" 3 "Dlights" 4 "Render distance" 5 "Flares" 6 "Decals" 7 }, none, "Output various render statistics to console\netj_speeds (r_speeds)")
+        YESNO               (SETTINGS_ITEM_POS(6), "Log center prints:", 0.2, SETTINGS_ITEM_H, "etj_logCenterPrint", "Log center prints into console (excl. save messages)\netj_logCenterPrint")
+        YESNO               (SETTINGS_ITEM_POS(7), "Notify messages:", 0.2, SETTINGS_ITEM_H, "etj_drawNotify", "Draw console output at top left\netj_drawNotify (con_drawnotify)")
+        COMBO               (SETTINGS_COMBO_POS(8), "Renderer speeds:", 0.2, SETTINGS_ITEM_H, "etj_speeds", cvarFloatList { "Off" 0 "Surfaces" 1 "Culling" 2 "Viewcluster" 3 "Dlights" 4 "Render distance" 5 "Flares" 6 "Decals" 7 }, none, "Output various render statistics to console\netj_speeds (r_speeds)")
 
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -1169,6 +1169,34 @@ CENTER PRINTING
 ===============================================================================
 */
 
+namespace ETJump {
+void logCenterPrint() {
+  std::string msg = cg.centerPrint;
+
+  // we don't want newlines in the console
+  // this is called before center print gets automatically word wrapped
+  // to fit on screen properly, so it's fairly safe to assume that
+  // explicit newlines should be replaced with whitespace
+  StringUtil::replaceAll(msg, "\n", " ");
+
+  // it's possible to send an empty center print/only whitespace to "clear"
+  // whatever is being displayed, but we don't want to log that obviously
+  if (msg.empty() || std::all_of(msg.begin(), msg.end(),
+                                 [](const char c) { return isspace(c); })) {
+    return;
+  }
+
+  // don't log consecutive messages that are being re-triggered
+  if (cg.time + cg_centertime.integer * 1000 > cg.lastCenterPrintLogTime &&
+      Q_stricmp(msg.c_str(), cg.lastLoggedCenterPrint)) {
+    cg.lastCenterPrintLogTime = cg.time;
+    Q_strncpyz(cg.lastLoggedCenterPrint, msg.c_str(),
+               sizeof(cg.lastLoggedCenterPrint));
+    CG_Printf("%s\n", msg.c_str());
+  }
+}
+}
+
 /*
 ==============
 CG_CenterPrint
@@ -1179,7 +1207,8 @@ for a few moments
 */
 #define CP_LINEWIDTH 56 // NERVE - SMF
 
-void CG_CenterPrint(const char *str, int y, int charWidth) {
+void CG_CenterPrint(const char *str, const int y, const int charWidth,
+                    const bool log) {
   char *s;
   int i, len;                    // NERVE - SMF
   qboolean neednewline = qfalse; // NERVE - SMF
@@ -1192,6 +1221,10 @@ void CG_CenterPrint(const char *str, int y, int charWidth) {
 
   Q_strncpyz(cg.centerPrint, str, sizeof(cg.centerPrint));
   cg.centerPrintPriority = priority; // NERVE - SMF
+
+  if (log && etj_logCenterPrint.integer) {
+    ETJump::logCenterPrint();
+  }
 
   // NERVE - SMF - turn spaces into newlines, if we've run over the
   // linewidth
@@ -1234,8 +1267,8 @@ Called for important messages that should stay in the center of the screen
 for a few moments
 ==============
 */
-void CG_PriorityCenterPrint(const char *str, int y, int charWidth,
-                            int priority) {
+void CG_PriorityCenterPrint(const char *str, const int y, const int charWidth,
+                            const int priority, const bool log) {
   char *s;
   int i, len;                    // NERVE - SMF
   qboolean neednewline = qfalse; // NERVE - SMF
@@ -1247,6 +1280,10 @@ void CG_PriorityCenterPrint(const char *str, int y, int charWidth,
 
   Q_strncpyz(cg.centerPrint, str, sizeof(cg.centerPrint));
   cg.centerPrintPriority = priority; // NERVE - SMF
+
+  if (log && etj_logCenterPrint.integer) {
+    ETJump::logCenterPrint();
+  }
 
   // NERVE - SMF - turn spaces into newlines, if we've run over the
   // linewidth
@@ -1300,6 +1337,10 @@ static void CG_DrawCenterString(void) {
   if (!color) {
     cg.centerPrintTime = 0;
     cg.centerPrintPriority = 0;
+
+    // center print has faded, clear last logged message
+    // to allow same message to be re-logged
+    memset(cg.lastLoggedCenterPrint, 0, sizeof(cg.lastLoggedCenterPrint));
     return;
   }
 
@@ -3374,7 +3415,9 @@ void CG_DrawCompassIcon(float x, float y, float w, float h, vec3_t origin,
   x += w;
   y += h;
 
-  { w = sqrt((w * w) + (h * h)) / 3.f * 2.f * 0.9f; }
+  {
+    w = sqrt((w * w) + (h * h)) / 3.f * 2.f * 0.9f;
+  }
 
   x = x + (cos(angle) * w);
   y = y + (sin(angle) * w);

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -911,6 +911,9 @@ typedef struct {
   int centerPrintLines;
   int centerPrintPriority; // NERVE - SMF
 
+  char lastLoggedCenterPrint[1024];
+  int lastCenterPrintLogTime;
+
   // fade in/out
   int fadeTime;
   float fadeRate;
@@ -2790,6 +2793,8 @@ extern vmCvar_t etj_recordingStatusY;
 extern vmCvar_t etj_smoothAngles;
 extern vmCvar_t etj_autoSprint;
 
+extern vmCvar_t etj_logCenterPrint;
+
 //
 // cg_main.c
 //
@@ -2968,9 +2973,9 @@ void CG_StatsDebugAddText(const char *text);
 
 void CG_AddLagometerFrameInfo(void);
 void CG_AddLagometerSnapshotInfo(snapshot_t *snap);
-void CG_CenterPrint(const char *str, int y, int charWidth);
-void CG_PriorityCenterPrint(const char *str, int y, int charWidth,
-                            int priority);              // NERVE - SMF
+void CG_CenterPrint(const char *str, int y, int charWidth, bool log = true);
+void CG_PriorityCenterPrint(const char *str, int y, int charWidth, int priority,
+                            bool log = true);           // NERVE - SMF
 void CG_ObjectivePrint(const char *str, int charWidth); // NERVE - SMF
 void CG_DrawActive(stereoFrame_t stereoView);
 void CG_CheckForCursorHints(void);

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -675,6 +675,8 @@ vmCvar_t etj_recordingStatusY;
 vmCvar_t etj_smoothAngles;
 vmCvar_t etj_autoSprint;
 
+vmCvar_t etj_logCenterPrint;
+
 typedef struct {
   vmCvar_t *vmCvar;
   const char *cvarName;
@@ -1266,6 +1268,8 @@ cvarTable_t cvarTable[] = {
 
     {&etj_smoothAngles, "etj_smoothAngles", "1", CVAR_ARCHIVE},
     {&etj_autoSprint, "etj_autoSprint", "0", CVAR_ARCHIVE},
+
+    {&etj_logCenterPrint, "etj_logCenterPrint", "0", CVAR_ARCHIVE},
 };
 
 int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -2854,7 +2854,8 @@ static void CG_ServerCommand(void) {
       saveMsg += '\n' + remainingSavesStr;
     }
 
-    CPri(saveMsg.c_str());
+    CG_CenterPrint(CG_LocalizeServerCommand(saveMsg.c_str()),
+                   SCREEN_HEIGHT - SCREEN_HEIGHT * 0.2, SMALLCHAR_WIDTH, false);
     return;
   }
 


### PR DESCRIPTION
When enabled, prints centerprints to console, excluding save messages.

Consecutive, identical messages are not logged as long as the message re-appears while the previous message is still up (as determined by `cg_centertime`). Once the message has faded from the screen, identical message may be logged again.

This bypasses `cg_centertime 0`, messages are always logged if the cvar is enabled, even if they are not shown on screen.