### PR TITLE
Fix FS API return values

### DIFF
--- a/src/game/etj_file.h
+++ b/src/game/etj_file.h
@@ -42,7 +42,7 @@ public:
   typedef int FileHandle;
   enum class Mode { Read, Write, Append, AppendSync };
 
-  static constexpr int FILE_NOT_FOUND = -1;
+  static constexpr int FILE_NOT_FOUND = 0;
   static constexpr int INVALID_FILE_HANDLE = 0;
   static constexpr int READ_ALL_BYTES = -1;
 

--- a/src/game/etj_filesystem.cpp
+++ b/src/game/etj_filesystem.cpp
@@ -68,7 +68,7 @@ bool FileSystem::remove(const std::string &path) {
 
 bool FileSystem::exists(const std::string &path) {
   const int length = trap_FS_FOpenFile(path.c_str(), nullptr, FS_READ);
-  return length != File::FILE_NOT_FOUND;
+  return length > File::FILE_NOT_FOUND;
 }
 
 bool FileSystem::safeCopy(const std::string &src, const std::string &dst) {


### PR DESCRIPTION
`trap_FS_FOpenFile` returns 0 or -1 if the mode is `FS_READ`, 0 for other modes, except -1 if handle is null. Truly the best and most well-designed API in the game.

Also, add back explicit handling for `FS_READ` on File constructor and throw an error on invalid mode.

refs #1679 