### PR TITLE
Portalgun pickup fixes

### DIFF
--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -1108,8 +1108,13 @@ void G_CheckForCursorHints(gentity_t *ent) {
               hintType = HINT_TREASURE;
               break;
             case IT_WEAPON: {
-              qboolean canPickup =
-                  COM_BitCheck(ent->client->ps.weapons, it->giTag);
+              bool canPickup = COM_BitCheck(ent->client->ps.weapons, it->giTag);
+
+              // portal gun works the opposite way from other weapons:
+              // we can only pick it up if we don't have it
+              if (it->giTag == WP_PORTAL_GUN) {
+                canPickup = !canPickup;
+              }
 
               if (!canPickup) {
                 if (it->giTag == WP_AMMO) {

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -494,16 +494,17 @@ whatever value it is. People with the same portal team value can use eachothers
 portals. Clear portal team on death, team switch etc.
 */
 void SP_weapon_portalgun(gentity_t *ent) {
-
-  // TODO: spawn portalgun ent
-  // gentity_t*  ent;
   gitem_t *item;
 
   G_SpawnInt("portal_team", "0", &ent->portalTeam);
 
   item = BG_FindItemForWeapon(WP_PORTAL_GUN);
 
-  // ent = G_Spawn();
+  char *noise{};
+
+  if (G_SpawnString("noise", "", &noise)) {
+    ent->noise_index = G_SoundIndex(noise);
+  }
 
   ent->s.eType = ET_ITEM;
   ent->s.modelindex = item - bg_itemlist; // store item number in modelindex


### PR DESCRIPTION
* Add missing `noise` key support for feature parity with other weapon and item entities, let's mappers override the default pickup sound
* Fix cursorhints for portalgun pickups - cursorhint is now only shown if you don't already have a portalgun, as opposed to only showing when you already have it.