### PR TITLE
Center print improvements

### DIFF
--- a/src/cgame/cg_limbopanel.cpp
+++ b/src/cgame/cg_limbopanel.cpp
@@ -1084,7 +1084,7 @@ void CG_LimboPanel_SendSetupMsg(qboolean forceteam) {
     CG_PriorityCenterPrint(va("You will spawn as an %s %s with a %s.", str,
                               BG_ClassnameForNumber(CG_LimboPanel_GetClass()),
                               wt ? wt->desc : "^1UNKNOWN WEAPON"),
-                           SCREEN_HEIGHT - 88, SMALLCHAR_WIDTH, -1);
+                           SCREEN_HEIGHT - 88, SMALLCHAR_WIDTH, -1, false);
   }
 
   cgs.limboLoadoutSelected = qtrue;

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -2324,13 +2324,12 @@ static void CG_ServerCommand(void) {
     return;
   }
 
-  if (!Q_stricmp(cmd, "cp")) {
-    // NERVE - SMF
-    int args = trap_Argc();
-    char *s;
+  const bool cpNoLog = !Q_stricmp(cmd, "cpnl");
+  if (!Q_stricmp(cmd, "cp") || cpNoLog) {
+    const int args = trap_Argc();
 
     if (args >= 3) {
-      s = CG_TranslateString(CG_Argv(1));
+      char *s = CG_TranslateString(CG_Argv(1));
 
       if (args == 4) {
         s = va("%s%s", CG_Argv(3), s);
@@ -2343,11 +2342,11 @@ static void CG_ServerCommand(void) {
                   CG_LocalizeServerCommand(CG_Argv(1)));
       }
       CG_PriorityCenterPrint(s, SCREEN_HEIGHT - (SCREEN_HEIGHT * 0.20),
-                             SMALLCHAR_WIDTH, Q_atoi(CG_Argv(2)));
+                             SMALLCHAR_WIDTH, Q_atoi(CG_Argv(2)), !cpNoLog);
     } else {
       CG_CenterPrint(CG_LocalizeServerCommand(CG_Argv(1)),
-                     SCREEN_HEIGHT - (SCREEN_HEIGHT * 0.20),
-                     SMALLCHAR_WIDTH); //----(SA)	modified
+                     SCREEN_HEIGHT - (SCREEN_HEIGHT * 0.20), SMALLCHAR_WIDTH,
+                     !cpNoLog);
     }
     return;
   }

--- a/src/game/etj_printer.cpp
+++ b/src/game/etj_printer.cpp
@@ -22,8 +22,6 @@
  * SOFTWARE.
  */
 
-#include <utility>
-
 #include "etj_printer.h"
 #include "etj_string_utilities.h"
 #include "g_local.h"
@@ -81,7 +79,7 @@ void Printer::consoleAll(const std::string &message) {
   const auto splits = ETJump::wrapWords(message, '\n', BYTES_PER_PACKET);
 
   for (const auto &split : splits) {
-    trap_SendServerCommand(-1, va("print \"%s\"", split.c_str()));
+    trap_SendServerCommand(ALL_CLIENTS, va("print \"%s\"", split.c_str()));
 
     if (g_dedicated.integer) {
       G_Printf("%s", split.c_str());
@@ -134,30 +132,65 @@ void Printer::popup(gclient_t *client, const std::string &message) {
 }
 
 void Printer::popupAll(const std::string &message) {
-  trap_SendServerCommand(-1, va("cpm \"%s\n\"", message.c_str()));
+  trap_SendServerCommand(ALL_CLIENTS, va("cpm \"%s\n\"", message.c_str()));
 
   if (g_dedicated.integer) {
     G_Printf("%s\n", message.c_str());
   }
 }
 
-void Printer::center(int clientNum, const std::string &message) {
-  trap_SendServerCommand(clientNum,
-                         ETJump::stringFormat("cp \"%s\n\"", message).c_str());
+void Printer::center(int clientNum, const std::string &message, bool log) {
+  const std::string cmd = log ? "cp" : "cpnl";
+  trap_SendServerCommand(
+      clientNum, ETJump::stringFormat("%s \"%s\n\"", cmd, message).c_str());
 }
 
-void Printer::center(gentity_t *ent, const std::string &message) {
+void Printer::center(gentity_t *ent, const std::string &message, bool log) {
   const int clientNum = ent ? ClientNum(ent) : CONSOLE_CLIENT_NUMBER;
-  center(clientNum, message);
+  center(clientNum, message, log);
 }
 
-void Printer::center(gclient_t *client, const std::string &message) {
+void Printer::center(gclient_t *client, const std::string &message, bool log) {
   const int clientNum = client ? ClientNum(client) : CONSOLE_CLIENT_NUMBER;
-  center(clientNum, message);
+  center(clientNum, message, log);
 }
 
-void Printer::centerAll(const std::string &message) {
-  trap_SendServerCommand(-1, va("cp \"%s\n\"", message.c_str()));
+void Printer::centerAll(const std::string &message, bool log) {
+  const std::string cmd = log ? "cp" : "cpnl";
+  trap_SendServerCommand(
+      ALL_CLIENTS, ETJump::stringFormat("%s \"%s\n\"", cmd, message).c_str());
+
+  if (g_dedicated.integer) {
+    G_Printf("%s\n", message.c_str());
+  }
+}
+
+void Printer::centerPriority(int clientNum, const std::string &message,
+                             const int priority, bool log) {
+  const std::string cmd = log ? "cp" : "cpnl";
+  trap_SendServerCommand(
+      clientNum,
+      ETJump::stringFormat("%s \"%s\" %i", cmd, message, priority).c_str());
+}
+
+void Printer::centerPriority(gentity_t *ent, const std::string &message,
+                             const int priority, bool log) {
+  const int clientNum = ent ? ClientNum(ent) : CONSOLE_CLIENT_NUMBER;
+  centerPriority(clientNum, message, priority, log);
+}
+
+void Printer::centerPriority(gclient_t *client, const std::string &message,
+                             const int priority, bool log) {
+  const int clientNum = client ? ClientNum(client) : CONSOLE_CLIENT_NUMBER;
+  centerPriority(clientNum, message, priority, log);
+}
+
+void Printer::centerPriorityAll(const std::string &message, const int priority,
+                                bool log) {
+  const std::string cmd = log ? "cp" : "cpnl";
+  trap_SendServerCommand(
+      ALL_CLIENTS,
+      ETJump::stringFormat("%s \"%s\" %i", cmd, message, priority).c_str());
 
   if (g_dedicated.integer) {
     G_Printf("%s\n", message.c_str());
@@ -183,7 +216,7 @@ void Printer::banner(gclient_t *client, const std::string &message) {
 }
 
 void Printer::bannerAll(const std::string &message) {
-  trap_SendServerCommand(-1, va("bp \"%s\n\"", message.c_str()));
+  trap_SendServerCommand(ALL_CLIENTS, va("bp \"%s\n\"", message.c_str()));
 
   if (g_dedicated.integer) {
     G_Printf("%s\n", message.c_str());
@@ -202,5 +235,5 @@ void Printer::command(const std::vector<int> &clientNums,
 }
 
 void Printer::commandAll(const std::string &command) {
-  trap_SendServerCommand(-1, command.c_str());
+  trap_SendServerCommand(ALL_CLIENTS, command.c_str());
 }

--- a/src/game/etj_printer.h
+++ b/src/game/etj_printer.h
@@ -29,12 +29,14 @@
 
 struct gentity_s;
 struct gclient_s;
-typedef gentity_s gentity_t;
-typedef gclient_s gclient_t;
+
+using gentity_t = gentity_s;
+using gclient_t = gclient_s;
 
 class Printer {
 public:
   static constexpr int CONSOLE_CLIENT_NUMBER = -1;
+  static constexpr int ALL_CLIENTS = -1;
 
   /**
    * Prints the message to server console and log. Will
@@ -114,21 +116,53 @@ public:
   static void popupAll(const std::string &message);
 
   /**
-   * Sends a center print message to target client. If client num is -1
-   * sends to console.
+   * Sends a center print message to target client.
+   * If client num is -1, sends to all clients.
+   * If log is true, the client will log the message to console,
+   * if 'etj_logCenterPrint' is set
    * If pointer in overloads is nullptr, prints to console.
    * @param clientNum
    * @param message
    */
-  static void center(int clientNum, const std::string &message);
-  static void center(gentity_t *ent, const std::string &message);
-  static void center(gclient_t *client, const std::string &message);
+  static void center(int clientNum, const std::string &message,
+                     bool log = true);
+  static void center(gentity_t *ent, const std::string &message,
+                     bool log = true);
+  static void center(gclient_t *client, const std::string &message,
+                     bool log = true);
 
   /**
-   * Broadcasts a left banner message to all clients
+   * Broadcasts a center print message to all clients
    * @param message The message
    */
-  static void centerAll(const std::string &message);
+  static void centerAll(const std::string &message, bool log = true);
+
+  /**
+   * Sends a center print message to target client with priority.
+   * If client num is -1, sends to all clients.
+   * If log is true, the client will log the message to console,
+   * if 'etj_logCenterPrint' is set
+   * If pointer in overloads is nullptr, prints to console.
+   * @param clientNum
+   * @param message
+   * @param priority
+   * @param log
+   */
+  static void centerPriority(int clientNum, const std::string &message,
+                             int priority, bool log = true);
+  static void centerPriority(gentity_t *ent, const std::string &message,
+                             int priority, bool log = true);
+  static void centerPriority(gclient_t *client, const std::string &message,
+                             int priority, bool log = true);
+
+  /**
+   * Broadcasts a center print message to all clients with priority
+   * @param message The message
+   * @param priority
+   * @param log
+   */
+  static void centerPriorityAll(const std::string &message, int priority,
+                                bool log = true);
 
   /**
    * Sends a banner message to the client. If client num is -1 sends to console.

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -4672,7 +4672,8 @@ void Cmd_Class_f(gentity_t *ent) {
                       ETJump::stringFormat("You will spawn as an %s %s",
                                            ETJump::getPlayerTeamName(
                                                ent->client->sess.sessionTeam),
-                                           loadout.description));
+                                           loadout.description),
+                      false);
       break;
     }
   }

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2586,6 +2586,8 @@ bool canSetFtTeamjumpMode(int clientNum, const gentity_t *ent);
 void setFireteamTeamjumpMode(fireteamData_t *ft, bool teamjumpMode);
 } // namespace ETJump
 
+// center prints sent through this are never logged
+// on client, if 'etj_logCenterPrint' is set
 void G_PrintClientSpammyCenterPrint(int entityNum, const char *text);
 
 void aagun_fire(gentity_t *other);

--- a/src/game/g_missile.cpp
+++ b/src/game/g_missile.cpp
@@ -1997,7 +1997,8 @@ gentity_t *fire_grenade(gentity_t *self, const vec3_t start, const vec3_t dir,
       // JPW NERVE sets to score below if dynamite is in
       // trigger_objective_info & it's an objective
       bolt->accuracy = 0;
-      Printer::center(ClientNum(self), "Dynamite is set, but NOT armed!");
+      Printer::center(ClientNum(self), "Dynamite is set, but NOT armed!",
+                      false);
       // differentiate non-armed dynamite with non-pulsing dlight
       bolt->s.teamNum =
           self->client ? self->client->sess.sessionTeam + 4 : self->s.teamNum;

--- a/src/game/g_utils.cpp
+++ b/src/game/g_utils.cpp
@@ -7,6 +7,7 @@
 
 #include <unordered_map>
 
+#include "etj_printer.h"
 #include "g_local.h"
 #include "etj_string_utilities.h"
 
@@ -1224,7 +1225,7 @@ void G_PrintClientSpammyCenterPrint(int entityNum, const char *text) {
     return;
   }
 
-  trap_SendServerCommand(entityNum, va("cp \"%s\" 1", text));
+  Printer::centerPriority(entityNum, text, 1, false);
   g_entities[entityNum].client->lastSpammyCentrePrintTime = level.time;
 }
 

--- a/src/game/g_weapon.cpp
+++ b/src/game/g_weapon.cpp
@@ -1833,8 +1833,7 @@ void Weapon_Engineer(gentity_t *ent) {
           }
 
           if (traceEnt->health >= 250) {
-            // traceEnt->health = 255;
-            trap_SendServerCommand(clientNum, "cp \"Landmine armed...\" 1");
+            Printer::centerPriority(clientNum, "Landmine armed...", 1, false);
           } else {
             return;
           }
@@ -1872,7 +1871,7 @@ void Weapon_Engineer(gentity_t *ent) {
           G_PrintClientSpammyCenterPrint(clientNum, "Defusing landmine");
 
           if (traceEnt->health >= 250) {
-            trap_SendServerCommand(clientNum, "cp \"Landmine defused...\" 1");
+            Printer::centerPriority(clientNum, "Landmine defused...", 1, false);
 
             Add_Ammo(ent, WP_LANDMINE, 1, qfalse);
 
@@ -2034,9 +2033,9 @@ void Weapon_Engineer(gentity_t *ent) {
         // bani
         if (friendlyObj && !enemyObj) {
           G_FreeEntity(traceEnt);
-          trap_SendServerCommand(
-              clientNum,
-              "cp \"You cannot arm dynamite near a friendly objective!\" 1");
+          Printer::centerPriority(
+              clientNum, "You cannot arm dynamite near a friendly objective!",
+              1, false);
           return;
         }
 
@@ -2062,9 +2061,9 @@ void Weapon_Engineer(gentity_t *ent) {
 
         // Gordon: moved down here to prevent two prints
         // when dynamite IS near objective
-        trap_SendServerCommand(
-            clientNum,
-            "cp \"Dynamite is now armed with a 30 second timer!\" 1");
+        Printer::centerPriority(clientNum,
+                                "Dynamite is now armed with a 30 second timer!",
+                                1, false);
 
         // check if player is in trigger objective field
         // NERVE - SMF - made this the actual bounding box of dynamite


### PR DESCRIPTION
* Added priority center prints to `Printer` class to perform priority center prints
* Added option to filter a center print from getting logged via `etj_logCenterPrint`
* Filtered some center prints from logging by default, such as dynamite/landmine/satchel arm/disarm prints & class selection prints

fixes #1661 