### PR TITLE
Relocate pmove constants to bg_local.h

### DIFF
--- a/src/cgame/etj_snaphud.cpp
+++ b/src/cgame/etj_snaphud.cpp
@@ -30,6 +30,8 @@
 #include "etj_cgaz.h"
 #include "etj_cvar_update_handler.h"
 
+#include "../game/bg_local.h"
+
 // Snaphud implementation based on cgame_proxymod
 // HUGE thanks to Jelvan1 for his snaphud code
 // https://github.com/Jelvan1/cgame_proxymod/

--- a/src/game/bg_local.h
+++ b/src/game/bg_local.h
@@ -34,29 +34,29 @@ extern pmove_t *pm;
 extern pml_t pml;
 
 // movement parameters
-extern float pm_stopspeed;
-// extern	float	pm_duckScale;
 
-//----(SA)	modified
-extern float pm_waterSwimScale;
-extern float pm_waterWadeScale;
-extern float pm_slagSwimScale;
-extern float pm_slagWadeScale;
+inline constexpr float pm_stopspeed = 100;
 
-extern float pm_proneSpeedScale;
+inline constexpr float pm_waterSwimScale = 0.5;
+inline constexpr float pm_waterWadeScale = 0.70;
+inline constexpr float pm_slagSwimScale = 0.30;
+inline constexpr float pm_slagWadeScale = 0.70;
 
-extern float pm_accelerate;
-extern float pm_airaccelerate;
-extern float pm_wateraccelerate;
-extern float pm_slagaccelerate;
-extern float pm_flyaccelerate;
+// was: 0.18 (too slow) then: 0.24 (too fast)
+inline constexpr float pm_proneSpeedScale = 0.21;
 
-extern float pm_friction;
-extern float pm_waterfriction;
-extern float pm_slagfriction;
-extern float pm_flightfriction;
+inline constexpr float pm_accelerate = 10;
+inline constexpr float pm_airaccelerate = 1;
+inline constexpr float pm_wateraccelerate = 4;
+inline constexpr float pm_slagaccelerate = 2;
+inline constexpr float pm_flyaccelerate = 8;
 
-//----(SA)	end
+inline constexpr float pm_friction = 6;
+inline constexpr float pm_waterfriction = 1;
+inline constexpr float pm_slagfriction = 1;
+inline constexpr float pm_flightfriction = 3;
+inline constexpr float pm_ladderfriction = 14;
+inline constexpr float pm_spectatorfriction = 5.0f;
 
 extern int c_pmove;
 

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -21,9 +21,10 @@ extern vmCvar_t g_cheats;
 #endif
 
 namespace ETJump {
-static const int JUMP_DELAY_TIME = 850;
-static const int PRONE_JUMP_DELAY_TIME = 650;
-static const int PRONE_DELAY_TIME = 750;
+inline constexpr int JUMP_DELAY_TIME = 850;
+inline constexpr int PRONE_JUMP_DELAY_TIME = 650;
+inline constexpr int PRONE_DELAY_TIME = 750;
+
 static bool hasJustStoodUp() {
   return pm->pmext->proneTime - pm->pmext->jumpTime == PRONE_JUMP_DELAY_TIME;
 }
@@ -42,33 +43,6 @@ static void bgPrint(const std::string &msg, const Targs &...fargs) {
 
 pmove_t *pm;
 pml_t pml;
-
-// movement parameters
-float pm_stopspeed = 100;
-// float	pm_duckScale = 0.25;
-
-//----(SA)	modified
-float pm_waterSwimScale = 0.5;
-float pm_waterWadeScale = 0.70;
-float pm_slagSwimScale = 0.30;
-float pm_slagWadeScale = 0.70;
-
-float pm_proneSpeedScale = 0.21; // was: 0.18 (too slow) then: 0.24 (too fast)
-
-float pm_accelerate = 10;
-float pm_airaccelerate = 1;
-float pm_wateraccelerate = 4;
-float pm_slagaccelerate = 2;
-float pm_flyaccelerate = 8;
-
-float pm_friction = 6;
-float pm_waterfriction = 1;
-float pm_slagfriction = 1;
-float pm_flightfriction = 3;
-float pm_ladderfriction = 14;
-float pm_spectatorfriction = 5.0f;
-
-//----(SA)	end
 
 int c_pmove = 0;
 

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -405,11 +405,6 @@ inline constexpr int PMF_TIME_LOCKPLAYER = 32768;
 inline constexpr int PMF_ALL_TIMES = PMF_TIME_WATERJUMP | PMF_TIME_LAND |
                                      PMF_TIME_KNOCKBACK | PMF_TIME_LOCKPLAYER;
 
-extern float pm_stopspeed;
-extern float pm_accelerate;
-extern float pm_airaccelerate;
-extern float pm_friction;
-
 typedef struct {
   qboolean bAutoReload; // do we predict autoreload of weapons
 


### PR DESCRIPTION
Some of these are already needed in cgame, and it just makes more sense to declare them here rather than in bg_pmove and expose them via extern in headers.