### PR TITLE
Make static dlights fully client sided

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -4533,12 +4533,9 @@ static void drawCoronas() {
 }
 
 static void drawClientDlights() {
-  // TODO: demo compatibility
-  /*
   if (demoCompatibility->flags.serverSideDlights) {
     return;
   }
-  */
 
   for (int i = 0; i < cg.numDlights; i++) {
     centity_t *dlight = &cgs.dlights[i];

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -4514,8 +4514,9 @@ void CG_DrawMiscGamemodels() {
   }
 }
 
-void CG_DrawCoronas() {
-  if (ETJump::demoCompatibility->flags.serverSideCoronas) {
+namespace ETJump {
+static void drawCoronas() {
+  if (demoCompatibility->flags.serverSideCoronas) {
     return;
   }
 
@@ -4529,6 +4530,26 @@ void CG_DrawCoronas() {
 
     CG_Corona(corona);
   }
+}
+
+static void drawClientDlights() {
+  // TODO: demo compatibility
+  /*
+  if (demoCompatibility->flags.serverSideDlights) {
+    return;
+  }
+  */
+
+  for (int i = 0; i < cg.numDlights; i++) {
+    centity_t *dlight = &cgs.dlights[i];
+
+    if (!trap_R_inPVS(cg.refdef_current->vieworg, dlight->lerpOrigin)) {
+      continue;
+    }
+
+    CG_AddLightstyle(dlight);
+  }
+}
 }
 
 void SetFov(float fov) {
@@ -4674,7 +4695,8 @@ void CG_DrawActive(stereoFrame_t stereoView) {
   // Gordon
   CG_DrawMiscGamemodels();
 
-  CG_DrawCoronas();
+  ETJump::drawCoronas();
+  ETJump::drawClientDlights();
 
   if (!(cg.limboEndCinematicTime > cg.time && cg.showGameView)) {
     for (int i = 0; i < MAX_RENDER_STRINGS; i++) {

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1088,6 +1088,7 @@ typedef struct {
 
   int numMiscGameModels;
   int numCoronas;
+  int numDlights;
 
   qboolean showGameView;
   qboolean showFireteamMenu;
@@ -1857,6 +1858,7 @@ typedef struct {
 
 inline constexpr int MAX_STATIC_GAMEMODELS = 1024;
 inline constexpr int MAX_STATIC_CORONAS = 1024;
+inline constexpr int MAX_STATIC_DLIGHTS = 1024;
 
 typedef struct cg_gamemodel_s {
   qhandle_t model;
@@ -2088,6 +2090,7 @@ typedef struct {
 
   cg_gamemodel_t miscGameModels[MAX_STATIC_GAMEMODELS];
   centity_t coronas[MAX_STATIC_CORONAS];
+  centity_t dlights[MAX_STATIC_DLIGHTS];
 
   vec2_t ccMenuPos;
   qboolean ccMenuShowing;
@@ -3100,6 +3103,7 @@ void CG_PositionRotatedEntityOnTag(refEntity_t *entity,
                                    const refEntity_t *parent,
                                    const char *tagName);
 void CG_Corona(centity_t *cent);
+void CG_AddLightstyle(centity_t *cent);
 
 //
 // cg_weapons.c

--- a/src/cgame/etj_demo_compatibility.cpp
+++ b/src/cgame/etj_demo_compatibility.cpp
@@ -148,6 +148,11 @@ void DemoCompatibility::setupCompatibilityFlags() {
         "- Adjusted event indices for ET_FAKEBRUSH and "
         "ET_TELEPORT_TRIGGER_CLIENT");
   }
+
+  if (!isCompatible({3, 4, 0})) {
+    flags.serverSideDlights = true;
+    compatibilityStrings.emplace_back("- Using fully server-side dlights");
+  }
 }
 
 int DemoCompatibility::adjustedEventNum(const int event) const {

--- a/src/cgame/etj_demo_compatibility.h
+++ b/src/cgame/etj_demo_compatibility.h
@@ -59,6 +59,7 @@ public:
     bool adjustEvGeneralClientSoundVolume = false;
     bool adjustEvVelocityPushTrigger = false;
     bool adjustEvFakebrushAndClientTeleporter = false;
+    bool serverSideDlights = false;
   };
 
   // everything in here will be set to false unless we're on demo playback

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -1866,6 +1866,28 @@ inline constexpr float CH_MAX_DIST = 1024.0f;
 // max dist for zooming hints
 inline constexpr float CH_MAX_DIST_ZOOM = 8192.0f;
 
+inline constexpr int NUM_PREDEF_DLIGHT_STRINGS = 19;
+inline constexpr std::array<const char *, NUM_PREDEF_DLIGHT_STRINGS>
+    predef_lightstyles = {"mmnmmommommnonmmonqnmmo",
+                          "abcdefghijklmnopqrstuvwxyzyxwvutsrqponmlkjihgfedcba",
+                          "mmmmmaaaaammmmmaaaaaabcdefgabcdefg",
+                          "ma",
+                          "jklmnopqrstuvwxyzyxwvutsrqponmlkj",
+                          "nmonqnmomnmomomono",
+                          "mmmaaaabcdefgmmmmaaaammmaamm",
+                          "aaaaaaaazzzzzzzz",
+                          "mmamammmmammamamaaamammma",
+                          "abcdefghijklmnopqrrqponmlkjihgfedcba",
+                          "mmnommomhkmmomnonmmonqnmmo",
+                          "kmamaamakmmmaakmamakmakmmmma",
+                          "kmmmakakmmaaamammamkmamakmmmma",
+                          "mmnnoonnmmmmmmmmmnmmmmnonmmmmmmm",
+                          "mmmmnonmmmmnmmmmmnonmmmmmnmmmmmmm",
+                          "zzzzzzzzaaaaaaaa",
+                          "zzzzzzzzaaaaaaaaaaaaaaaa",
+                          "aaaaaaaazzzzzzzzaaaaaaaa",
+                          "aaaaaaaaaaaaaaaazzzzzzzz"};
+
 void BG_EvaluateTrajectory(const trajectory_t *tr, int atTime, vec3_t result,
                            qboolean isAngle, int splinePath);
 void BG_EvaluateTrajectoryDelta(const trajectory_t *tr, int atTime,

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -1318,32 +1318,6 @@ void SP_corona(gentity_t *ent) {
   }
 }
 
-// (SA) dlights and dlightstyles
-// TTimo gcc: lots of braces around scalar initializer
-// char* predef_lightstyles[] = {
-//	{"mmnmmommommnonmmonqnmmo"},
-
-const char *predef_lightstyles[] = {
-    "mmnmmommommnonmmonqnmmo",
-    "abcdefghijklmnopqrstuvwxyzyxwvutsrqponmlkjihgfedcba",
-    "mmmmmaaaaammmmmaaaaaabcdefgabcdefg",
-    "ma",
-    "jklmnopqrstuvwxyzyxwvutsrqponmlkj",
-    "nmonqnmomnmomomono",
-    "mmmaaaabcdefgmmmmaaaammmaamm",
-    "aaaaaaaazzzzzzzz",
-    "mmamammmmammamamaaamammma",
-    "abcdefghijklmnopqrrqponmlkjihgfedcba",
-    "mmnommomhkmmomnonmmonqnmmo",
-    "kmamaamakmmmaakmamakmakmmmma",
-    "kmmmakakmmaaamammamkmamakmmmma",
-    "mmnnoonnmmmmmmmmmnmmmmnonmmmmmmm",
-    "mmmmnonmmmmnmmmmmnonmmmmmnmmmmmmm",
-    "zzzzzzzzaaaaaaaa",
-    "zzzzzzzzaaaaaaaaaaaaaaaa",
-    "aaaaaaaazzzzzzzzaaaaaaaa",
-    "aaaaaaaaaaaaaaaazzzzzzzz"};
-
 /*
 ==============
 dlight_finish_spawning
@@ -1455,17 +1429,23 @@ void SP_dlight(gentity_t *ent) {
   char *snd, *shader;
   int offset, style, atten;
 
-  G_SpawnInt("offset", "0",
-             &offset);              // starting index into the stylestring
-  G_SpawnInt("style", "0", &style); // predefined stylestring
-  G_SpawnString("sound", "", &snd); //
-  G_SpawnInt("atten", "0", &atten); //
-  G_SpawnString("shader", "",
-                &shader); // name of shader to use for this dlight image
-
   if (G_SpawnString("sound", "0", &snd)) {
     ent->soundLoop = G_SoundIndex(snd);
   }
+
+  // client-side dlight
+  if (!ent->targetname && !ent->scriptName && !ent->spawnflags &&
+      !ent->soundLoop) {
+    G_FreeEntity(ent);
+    return;
+  }
+
+  G_SpawnInt("offset", "0",
+             &offset);              // starting index into the stylestring
+  G_SpawnInt("style", "0", &style); // predefined stylestring
+  G_SpawnInt("atten", "0", &atten); //
+  G_SpawnString("shader", "",
+                &shader); // name of shader to use for this dlight image
 
   if (ent->dl_stylestring &&
       strlen(ent->dl_stylestring)) // if they're specified in a string,


### PR DESCRIPTION
Any dlight that doesn't have a `targetname`, `scriptname`, `spawnflags` or `sound` can be fully processed on client side. This allows more than 16 dlights in a map, if the dlights don't require any server-side processing. There's no real limit to these (arbitrarily set to 1024), but the renderer has a limit of 32 dlights in a scene, and will drop any extra dlights. This should be documented in the entity definition file.

Need to do a couple of more tests on this but it's probably fine. I do want to explore `sound` key processing on client side later still, but it's not a high priority issue.

refs #201 