### PR TITLE
Fix potential crash with /players command

### DIFF
--- a/src/game/etj_string_utilities.cpp
+++ b/src/game/etj_string_utilities.cpp
@@ -383,22 +383,23 @@ void ETJump::StringUtil::removeLeadingChars(std::string &str,
 }
 
 std::string ETJump::StringUtil::truncate(const std::string &str,
-                                         const int len) {
+                                         const size_t len) {
   // TODO: check for stripped string length here too, once sanitize() is fixed
   //  https://github.com/etjump/etjump/issues/1684
-  if (str.empty() || len < 0) {
+  if (str.empty()) {
     return str;
   }
 
-  const auto isColorString = [&](const std::string &s, const int idx) {
-    return s[idx] == '^' && s[idx + 1] != std::string::npos &&
+  const auto isColorString = [&](const std::string &s, const size_t idx) {
+    return s[idx] == '^' &&
+           static_cast<size_t>(s[idx + 1]) != std::string::npos &&
            s[idx + 1] != '^';
   };
 
-  int outLen = len;
-  int idx = 0;
+  size_t outLen = len;
+  size_t idx = 0;
 
-  for (int i = 0; i < outLen && outLen < str.length(); i++) {
+  for (size_t i = 0; i < outLen && outLen < str.length(); i++) {
     if (isColorString(str, idx)) {
       outLen += 2;
       idx += 2;

--- a/src/game/etj_string_utilities.cpp
+++ b/src/game/etj_string_utilities.cpp
@@ -381,3 +381,34 @@ void ETJump::StringUtil::removeLeadingChars(std::string &str,
     str.erase(0, pos);
   }
 }
+
+std::string ETJump::StringUtil::truncate(const std::string &str,
+                                         const int len) {
+  // TODO: check for stripped string length here too, once sanitize() is fixed
+  //  https://github.com/etjump/etjump/issues/1684
+  if (str.empty() || len < 0) {
+    return str;
+  }
+
+  const auto isColorString = [&](const std::string &s, const int idx) {
+    return s[idx] == '^' && s[idx + 1] != std::string::npos &&
+           s[idx + 1] != '^';
+  };
+
+  int outLen = len;
+  int idx = 0;
+
+  for (int i = 0; i < outLen && outLen < str.length(); i++) {
+    if (isColorString(str, idx)) {
+      outLen += 2;
+      idx += 2;
+      i++;
+      continue;
+    }
+
+    idx++;
+  }
+
+  std::string out = str.substr(0, outLen);
+  return out;
+}

--- a/src/game/etj_string_utilities.h
+++ b/src/game/etj_string_utilities.h
@@ -128,7 +128,7 @@ void removeLeadingChars(std::string &str, char charToRemove);
 // color codes are excluded from the truncation length, so this can be used
 // to truncate colored strings to display only a certain number of characters
 // e.g. truncate("^1foo^2bar", 3) -> "^1foo"
-std::string truncate(const std::string &str, int len);
+std::string truncate(const std::string &str, size_t len);
 
 // sorts strings either with case sensitivity or insensitivity
 // identical strings are kept in order

--- a/src/game/etj_string_utilities.h
+++ b/src/game/etj_string_utilities.h
@@ -124,6 +124,12 @@ void removeTrailingChars(std::string &str, char charToRemove);
 // if input contains only chars to remove, result is empty string
 void removeLeadingChars(std::string &str, char charToRemove);
 
+// truncates a string, preserving any color codes in the string
+// color codes are excluded from the truncation length, so this can be used
+// to truncate colored strings to display only a certain number of characters
+// e.g. truncate("^1foo^2bar", 3) -> "^1foo"
+std::string truncate(const std::string &str, int len);
+
 // sorts strings either with case sensitivity or insensitivity
 // identical strings are kept in order
 template <typename T>

--- a/src/game/g_cmds_ext.cpp
+++ b/src/game/g_cmds_ext.cpp
@@ -229,7 +229,7 @@ void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
   int idNum, count = 0;
   int userRate, userSnaps;
   gclient_t *client;
-  char name[MAX_NETNAME], info[256];
+  char info[256];
   const char *s;
   char userinfo[MAX_INFO_STRING];
   const char *team;
@@ -256,12 +256,6 @@ void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
   for (int i = 0; i < level.numConnectedClients; i++) {
     idNum = level.sortedClients[i]; // level.sortedNames[i];
     client = &level.clients[idNum];
-
-    Q_strncpyz(name, client->pers.netname, sizeof(name));
-    // exclude color codes from the max string length
-    const auto colorChars =
-        static_cast<int>(strlen(name)) - Q_PrintStrlen(name);
-    name[23 + colorChars] = 0;
 
     // player info
     if (client->pers.connected == CON_CONNECTING) {
@@ -308,12 +302,19 @@ void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
         break;
     }
 
+    const std::string name =
+        ETJump::StringUtil::truncate(client->pers.netname, 23);
+
     if (ent) {
-      Printer::console(clientNum, va("%s%2d  %-*s^7%s\n", team, idNum,
-                                     25 + colorChars, name, info));
+      const int colorChars =
+          strlen(client->pers.netname) - Q_PrintStrlen(client->pers.netname);
+      Printer::console(clientNum,
+                       ETJump::stringFormat("%s%2d  %-*s^7%s\n", team, idNum,
+                                            25 + colorChars, name, info));
     } else {
-      G_Printf("%s%2d  %-25s%s\n", team, idNum,
-               ETJump::sanitize(name, false).c_str(), info);
+      char cleanName[MAX_NETNAME];
+      Q_strncpyz(cleanName, name.c_str(), sizeof(cleanName));
+      G_Printf("%s%2d  %-25s%s\n", team, idNum, Q_CleanStr(cleanName), info);
     }
 
     count++;

--- a/tests/string_utilities_tests.cpp
+++ b/tests/string_utilities_tests.cpp
@@ -281,3 +281,39 @@ TEST_F(StringUtilitiesTests, sortStrings_SortWithCase) {
   ASSERT_EQ(vec[4], "aA");
   ASSERT_EQ(vec[5], "aC");
 }
+
+TEST_F(StringUtilitiesTests, truncate_BasicTruncate) {
+  const std::string in = "^1test^2test";
+
+  ASSERT_EQ(StringUtil::truncate(in, 4), "^1test");
+  ASSERT_EQ(StringUtil::truncate(in, 2), "^1te");
+  ASSERT_EQ(StringUtil::truncate(in, 8), "^1test^2test");
+  ASSERT_EQ(StringUtil::truncate(in, 10), "^1test^2test");
+  ASSERT_EQ(StringUtil::truncate(in, 11), "^1test^2test");
+  ASSERT_EQ(StringUtil::truncate(in, 12), "^1test^2test");
+  ASSERT_EQ(StringUtil::truncate(in, 13), "^1test^2test");
+}
+
+TEST_F(StringUtilitiesTests, truncate_InvalidInput) {
+  const std::string in = "^1test^2test";
+
+  ASSERT_EQ(StringUtil::truncate(in, -1), "^1test^2test");
+  ASSERT_EQ(StringUtil::truncate("", 10), "");
+}
+
+TEST_F(StringUtilitiesTests, truncate_LenIsInColorCode) {
+  const std::string in = "^1test^2test";
+
+  ASSERT_EQ(StringUtil::truncate(in, 5), "^1test^2t");
+  ASSERT_EQ(StringUtil::truncate(in, 6), "^1test^2te");
+}
+
+TEST_F(StringUtilitiesTests, truncate_MultipleCarets) {
+  const std::string in = "^^1test^^^2test";
+
+  ASSERT_EQ(StringUtil::truncate(in, 1), "^");
+  ASSERT_EQ(StringUtil::truncate(in, 3), "^^1te");
+  ASSERT_EQ(StringUtil::truncate(in, 6), "^^1test^");
+  ASSERT_EQ(StringUtil::truncate(in, 7), "^^1test^^");
+  ASSERT_EQ(StringUtil::truncate(in, 9), "^^1test^^^2te");
+}


### PR DESCRIPTION
Certain names could cause a crash when calculating string padding for the command output. This adds a proper string truncation method that takes color codes into account for string length.

fixes #1677 