### PR TITLE
Replace result_of_t with invoke_result_t in container utils

### DIFF
--- a/src/game/etj_container_utilities.h
+++ b/src/game/etj_container_utilities.h
@@ -35,7 +35,7 @@ namespace Container {
 template <typename InputContainer, typename UnaryFunction>
 auto map(const InputContainer &container, UnaryFunction &&func) {
   using InputType = typename InputContainer::value_type;
-  using ResultType = std::result_of_t<UnaryFunction(InputType)>;
+  using ResultType = std::invoke_result_t<UnaryFunction, InputType>;
 
   std::vector<ResultType> result;
   result.reserve(container.size());


### PR DESCRIPTION
`result_of` is deprecated in C++17 and will be fully removed in C++20.