### PR TITLE
Fix Linux HWID generation leaving an open socket

### DIFF
--- a/src/cgame/etj_operating_system_linux.cpp
+++ b/src/cgame/etj_operating_system_linux.cpp
@@ -85,8 +85,9 @@ std::string ETJump::OperatingSystem::getHwid() {
     }
   }
 
+  closeSocket(sock);
+
   if (!success) {
-    closeSocket(sock);
     return "NOHWID";
   }
 


### PR DESCRIPTION
Success path never closed the socket that was opened.