### PR TITLE
Move to C++17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         include:
           - arch: x64
             platforms: "\"x86_64;arm64\""
-            osx-target: "10.10"
+            osx-target: "10.12"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
         include:
           - arch: x64
             platforms: "\"x86_64;arm64\""
-            osx-target: "10.10"
+            osx-target: "10.12"
 
     steps:
     - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ string(REGEX MATCH "VERSION_PATCH ([0-9]+)" _patch_match "${version_content}")
 set(VERSION_PATCH "${CMAKE_MATCH_1}")
 
 project(etjump VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" HOMEPAGE_URL "etjump.com" LANGUAGES C CXX)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 option(BUILD_TESTS "Enable tests building (ON by default)" ON)
 

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -117,5 +117,5 @@ function(create_compiler_opts target)
 			_SCL_SECURE_NO_WARNINGS>
 		${arg_DEFINE})
 
-	target_compile_features(${target} INTERFACE cxx_std_14)
+	target_compile_features(${target} INTERFACE cxx_std_17)
 endfunction()


### PR DESCRIPTION
Any platform that is still supported should also have a new enough `GLIBCXX` that this shouldn't cause issues.