### PR TITLE
Automatically center mapscript brush origins

### DIFF
--- a/src/game/etj_entity_utilities.cpp
+++ b/src/game/etj_entity_utilities.cpp
@@ -135,4 +135,28 @@ void EntityUtilities::setCursorhintFromString(int &value,
   }
 }
 
+void EntityUtilities::centerBrushOrigin(gentity_t *ent) {
+  // this should not be called if the entity is linked
+  assert(!ent->r.linked);
+
+  // no need to do anything if origin is already centered
+  if (VectorCompareAbs(ent->r.mins, ent->r.maxs)) {
+    return;
+  }
+
+  vec3_t brushExtents{};
+  VectorSubtract(ent->r.maxs, ent->r.mins, brushExtents);
+  VectorScale(brushExtents, 0.5f, brushExtents);
+
+  vec3_t originOffset;
+  VectorAdd(ent->r.mins, brushExtents, originOffset);
+
+  for (int i = 0; i < 3; i++) {
+    ent->r.currentOrigin[i] += originOffset[i];
+    ent->r.mins[i] = -brushExtents[i];
+    ent->r.maxs[i] = brushExtents[i];
+  }
+
+  VectorCopy(ent->r.currentOrigin, ent->s.origin);
+}
 } // namespace ETJump

--- a/src/game/etj_entity_utilities.cpp
+++ b/src/game/etj_entity_utilities.cpp
@@ -144,6 +144,15 @@ void EntityUtilities::centerBrushOrigin(gentity_t *ent) {
     return;
   }
 
+  // store these so we can print them out later
+  vec3_t oldOrigin;
+  vec3_t oldMins;
+  vec3_t oldMaxs;
+
+  VectorCopy(ent->r.currentOrigin, oldOrigin);
+  VectorCopy(ent->r.mins, oldMins);
+  VectorCopy(ent->r.maxs, oldMaxs);
+
   vec3_t brushExtents{};
   VectorSubtract(ent->r.maxs, ent->r.mins, brushExtents);
   VectorScale(brushExtents, 0.5f, brushExtents);
@@ -158,5 +167,14 @@ void EntityUtilities::centerBrushOrigin(gentity_t *ent) {
   }
 
   VectorCopy(ent->r.currentOrigin, ent->s.origin);
+
+  // print the adjusted values if debugging script
+  if (g_scriptDebug.integer) {
+    G_Printf("Automatically adjusted values for entity %i (^3%s^7)\n- origin: "
+             "%s -> ^3%s\n^7- mins:   %s -> ^3%s\n^7- maxs:   %s -> ^3%s\n",
+             ent->s.number, ent->classname, vtos(oldOrigin),
+             vtos(ent->r.currentOrigin), vtos(oldMins), vtos(ent->r.mins),
+             vtos(oldMaxs), vtos(ent->r.maxs));
+  }
 }
 } // namespace ETJump

--- a/src/game/etj_entity_utilities.cpp
+++ b/src/game/etj_entity_utilities.cpp
@@ -145,9 +145,9 @@ void EntityUtilities::centerBrushOrigin(gentity_t *ent) {
   }
 
   // store these so we can print them out later
-  vec3_t oldOrigin;
-  vec3_t oldMins;
-  vec3_t oldMaxs;
+  vec3_t oldOrigin{};
+  vec3_t oldMins{};
+  vec3_t oldMaxs{};
 
   VectorCopy(ent->r.currentOrigin, oldOrigin);
   VectorCopy(ent->r.mins, oldMins);
@@ -157,7 +157,7 @@ void EntityUtilities::centerBrushOrigin(gentity_t *ent) {
   VectorSubtract(ent->r.maxs, ent->r.mins, brushExtents);
   VectorScale(brushExtents, 0.5f, brushExtents);
 
-  vec3_t originOffset;
+  vec3_t originOffset{};
   VectorAdd(ent->r.mins, brushExtents, originOffset);
 
   for (int i = 0; i < 3; i++) {

--- a/src/game/etj_entity_utilities.h
+++ b/src/game/etj_entity_utilities.h
@@ -41,5 +41,10 @@ public:
   // sets 'value' to corresponding cursorhint from 'hint'
   // if 'hint' isn't found in hintStrings, no modification is performed
   static void setCursorhintFromString(int &value, const std::string &hint);
+
+  // fixes brush origin to be in the center of the brush,
+  // and adjusts mins/maxs accordingly
+  // this must be called before linking, so we link with correct values!
+  static void centerBrushOrigin(gentity_t *ent);
 };
 } // namespace ETJump

--- a/src/game/etj_timerun_entities.cpp
+++ b/src/game/etj_timerun_entities.cpp
@@ -32,6 +32,7 @@
 #include "etj_printer.h"
 #include "etj_string_utilities.h"
 #include "etj_timerun_v2.h"
+#include "etj_entity_utilities.h"
 
 namespace ETJump {
 std::map<std::string, int> TimerunEntity::runIndices;
@@ -262,6 +263,7 @@ void TriggerStartTimerExt::spawn(gentity_t *self) {
 
   self->s.eType = ET_TRIGGER_MULTIPLE;
   InitTrigger(self);
+  EntityUtilities::centerBrushOrigin(self);
   trap_LinkEntity(self);
 }
 
@@ -343,6 +345,7 @@ void TriggerStopTimerExt::spawn(gentity_t *self) {
 
   self->s.eType = ET_TRIGGER_MULTIPLE;
   InitTrigger(self);
+  EntityUtilities::centerBrushOrigin(self);
   trap_LinkEntity(self);
 }
 
@@ -413,6 +416,7 @@ void TriggerCheckpointExt::spawn(gentity_t *self) {
   };
   self->s.eType = ET_TRIGGER_MULTIPLE;
   InitTrigger(self);
+  EntityUtilities::centerBrushOrigin(self);
   trap_LinkEntity(self);
 }
 

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -3064,6 +3064,8 @@ void SP_func_fakebrush(gentity_t *ent) {
     G_Error("'func_fakebrush' does not have maxs\n");
   }
 
+  ETJump::EntityUtilities::centerBrushOrigin(ent);
+
   ent->clipmask = ent->r.contents;
 
   G_SetOrigin(ent, ent->s.origin);

--- a/src/game/g_trigger.cpp
+++ b/src/game/g_trigger.cpp
@@ -1,3 +1,4 @@
+#include "etj_entity_utilities.h"
 #include "g_local.h"
 #include "etj_save_system.h"
 #include "etj_entity_utilities_shared.h"
@@ -193,6 +194,8 @@ void SP_trigger_multiple_ext(gentity_t *ent) {
 #ifdef VISIBLE_TRIGGERS
   ent->r.svFlags &= ~SVF_NOCLIENT;
 #endif // VISIBLE_TRIGGERS
+
+  ETJump::EntityUtilities::centerBrushOrigin(ent);
 
   trap_LinkEntity(ent);
 }

--- a/src/game/q_math.cpp
+++ b/src/game/q_math.cpp
@@ -1126,6 +1126,16 @@ int VectorCompare(const vec3_t v1, const vec3_t v2) {
   return 1;
 }
 
+bool VectorCompareAbs(const vec3_t v1, const vec3_t v2) {
+  if (std::abs(v1[0]) != std::abs(v2[0]) ||
+      std::abs(v1[1]) != std::abs(v2[1]) ||
+      std::abs(v1[2]) != std::abs(v2[2])) {
+    return false;
+  }
+
+  return true;
+}
+
 vec_t VectorNormalize(vec3_t v) {
   float length, ilength;
 

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -653,6 +653,7 @@ void ClearBounds(vec3_t mins, vec3_t maxs);
 void AddPointToBounds(const vec3_t v, vec3_t mins, vec3_t maxs);
 qboolean PointInBounds(const vec3_t v, const vec3_t mins, const vec3_t maxs);
 int VectorCompare(const vec3_t v1, const vec3_t v2);
+bool VectorCompareAbs(const vec3_t v1, const vec3_t v2);
 vec_t VectorLength(const vec3_t v);
 vec_t VectorLengthSquared(const vec3_t v);
 vec_t VectorLength2(vec2_t const v);


### PR DESCRIPTION
Automatically set the origin of mapscript-spawned brushes to be at the center of the brush, and adjust mins/maxs accordingly. This makes sure brushes get properly assigned to correct PVS when linked, but still lets people create brushes in mapscripts by using the simple method of setting mins to "0 0 0" and maxs to the brush size.