### PR TITLE
Improve Visual Studio project & development

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,11 @@ option(USE_ASAN "Enable address sanitizer on supported compilers" OFF)
 option(USE_LSAN "Enable leak sanitizer on supported compilers" OFF)
 option(USE_UBSAN "Enable undefined behavior sanitizer on supported compilers" OFF)
 
-set(BUNDLED_TARGETS_FOLDER Bundled)
-set(PACKING_TARGETS_FOLDER Package)
-set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER CMake)
+# provide options for Visual Studio to automatically setup debugger paths
+if (CMAKE_GENERATOR_NAME MATCHES "Visual Studio")
+	set(ET_PATH "" CACHE STRING "Path to ET installation used during development")
+	set(ET_EXE_NAME "" CACHE STRING "Name of the engine for launching the game (ET.exe, etl.exe, ETe.exe etc.)")
+endif ()
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
@@ -95,6 +96,13 @@ target_link_libraries(libsqlite PRIVATE cxx_compiler_opts_w0)
 target_link_libraries(fmt PRIVATE cxx_compiler_opts_w0)
 target_link_libraries(libsqlite_modern_cpp INTERFACE cxx_compiler_opts_w0)
 
+# setup directories for IDEs that use them (Visual Studio, XCode...)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER CMake)
+
+set(BUNDLED_TARGETS_FOLDER Bundled)
+set(PACKING_TARGETS_FOLDER Package)
+
 set_target_properties(gmock gmock_main gtest gtest_main libjson libsha1 libsqlite libsqlite_modern_cpp libuuid4 fmt
                       PROPERTIES FOLDER ${BUNDLED_TARGETS_FOLDER})
 
@@ -103,11 +111,13 @@ add_subdirectory(src/game)
 add_subdirectory(src/ui)
 add_subdirectory(assets)
 
-set_target_properties(mod_pk3 mod_release 
-                      PROPERTIES FOLDER ${PACKING_TARGETS_FOLDER})
+set_target_properties(mod_pk3 mod_release remove_old_pk3
+		PROPERTIES FOLDER ${PACKING_TARGETS_FOLDER})
 
 # set cgame as startup project in Visual Studio
-set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT cgame)
+if (CMAKE_GENERATOR MATCHES "Visual Studio")
+	set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT cgame)
+endif()
 
 if (BUILD_TESTS)
 	message(STATUS "Enabling tests building -- done")

--- a/docs/compiling.md
+++ b/docs/compiling.md
@@ -103,6 +103,8 @@ This option gives best control over the solution and provides familiar usage exp
     ```
     * Replace the Visual Studio version with the version you have installed, use `cmake --help` or see [CMake documetation](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#visual-studio-generators).
     * 64-bit architecture is also supported on Windows, and can be generated with `-A x64`. Note that ET 2.60b does not support 64-bit mods on Windows, and you need to debug and run the game with a 64-bit engine, such as [ET: Legacy](https://www.etlegacy.com/) or [ETe](https://github.com/etfdevs/ETe).
+    * CMake variable `ET_PATH` can be used to point CMake to your development installation - Visual Studio sets up debugging with some pre-defined parameters, and this path will be used as `fs_homepath` and the directory where the game is located.
+    * CMake variable `ET_EXE_NAME` can be used to set the engine that gets launched from `ET_PATH` to debug.
 
 2. Open up generated `sln` solution (located in `build` directory) in `Visual Studio`. 
 3. Use `Build` > `Build Solution` option to start compilation process.

--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -127,10 +127,13 @@ set_target_properties(cgame PROPERTIES
 	LIBRARY_OUTPUT_DIRECTORY_RELEASE "${BASE_DIR_PATH}")
 set_target_platform_details(cgame)
 
-set_target_properties(cgame PROPERTIES
-	VS_DEBUGGER_COMMAND "$(ETROOT)\\ET.exe"
-	VS_DEBUGGER_COMMAND_ARGUMENTS "+set fs_basepath \"$(SolutionDir)\" +set fs_homepath . +set fs_game ${CMAKE_PROJECT_NAME} +set sv_pure 0"
-	VS_DEBUGGER_WORKING_DIRECTORY "$(ETROOT)")
+if (CMAKE_GENERATOR_NAME MATCHES "Visual Studio")
+	set_target_properties(cgame PROPERTIES
+			VS_DEBUGGER_COMMAND "${ET_PATH}\\${ET_EXE_NAME}"
+			VS_DEBUGGER_COMMAND_ARGUMENTS "+set fs_basepath . +set fs_homepath \"${ET_PATH}\" +set fs_game ${CMAKE_PROJECT_NAME}"
+			VS_DEBUGGER_WORKING_DIRECTORY "$(SolutionDir)"
+	)
+endif ()
 
 if(APPLE)
 	# These are just for generating the hardware id


### PR DESCRIPTION
* Move `remove_old_pk3` target under `Package`
* Deprecate `ETROOT` environmental variable support in favor of `ET_PATH` and `ET_EXE_NAME` CMake options
* Better default path setup for debugger in Visual Studio
* Improve compiling/debugging documentation