### PR TITLE
Add CMake options to enable sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,12 @@ set(CMAKE_CXX_STANDARD 14)
 
 option(BUILD_TESTS "Enable tests building (ON by default)" ON)
 
+# provide individual options too in case a compiler only supports some sanitizers
+option(USE_SANITIZERS "Enable address, leak and undefined behavior sanitizers on supported compilers" OFF)
+option(USE_ASAN "Enable address sanitizer on supported compilers" OFF)
+option(USE_LSAN "Enable leak sanitizer on supported compilers" OFF)
+option(USE_UBSAN "Enable undefined behavior sanitizer on supported compilers" OFF)
+
 set(BUNDLED_TARGETS_FOLDER Bundled)
 set(PACKING_TARGETS_FOLDER Package)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -27,12 +33,27 @@ include(CompilerOptions)
 include(VersionDescription)
 include(SourceGroup)
 include(ParseChangelog)
+include(SetupSanitizers)
 
 get_version_description(GAME_VERSION)
 
 set(BASE_DIR "${CMAKE_PROJECT_NAME}")
 set(BASE_DIR_PATH "${CMAKE_BINARY_DIR}/${BASE_DIR}")
 file(MAKE_DIRECTORY "${BASE_DIR_PATH}")
+
+if (USE_SANITIZERS)
+	set(USE_ASAN ON CACHE BOOL "Enable address sanitizer" FORCE)
+
+	# don't enable these on MSVC as they are not supported
+	if (NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+		set(USE_LSAN ON CACHE BOOL "Enable leak sanitizer" FORCE)
+		set(USE_UBSAN ON CACHE BOOL "Enable undefined behavior sanitizer" FORCE)
+	endif ()
+endif ()
+
+if (USE_ASAN OR USE_LSAN OR USE_UBSAN)
+	setup_sanitizers()
+endif ()
 
 create_compiler_opts(cxx_compiler_opts WARN 3 DEFINE 
 	GAME_NAME="${CMAKE_PROJECT_NAME}" 

--- a/cmake/SetupSanitizers.cmake
+++ b/cmake/SetupSanitizers.cmake
@@ -1,0 +1,120 @@
+# note: Clang is only tested on Linux
+# this might not work at all on Apple Clang (or Windows for that matter)
+
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
+
+function(setup_sanitizers)
+    if (USE_ASAN)
+        setup_asan()
+    endif ()
+
+    if (USE_LSAN)
+        setup_lsan()
+    endif ()
+
+    if (USE_UBSAN)
+        setup_ubsan()
+    endif ()
+
+    # GCC/Clang need this for better stack traces
+    if (NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+        add_compile_options(-fno-omit-frame-pointer)
+    endif ()
+endfunction()
+
+function(setup_asan)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+        set(ASAN_COMPILER_FLAGS
+                /fsanitize=address)
+    elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(ASAN_COMPILER_FLAGS
+                -fsanitize=address
+                -fsanitize-address-use-after-scope)
+    else()
+        set(ASAN_COMPILER_FLAGS
+                -fsanitize=address,pointer-compare,pointer-subtract
+                -fsanitize-address-use-after-scope)
+    endif ()
+
+
+    set(CMAKE_REQUIRED_FLAGS "${ASAN_COMPILER_FLAGS}")
+    check_c_compiler_flag("${ASAN_COMPILER_FLAGS}" HAVE_FSANITIZE_ADDRESS_C)
+    check_cxx_compiler_flag("${ASAN_COMPILER_FLAGS}" HAVE_FSANITIZE_ADDRESS_CXX)
+
+    if (HAVE_FSANITIZE_ADDRESS_C AND HAVE_FSANITIZE_ADDRESS_CXX)
+        message(STATUS "Enabling address sanitizer for selected configuration")
+    else ()
+        message(FATAL_ERROR "Cannot enable address sanitizer, unsupported compiler")
+    endif ()
+    
+    add_compile_options("${ASAN_COMPILER_FLAGS}")
+
+    if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+        # for running address sanitizer outside of Visual Studio,
+        # the asan runtime libraries must be part of PATH (VS adds this automatically)
+        get_filename_component(COMPILER_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
+        message(STATUS "  If running outside of Visual Studio, add the following to your PATH if running un-sanitized executable:")
+        message(STATUS "  ${COMPILER_DIR}")
+    else ()
+        add_link_options("-fsanitize=address")
+
+        # Clang does not use shared asan libraries by default,
+        # which is incompatible with -Wl --no-undefined
+        if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            add_link_options("-shared-libasan")
+        endif ()
+    endif ()
+endfunction()
+
+function(setup_lsan)
+    # MSVC does not support leak sanitizer
+    if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+        message(FATAL_ERROR "Leak sanitizer is not supported on MSVC")
+    endif ()
+
+    # leak sanitizer is enabled by default with address sanitizer
+    if (USE_ASAN)
+        if (NOT USE_SANITIZERS)
+            message(STATUS "Not running leak sanitizer in standalone mode, exiting")
+        endif ()
+        return()
+    endif ()
+
+    set(LSAN_FLAGS -fsanitize=leak)
+
+    set(CMAKE_REQUIRED_FLAGS "${LSAN_FLAGS}")
+    check_c_compiler_flag("${LSAN_FLAGS}" HAVE_FSANITIZE_LEAK_C)
+    check_cxx_compiler_flag("${LSAN_FLAGS}" HAVE_FSANITIZE_LEAK_CXX)
+
+    if (HAVE_FSANITIZE_LEAK_C AND HAVE_FSANITIZE_LEAK_CXX)
+        message(STATUS "Enabling leak sanitizer for selected configuration")
+    else ()
+        message(FATAL_ERROR "Cannot enable leak sanitizer, unsupported compiler")
+    endif ()
+
+    add_compile_options("${LSAN_FLAGS}")
+    add_link_options("${LSAN_FLAGS}")
+endfunction()
+
+function(setup_ubsan)
+    # MSVC does not support undefined behavior sanitizer
+    if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+        message(FATAL_ERROR "Undefined behavior sanitizer is not supported on MSVC")
+    endif ()
+
+    set(UBSAN_FLAGS -fsanitize=undefined,float-cast-overflow,float-divide-by-zero)
+
+    set(CMAKE_REQUIRED_FLAGS "${UBSAN_FLAGS}")
+    check_c_compiler_flag("${UBSAN_FLAGS}" HAVE_FSANITIZE_UB_C)
+    check_cxx_compiler_flag("${UBSAN_FLAGS}" HAVE_FSANITIZE_UB_CXX)
+
+    if (HAVE_FSANITIZE_UB_C AND HAVE_FSANITIZE_UB_CXX)
+        message(STATUS "Enabling undefined behavior sanitizer for selected configuration")
+    else ()
+        message(FATAL_ERROR "Cannot enable undefined behavior sanitizer, unsupported compiler")
+    endif ()
+
+    add_compile_options("${UBSAN_FLAGS}")
+    add_link_options("${UBSAN_FLAGS}")
+endfunction()


### PR DESCRIPTION
Adds following CMake options:
* `USE_SANITIZERS` - enable all supported sanitizers for the compiler
* `USE_ASAN` - enable address sanitizer
* `USE_LSAN` - enable leak sanitizer (for standalone mode, this is implied by address sanitizer)
* `USE_UBSAN` - enable undefined behavior sanitizer

`USE_SANITIZERS` only enables address sanitizer on MSVC, as it does not support lsan/ubsan (however, the MSVC asan does include some of the checks that lsan/ubsan do).

On GCC/Clang, `-fno-omit-frame-pointer` is automatically added to compiler options for better stack traces.

On Clang, `-shared-libasan` is automatically added as Clang does not use it by default, and static libraries are incompatible with `-Wl,--no-undefined`