### PR TITLE
Refactor pmove utils to a global object

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4197,6 +4197,7 @@ extern std::array<bool, MAX_CLIENTS> tempTraceIgnoredClients;
 extern std::shared_ptr<PlayerBBox> playerBBox;
 extern std::unique_ptr<SavePos> savePos;
 extern std::unique_ptr<SyscallExt> syscallExt;
+extern std::unique_ptr<PmoveUtils> pmoveUtils;
 
 void addRealLoopingSound(const vec3_t origin, const vec3_t velocity,
                          sfxHandle_t sfx, int range, int volume, int soundTime);

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 
 #include "cg_local.h"
+#include "etj_pmove_utils.h"
 
 //========================
 extern pmove_t cg_pmove;
@@ -2152,6 +2153,11 @@ void CG_DrawActiveFrame(int serverTime, stereoFrame_t stereoView,
     // origin
     trap_SetClientLerpOrigin(cg.refdef.vieworg[0], cg.refdef.vieworg[1],
                              cg.refdef.vieworg[2]);
+
+    // setup pmove for renderables
+    if (ETJump::pmoveUtils->check()) {
+      ETJump::pmoveUtils->runPmove();
+    }
 
     // actually issue the rendering calls
     CG_DrawActive(stereoView);

--- a/src/cgame/etj_accel_color.cpp
+++ b/src/cgame/etj_accel_color.cpp
@@ -29,13 +29,13 @@
 #include "etj_cgaz.h"
 
 namespace ETJump {
-void AccelColor::setAccelColor(int &style, float &speed, float &alpha,
-                               const pmove_t *pm, const playerState_t *ps,
+void AccelColor::setAccelColor(const int style, const float speed,
+                               const float alpha, const pmove_t *pm,
+                               const playerState_t *ps,
                                std::list<StoredSpeed> &storedSpeeds,
-                               vec3_t &accel, vec4_t &color) {
-  if (style == Style::Simple ||
-      (style == Style::Advanced &&
-       lowSpeedOnGround(speed, ps->groundEntityNum))) {
+                               const vec3_t &accel, vec4_t &color) {
+  if (style == Simple ||
+      (style == Advanced && lowSpeedOnGround(speed, ps->groundEntityNum))) {
     float avgAccel = calcAvgAccel(storedSpeeds);
     vec4_t currentAccelColor;
     Vector4Copy(colorGreen, currentAccelColor);
@@ -49,7 +49,7 @@ void AccelColor::setAccelColor(int &style, float &speed, float &alpha,
     frac = std::min(frac, 1.f);
 
     LerpColor(colorWhite, currentAccelColor, color, frac);
-  } else if (style == Style::Advanced) {
+  } else if (style == Advanced) {
     calcAccelColor(pm, ps, accel, color);
   }
 
@@ -57,20 +57,20 @@ void AccelColor::setAccelColor(int &style, float &speed, float &alpha,
 }
 
 void AccelColor::calcAccelColor(const pmove_t *pm, const playerState_t *ps,
-                                vec3_t &accel, vec4_t &outColor) {
+                                const vec3_t &accel, vec4_t &outColor) {
   vec4_t color;
-  const int8_t ucmdScale = CMDSCALE_DEFAULT;
-  const usercmd_t cmd = PmoveUtils::getUserCmd(*ps, ucmdScale);
+  const usercmd_t *cmd = pmoveUtils->getUserCmd();
 
   float speedX = ps->velocity[0];
   float speedY = ps->velocity[1];
 
-  const float accelAngle = RAD2DEG(std::atan2(-cmd.rightmove, cmd.forwardmove));
+  const float accelAngle =
+      RAD2DEG(std::atan2(-cmd->rightmove, cmd->forwardmove));
   const float accelAngleAlt =
-      RAD2DEG(std::atan2(cmd.rightmove, cmd.forwardmove));
+      RAD2DEG(std::atan2(cmd->rightmove, cmd->forwardmove));
 
   // max acceleration possible per frame
-  const float frameAccel = PmoveUtils::getFrameAccel(*ps, pm, true);
+  const float frameAccel = pmoveUtils->getFrameAccel(true);
   const float gravityAccel =
       -std::round(static_cast<float>(ps->gravity) * pm->pmext->frametime);
 
@@ -178,9 +178,9 @@ void AccelColor::calcAccelColor(const pmove_t *pm, const playerState_t *ps,
 
   // we want a solid color all the time, no dark tints
   if (color[0] != 0.0f && color[1] != 0.0f) { // if we have a mix of R & G
-    size_t maxColorIndex = color[0] > color[1] ? 0 : 1;
-    float maxShade = 1.0f; // min value to show per color
-    float coef = maxShade / color[maxColorIndex];
+    const size_t maxColorIndex = color[0] > color[1] ? 0 : 1;
+    constexpr float maxShade = 1.0f; // min value to show per color
+    const float coef = maxShade / color[maxColorIndex];
 
     VectorScale(color, coef, color);
   }

--- a/src/cgame/etj_accel_color.h
+++ b/src/cgame/etj_accel_color.h
@@ -42,10 +42,10 @@ public:
 
   static void popOldStoredSpeeds(std::list<StoredSpeed> &storedSpeeds,
                                  int time);
-  static void setAccelColor(int &style, float &speed, float &alpha,
+  static void setAccelColor(int style, float speed, float alpha,
                             const pmove_t *pm, const playerState_t *ps,
-                            std::list<StoredSpeed> &storedSpeeds, vec3_t &accel,
-                            vec4_t &color);
+                            std::list<StoredSpeed> &storedSpeeds,
+                            const vec3_t &accel, vec4_t &color);
   static bool lowSpeedOnGround(float speed, int groundEntityNum);
 
 private:
@@ -54,6 +54,6 @@ private:
 
   static float calcAvgAccel(std::list<StoredSpeed> &storedSpeeds);
   static void calcAccelColor(const pmove_t *pm, const playerState_t *ps,
-                             vec3_t &accel, vec4_t &outColor);
+                             const vec3_t &accel, vec4_t &outColor);
 };
 } // namespace ETJump

--- a/src/cgame/etj_accelmeter_drawable.cpp
+++ b/src/cgame/etj_accelmeter_drawable.cpp
@@ -98,12 +98,9 @@ bool AccelMeter::beforeRender() {
 
   playing = cg.snap->ps.clientNum == cg.clientNum && !cg.demoPlayback;
 
-  const int8_t ucmdScale = CMDSCALE_DEFAULT;
-  const usercmd_t cmd = PmoveUtils::getUserCmd(*ps, ucmdScale);
+  pm = pmoveUtils->getPmove();
 
-  pm = PmoveUtils::getPmove(cmd);
-
-  if (PmoveUtils::skipUpdate(lastUpdateTime, pm, ps)) {
+  if (pmoveUtils->skipUpdate(lastUpdateTime)) {
     return true;
   }
 

--- a/src/cgame/etj_accelmeter_drawable.h
+++ b/src/cgame/etj_accelmeter_drawable.h
@@ -57,7 +57,7 @@ class AccelMeter : public IRenderable {
   void startListeners();
   static bool canSkipDraw();
 
-  pmove_t *pm{};
+  const pmove_t *pm{};
   playerState_t *ps = &cg.predictedPlayerState;
 
 public:

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -81,20 +81,21 @@ void CGaz::startListeners() {
   });
 }
 
-void CGaz::UpdateCGaz1(vec3_t wishvel, int8_t uCmdScale, usercmd_t cmd) {
+void CGaz::UpdateCGaz1(vec3_t wishvel, const int8_t uCmdScale) const {
   // set default key combination if no user input
-  if (!cmd.forwardmove && !cmd.rightmove) {
+  if (!pm->cmd.forwardmove && !pm->cmd.rightmove) {
+    usercmd_t cmd = pm->cmd;
     cmd.forwardmove = uCmdScale;
 
     // recalculate wishvel with defaulted forwardmove
-    PmoveUtils::PM_UpdateWishvel(wishvel, cmd, pm->pmext->forward,
-                                 pm->pmext->right, pm->pmext->up, *ps);
+    pmoveUtils->updateWishvel(wishvel, pm->pmext->forward, pm->pmext->right,
+                              pm->pmext->up, cmd);
   }
 
   yaw = atan2f(wishvel[1], wishvel[0]) - drawVel;
 }
 
-void CGaz::UpdateCGaz2() {
+void CGaz::UpdateCGaz2() const {
   drawVel = AngleNormalize180(ps->viewangles[YAW] -
                               AngleNormalize180(RAD2DEG(drawVel)));
   drawVel = DEG2RAD(drawVel);
@@ -134,7 +135,7 @@ void CGaz::UpdateDraw(float wishspeed, const playerState_t *ps,
   drawVel = atan2f(pm->pmext->velocity[1], pm->pmext->velocity[0]);
 }
 
-float CGaz::UpdateDrawSnap(const playerState_t *ps, pmove_t *pm) {
+float CGaz::UpdateDrawSnap(const playerState_t *ps, const pmove_t *pm) {
   // don't highlight snapzone on very low velocities,
   // or if drawing isn't requested
   if (!etj_CGaz1DrawSnapZone.integer || !(etj_drawCGaz.integer & 1) ||
@@ -217,15 +218,7 @@ bool CGaz::beforeRender() {
   if (canSkipDraw()) {
     return false;
   }
-
-  const auto uCmdScale = static_cast<int8_t>(ps->stats[STAT_USERCMD_BUTTONS] &
-                                                     (BUTTON_WALKING << 8)
-                                                 ? CMDSCALE_WALK
-                                                 : CMDSCALE_DEFAULT);
-  const usercmd_t cmd = PmoveUtils::getUserCmd(*ps, uCmdScale);
-
-  // get correct pmove state
-  pm = PmoveUtils::getPmove(cmd);
+  pm = pmoveUtils->getPmove();
 
   // water and ladder movement are not important
   // since speed is capped anyway
@@ -234,7 +227,7 @@ bool CGaz::beforeRender() {
     return false;
   }
 
-  if (PmoveUtils::skipUpdate(lastUpdateTime, pm, ps)) {
+  if (pmoveUtils->skipUpdate(lastUpdateTime)) {
     return true;
   }
 
@@ -245,12 +238,11 @@ bool CGaz::beforeRender() {
           : pm->pmext->scaleAlt;
 
   vec3_t wishvel;
-  float wishspeed =
-      PmoveUtils::PM_GetWishspeed(wishvel, scale, cmd, pm->pmext->forward,
-                                  pm->pmext->right, pm->pmext->up, *ps, pm);
+  float wishspeed = pmoveUtils->getWishspeed(wishvel, scale, pm->pmext->forward,
+                                             pm->pmext->right, pm->pmext->up);
 
   // set default wishspeed for drawing if no user input
-  if (!cmd.forwardmove && !cmd.rightmove) {
+  if (!pm->cmd.forwardmove && !pm->cmd.rightmove) {
     wishspeed = static_cast<float>(ps->speed) * ps->sprintSpeedScale;
   }
 
@@ -260,7 +252,8 @@ bool CGaz::beforeRender() {
   drawSnap = UpdateDrawSnap(ps, pm);
 
   if (etj_drawCGaz.integer & 1) {
-    UpdateCGaz1(wishvel, uCmdScale, cmd);
+    const int8_t uCmdScale = pmoveUtils->getUserCmdScale();
+    UpdateCGaz1(wishvel, uCmdScale);
   }
   if (etj_drawCGaz.integer & 2) {
     UpdateCGaz2();
@@ -396,25 +389,19 @@ bool CGaz::strafingForwards(const playerState_t &ps, const pmove_t *pm) {
   const float speed = VectorLength2(ps.velocity);
 
   // get sprint scale
-  const float scale = PmoveUtils::PM_SprintScale(&ps);
-
-  // get usercmd
-  const auto ucmdScale =
-      static_cast<int8_t>(ps.stats[STAT_USERCMD_BUTTONS] & (BUTTON_WALKING << 8)
-                              ? CMDSCALE_WALK
-                              : CMDSCALE_DEFAULT);
-  const usercmd_t cmd = PmoveUtils::getUserCmd(ps, ucmdScale);
+  const float scale = pmoveUtils->getSprintScale();
+  const usercmd_t *cmd = pmoveUtils->getUserCmd();
 
   // not strafing if speed lower than ground speed or no user input
   if (speed < static_cast<float>(ps.speed) * scale ||
-      (cmd.forwardmove == 0 && cmd.rightmove == 0)) {
+      (cmd->forwardmove == 0 && cmd->rightmove == 0)) {
     return false;
   }
 
   // get wishvel
   vec3_t wishvel;
-  PmoveUtils::PM_UpdateWishvel(wishvel, cmd, pm->pmext->forward,
-                               pm->pmext->right, pm->pmext->up, ps);
+  pmoveUtils->updateWishvel(wishvel, pm->pmext->forward, pm->pmext->right,
+                            pm->pmext->up, *cmd);
 
   // get angle between wishvel and player velocity
   const float wishvelAngle = RAD2DEG(std::atan2(wishvel[1], wishvel[0]));
@@ -425,9 +412,9 @@ bool CGaz::strafingForwards(const playerState_t &ps, const pmove_t *pm) {
   // fullbeat / halfbeat / invert (holding +moveleft) or
   // fullbeat / halfbeat / invert (holding +moveright) or
   // nobeat
-  if ((cmd.rightmove < 0 && diffAngle >= 0) ||
-      (cmd.rightmove > 0 && diffAngle < 0) ||
-      (cmd.forwardmove != 0 && diffAngle >= 0)) {
+  if ((cmd->rightmove < 0 && diffAngle >= 0) ||
+      (cmd->rightmove > 0 && diffAngle < 0) ||
+      (cmd->forwardmove != 0 && diffAngle >= 0)) {
     return true;
   }
 
@@ -435,16 +422,7 @@ bool CGaz::strafingForwards(const playerState_t &ps, const pmove_t *pm) {
 }
 
 float CGaz::getOptAngle(const playerState_t &ps, const pmove_t *pm,
-                        bool alternate) {
-  const auto uCmdScale =
-      static_cast<int8_t>(ps.stats[STAT_USERCMD_BUTTONS] & (BUTTON_WALKING << 8)
-                              ? CMDSCALE_WALK
-                              : CMDSCALE_DEFAULT);
-  const usercmd_t cmd = PmoveUtils::getUserCmd(ps, uCmdScale);
-
-  // get correct pmove state
-  pm = PmoveUtils::getPmove(cmd);
-
+                        const bool alternate) {
   // water and ladder movement are not important
   // since speed is capped anyway
   // check this only after we have a valid pmove
@@ -459,12 +437,11 @@ float CGaz::getOptAngle(const playerState_t &ps, const pmove_t *pm,
           : pm->pmext->scaleAlt;
 
   vec3_t wishvel;
-  float wishspeed =
-      PmoveUtils::PM_GetWishspeed(wishvel, scale, cmd, pm->pmext->forward,
-                                  pm->pmext->right, pm->pmext->up, ps, pm);
+  float wishspeed = pmoveUtils->getWishspeed(wishvel, scale, pm->pmext->forward,
+                                             pm->pmext->right, pm->pmext->up);
 
   // set default wishspeed for drawing if no user input
-  if (!cmd.forwardmove && !cmd.rightmove) {
+  if (!pm->cmd.forwardmove && !pm->cmd.rightmove) {
     wishspeed = static_cast<float>(ps.speed) * ps.sprintSpeedScale;
   }
 
@@ -472,7 +449,7 @@ float CGaz::getOptAngle(const playerState_t &ps, const pmove_t *pm,
 
   // no meaningful value if speed lower than ground speed or no user input
   if (state.vf < state.wishspeed ||
-      (cmd.forwardmove == 0 && cmd.rightmove == 0)) {
+      (pm->cmd.forwardmove == 0 && pm->cmd.rightmove == 0)) {
     return 0;
   }
 
@@ -480,8 +457,8 @@ float CGaz::getOptAngle(const playerState_t &ps, const pmove_t *pm,
   const bool forwards = strafingForwards(ps, pm);
 
   // get variables associated with optimal angle
-  const float accelAngle = RAD2DEG(
-      std::atan2(alternate ? cmd.rightmove : -cmd.rightmove, cmd.forwardmove));
+  const float accelAngle = RAD2DEG(std::atan2(
+      alternate ? pm->cmd.rightmove : -pm->cmd.rightmove, pm->cmd.forwardmove));
 
   float perAngle = RAD2DEG(drawOpt);
   float velAngle = RAD2DEG(drawVel);
@@ -497,13 +474,13 @@ float CGaz::getOptAngle(const playerState_t &ps, const pmove_t *pm,
   // shift yaw to optimal angle for all strafe styles
   float opt = ps.viewangles[YAW];
 
-  if (cmd.rightmove < 0) {
+  if (pm->cmd.rightmove < 0) {
     // fullbeat / halfbeat / invert (holding +moveleft)
     opt = velAngle + perAngle - accelAngle;
-  } else if (cmd.rightmove > 0) {
+  } else if (pm->cmd.rightmove > 0) {
     // fullbeat / halfbeat / invert (holding +moveright)
     opt = velAngle - perAngle - accelAngle;
-  } else if (cmd.forwardmove != 0) {
+  } else if (pm->cmd.forwardmove != 0) {
     // nobeat
     opt = velAngle + perAngle;
   }

--- a/src/cgame/etj_cgaz.h
+++ b/src/cgame/etj_cgaz.h
@@ -72,19 +72,19 @@ private:
   vec4_t CGaz2Colors[2]{};
 
   bool canSkipDraw() const;
-  void UpdateCGaz1(vec3_t wishvel, int8_t uCmdScale, usercmd_t cmd);
-  void UpdateCGaz2();
+  void UpdateCGaz1(vec3_t wishvel, int8_t uCmdScale) const;
+  void UpdateCGaz2() const;
   static float GetSlickGravity(const playerState_t *ps, const pmove_t *pm);
   static float UpdateDrawMin(state_t const *state);
   static float UpdateDrawOpt(state_t const *state);
   static float UpdateDrawMaxCos(state_t const *state);
   static float UpdateDrawMax(state_t const *state);
-  static float UpdateDrawSnap(const playerState_t *ps, pmove_t *pm);
+  static float UpdateDrawSnap(const playerState_t *ps, const pmove_t *pm);
   static void UpdateDraw(float wishspeed, const playerState_t *ps,
                          const pmove_t *pm);
   void startListeners();
 
-  playerState_t *ps = &cg.predictedPlayerState;
-  pmove_t *pm{};
+  const playerState_t *ps = &cg.predictedPlayerState;
+  const pmove_t *pm{};
 };
 } // namespace ETJump

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -93,6 +93,7 @@ std::array<bool, MAX_CLIENTS> tempTraceIgnoredClients;
 std::shared_ptr<PlayerBBox> playerBBox;
 std::unique_ptr<SavePos> savePos;
 std::unique_ptr<SyscallExt> syscallExt;
+std::unique_ptr<PmoveUtils> pmoveUtils;
 } // namespace ETJump
 
 static bool isInitialized{false};
@@ -236,6 +237,10 @@ void init() {
   rtvHandler->initialize();
 
   demoCompatibility = std::make_unique<DemoCompatibility>();
+
+  // must be initialized before accelColor & renderables!
+  pmoveUtils = std::make_unique<PmoveUtils>();
+
   accelColor = std::make_shared<AccelColor>();
 
   playerBBox = std::make_shared<PlayerBBox>();
@@ -823,9 +828,9 @@ void runFrameEnd() {
     static int lastActivity = -minAutoSpecDelay;
 
     const auto ps = getValidPlayerState();
-    const usercmd_t cmd = PmoveUtils::getUserCmd(*ps, CMDSCALE_DEFAULT);
+    const usercmd_t *cmd = pmoveUtils->getUserCmd();
     const auto team = cgs.clientinfo[cg.clientNum].team;
-    const bool moving = (cmd.forwardmove || cmd.rightmove || cmd.forwardmove);
+    const bool moving = cmd->forwardmove || cmd->rightmove || cmd->upmove;
     const bool following = ps->pm_flags & PMF_FOLLOW;
 
     if (team != TEAM_SPECTATOR || (!following && moving) ||

--- a/src/cgame/etj_pmove_utils.h
+++ b/src/cgame/etj_pmove_utils.h
@@ -29,36 +29,55 @@
 namespace ETJump {
 class PmoveUtils {
 public:
-  // returns real userCmd for players and a faked
-  // one for spectators/demo playback
-  static usercmd_t getUserCmd(const playerState_t &ps, int8_t uCmdScale);
-
-  // returns cg_pmove for players or runs PmoveSingle again
-  // for spectators/demo playback to get correct values for pmext
-  static pmove_t *getPmove(usercmd_t cmd);
+  PmoveUtils();
+  ~PmoveUtils() = default;
+  bool check() const;
+  void runPmove();
 
   // returns either sprintSpeedScale or runSpeedScale
-  static float PM_SprintScale(const playerState_t *ps);
+  float getSprintScale() const;
 
   // calculates wishspeed projected onto flat ground plane
-  static float PM_GetWishspeed(vec3_t wishvel, float scale, usercmd_t cmd,
-                               vec3_t forward, vec3_t right, vec3_t up,
-                               const playerState_t &ps, const pmove_t *pm);
+  float getWishspeed(vec3_t wishvel, float scale, vec3_t forward, vec3_t right,
+                     vec3_t up);
 
   // updates XY wishvel based on cmdScale and angle vectors
   // projects velocity down to a flat ground plane
   // Z vector is taken as input for AngleVectors
-  static void PM_UpdateWishvel(vec3_t wishvel, usercmd_t cmd, vec3_t forward,
-                               vec3_t right, vec3_t up,
-                               const playerState_t &ps);
+  // this takes in usercmd_t instead of using the class member variable,
+  // so cgaz & snaphud can send in a "fake" usercmd for drawing
+  // if there's no user input
+  void updateWishvel(vec3_t wishvel, vec3_t forward, vec3_t right, vec3_t up,
+                     const usercmd_t &ucmd);
 
   // returns total acceleration per frame
-  static float getFrameAccel(const playerState_t &ps, const pmove_t *pm,
-                             bool upmoveTrueness);
+  float getFrameAccel(bool upmoveTrueness);
 
   // if an update should happen, updates lastUpdateTime to current frametime
   // and returns false
-  static bool skipUpdate(int &lastUpdateTime, const pmove_t *pm,
-                         const playerState_t *ps);
+  bool skipUpdate(int &lastUpdateTime);
+
+  const pmove_t *getPmove() const;
+  const usercmd_t *getUserCmd() const;
+  int8_t getUserCmdScale() const;
+
+private:
+  void initCvars();
+  void setupCallbacks();
+  void setPmoveStatus();
+  void setupUserCmd();
+  void setupPmove();
+
+  pmove_t pm{};
+  pmoveExt_t pmext{};
+  usercmd_t cmd{};
+  playerState_t *ps = &cg.predictedPlayerState;
+
+  // a lot of drawables need this so make it accessible here since
+  // we need to calculate it here to set up usercmd anyway
+  int8_t uCmdScale{};
+
+  bool doPmove{};
+  std::vector<const vmCvar_t *> cvars{};
 };
 } // namespace ETJump

--- a/src/cgame/etj_snaphud.h
+++ b/src/cgame/etj_snaphud.h
@@ -41,16 +41,16 @@ public:
 
   void render() const override;
   bool beforeRender() override;
-  static CurrentSnap getCurrentSnap(const playerState_t &ps, pmove_t *pm,
+  static CurrentSnap getCurrentSnap(const playerState_t &ps, const pmove_t *pm,
                                     bool upmoveTrueness);
-  static bool inMainAccelZone(const playerState_t &ps, pmove_t *pm);
+  static bool inMainAccelZone(const playerState_t &ps, const pmove_t *pm);
 
   Snaphud();
   ~Snaphud() {};
 
 private:
   bool canSkipDraw() const;
-  void InitSnaphud(vec3_t wishvel, int8_t uCmdScale, usercmd_t cmd);
+  void InitSnaphud(vec3_t wishvel, int8_t uCmdScale);
   void UpdateMaxSnapZones();
   void UpdateSnapState();
   void PrepareDrawables();
@@ -86,8 +86,8 @@ private:
   bool borderOnly{};
   int lastUpdateTime{};
 
-  playerState_t *ps = &cg.predictedPlayerState;
-  pmove_t *pm{};
+  const playerState_t *ps = &cg.predictedPlayerState;
+  const pmove_t *pm{};
 
   struct DrawableSnap {
     int bSnap;

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -79,12 +79,9 @@ bool DrawSpeed::beforeRender() {
 
   playing = cg.snap->ps.clientNum == cg.clientNum && !cg.demoPlayback;
 
-  const int8_t ucmdScale = CMDSCALE_DEFAULT;
-  const usercmd_t cmd = PmoveUtils::getUserCmd(*ps, ucmdScale);
+  pm = pmoveUtils->getPmove();
 
-  pm = PmoveUtils::getPmove(cmd);
-
-  if (PmoveUtils::skipUpdate(lastUpdateTime, pm, ps)) {
+  if (pmoveUtils->skipUpdate(lastUpdateTime)) {
     return true;
   }
 

--- a/src/cgame/etj_speed_drawable.h
+++ b/src/cgame/etj_speed_drawable.h
@@ -51,8 +51,8 @@ class DrawSpeed : public IRenderable {
   vec3_t accel{};
   vec4_t speedColor{};
 
-  playerState_t *ps = &cg.predictedPlayerState;
-  pmove_t *pm{};
+  const playerState_t *ps = &cg.predictedPlayerState;
+  const pmove_t *pm{};
   int textStyle{};
   int lastUpdateTime{0};
   int accelColorStyle{};

--- a/src/cgame/etj_strafe_quality_drawable.h
+++ b/src/cgame/etj_strafe_quality_drawable.h
@@ -54,7 +54,8 @@ class StrafeQuality : public IRenderable {
   bool canSkipDraw() const;
   bool canSkipUpdate(usercmd_t cmd);
 
-  pmove_t *pm{};
+  const pmove_t *pm{};
+  const playerState_t *ps = &cg.predictedPlayerState;
 
 public:
   StrafeQuality();

--- a/src/cgame/etj_upmove_meter_drawable.cpp
+++ b/src/cgame/etj_upmove_meter_drawable.cpp
@@ -107,12 +107,10 @@ void UpmoveMeter::resetUpmoveMeter() {
 }
 
 bool UpmoveMeter::beforeRender() {
-  const playerState_t &ps = cg.predictedPlayerState;
-
   // update team before checking if we should draw or not,
   // since we don't draw for spectators
-  if (team_ != ps.persistant[PERS_TEAM]) {
-    team_ = ps.persistant[PERS_TEAM];
+  if (team_ != ps->persistant[PERS_TEAM]) {
+    team_ = ps->persistant[PERS_TEAM];
     // reset upon team change
     // note: not handled by consoleCommandsHandler because team
     // is needed in render() either ways
@@ -123,16 +121,10 @@ bool UpmoveMeter::beforeRender() {
     return false;
   }
 
-  // get usercmd
-  // cmdScale is only checked here to be 0 or !0
-  // so we can just use CMDSCALE_DEFAULT
-  const int8_t ucmdScale = CMDSCALE_DEFAULT;
-  const usercmd_t cmd = PmoveUtils::getUserCmd(ps, ucmdScale);
-
   // get correct pmove
-  pm = PmoveUtils::getPmove(cmd);
+  pm = pmoveUtils->getPmove();
 
-  if (PmoveUtils::skipUpdate(lastUpdateTime, pm, &ps)) {
+  if (pmoveUtils->skipUpdate(lastUpdateTime)) {
     return true;
   }
 
@@ -141,8 +133,8 @@ bool UpmoveMeter::beforeRender() {
     return true;
   }
 
-  const bool inAir = ps.groundEntityNum == ENTITYNUM_NONE;
-  const bool jumping = cmd.upmove > 0;
+  const bool inAir = ps->groundEntityNum == ENTITYNUM_NONE;
+  const bool jumping = pm->cmd.upmove > 0;
 
   // determine current state
   state_t state;
@@ -218,9 +210,6 @@ bool UpmoveMeter::beforeRender() {
         jump_.preDelay = jump_.t_jumpPreGround - lastUpdateTime;
       }
       jump_.postDelay = lastUpdateTime - jump_.t_groundTouch; // ms
-      break;
-
-    default:
       break;
   }
 

--- a/src/cgame/etj_upmove_meter_drawable.h
+++ b/src/cgame/etj_upmove_meter_drawable.h
@@ -72,10 +72,11 @@ class UpmoveMeter : public IRenderable {
   static constexpr float graphX_ = 8.0f;
   static constexpr float graphY_ = 8.0f;
 
-  CvarValue::Size textSize;
+  CvarValue::Size textSize{};
 
   int lastUpdateTime{};
-  pmove_t *pm{};
+  const pmove_t *pm{};
+  const playerState_t *ps = &cg.predictedPlayerState;
 
   void startListeners();
   void parseAllColors();

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -568,8 +568,8 @@ void PM_UpdateViewAngles(playerState_t *ps, pmoveExt_t *pmext, usercmd_t *cmd,
 void Pmove(pmove_t *pmove);
 void PmoveSingle(pmove_t *pmove);
 
-inline constexpr int CMDSCALE_DEFAULT = 127;
-inline constexpr int CMDSCALE_WALK = 64;
+inline constexpr int8_t CMDSCALE_DEFAULT = 127;
+inline constexpr int8_t CMDSCALE_WALK = 64;
 
 //===================================================================================
 


### PR DESCRIPTION
The main motivations for this are to reduce the amount of boilerplate required to setup fake pmove for renderables, and to improve performance. Rather than having every single renderable that requires a fake pmove for drawing to call a static method which runs `PmoveSingle`, there's now a global object that has a getters which return pointer to `pmove_t` or `usercmd_t` structs, owned by the pmove utils class. The actual fake pmove is ran after `CG_PredictPlayerstate`, but before `CG_DrawActive` is called, so it's always valid and up-to-date before renderables use it. It's only ran if there's a renderable enabled that requires the fake pmove.

Performance wise, this is roughly a 5% improvement to fps on spec/demo playback, based on my test scenarios. Nothing massive, but consistent and measurable.

There some more simplifications that could still be done to some of the renderables with this new setup, but this is good enough for now.