### PR TITLE
Update Linux runners to Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
   Linux:
     name: Linux ${{ matrix.arch }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -140,7 +140,7 @@ jobs:
 
   package:
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [Windows, Linux, macOS]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
   Linux:
     name: Linux ${{ matrix.arch }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -122,7 +122,7 @@ jobs:
         path: ${{ github.workspace }}/build/etjump
 
   package:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [Windows, Linux, macOS]
 
     steps:


### PR DESCRIPTION
20.04 runner is EOL starting next month, and Ubuntu 20.04 LTS itself moves to 'expanded security maintenance only' state starting June.

fixes #1615 