### PR TITLE
Revert "Fix autoload/deathcam skip load spawn position (#1516)"

### DIFF
--- a/src/game/etj_save_system.cpp
+++ b/src/game/etj_save_system.cpp
@@ -292,12 +292,7 @@ void SaveSystem::load(gentity_t *ent) {
 
     // allow fast respawn + load if we got gibbed to skip death sequence
     if (ent->client->ps.stats[STAT_HEALTH] <= GIB_HEALTH) {
-      ent->client->respawnFromLoad = true;
-      // set origin to the save slot origin here before calling respawm,
-      // so we can grab the spawn position from player origin
-      G_SetOrigin(ent, pos->origin);
       respawn(ent);
-      ent->client->respawnFromLoad = false;
     }
 
     teleportPlayer(ent, pos);
@@ -748,15 +743,6 @@ void SaveSystem::loadPositionsFromDatabase(gentity_t *ent) {
   }
 }
 
-void SaveSystem::invalidateTeamQuickDeployPosition(gentity_t *ent,
-                                                   team_t team) {
-  const auto pos = getValidTeamQuickDeploySave(ent, team);
-
-  if (pos) {
-    pos->isValid = false;
-  }
-}
-
 void SaveSystem::storeTeamQuickDeployPosition(gentity_t *ent, team_t team) {
   const auto lastValidSave = getValidTeamSaveForSlot(ent, team, 0);
 
@@ -767,16 +753,14 @@ void SaveSystem::storeTeamQuickDeployPosition(gentity_t *ent, team_t team) {
   }
 }
 
-bool SaveSystem::loadOnceTeamQuickDeployPosition(gentity_t *ent, team_t team) {
+void SaveSystem::loadOnceTeamQuickDeployPosition(gentity_t *ent, team_t team) {
   const auto validSave = getValidTeamQuickDeploySave(ent, team);
 
   if (validSave) {
     restoreStanceFromSave(ent, validSave);
     teleportPlayer(ent, validSave);
-    return true;
+    validSave->isValid = false;
   }
-
-  return false;
 }
 
 SaveSystem::SavePosition *
@@ -987,7 +971,5 @@ void SaveSystem::teleportPlayer(gentity_t *ent, SavePosition *pos) {
   }
 
   client->ps.pm_time = 1; // Crashland + instant load bug fix.
-  BG_PlayerStateToEntityState(&ent->client->ps, &ent->s, qtrue);
-  trap_LinkEntity(ent);
 }
 } // namespace ETJump

--- a/src/game/etj_save_system.h
+++ b/src/game/etj_save_system.h
@@ -128,9 +128,7 @@ public:
   void loadPositionsFromDatabase(gentity_t *ent);
 
   void storeTeamQuickDeployPosition(gentity_t *ent, team_t team);
-  // true if valid position was loaded
-  bool loadOnceTeamQuickDeployPosition(gentity_t *ent, team_t team);
-  void invalidateTeamQuickDeployPosition(gentity_t *ent, team_t team);
+  void loadOnceTeamQuickDeployPosition(gentity_t *ent, team_t team);
 
 private:
   // Saves backup position

--- a/src/game/etj_savepos_command_handler.cpp
+++ b/src/game/etj_savepos_command_handler.cpp
@@ -40,12 +40,7 @@ void SavePosHandler::execSaveposCommand(gentity_t *ent,
   }
 
   if (ent->client->ps.stats[STAT_HEALTH] <= GIB_HEALTH) {
-    ent->client->respawnFromLoad = true;
-    // set origin from savepos before calling respawn, so we can grab
-    // the spawnpoint location from the savepos
-    G_SetOrigin(ent, data.pos.origin);
     respawn(ent);
-    ent->client->respawnFromLoad = false;
   }
 
   game.timerunV2->interrupt(ClientNum(ent));

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1515,6 +1515,15 @@ void SpectatorClientEndFrame(gentity_t *ent) {
 
     if (do_respawn) {
       reinforce(ent);
+      if (ent->client->pers.autoLoad) {
+        // need to do this here as reinforce will override any value set in
+        // clientspawn (ClientSpawn gets called twice, and we only want to
+        // call this once --> first call sets the origin, second call resets
+        // the origin (since we're no longer setting the origin
+        // as we already set it))
+        ETJump::saveSystem->loadOnceTeamQuickDeployPosition(
+            ent, ent->client->sess.sessionTeam);
+      }
       return;
     }
 

--- a/src/game/g_combat.cpp
+++ b/src/game/g_combat.cpp
@@ -11,7 +11,6 @@
 #include "etj_string_utilities.h"
 #include "etj_printer.h"
 #include "etj_missilepad.h"
-#include "etj_save_system.h"
 
 extern vec3_t muzzleTrace;
 
@@ -571,11 +570,6 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker,
   } else if ((meansOfDeath == MOD_SUICIDE &&
               g_gamestate.integer == GS_PLAYING)) {
     limbo(self, qtrue);
-  }
-
-  if (meansOfDeath != MOD_SWITCHTEAM) {
-    ETJump::saveSystem->invalidateTeamQuickDeployPosition(
-        self, self->client->sess.sessionTeam);
   }
 
   if (!self->client->sess.runSpawnflags ||

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1176,8 +1176,6 @@ struct gclient_s {
 
   int lastRevivePushTime;
 
-  bool respawnFromLoad;
-
   int numLagFrames; // for tracking high ping on timeruns to counter lag abuse
 };
 
@@ -1594,7 +1592,7 @@ void G_TouchTriggers(gentity_t *ent);
 
 void G_AddPredictableEvent(gentity_t *ent, int event, int eventParm);
 void G_AddEvent(gentity_t *ent, int event, int eventParm);
-void G_SetOrigin(gentity_t *ent, const vec3_t origin);
+void G_SetOrigin(gentity_t *ent, vec3_t origin);
 void AddRemap(const char *oldShader, const char *newShader, float timeOffset);
 const char *BuildShaderStateConfig();
 void G_SetAngle(gentity_t *ent, vec3_t angle);

--- a/src/game/g_utils.cpp
+++ b/src/game/g_utils.cpp
@@ -888,7 +888,7 @@ G_SetOrigin
 Sets the pos trajectory for a fixed position
 ================
 */
-void G_SetOrigin(gentity_t *ent, const vec3_t origin) {
+void G_SetOrigin(gentity_t *ent, vec3_t origin) {
   VectorCopy(origin, ent->s.pos.trBase);
   ent->s.pos.trType = TR_STATIONARY;
   ent->s.pos.trTime = 0;


### PR DESCRIPTION
This reverts commit da0cfac12271a6a10c886942348177857df47159.

This breaks things too much and doesn't make much sense when you really think about it. Players are supposed to spawn on spawn points, not in arbitrary locations in the map. The purpose of this cvar was never to change that, but rather just execute 'load' command automatically when you join a team. Having autoload bypass the whole process of spawning into a spawnpoint makes it impossible for mappers to create maps which assume that certain set of actions are performed for the player once they spawn (e.g. trigger a target_init entity). There's no perfect solution to that atm either, but I am working on something in regard to that.