### PR TITLE
Fix Clang color diagnostics flag

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -49,7 +49,7 @@ function(create_compiler_opts target)
 		-pipe
 		-fPIC
 		-fvisibility=hidden
-		-fdiagnostics-color=always
+		-fcolor-diagnostics
 		$<IF:$<STREQUAL:${WARN_LEVEL},0>,-w,-Wall -Wextra -Wpedantic -Wcast-qual>
 		-Wno-unused-parameter
 		-Wno-missing-field-initializers


### PR DESCRIPTION
`-fcolor-diagnostics` is the correct flag to use with Clang, `-fdiagnostics-color=always` is for GCC.