### PR TITLE
Fix chat replay potentially writing a null JSON object

### DIFF
--- a/src/cgame/etj_savepos.cpp
+++ b/src/cgame/etj_savepos.cpp
@@ -194,7 +194,7 @@ void SavePos::parseSavepos(const std::string &file) {
       "savepos/" + (file.empty() ? defaultName + ".dat" : file);
 
   if (!JsonUtils::readFile(filename, root, &errors)) {
-    CG_Printf("%s", errors.c_str());
+    CG_Printf("%s\n", errors.c_str());
     return;
   }
 

--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -171,6 +171,13 @@ void ChatReplay::readChatsFromFile() {
 }
 
 void ChatReplay::writeChatsToFile() {
+  // if the chat replay file does not exist, and there have been no chats
+  // to store during current session, the replay buffer will be empty
+  // -> exit so we don't write a null JSON object for no reason
+  if (chatReplayBuffer.empty()) {
+    return;
+  }
+
   Json::Value root;
 
   for (const auto &msg : chatReplayBuffer) {

--- a/src/game/etj_custom_map_votes.cpp
+++ b/src/game/etj_custom_map_votes.cpp
@@ -248,7 +248,7 @@ void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
                        stringFormat("^3add-customvote: ^7couldn't open the "
                                     "file ^3'%s' ^7for reading:\n",
                                     customVotesFile));
-      Printer::console(clientNum, errors);
+      Printer::console(clientNum, errors + '\n');
       return;
     }
   }
@@ -273,7 +273,7 @@ void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
                      stringFormat("^3add-customvote: ^7couldn't open the file "
                                   "^3'%s' ^7for writing:\n",
                                   customVotesFile));
-    Printer::console(clientNum, errors);
+    Printer::console(clientNum, errors + '\n');
     return;
   }
 
@@ -295,7 +295,7 @@ void CustomMapVotes::deleteCustomvoteList(int clientNum,
                      stringFormat("^3delete-customvote: ^7couldn't open the "
                                   "file ^3'%s' ^7for reading.\n",
                                   customVotesFile));
-    Printer::console(clientNum, errors);
+    Printer::console(clientNum, errors + '\n');
     return;
   }
 
@@ -324,7 +324,7 @@ void CustomMapVotes::deleteCustomvoteList(int clientNum,
                      stringFormat("^3delete-customvote: ^7couldn't open the "
                                   "file ^3'%s' ^7for writing.\n",
                                   customVotesFile));
-    Printer::console(clientNum, errors);
+    Printer::console(clientNum, errors + '\n');
     return;
   }
 
@@ -351,7 +351,7 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
                      stringFormat("^3edit-customvote: ^7couldn't open the file "
                                   "^3'%s' ^7for reading.\n",
                                   customVotesFile));
-    Printer::console(clientNum, errors);
+    Printer::console(clientNum, errors + '\n');
     return;
   }
 
@@ -450,7 +450,7 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
                      stringFormat("^3edit-customvote: ^7couldn't open the file "
                                   "^3'%s' ^7for writing.\n",
                                   customVotesFile));
-    Printer::console(clientNum, errors);
+    Printer::console(clientNum, errors + '\n');
     return;
   }
 

--- a/src/game/etj_json_utilities.cpp
+++ b/src/game/etj_json_utilities.cpp
@@ -35,7 +35,7 @@ bool JsonUtils::writeFile(const std::string &file, const Json::Value &root,
 
   if (file.empty()) {
     if (errors) {
-      *errors = "Failed to write JSON file: empty filename\n";
+      *errors = "Failed to write JSON file: empty filename";
     }
 
     return false;
@@ -48,7 +48,7 @@ bool JsonUtils::writeFile(const std::string &file, const Json::Value &root,
     return true;
   } catch (const File::WriteFailedException &e) {
     if (errors) {
-      *errors = stringFormat("Failed to write JSON file: %s\n", e.what());
+      *errors = stringFormat("Failed to write JSON file: %s", e.what());
     }
 
     return false;
@@ -64,7 +64,7 @@ bool JsonUtils::readFile(const std::string &file, Json::Value &root,
 
     if (errors) {
       *errors = stringFormat(
-          "Failed to read JSON file: unable to open file '%s' for reading\n",
+          "Failed to read JSON file: unable to open file '%s' for reading",
           file);
     }
 

--- a/src/game/etj_json_utilities.cpp
+++ b/src/game/etj_json_utilities.cpp
@@ -61,6 +61,13 @@ bool JsonUtils::readFile(const std::string &file, Json::Value &root,
 
   if (!fIn) {
     fIn.close();
+
+    if (errors) {
+      *errors = stringFormat(
+          "Failed to read JSON file: unable to open file '%s' for reading\n",
+          file);
+    }
+
     return false;
   }
 

--- a/src/game/etj_motd.cpp
+++ b/src/game/etj_motd.cpp
@@ -110,7 +110,7 @@ void Motd::generateMotdFile() {
     G_Printf("Generated new motd file '%s'\n", g_motdFile.string);
     initialize();
   } else {
-    G_Printf("%s", errors.c_str());
+    G_Printf("%s\n", errors.c_str());
   }
 }
 } // namespace ETJump


### PR DESCRIPTION
If the replay file is empty/doesn't exists, and no chats were written during a session, a null JSON object was written to the file, which then failed to parse on load. This wasn't causing any issue per se, as the next valid message to store would just overwrite the null object, but better not write that to begin with.

refs #1335 