### PR TITLE
Fix exploit with callvote args

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -2370,7 +2370,7 @@ bool RockTheVote(gentity_t *ent, Arguments argv) {
   return true;
 }
 
-// ensures custom vote command options are not just color codes
+// ensures custom vote command options are valid
 bool validateCustomVoteCommand(const std::string &cmdName, const int &clientNum,
                                const ETJump::CommandParser::Command &command) {
   bool commandOk = true;
@@ -2380,6 +2380,14 @@ bool validateCustomVoteCommand(const std::string &cmdName, const int &clientNum,
       Printer::chat(clientNum,
                     ETJump::stringFormat("^3%s: ^7'%s' cannot be empty.",
                                          cmdName, op.first));
+      commandOk = false;
+    }
+
+    if (op.first == "name" && !ETJump::isValidVoteString(op.second.text)) {
+      Printer::chat(
+          clientNum,
+          ETJump::stringFormat("^3%s: ^7%s '%s' contains invalid characters.",
+                               cmdName, op.first, op.second.text));
       commandOk = false;
     }
   }

--- a/src/game/etj_custom_map_votes.cpp
+++ b/src/game/etj_custom_map_votes.cpp
@@ -91,6 +91,14 @@ void CustomMapVotes::loadCustomvotes(const bool init) {
       return;
     }
 
+    if (!isValidVoteString(customMapVotes_[curr].type)) {
+      logger->error(
+          "Failed to parse custom vote - name '%s' contains invalid characters",
+          customMapVotes_[curr].type);
+      customMapVotes_.pop_back();
+      continue;
+    }
+
     customMapVotes_[curr].type = sanitize(customMapVotes_[curr].type, true);
 
     if (customMapVotes_[curr].type.empty()) {

--- a/src/game/etj_string_utilities.cpp
+++ b/src/game/etj_string_utilities.cpp
@@ -301,11 +301,6 @@ bool ETJump::StringUtil::endsWith(const std::string &str,
          0;
 }
 
-bool ETJump::StringUtil::contains(const std::string &str,
-                                  const std::string &text) {
-  return str.find(text) != std::string::npos;
-}
-
 bool ETJump::StringUtil::iEqual(const std::string &str1,
                                 const std::string &str2, bool sanitized) {
   if (sanitized) {

--- a/src/game/etj_string_utilities.h
+++ b/src/game/etj_string_utilities.h
@@ -103,7 +103,12 @@ void stringSubstitute(std::string &input, char character,
 
 bool startsWith(const std::string &str, const std::string &prefix);
 bool endsWith(const std::string &str, const std::string &suffix);
-bool contains(const std::string &str, const std::string &text);
+
+template <typename T>
+bool contains(const std::string &str, const T &text) {
+  return str.find(text) != std::string::npos;
+}
+
 // case-insensitive string comparison, optionally with sanitized strings
 bool iEqual(const std::string &str1, const std::string &str2,
             bool sanitized = false);

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -2585,6 +2585,13 @@ void setCvString(char *voteMsg, char *voteArg) {
   Com_sprintf(level.voteInfo.voteString, sizeof(level.voteInfo.voteString),
               voteStringFormat, voteMsg, voteArg);
 }
+
+bool isValidVoteString(const std::string &str) {
+  return std::none_of(
+      tokenDelimiters.cbegin(), tokenDelimiters.cend(),
+      [&](const char token) { return StringUtil::contains(str, token); });
+}
+
 } // namespace ETJump
 
 /*
@@ -2606,7 +2613,7 @@ void Cmd_CallVote_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
   trap_Argv(1, arg1, sizeof(arg1));
   trap_Argv(2, arg2, sizeof(arg2));
 
-  if (strchr(arg1, ';') || strchr(arg2, ';')) {
+  if (!ETJump::isValidVoteString(arg1) || !ETJump::isValidVoteString(arg2)) {
     Printer::popup(clientNum, "Invalid vote string.");
     return;
   }

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1853,6 +1853,10 @@ void Cmd_Team2_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue);
 void Cmd_SetWeapons_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue);
 void Cmd_SetClass_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue);
 
+namespace ETJump {
+bool isValidVoteString(const std::string &str);
+}
+
 //
 // g_main.c
 //

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -310,6 +310,9 @@ inline constexpr int MAX_BINARY_MESSAGE = 32768; // max length of binary message
 
 inline constexpr int MAX_VA_STRING = 32000;
 
+// delimiter characters for command tokenization
+constexpr std::array<char, 3> tokenDelimiters = {';', '\n', '\r'};
+
 typedef enum {
   MESSAGE_EMPTY = 0,
   MESSAGE_WAITING,          // rate/packet limited


### PR DESCRIPTION
Old bug originating from q3, has been fixed engine side for years in ETL/ETe, but 2.60b was still vulnerable.