### PR TITLE
Fix potential server crash with target_rumble

### DIFF
--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -1314,7 +1314,9 @@ void target_rumble_use(gentity_t *ent, gentity_t *other, gentity_t *activator) {
     ent->nextthink = level.time + 50;
   } else {
     ent->spawnflags |= 1;
-    ent->think = NULL;
+    ent->think = nullptr;
+    ent->nextthink = 0;
+    ent->s.loopSound = 0; // turn it off since the entity is off
     ent->count = 0;
   }
 }


### PR DESCRIPTION
Old etmain bug, prevent the entity from thinking when re-triggered before the rumble was finished, to prevent server crashing due to null `ent->think`.