### PR TITLE
Fix sanitize() handling color strings incorrectly

### DIFF
--- a/src/game/etj_string_utilities.cpp
+++ b/src/game/etj_string_utilities.cpp
@@ -86,34 +86,24 @@ std::string ETJump::getBestMatch(const std::vector<std::string> &words,
   return smallest->first;
 }
 
-static void SanitizeConstString(const char *in, char *out, const bool toLower,
-                                const bool removeEscapeChars) {
-  while (*in) {
-    if (*in == 27 || *in == '^') {
-      in++; // skip color code
-      if (*in) {
-        in++;
-      }
+std::string ETJump::sanitize(const std::string &text, const bool toLower,
+                             const bool removeControlChars) {
+  std::string out;
+
+  for (size_t i = 0; i < text.length(); ++i) {
+    if (StringUtil::isColorString(text, i)) {
+      i++;
       continue;
     }
 
-    if (removeEscapeChars && *in < 32) {
-      in++;
+    if (removeControlChars && text[i] < 32) {
       continue;
     }
 
-    *out++ = toLower ? static_cast<char>(tolower(*in++)) : *in++;
+    out += toLower ? static_cast<char>(std::tolower(text[i])) : text[i];
   }
 
-  *out = 0;
-}
-
-std::string ETJump::sanitize(const std::string &text, const bool toLower,
-                             const bool removeEscapeChars) {
-  const size_t len = text.length();
-  std::vector<char> out(len + 1);
-  SanitizeConstString(text.c_str(), out.data(), toLower, removeEscapeChars);
-  return {out.data()};
+  return out;
 }
 
 std::string ETJump::getValue(const char *value,
@@ -382,19 +372,18 @@ void ETJump::StringUtil::removeLeadingChars(std::string &str,
   }
 }
 
+bool ETJump::StringUtil::isColorString(const std::string &str,
+                                       const size_t idx) {
+  return str[idx] == '^' &&
+         static_cast<size_t>(str[idx + 1]) != std::string::npos &&
+         str[idx + 1] != '^';
+}
+
 std::string ETJump::StringUtil::truncate(const std::string &str,
                                          const size_t len) {
-  // TODO: check for stripped string length here too, once sanitize() is fixed
-  //  https://github.com/etjump/etjump/issues/1684
-  if (str.empty()) {
+  if (str.empty() || str.length() <= len || sanitize(str).length() <= len) {
     return str;
   }
-
-  const auto isColorString = [&](const std::string &s, const size_t idx) {
-    return s[idx] == '^' &&
-           static_cast<size_t>(s[idx + 1]) != std::string::npos &&
-           s[idx + 1] != '^';
-  };
 
   size_t outLen = len;
   size_t idx = 0;

--- a/src/game/etj_string_utilities.h
+++ b/src/game/etj_string_utilities.h
@@ -34,7 +34,7 @@ std::string hash(const std::string &input);
 std::string getBestMatch(const std::vector<std::string> &words,
                          const std::string &current);
 std::string sanitize(const std::string &text, bool toLower = false,
-                     bool removeEscapeChars = true);
+                     bool removeControlChars = true);
 // returns the value if it's specified, else the default value
 std::string getValue(const char *value, const std::string &defaultValue = "");
 std::string getValue(const std::string &value,
@@ -123,6 +123,10 @@ void removeTrailingChars(std::string &str, char charToRemove);
 
 // if input contains only chars to remove, result is empty string
 void removeLeadingChars(std::string &str, char charToRemove);
+
+// true if the character in the given index is a color string
+// std::string version of Q_IsColorString macro from q_shared.h
+bool isColorString(const std::string &str, size_t idx);
 
 // truncates a string, preserving any color codes in the string
 // color codes are excluded from the truncation length, so this can be used

--- a/tests/string_utilities_tests.cpp
+++ b/tests/string_utilities_tests.cpp
@@ -317,3 +317,31 @@ TEST_F(StringUtilitiesTests, truncate_MultipleCarets) {
   ASSERT_EQ(StringUtil::truncate(in, 7), "^^1test^^");
   ASSERT_EQ(StringUtil::truncate(in, 9), "^^1test^^^2te");
 }
+
+TEST_F(StringUtilitiesTests, sanitize_basicSanitize) {
+  ASSERT_EQ(sanitize("^1test ^2test"), "test test");
+  ASSERT_EQ(sanitize("test TEST"), "test TEST");
+  ASSERT_EQ(sanitize("test^1 TEST"), "test TEST");
+  ASSERT_EQ(sanitize("test test^1"), "test test");
+}
+
+TEST_F(StringUtilitiesTests, sanitize_lowercasesCorrectly) {
+  ASSERT_EQ(sanitize("^1TEST ^2test", true), "test test");
+  ASSERT_EQ(sanitize("Test TEST", true), "test test");
+  ASSERT_EQ(sanitize("TEST^1 teST", true), "test test");
+  ASSERT_EQ(sanitize("TEST TeSt^1", true), "test test");
+}
+
+TEST_F(StringUtilitiesTests, sanitize_handlesControlCharacters) {
+  const std::string in = "^1te\x19=st ^2TEST";
+
+  ASSERT_EQ(sanitize(in), "te=st TEST");
+  ASSERT_EQ(sanitize(in, true, false), "te\x19=st test");
+}
+
+TEST_F(StringUtilitiesTests, sanitize_multipleCarets) {
+  const std::string in = "^^1test ^^^2TEST";
+
+  ASSERT_EQ(sanitize(in), "^test ^^TEST");
+  ASSERT_EQ(sanitize(in, true), "^test ^^test");
+}


### PR DESCRIPTION
Explicitly check for a string being a color string rather than just greedily removing every `^` + following character, to avoid strings with escaped carets from being incorrectly sanitized. This might have some unexpected breakage as this is quite widely used in the code base, but luckily this is not too common of a scenario, and it has worked fine for the most part.

fixes #1684 