### PR TITLE
Small optimization to explicit crosshair drawing

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -4352,10 +4352,13 @@ static void CG_Draw2D() {
 
     // crosshair is the only renderable that should be drawn here
     for (const auto &r : ETJump::renderables) {
-      if (auto crosshair = std::dynamic_pointer_cast<ETJump::Crosshair>(r)) {
+      if (const auto &crosshair =
+              std::dynamic_pointer_cast<ETJump::Crosshair>(r)) {
         if (crosshair->beforeRender()) {
           crosshair->render();
         }
+
+        break;
       }
     }
     CG_DrawFlashFade();

--- a/src/cgame/cg_sound.cpp
+++ b/src/cgame/cg_sound.cpp
@@ -1799,11 +1799,13 @@ void CG_SpeakerEditorDraw(void) {
 
     // render crosshair
     for (const auto &r : ETJump::renderables) {
-      if (const auto crosshair =
+      if (const auto &crosshair =
               std::dynamic_pointer_cast<ETJump::Crosshair>(r)) {
         if (crosshair->beforeRender()) {
           crosshair->render();
         }
+
+        break;
       }
     }
 


### PR DESCRIPTION
Break out of the loop when we find the crosshair renderable.

refs #993
refs #1580 