### PR TITLE
Improve viewpos & setviewpos

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -23,10 +23,13 @@ CG_Viewpos_f
 Debugging command to print the current position
 =============
 */
-static void CG_Viewpos_f(void) {
-  CG_Printf("(%i %i %i) : %i\n", (int)cg.refdef.vieworg[0],
-            (int)cg.refdef.vieworg[1], (int)cg.refdef.vieworg[2],
-            (int)cg.refdefViewAngles[YAW]);
+static void CG_Viewpos_f() {
+  CG_Printf("(%i %i %i) : %i %i %i\n", static_cast<int>(cg.refdef.vieworg[0]),
+            static_cast<int>(cg.refdef.vieworg[1]),
+            static_cast<int>(cg.refdef.vieworg[2]),
+            static_cast<int>(cg.refdefViewAngles[PITCH]),
+            static_cast<int>(cg.refdefViewAngles[YAW]),
+            static_cast<int>(cg.refdefViewAngles[ROLL]));
 }
 
 void CG_LimboMenu_f(void) {

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -3120,28 +3120,32 @@ Cmd_SetViewpos_f
 =================
 */
 void Cmd_SetViewpos_f(gentity_t *ent) {
+  if (!g_cheats.integer) {
+    Printer::console(ent, "Cheats are not enabled on this server.\n");
+    return;
+  }
+
+  const int argc = trap_Argc();
+
+  if (argc != 4 && argc != 7) {
+    Printer::console(
+        ent, "Usage:\nsetviewpos x y z\nsetviewpos x y z pitch yaw roll\n");
+    return;
+  }
+
   vec3_t origin, angles;
   char buffer[MAX_TOKEN_CHARS];
-  int i;
 
-  if (!g_cheats.integer) {
-    trap_SendServerCommand(ent - g_entities,
-                           va("print \"Cheats are not enabled "
-                              "on this server.\n\""));
-    return;
-  }
-  if (trap_Argc() != 7) {
-    trap_SendServerCommand(ent - g_entities,
-                           va("print \"usage: setviewpos x y z "
-                              "pitch yaw roll\n\""));
-    return;
-  }
-
-  for (i = 0; i < 3; i++) {
+  for (int i = 0; i < 3; i++) {
     trap_Argv(i + 1, buffer, sizeof(buffer));
     origin[i] = Q_atof(buffer);
-    trap_Argv(i + 4, buffer, sizeof(buffer));
-    angles[i] = AngleNormalize180(Q_atof(buffer));
+
+    if (argc == 4) {
+      angles[i] = ent->client->ps.viewangles[i];
+    } else {
+      trap_Argv(i + 4, buffer, sizeof(buffer));
+      angles[i] = AngleNormalize180(Q_atof(buffer));
+    }
   }
 
   DirectTeleport(ent, origin, angles);


### PR DESCRIPTION
* `viewpos` now prints all viewangles rather than just yaw angle.
* `setviewpos` can now take either 3 or 6 arguments. If angles are not given as arguments, they are not modified and are passed to the new position as-is.