### PR TITLE
Remove location system from the mod

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -1527,7 +1527,6 @@ void CG_InitConsoleCommands() {
   trap_AddCommand("readyteam");
   trap_AddCommand("ready");
   trap_AddCommand("ref");
-  trap_AddCommand("say_teamnl");
   trap_AddCommand("say_team");
   trap_AddCommand("say_buddy");
   trap_AddCommand("say_admin");

--- a/src/cgame/cg_popupmessages.cpp
+++ b/src/cgame/cg_popupmessages.cpp
@@ -428,7 +428,8 @@ void CG_DrawPMItems(void) {
 
   // show repeats counter
   if (cg_pmWaitingList->repeats > 1) {
-    msg = va("%s ^9(x%d)", cg_pmWaitingList->message, cg_pmWaitingList->repeats);
+    msg =
+        va("%s ^9(x%d)", cg_pmWaitingList->message, cg_pmWaitingList->repeats);
   } else {
     msg = (char *)&cg_pmWaitingList->message;
   }
@@ -554,9 +555,8 @@ const char *CG_GetPMItemText(centity_t *cent) {
       if (cgs.clientinfo[cg.clientNum].team == cent->currentState.effect2Time) {
         return NULL;
       }
-      return va("Spotted by %s^7 at %s",
-                cgs.clientinfo[cent->currentState.effect3Time].name,
-                BG_GetLocationString(cent->currentState.origin));
+      return va("Spotted by %s^7",
+                cgs.clientinfo[cent->currentState.effect3Time].name);
     case PM_OBJECTIVE:
       switch (cent->currentState.density) {
         case 0:

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -1432,7 +1432,6 @@ void CG_VoiceChatLocal(int mode, qboolean voiceOnly, int clientNum, int color,
   sfxHandle_t snd;
   qhandle_t sprite;
   bufferedVoiceChat_t vchat;
-  const char *loc = " "; // NERVE - SMF
   const char *msgColor = "^z";
   const char *msgTime = "";
   qtime_t t;
@@ -1458,14 +1457,6 @@ void CG_VoiceChatLocal(int mode, qboolean voiceOnly, int clientNum, int color,
       VectorCopy(origin, vchat.origin); // NERVE - SMF
       Q_strncpyz(vchat.cmd, vsay->id, sizeof(vchat.cmd));
 
-      if (mode != SAY_ALL) {
-        // NERVE - SMF - get location
-        loc = BG_GetLocationString(origin);
-        if (!loc || !*loc) {
-          loc = " ";
-        }
-      }
-
       if (vsay->custom[0] != '\0') {
         chat = vsay->custom;
       }
@@ -1483,13 +1474,13 @@ void CG_VoiceChatLocal(int mode, qboolean voiceOnly, int clientNum, int color,
       }
 
       if (mode == SAY_TEAM) {
-        Com_sprintf(vchat.message, sizeof(vchat.message),
-                    "%s(%s^7)^3(%s): %c%c%s", msgTime, ci->name, loc,
-                    Q_COLOR_ESCAPE, color, CG_TranslateString(chat));
+        Com_sprintf(vchat.message, sizeof(vchat.message), "%s(%s^7)^3: %c%c%s",
+                    msgTime, ci->name, Q_COLOR_ESCAPE, color,
+                    CG_TranslateString(chat));
       } else if (mode == SAY_BUDDY) {
-        Com_sprintf(vchat.message, sizeof(vchat.message),
-                    "%s<%s^7>^3<%s>: %c%c%s", msgTime, ci->name, loc,
-                    Q_COLOR_ESCAPE, color, CG_TranslateString(chat));
+        Com_sprintf(vchat.message, sizeof(vchat.message), "%s<%s^7>^3: %c%c%s",
+                    msgTime, ci->name, Q_COLOR_ESCAPE, color,
+                    CG_TranslateString(chat));
       } else {
         Com_sprintf(vchat.message, sizeof(vchat.message), "%s%s^3: %c%c%s",
                     msgTime, ci->name, Q_COLOR_ESCAPE, color,

--- a/src/cgame/cg_spawn.cpp
+++ b/src/cgame/cg_spawn.cpp
@@ -410,8 +410,6 @@ void SP_worldspawn(void) {
   cg.mapcoordsScale[0] = 1 / (cg.mapcoordsMaxs[0] - cg.mapcoordsMins[0]);
   cg.mapcoordsScale[1] = 1 / (cg.mapcoordsMaxs[1] - cg.mapcoordsMins[1]);
 
-  BG_InitLocations(cg.mapcoordsMins, cg.mapcoordsMaxs);
-
   CG_SpawnString("atmosphere", "", &s);
   CG_EffectParse(s);
 

--- a/src/game/bg_misc.cpp
+++ b/src/game/bg_misc.cpp
@@ -5054,67 +5054,6 @@ qboolean BG_IsScopedWeapon(int weapon) {
   return qfalse;
 }
 
-///////////////////////////////////////////////////////////////////////////////
-typedef struct locInfo_s {
-  vec2_t gridStartCoord;
-  vec2_t gridStep;
-} locInfo_t;
-
-static locInfo_t locInfo;
-
-void BG_InitLocations(vec2_t world_mins, vec2_t world_maxs) {
-  // keep this in sync with CG_DrawGrid
-  locInfo.gridStep[0] = 1200.f;
-  locInfo.gridStep[1] = 1200.f;
-
-  // ensure minimal grid density
-  while (locInfo.gridStep[0] > 50.f &&
-         (world_maxs[0] - world_mins[0]) / locInfo.gridStep[0] < 7)
-    locInfo.gridStep[0] -= 50.f;
-  while (locInfo.gridStep[1] > 50.f &&
-         (world_mins[1] - world_maxs[1]) / locInfo.gridStep[1] < 7)
-    locInfo.gridStep[1] -= 50.f;
-
-  locInfo.gridStartCoord[0] =
-      world_mins[0] +
-      .5f * ((((world_maxs[0] - world_mins[0]) / locInfo.gridStep[0]) -
-              ((int)((world_maxs[0] - world_mins[0]) / locInfo.gridStep[0]))) *
-             locInfo.gridStep[0]);
-  locInfo.gridStartCoord[1] =
-      world_mins[1] -
-      .5f * ((((world_mins[1] - world_maxs[1]) / locInfo.gridStep[1]) -
-              ((int)((world_mins[1] - world_maxs[1]) / locInfo.gridStep[1]))) *
-             locInfo.gridStep[1]);
-}
-
-char *BG_GetLocationString(vec_t *pos) {
-  static char coord[6];
-  int x, y;
-
-  coord[0] = '\0';
-
-  x = (pos[0] - locInfo.gridStartCoord[0]) / locInfo.gridStep[0];
-  y = (locInfo.gridStartCoord[1] - pos[1]) / locInfo.gridStep[1];
-
-  if (x < 0) {
-    x = 0;
-  }
-  if (y < 0) {
-    y = 0;
-  }
-
-  // if coords get pretty big,
-  // mostly because of getting out of mapcoords, and gridstep being
-  // calculated wrong just set them to 0 character
-  if (x > 26) {
-    x = -17;
-  }
-
-  Com_sprintf(coord, sizeof(coord), "%c,%i", 'A' + x, y);
-
-  return coord;
-}
-
 qboolean BG_BBoxCollision(vec3_t min1, vec3_t max1, vec3_t min2, vec3_t max2) {
   int i;
 

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -142,13 +142,12 @@ static constexpr int MG42_HEAT_RECOVERY = 2000;
 #define AAGUN_RATE_OF_FIRE 100
 #define MG42_YAWSPEED 300.f // degrees per second
 
-static constexpr int SAY_ALL = 0;
-static constexpr int SAY_TEAM = 1;
-static constexpr int SAY_BUDDY = 2;
-static constexpr int SAY_TEAMNL = 3;
-static constexpr int SAY_ADMIN = 4;
-
-// RF, client damage identifiers
+enum ChatMode {
+  SAY_ALL,
+  SAY_TEAM,
+  SAY_BUDDY,
+  SAY_ADMIN,
+};
 
 // Arnout: different entity states
 typedef enum {
@@ -2441,9 +2440,6 @@ void BG_LinearPathOrigin2(float radius, splinePath_t **pSpline,
                           float *deltaTime, vec3_t result, qboolean backwards);
 
 int BG_MaxAmmoForWeapon(weapon_t weaponNum, int *skill);
-
-void BG_InitLocations(vec2_t world_mins, vec2_t world_maxs);
-char *BG_GetLocationString(vec_t *pos);
 
 // START Mad Doc - TDF
 typedef struct botpool_x {

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -1963,7 +1963,8 @@ void G_SayTo(gentity_t *ent, gentity_t *other, int mode, int color,
   if (!other || !other->inuse || !other->client) {
     return;
   }
-  if ((mode == SAY_TEAM || mode == SAY_TEAMNL) && !OnSameTeam(ent, other)) {
+
+  if (mode == SAY_TEAM && !OnSameTeam(ent, other)) {
     return;
   }
 
@@ -2006,7 +2007,6 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
   char text[MAX_CHAT_TEXT];
   const char *escapedName = nullptr;
   qboolean localize = qfalse;
-  char *loc;
   const char *printText = nullptr;
   const int clientNum = ClientNum(ent);
 
@@ -2017,25 +2017,18 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
       Com_sprintf(name, sizeof(name), "%s^7: ", ent->client->pers.netname);
       color = COLOR_GREEN;
       break;
-    case SAY_BUDDY:
-      localize = qtrue;
-      loc = BG_GetLocationString(ent->r.currentOrigin);
-      Com_sprintf(name, sizeof(name),
-                  "[lof](%s^7) (%s): ", ent->client->pers.netname, loc);
-      color = COLOR_YELLOW;
-      break;
     case SAY_TEAM:
       localize = qtrue;
       G_LogPrintf("sayteam: %s: %s\n", ent->client->pers.netname, chatText);
-      loc = BG_GetLocationString(ent->r.currentOrigin);
       Com_sprintf(name, sizeof(name),
-                  "[lof](%s^7) (%s): ", ent->client->pers.netname, loc);
+                  "[lof](%s^7): ", ent->client->pers.netname);
       color = COLOR_CYAN;
       break;
-    case SAY_TEAMNL:
-      G_LogPrintf("sayteamnl: %s: %s\n", ent->client->pers.netname, chatText);
-      Com_sprintf(name, sizeof(name), "(%s^7): ", ent->client->pers.netname);
-      color = COLOR_CYAN;
+    case SAY_BUDDY:
+      localize = qtrue;
+      Com_sprintf(name, sizeof(name),
+                  "[lof](%s^7): ", ent->client->pers.netname);
+      color = COLOR_YELLOW;
       break;
     case SAY_ADMIN:
       Printer::logAdminLn(ETJump::stringFormat(

--- a/src/game/g_cmds_ext.cpp
+++ b/src/game/g_cmds_ext.cpp
@@ -73,9 +73,6 @@ static const cmd_reference_t aCommandInfo[] = {
     {"readyteam", qfalse, qtrue, G_teamready_cmd,
      ":^7 Sets an entire team's status to ^5ready^7 to start a match"},
 
-    {"say_teamnl", qtrue, qtrue, G_say_teamnl_cmd,
-     "<msg>:^7 Sends a team chat without location info"},
-
     {"scores", qtrue, qtrue, G_scores_cmd,
      ":^7 Displays current match stat info"},
 
@@ -384,15 +381,6 @@ void G_ready_cmd(gentity_t *ent, unsigned int dwCommand, qboolean state) {
   }
 
   G_readyMatchState();
-}
-
-// ************** SAY_TEAMNL
-//
-// Team chat w/no location info
-void G_say_teamnl_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
-  if (!ent->client->sess.muted) {
-    Cmd_Say_f(ent, SAY_TEAMNL, qfalse, qtrue);
-  }
 }
 
 // ************** SCORES

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2677,7 +2677,6 @@ qboolean G_cmdDebounce(gentity_t *ent, const char *pszCommand);
 void G_commands_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue);
 void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fDump);
 void G_ready_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fDump);
-void G_say_teamnl_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue);
 void G_scores_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue);
 void G_specinvite_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fLock);
 void G_statsall_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fDump);

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -1284,8 +1284,6 @@ void SP_worldspawn(void) {
     level.mapcoordsValid = qtrue;
   }
 
-  BG_InitLocations(level.mapcoordsMins, level.mapcoordsMaxs);
-
   trap_SetConfigstring(CS_MOTD, g_motd.string); // message of the day
 
   G_SpawnString("spawnflags", "0", &s);


### PR DESCRIPTION
The location system has never really been useful for us, especially since we have removed the grid overlay entirely from command map. It was also often breaking on large maps because there were not enough letters to denote the X coordinate. The mapcoords system is still intact so command map works for displaying player positions.

fixes #1650 