### PR TITLE
Improve File & Filesystem classes

### DIFF
--- a/src/cgame/etj_client_authentication.cpp
+++ b/src/cgame/etj_client_authentication.cpp
@@ -62,7 +62,7 @@ std::string ETJump::ClientAuthentication::getGuid() {
     File guidFile(GUID_FILE);
     auto guid = guidFile.read();
     return std::string(begin(guid), end(guid));
-  } catch (const File::FileNotFoundException &) {
+  } catch (const File::FileIOException &) {
     return createGuid();
   }
 }
@@ -79,12 +79,12 @@ std::string ETJump::ClientAuthentication::createGuid() const {
 
 ETJump::ClientAuthentication::OperationResult
 ETJump::ClientAuthentication::saveGuid(const std::string &guid) const {
-  File guidFile(GUID_FILE, File::Mode::Write);
   try {
+    const File guidFile(GUID_FILE, File::Mode::Write);
     guidFile.write(guid);
     return {true, ""};
-  } catch (const File::WriteFailedException &wfe) {
-    return {false, std::string("saving guid failed: ") + wfe.what() +
+  } catch (const File::FileIOException &e) {
+    return {false, std::string("saving guid failed: ") + e.what() +
                        " Using temporary guid."};
   }
 }

--- a/src/game/etj_file.h
+++ b/src/game/etj_file.h
@@ -33,39 +33,30 @@
 namespace ETJump {
 class File {
 public:
-  class FileNotFoundException : public std::runtime_error {
+  class FileIOException : public std::runtime_error {
   public:
-    explicit FileNotFoundException(const std::string &message)
-        : runtime_error(message) {}
-  };
-
-  class WriteFailedException : public std::runtime_error {
-  public:
-    explicit WriteFailedException(const std::string &message)
-        : runtime_error(message) {}
+    explicit FileIOException(const std::string &what)
+        : std::runtime_error(what) {}
   };
 
   typedef int FileHandle;
   enum class Mode { Read, Write, Append, AppendSync };
 
-  static const int FILE_NOT_FOUND = -1;
-  static const int INVALID_FILE_HANDLE = 0;
-  static const int READ_ALL_BYTES = -1;
+  static constexpr int FILE_NOT_FOUND = -1;
+  static constexpr int INVALID_FILE_HANDLE = 0;
+  static constexpr int READ_ALL_BYTES = -1;
 
-  // throws FileNotFoundException if the mode is read and there's no
-  // such file.
-  // Write will create the file in that case
+  // throws FileIOException if file handle cannot be opened
+  // (file not found, path is not writable etc.)
   explicit File(std::string path, Mode mode = Mode::Read);
   ~File();
 
   // reads `bytes` bytes from the file.
   // if file length < bytes, reads length bytes
-  std::vector<char> read(int bytes = READ_ALL_BYTES);
+  std::vector<char> read(int bytes = READ_ALL_BYTES) const;
 
   // writes all data to the file
-  // throws std::logic_error if mode is Read
-  // throws WriteFailedException if written bytes count != data bytes
-  // count
+  // throws FileIOException if operation fails
   void write(const std::string &data) const;
   void write(const std::vector<char> &data) const;
   void write(const char *data, int len) const;

--- a/src/game/etj_filesystem.h
+++ b/src/game/etj_filesystem.h
@@ -47,7 +47,7 @@ public:
     static std::string buildOSPath(const std::string &file);
 
   public:
-    static std::string sanitize(std::string path);
+    static std::string sanitize(const std::string &path);
     static std::string sanitizeFile(std::string path);
     static std::string sanitizeFolder(std::string path);
 

--- a/src/game/etj_json_utilities.cpp
+++ b/src/game/etj_json_utilities.cpp
@@ -41,12 +41,11 @@ bool JsonUtils::writeFile(const std::string &file, const Json::Value &root,
     return false;
   }
 
-  const File fOut(file, File::Mode::Write);
-
   try {
+    const File fOut(file, File::Mode::Write);
     fOut.write(output);
     return true;
-  } catch (const File::WriteFailedException &e) {
+  } catch (const File::FileIOException &e) {
     if (errors) {
       *errors = stringFormat("Failed to write JSON file: %s", e.what());
     }


### PR DESCRIPTION
* Simplify exception handling - just throw a generic `FileIOException` for every error, we don't really care if the exception is due to a failed write, logic error or whatever, because it's in no way actionable.
* Throw exception if file handle cannot be acquired for other modes than Read, otherwise there's no indication that a write fails on cgame/ui, because `trap_FS_Write` only returns bytes written in qagame.