### PR TITLE
Fix debugger paths setup for Visual Studio with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ option(USE_LSAN "Enable leak sanitizer on supported compilers" OFF)
 option(USE_UBSAN "Enable undefined behavior sanitizer on supported compilers" OFF)
 
 # provide options for Visual Studio to automatically setup debugger paths
-if (CMAKE_GENERATOR_NAME MATCHES "Visual Studio")
+if (CMAKE_GENERATOR MATCHES "Visual Studio")
 	set(ET_PATH "" CACHE STRING "Path to ET installation used during development")
 	set(ET_EXE_NAME "" CACHE STRING "Name of the engine for launching the game (ET.exe, etl.exe, ETe.exe etc.)")
 endif ()

--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -127,7 +127,7 @@ set_target_properties(cgame PROPERTIES
 	LIBRARY_OUTPUT_DIRECTORY_RELEASE "${BASE_DIR_PATH}")
 set_target_platform_details(cgame)
 
-if (CMAKE_GENERATOR_NAME MATCHES "Visual Studio")
+if (CMAKE_GENERATOR MATCHES "Visual Studio")
 	set_target_properties(cgame PROPERTIES
 			VS_DEBUGGER_COMMAND "${ET_PATH}\\${ET_EXE_NAME}"
 			VS_DEBUGGER_COMMAND_ARGUMENTS "+set fs_basepath . +set fs_homepath \"${ET_PATH}\" +set fs_game ${CMAKE_PROJECT_NAME}"


### PR DESCRIPTION
I have no idea what happened to these, I tested them when I made them and they worked, I guess I just changed `CMAKE_GENERATOR` to `CMAKE_GENERATOR_NAME` when moving things around or something.

refs #1630 