### PR TITLE
Cap dlight stylestring length on spawn

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -330,7 +330,7 @@ typedef struct centity_s {
   int dl_oldframe;
   float dl_backlerp;
   int dl_time;
-  char dl_stylestring[64];
+  char dl_stylestring[MAX_DLIGHT_STYLESTRING];
   int dl_sound;
   int dl_atten;
 

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -1354,6 +1354,13 @@ dlight_finish_spawning
 ==============
 */
 void dlight_finish_spawning(gentity_t *ent) {
+  if (strlen(ent->dl_stylestring) >= MAX_DLIGHT_STYLESTRING) {
+    char tmp[MAX_DLIGHT_STYLESTRING]{};
+    // Q_strncpyz will null-terminate the string at max length
+    Q_strncpyz(tmp, ent->dl_stylestring, MAX_DLIGHT_STYLESTRING);
+    ent->dl_stylestring = tmp;
+  }
+
   G_FindConfigstringIndex(va("%i %s %i %i %i", ent->s.number,
                              ent->dl_stylestring, ent->health, ent->soundLoop,
                              ent->dl_atten),

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -1145,6 +1145,7 @@ static constexpr int MAX_SUBMODELS = 512;
 
 #define MAX_CONFIGSTRINGS 1024
 
+static constexpr size_t MAX_DLIGHT_STYLESTRING = 64;
 #define MAX_DLIGHT_CONFIGSTRINGS 16
 #define MAX_SPLINE_CONFIGSTRINGS 8
 


### PR DESCRIPTION
Since the cgame array is 64 characters, there's no need to ever write more than 64 characters as the length to configstrings either.

refs #1622 