### PR TITLE
Fix incorrect int to qboolean casts

### DIFF
--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -3148,7 +3148,6 @@ PM_CheckforReload
 */
 void PM_CheckForReload(int weapon) {
   qboolean autoreload;
-  qboolean reloadRequested;
   int clipWeap, ammoWeap;
 
   if (pm->noWeapClips) // no need to reload
@@ -3164,7 +3163,7 @@ void PM_CheckForReload(int weapon) {
   }
 
   // user is forcing a reload (manual reload)
-  reloadRequested = (qboolean)(pm->cmd.wbuttons & WBUTTON_RELOAD);
+  const bool reloadRequested = pm->cmd.wbuttons & WBUTTON_RELOAD;
 
   switch (pm->ps->weaponstate) {
     case WEAPON_RAISING:

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -766,8 +766,6 @@ void G_CheckForCursorHints(gentity_t *ent) {
   gentity_t *checkEnt, *traceEnt = 0;
   playerState_t *ps;
   int hintType, hintDist, hintVal;
-  qboolean zooming;   // indirectHit means the checkent was not the ent
-                      // hit by the trace (checkEnt!=traceEnt)
   int trace_contents; // DHM - Nerve
   int numOfIgnoredEnts = 0;
 
@@ -777,7 +775,7 @@ void G_CheckForCursorHints(gentity_t *ent) {
 
   ps = &ent->client->ps;
 
-  zooming = (qboolean)(ps->eFlags & EF_ZOOMING);
+  const bool zooming = ps->eFlags & EF_ZOOMING;
 
   AngleVectors(ps->viewangles, forward, right, up);
 

--- a/src/game/g_mover.cpp
+++ b/src/game/g_mover.cpp
@@ -711,10 +711,9 @@ SetMoverState
 void SetMoverState(gentity_t *ent, moverState_t moverState, int time) {
   vec3_t delta;
   float f;
-  qboolean kicked = qfalse, soft = qfalse;
 
-  kicked = (qboolean)(ent->flags & FL_KICKACTIVATE);
-  soft = (qboolean)(ent->flags & FL_SOFTACTIVATE); //----(SA)	added
+  const bool kicked = ent->flags & FL_KICKACTIVATE;
+  const bool soft = ent->flags & FL_SOFTACTIVATE;
 
   ent->moverState = moverState;
   ent->s.pos.trTime = time;
@@ -2126,9 +2125,7 @@ func_invisible_user's using the regular rules of doors.
 ==============
 */
 void G_TryDoor(gentity_t *ent, gentity_t *other, gentity_t *activator) {
-  qboolean walking = qfalse;
-
-  walking = (qboolean)(ent->flags & FL_SOFTACTIVATE);
+  const bool walking = ent->flags & FL_SOFTACTIVATE;
 
   if ((ent->s.apos.trType == TR_STATIONARY &&
        ent->s.pos.trType == TR_STATIONARY)) {

--- a/src/game/g_svcmds.cpp
+++ b/src/game/g_svcmds.cpp
@@ -424,12 +424,10 @@ gclient_t *ClientForString(const char *s) {
 
 // fretn
 
-static qboolean G_Is_SV_Running(void) {
-
-  char cvar[MAX_TOKEN_CHARS];
-
+static bool G_Is_SV_Running() {
+  char cvar[MAX_CVAR_VALUE_STRING];
   trap_Cvar_VariableStringBuffer("sv_running", cvar, sizeof(cvar));
-  return (qboolean)Q_atoi(cvar);
+  return Q_atoi(cvar);
 }
 
 // -fretn


### PR DESCRIPTION
Casting an int to a qboolean is invalid since qboolean is just an enum and the cast doesn't actually narrow it down to just 0 or 1.