### PR TITLE
Add cvar to disable menu flashing

### DIFF
--- a/assets/scripts/trickjump.shader
+++ b/assets/scripts/trickjump.shader
@@ -936,3 +936,28 @@ gfx/2d/colorpicker_mask
 		rgbGen vertex
 	}
 }
+
+// menu background shader without the lightning effect
+ui/assets/et_clouds_noflash
+{
+	nopicmip
+	{
+		map textures/skies_sd/wurzburg_clouds.tga
+		rgbGen identityLighting
+		tcMod scale 0.65 0.75
+		tcMod scroll 0.0025 -0.002
+	}
+	{
+		map textures/skies_sd/wurzburg_clouds.tga
+		blendFunc GL_DST_COLOR GL_ONE
+		rgbGen identityLighting
+		tcMod scale 1.35 0.96
+		tcMod scroll 0.055 -0.04
+	}
+	{
+		clampmap ui/assets/background_mask.tga
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen identity
+		tcMod stretch sin 1.1 0.1 0 0.0125
+	}
+}

--- a/assets/ui/etjump_settings_general_client.menu
+++ b/assets/ui/etjump_settings_general_client.menu
@@ -52,7 +52,7 @@ menuDef {
 #ifdef VET
         MULTI               (SETTINGS_ITEM_POS(3), "Rendering primitives:", 0.2, SETTINGS_ITEM_H, "r_primitives", cvarFloatList { "Auto" 0 "Multiple glArrayElement" 1 "Single glDrawElements" 2 }, "Sets rendering primitives mode (ET 2.60b only)\nSetting this to 'Single glDrawElements' is recommended on modern systems for best performance\nr_primitives")
 #else
-        COMBO_BIT           (SETTINGS_COMBO_POS(3), "Use quiet exec", 0.2, SETTINGS_ITEM_H, "etj_useExecQuiet", cvarFloatList { "Map autoexec" 1 "Team autoexec" 2 }, none, "Use 'execq' when executing autoexec configs\netj_useExecQuiet")
+        COMBO_BIT           (SETTINGS_COMBO_POS(3), "Use quiet exec:", 0.2, SETTINGS_ITEM_H, "etj_useExecQuiet", cvarFloatList { "Map autoexec" 1 "Team autoexec" 2 }, none, "Use 'execq' when executing autoexec configs\netj_useExecQuiet")
 #endif
 
 

--- a/assets/ui/etjump_settings_general_console.menu
+++ b/assets/ui/etjump_settings_general_console.menu
@@ -6,7 +6,7 @@
 #define MENU_NAME "etjump_settings_general_console"
 #define GROUP_NAME "group_etjump_settings_general"
 
-#define NUM_SUBMENUS 3
+#define NUM_SUBMENUS 4
 #define SIDEBAR_BTN_Y (SIDEBAR_Y + (SIDEBAR_H * 0.5) - (((NUM_SUBMENUS * SIDEBAR_BTN_H) + (MAIN_ELEMENT_MARGIN * (NUM_SUBMENUS - 1))) * 0.5))
 
 menuDef {
@@ -42,6 +42,7 @@ menuDef {
     SIDEBUTTON          (1, "GAMEPLAY", close MENU_NAME; open etjump_settings_general_gameplay)
     SIDEBUTTON          (2, "CLIENT", close MENU_NAME; open etjump_settings_general_client)
     SIDEBUTTON_ACTIVE   (3, "CONSOLE", close MENU_NAME; open MENU_NAME)
+    SIDEBUTTON          (4, "UI", close MENU_NAME; open etjump_settings_general_ui)
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "CONSOLE")
 

--- a/assets/ui/etjump_settings_general_gameplay.menu
+++ b/assets/ui/etjump_settings_general_gameplay.menu
@@ -6,7 +6,7 @@
 #define MENU_NAME "etjump_settings_general_gameplay"
 #define GROUP_NAME "group_etjump_settings_general"
 
-#define NUM_SUBMENUS 3
+#define NUM_SUBMENUS 4
 #define SIDEBAR_BTN_Y (SIDEBAR_Y + (SIDEBAR_H * 0.5) - (((NUM_SUBMENUS * SIDEBAR_BTN_H) + (MAIN_ELEMENT_MARGIN * (NUM_SUBMENUS - 1))) * 0.5))
 
 menuDef {
@@ -42,6 +42,7 @@ menuDef {
     SIDEBUTTON_ACTIVE   (1, "GAMEPLAY", close MENU_NAME; open MENU_NAME)
     SIDEBUTTON          (2, "CLIENT", close MENU_NAME; open etjump_settings_general_client)
     SIDEBUTTON          (3, "CONSOLE", close MENU_NAME; open etjump_settings_general_console)
+    SIDEBUTTON          (4, "UI", close MENU_NAME; open etjump_settings_general_ui)
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "GAMEPLAY")
 

--- a/assets/ui/etjump_settings_general_ui.menu
+++ b/assets/ui/etjump_settings_general_ui.menu
@@ -3,7 +3,7 @@
 #include "ui/menumacros.h"
 #include "ui/menumacros_ext.h"
 
-#define MENU_NAME "etjump_settings_general_client"
+#define MENU_NAME "etjump_settings_general_ui"
 #define GROUP_NAME "group_etjump_settings_general"
 
 #define NUM_SUBMENUS 4
@@ -40,20 +40,15 @@ menuDef {
     WINDOW_BLANK(SIDEBAR_X, SIDEBAR_Y, SIDEBAR_W, SIDEBAR_H)
 
     SIDEBUTTON          (1, "GAMEPLAY", close MENU_NAME; open etjump_settings_general_gameplay)
-    SIDEBUTTON_ACTIVE   (2, "CLIENT", close MENU_NAME; open MENU_NAME)
+    SIDEBUTTON          (2, "CLIENT", close MENU_NAME; open etjump_settings_general_client)
     SIDEBUTTON          (3, "CONSOLE", close MENU_NAME; open etjump_settings_general_console)
-    SIDEBUTTON          (4, "UI", close MENU_NAME; open etjump_settings_general_ui)
+    SIDEBUTTON_ACTIVE   (4, "UI", close MENU_NAME; open MENU_NAME)
 
-    SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "CLIENT")
+    SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "USER INTERFACE")
 
-        MULTI               (SETTINGS_ITEM_POS(1), "Max FPS:", 0.2, SETTINGS_ITEM_H, "com_maxfps", cvarFloatList { "43" 43 "76" 76 "125" 125 "250" 250 "333" 333 }, "Sets the FPS limit\ncom_maxfps")
-        MULTI               (SETTINGS_ITEM_POS(2), "Memory limit:", 0.2, SETTINGS_ITEM_H, "com_hunkmegs", cvarFloatList { "56MB" 56 "64MB" 64 "128MB" 128 "256MB" 256 "512MB" 512 }, "How much memory the client is allowed to use (restart required)\ncom_hunkmegs")
-
-#ifdef VET
-        MULTI               (SETTINGS_ITEM_POS(3), "Rendering primitives:", 0.2, SETTINGS_ITEM_H, "r_primitives", cvarFloatList { "Auto" 0 "Multiple glArrayElement" 1 "Single glDrawElements" 2 }, "Sets rendering primitives mode (ET 2.60b only)\nSetting this to 'Single glDrawElements' is recommended on modern systems for best performance\nr_primitives")
-#else
-        COMBO_BIT           (SETTINGS_COMBO_POS(3), "Use quiet exec", 0.2, SETTINGS_ITEM_H, "etj_useExecQuiet", cvarFloatList { "Map autoexec" 1 "Team autoexec" 2 }, none, "Use 'execq' when executing autoexec configs\netj_useExecQuiet")
-#endif
+        CVARFLOATLABEL      (SETTINGS_ITEM_POS(1), "etj_menuSensitivity", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        CACHEDSLIDER        (SETTINGS_ITEM_POS(1), "Menu sensitivity:", 0.2, SETTINGS_ITEM_H, etj_menuSensitivity 1.0 0.05 4.0 0.05, "Sets mouse sensitivity for menus\netj_menuSensitivity")
+        YESNO               (SETTINGS_ITEM_POS(2), "Disable menu flashing:", 0.2, SETTINGS_ITEM_H, etj_noMenuFlashing, "Disables the lightning effect from the menu background shader\n(vid_restart required)\netj_noMenuFlashing")
 
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)

--- a/assets/ui/global.menu
+++ b/assets/ui/global.menu
@@ -47,6 +47,13 @@ menuDef {
 	fullScreen	0
 	rect		0 0 640 480
 	visible		0
+
+  onOpen {
+      conditionalscript etj_noMenuFlashing 3
+        ( "hide clouds ; show clouds_noflash" )
+        ( "show clouds ; hide clouds_noflash" )
+        "1"
+  }
 						
 	itemDef {
 		name		"colour"
@@ -62,6 +69,15 @@ menuDef {
 		rect		0 0 640 480
 		style		WINDOW_STYLE_SHADER
 		background	"ui/assets/et_clouds"
+		visible		1
+		decoration
+	}
+
+	itemDef {
+		name		"clouds_noflash"
+		rect		0 0 640 480
+		style		WINDOW_STYLE_SHADER
+		background	"ui/assets/et_clouds_noflash"
 		visible		1
 		decoration
 	}

--- a/assets/ui/menus.txt
+++ b/assets/ui/menus.txt
@@ -84,6 +84,7 @@
 	loadMenu { "ui/etjump_settings_general_gameplay.menu" }
 	loadMenu { "ui/etjump_settings_general_client.menu" }
 	loadMenu { "ui/etjump_settings_general_console.menu" }
+	loadMenu { "ui/etjump_settings_general_ui.menu" }
 
 	loadMenu { "ui/etjump_settings_graphics_visuals.menu" }
 	loadMenu { "ui/etjump_settings_graphics_players.menu" }

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -130,6 +130,8 @@ extern vmCvar_t ui_currentChangelog;
 extern vmCvar_t etj_demoQueueCurrent;
 extern vmCvar_t etj_demoQueueDir;
 
+extern vmCvar_t etj_noMenuFlashing;
+
 inline constexpr int MAX_EDIT_LINE = 256;
 
 inline constexpr int MAX_MENUDEPTH = 8;

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -7849,6 +7849,8 @@ vmCvar_t ui_currentChangelog;
 vmCvar_t etj_demoQueueCurrent;
 vmCvar_t etj_demoQueueDir;
 
+vmCvar_t etj_noMenuFlashing;
+
 cvarTable_t cvarTable[] = {
 
     {&ui_glCustom, "ui_glCustom", "4",
@@ -8086,6 +8088,8 @@ cvarTable_t cvarTable[] = {
 
     {&etj_demoQueueCurrent, "etj_demoQueueCurrent", "", CVAR_TEMP | CVAR_ROM},
     {&etj_demoQueueDir, "etj_demoQueueDir", "demoqueue", CVAR_ARCHIVE},
+
+    {&etj_noMenuFlashing, "etj_noMenuFlashing", "0", CVAR_ARCHIVE | CVAR_LATCH},
 };
 
 int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);


### PR DESCRIPTION
`etj_noMenuFlashing` can be used to disable the lightning effect from the menu background shader. The lightning effect is especially problematic for people with photosensitive epilepsy, and it's just in general quite annoying.

This also adds a new category to `General` settings tab called `UI`, which is where this setting is located. `etj_menuSensitivity` was also moved here from underneath `Client` submenu.

Also fixes a missing colon from `etj_useExecQuiet` menu entry.

refs #1695 