### PR TITLE
Fix unknown command warning when disconnecting via menu

### DIFF
--- a/src/ui/ui_atoms.cpp
+++ b/src/ui/ui_atoms.cpp
@@ -234,6 +234,14 @@ qboolean UI_ConsoleCommand(const int realTime) {
     return qtrue;
   }
 
+  // catch this commnand here and do nothing, otherwise we get
+  // 'Unknown command "uiChatMenuOpen"' when we use in-game menu
+  // button to disconnect from a server as '_UI_KeyEvent' sends this,
+  // but cgame isn't loaded anymore to handle the command
+  if (!Q_stricmp(cmd, "uiChatMenuOpen")) {
+    return qtrue;
+  }
+
   return qfalse;
 }
 

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -7168,7 +7168,7 @@ void _UI_KeyEvent(int key, qboolean down) {
 
       // forward char events to regular key handling,
       // so we don't do out-of-bounds array access in engine
-      // 2.60b and ETL don't check for key array bounds when reading bind buffer
+      // 2.60b doesn't check for key array bounds when reading bind buffer
       if (key & K_CHAR_FLAG) {
         Menu_HandleKey(menu, key, down);
         return;


### PR DESCRIPTION
Catch the command for closing chat menu in the UI console command handler, as it's sent by UI key event handler, but cgame isn't loaded anymore to catch it.

refs #1640 