### PR TITLE
Add etj_useExecQuiet for map/team autoexecs

### DIFF
--- a/assets/ui/etjump_settings_general_client.menu
+++ b/assets/ui/etjump_settings_general_client.menu
@@ -55,6 +55,7 @@ menuDef {
 #else
         CVARFLOATLABEL      (SETTINGS_ITEM_POS(3), "etj_menuSensitivity", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         CACHEDSLIDER        (SETTINGS_ITEM_POS(3), "Menu sensitivity:", 0.2, SETTINGS_ITEM_H, etj_menuSensitivity 1.0 0.05 4.0 0.05, "Sets mouse sensitivity for menus\netj_menuSensitivity")
+        YESNO               (SETTINGS_ITEM_POS(4), "Use quiet exec", 0.2, SETTINGS_ITEM_H, "etj_useExecQuiet", "Use 'execq' when executing map and team-specific autoexec configs\netj_useExecQuiet")
 #endif
 
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2773,6 +2773,8 @@ extern vmCvar_t etj_onDemoPlaybackStart;
 
 extern vmCvar_t etj_HUD_noLerp;
 
+extern vmCvar_t etj_useExecQuiet;
+
 //
 // cg_main.c
 //

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -681,6 +681,8 @@ vmCvar_t etj_onDemoPlaybackStart;
 
 vmCvar_t etj_HUD_noLerp;
 
+vmCvar_t etj_useExecQuiet;
+
 typedef struct {
   vmCvar_t *vmCvar;
   const char *cvarName;
@@ -1278,6 +1280,7 @@ cvarTable_t cvarTable[] = {
     {&etj_onDemoPlaybackStart, "etj_onDemoPlaybackStart", "", CVAR_ARCHIVE},
 
     {&etj_HUD_noLerp, "etj_HUD_noLerp", "0", CVAR_ARCHIVE},
+    {&etj_useExecQuiet, "etj_useExecQuiet", "0", CVAR_ARCHIVE},
 };
 
 int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -202,7 +202,10 @@ bool ETJump::configFileExists(const std::string &filename) {
 }
 
 void ETJump::execFile(const std::string &filename) {
-  trap_SendConsoleCommand(va("exec \"%s.cfg\"\n", filename.c_str()));
+  const std::string cmd = etj_useExecQuiet.integer
+                              ? stringFormat("execq \"%s.cfg\"\n", filename)
+                              : stringFormat("exec \"%s.cfg\"\n", filename);
+  trap_SendConsoleCommand(cmd.c_str());
 }
 
 bool ETJump::isValidClientNum(const int clientNum) {


### PR DESCRIPTION
When enabled, map and team-specific autoexecs are executed using `execq`, to omit the print about executing a config file from the console output.

Hidden from the menus on 2.60b as it does not support `execq` (which is why we can't just enable this implicitly)