### PR TITLE
Tweak demo compatibility info print for sv_fps status

### DIFF
--- a/src/cgame/etj_demo_compatibility.cpp
+++ b/src/cgame/etj_demo_compatibility.cpp
@@ -128,18 +128,14 @@ void DemoCompatibility::setupCompatibilityFlags() {
   if (!isCompatible({3, 2, 0})) {
     flags.serverSideCoronas = true;
     compatibilityStrings.emplace_back("- Using fully server-side coronas");
-  }
 
-  if (isCompatible({3, 2, 0})) {
+    flags.svFpsUnavailable = true;
+    compatibilityStrings.emplace_back(
+        "- Unable to determine sv_fps, assuming default");
+  } else if (!isCompatible({3, 3, 0})) {
     flags.svFpsInSysteminfo = true;
     compatibilityStrings.emplace_back(
-        "- sv_fps can be read from systeminfo string");
-  }
-
-  if (isCompatible({3, 3, 0})) {
-    flags.svFpsInCgs = true;
-    compatibilityStrings.emplace_back(
-        "- sv_fps can be read from client game static struct");
+        "- Using systeminfo string to determine sv_fps");
   }
 
   if (!isCompatible({3, 3, 0})) {

--- a/src/cgame/etj_demo_compatibility.h
+++ b/src/cgame/etj_demo_compatibility.h
@@ -51,8 +51,8 @@ class DemoCompatibility {
 public:
   struct CompatibilityFlags {
     bool serverSideCoronas = false;
+    bool svFpsUnavailable = false;
     bool svFpsInSysteminfo = false;
-    bool svFpsInCgs = false;
     bool adjustEntityTypes = false;
     bool noSavePosTimerunInfo = false;
     bool adjustEvTokens = false;

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -215,19 +215,18 @@ bool ETJump::isPlaying(const int clientNum) {
 }
 
 int ETJump::getSvFps() {
+  if (!cg.demoPlayback) {
+    return cgs.sv_fps;
+  }
+
   int fps;
 
-  if (cg.demoPlayback) {
-
-    if (demoCompatibility->flags.svFpsInCgs) {
-      fps = cgs.sv_fps;
-    } else if (demoCompatibility->flags.svFpsInSysteminfo) {
-      const char *cs = CG_ConfigString(CS_SYSTEMINFO);
-      fps = Q_atoi(Info_ValueForKey(cs, "sv_fps"));
-    } else {
-      // no way to know for sure, assume default
-      fps = 1000 / DEFAULT_SV_FRAMETIME;
-    }
+  if (demoCompatibility->flags.svFpsUnavailable) {
+    // no way to know for sure, assume default
+    fps = 1000 / DEFAULT_SV_FRAMETIME;
+  } else if (demoCompatibility->flags.svFpsInSysteminfo) {
+    const char *cs = CG_ConfigString(CS_SYSTEMINFO);
+    fps = Q_atoi(Info_ValueForKey(cs, "sv_fps"));
   } else {
     fps = cgs.sv_fps;
   }


### PR DESCRIPTION
Only print scenarios where the info is not available, or we're using outdated method for determining it (systeminfo string).

refs #1470 