### PR TITLE
Add countdown command for fireteams

### DIFF
--- a/assets/ui/etjump_settings_general_gameplay.menu
+++ b/assets/ui/etjump_settings_general_gameplay.menu
@@ -66,7 +66,7 @@ menuDef {
         CVARINTLABEL        (SETTINGS_ITEM_POS(17), "etj_autoSpecDelay", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(17), "Auto spectate delay:", 0.2, SETTINGS_ITEM_H, etj_autoSpecDelay 10000 1000 30000 1000, "How long to stay idle for before automatically following next player\netj_autoSpecDelay")
         CVARINTLABEL        (SETTINGS_ITEM_POS(18), "etj_fireteamCountdownLength", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS(18), "Fireteam countdown length:", 0.2, SETTINGS_ITEM_H, etj_fireteamCountdownLength 3 1 10 1, "Default countdown length when using 'countdown' command without arguments\netj_fireteamCountdownLength")
+        SLIDER              (SETTINGS_ITEM_POS(18), "Fireteam countdown length:", 0.2, SETTINGS_ITEM_H, etj_fireteamCountdownLength 3 1 10 1, "Default countdown length when using 'fireteam countdown' command without arguments\netj_fireteamCountdownLength")
 
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)

--- a/assets/ui/etjump_settings_general_gameplay.menu
+++ b/assets/ui/etjump_settings_general_gameplay.menu
@@ -65,6 +65,8 @@ menuDef {
         YESNO               (SETTINGS_ITEM_POS(16), "Auto spectate:", 0.2, SETTINGS_ITEM_H, "etj_autoSpec", "Automatically spectate next player when idling in free spec or if the followed player is idle\netj_autoSpec")
         CVARINTLABEL        (SETTINGS_ITEM_POS(17), "etj_autoSpecDelay", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(17), "Auto spectate delay:", 0.2, SETTINGS_ITEM_H, etj_autoSpecDelay 10000 1000 30000 1000, "How long to stay idle for before automatically following next player\netj_autoSpecDelay")
+        CVARINTLABEL        (SETTINGS_ITEM_POS(18), "etj_fireteamCountdownLength", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(18), "Fireteam countdown length:", 0.2, SETTINGS_ITEM_H, etj_fireteamCountdownLength 3 1 10 1, "Default countdown length when using 'countdown' command without arguments\netj_fireteamCountdownLength")
 
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)

--- a/src/cgame/cg_fireteams.cpp
+++ b/src/cgame/cg_fireteams.cpp
@@ -1013,7 +1013,7 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
                 CG_EventHandling(CGAME_EVENT_NONE, qfalse);
                 break;
               case FTMenuOptions::FT_COUNTDOWN_START:
-                trap_SendConsoleCommand("countdown\n");
+                trap_SendConsoleCommand("fireteam countdown\n");
                 CG_EventHandling(CGAME_EVENT_NONE, qfalse);
                 break;
               default:
@@ -1060,7 +1060,7 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
                 CG_EventHandling(CGAME_EVENT_NONE, qfalse);
                 break;
               case FTMenuOptions::FT_COUNTDOWN_START:
-                trap_SendConsoleCommand("countdown\n");
+                trap_SendConsoleCommand("fireteam countdown\n");
                 CG_EventHandling(CGAME_EVENT_NONE, qfalse);
                 break;
               default:

--- a/src/cgame/cg_fireteams.cpp
+++ b/src/cgame/cg_fireteams.cpp
@@ -271,6 +271,16 @@ const char *ftOnMenuRulesListAlphaChars[] = {
     nullptr,
 };
 
+const char *ftOnCommonList[] = {
+    "Start countdown",
+    nullptr,
+};
+
+const char *ftOnCommonListAlphaChars[] = {
+    "C",
+    nullptr,
+};
+
 const char *ftLeaderMenuList[] = {
     "Disband", "Leave", "Invite",           "Kick",
     "Warn",    "Rules", "%s teamjump mode", nullptr,
@@ -713,6 +723,27 @@ void CG_Fireteams_MenuText_Draw(panel_button_t *button) {
             y += button->rect.h;
           }
         }
+
+        // FIXME: I hate this...
+        for (i = 0; ftOnCommonList[i]; i++) {
+          const char *str = nullptr;
+
+          if (cg_quickMessageAlt.integer) {
+            str = va(
+                "%i. %s",
+                (i + 1 + static_cast<int>(FTMenuOptions::FT_COUNTDOWN_START)) %
+                    10,
+                ftOnCommonList[i]);
+          } else {
+            str = va("%s. %s", ftOnCommonListAlphaChars[i], ftOnCommonList[i]);
+          }
+
+          CG_Text_Paint_Ext(button->rect.x, y, button->font->scalex,
+                            button->font->scaley, button->font->colour, str, 0,
+                            0, button->font->style, button->font->font);
+
+          y += button->rect.h;
+        }
       }
       break;
 
@@ -965,22 +996,31 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
         return qtrue;
       } else {
         if (!CG_IsFireTeamLeader(cg.clientNum)) {
-          if (i >= 2) {
+          if (i >= static_cast<int>(FTMenuOptions::FT_INVITE) &&
+              i != static_cast<int>(FTMenuOptions::FT_COUNTDOWN_START)) {
             break;
           }
 
-          if (i == 0 && !CG_CountPlayersNF()) {
+          if (i == static_cast<int>(FTMenuOptions::FT_DISBAND_PROPOSE) &&
+              !CG_CountPlayersNF()) {
             break;
           }
 
           if (doaction) {
-            if (i == 1) {
-              trap_SendConsoleCommand("fireteam leave\n");
-              CG_EventHandling(CGAME_EVENT_NONE, qfalse);
-            } else {
-              cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_PROPOSE);
-              cgs.ftMenuModeEx = 0;
-              cgs.ftMenuPos = i;
+            switch (static_cast<FTMenuOptions>(i)) {
+              case FTMenuOptions::FT_CREATE_LEAVE:
+                trap_SendConsoleCommand("fireteam leave\n");
+                CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+                break;
+              case FTMenuOptions::FT_COUNTDOWN_START:
+                trap_SendConsoleCommand("countdown\n");
+                CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+                break;
+              default:
+                cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_PROPOSE);
+                cgs.ftMenuModeEx = 0;
+                cgs.ftMenuPos = i;
+                break;
             }
           }
 
@@ -1002,22 +1042,32 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
           }
 
           if (doaction) {
-            if (i == static_cast<int>(FTMenuOptions::FT_DISBAND_PROPOSE)) {
-              trap_SendConsoleCommand("fireteam disband\n");
-              CG_EventHandling(CGAME_EVENT_NONE, qfalse);
-            } else if (i == static_cast<int>(FTMenuOptions::FT_CREATE_LEAVE)) {
-              trap_SendConsoleCommand("fireteam leave\n");
-              CG_EventHandling(CGAME_EVENT_NONE, qfalse);
-            } else if (i == static_cast<int>(FTMenuOptions::FT_TJMODE)) {
-              trap_SendConsoleCommand(va(
-                  "fireteam teamjump %i",
-                  cgs.clientinfo[cg.clientNum].fireteamData->teamJumpMode ? 0
-                                                                          : 1));
-              CG_EventHandling(CGAME_EVENT_NONE, qfalse);
-            } else {
-              cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_ADMIN);
-              cgs.ftMenuModeEx = 0;
-              cgs.ftMenuPos = i;
+            switch (static_cast<FTMenuOptions>(i)) {
+              case FTMenuOptions::FT_DISBAND_PROPOSE:
+                trap_SendConsoleCommand("fireteam disband\n");
+                CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+                break;
+              case FTMenuOptions::FT_CREATE_LEAVE:
+                trap_SendConsoleCommand("fireteam leave\n");
+                CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+                break;
+              case FTMenuOptions::FT_TJMODE:
+                trap_SendConsoleCommand(
+                    va("fireteam teamjump %i",
+                       cgs.clientinfo[cg.clientNum].fireteamData->teamJumpMode
+                           ? 0
+                           : 1));
+                CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+                break;
+              case FTMenuOptions::FT_COUNTDOWN_START:
+                trap_SendConsoleCommand("countdown\n");
+                CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+                break;
+              default:
+                cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_ADMIN);
+                cgs.ftMenuModeEx = 0;
+                cgs.ftMenuPos = i;
+                break;
             }
           }
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2146,7 +2146,8 @@ enum class FTMenuOptions {
   FT_WARN = 4,
   FT_RULES = 5,
   FT_TJMODE = 6,
-  FT_MAX_OPTIONS = 7,
+  FT_COUNTDOWN_START = 7,
+  FT_MAX_OPTIONS = 8,
 };
 
 enum class FTMenuMode {
@@ -2512,6 +2513,7 @@ extern vmCvar_t etj_HUD_fireteam;
 extern vmCvar_t etj_fireteamPosX;
 extern vmCvar_t etj_fireteamPosY;
 extern vmCvar_t etj_fireteamAlpha;
+extern vmCvar_t etj_fireteamCountdownLength;
 
 // TODO: this is a bitflag option for etj_logBanner, move it elsewhere
 //  or just get rid of it entirely (why is this a bitflag to begin with???)

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -422,6 +422,7 @@ vmCvar_t etj_HUD_fireteam;
 vmCvar_t etj_fireteamPosX;
 vmCvar_t etj_fireteamPosY;
 vmCvar_t etj_fireteamAlpha;
+vmCvar_t etj_fireteamCountdownLength;
 
 vmCvar_t etj_logBanner;
 vmCvar_t etj_weaponVolume;
@@ -1002,6 +1003,8 @@ cvarTable_t cvarTable[] = {
     {&etj_fireteamPosX, "etj_fireteamPosX", "0", CVAR_ARCHIVE},
     {&etj_fireteamPosY, "etj_fireteamPosY", "0", CVAR_ARCHIVE},
     {&etj_fireteamAlpha, "etj_fireteamAlpha", "1.0", CVAR_ARCHIVE},
+    {&etj_fireteamCountdownLength, "etj_fireteamCountdownLength", "3",
+     CVAR_ARCHIVE},
 
     {&etj_logBanner, "etj_logBanner", "1", CVAR_ARCHIVE},
     {&etj_weaponVolume, "etj_weaponVolume", "1.0", CVAR_ARCHIVE},

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -362,6 +362,28 @@ void init() {
     trickjumpLines->toggleMarker(false);
   }
 
+  // Rather than just queuing chat messages on client side, we send this
+  // off to the server to handle. This way we don't need to worry about
+  // the countdown getting interrupted by flood protection.
+  // TODO: this should be elsewhere, this whole init stuff should be
+  // refactored at some point, it's all very messy
+  consoleCommandsHandler->subscribe(
+      "countdown", [](const std::vector<std::string> &args) {
+        if (!CG_IsOnFireteam(cg.clientNum)) {
+          CG_Printf("You must be in a fireteam to use ^3'countdown'\n");
+          return;
+        }
+
+        if (args.empty()) {
+          const int sec = etj_fireteamCountdownLength.integer > 0
+                              ? etj_fireteamCountdownLength.integer
+                              : 3;
+          trap_SendClientCommand(va("ftcountdown %i", sec));
+        } else {
+          trap_SendClientCommand(va("ftcountdown %i", Q_atoi(args[0].c_str())));
+        }
+      });
+
   CG_Printf(S_COLOR_LTGREY GAME_NAME " " S_COLOR_GREEN GAME_VERSION
                                      " " S_COLOR_LTGREY GAME_BINARY_NAME
                                      " init... " S_COLOR_GREEN "DONE\n");

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(qagame MODULE
 	"etj_entity_utilities_shared.cpp"
 	"etj_file.cpp"
 	"etj_filesystem.cpp"
+	"etj_fireteam_countdown.cpp"
 	"etj_inactivity_timer.cpp"
 	"etj_json_utilities.cpp"
 	"etj_levels.cpp"

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -40,7 +40,6 @@
 #include "etj_chat_replay.h"
 #include "etj_filesystem.h"
 #include "etj_savepos_command_handler.h"
-#include "etj_fireteam_countdown.h"
 
 typedef std::function<bool(gentity_t *ent, Arguments argv)> Command;
 typedef std::pair<std::function<bool(gentity_t *ent, Arguments argv)>, char>
@@ -490,45 +489,6 @@ static bool loadPos(gentity_t *ent, Arguments argv) {
 
   ETJump::SavePosHandler::execSaveposCommand(
       ent, ETJump::Container::skipFirstN(*argv, 1));
-  return true;
-}
-
-static bool addFtCountdown(gentity_t *ent, Arguments args) {
-  if (!ent || !ent->client) {
-    return false;
-  }
-
-  if (args->size() < 2) {
-    Printer::console(
-        ent, "Malformed 'countdown' command - no duration specified!\n");
-    return false;
-  }
-
-  if (ent->client->sess.muted) {
-    Printer::console(ent, "You are muted.\n");
-    return false;
-  }
-
-  const int clientNum = ClientNum(ent);
-
-  // sanity check
-  if (clientNum < 0 || clientNum >= MAX_CLIENTS) {
-    Printer::console(ent,
-                     "Malformed 'countdown' command - invalid clientNum!\n");
-    return false;
-  }
-
-  fireteamData_t *ft = nullptr;
-
-  if (!G_IsOnFireteam(clientNum, &ft)) {
-    return false;
-  }
-
-  // max 10s countdown, minimum 1s
-  // if the client side cvar is <= 0, the default value (3s) will be used
-  const auto seconds =
-      static_cast<int8_t>(std::clamp(Q_atoi(args->at(1).c_str()), 1, 10));
-  game.fireteamCountdown->addCountdown(clientNum, seconds);
   return true;
 }
 } // namespace ClientCommands
@@ -2688,7 +2648,6 @@ Commands::Commands() {
   commands_["requestnumcustomvotes"] = ClientCommands::sendNumCustomvotes;
   commands_["requestcustomvoteinfo"] = ClientCommands::sendCustomvoteInfo;
   commands_["loadpos"] = ClientCommands::loadPos;
-  commands_["ftcountdown"] = ClientCommands::addFtCountdown;
 }
 
 bool Commands::ClientCommand(gentity_t *ent, const std::string &commandStr) {

--- a/src/game/etj_fireteam_countdown.cpp
+++ b/src/game/etj_fireteam_countdown.cpp
@@ -1,0 +1,77 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_fireteam_countdown.h"
+#include "g_local.h"
+
+namespace ETJump {
+void FireteamCountdown::runFrame() {
+  // we can't erase the completed commands in the middle of the loop
+  // because it invalidates the iterator, so just add to-be-deleted
+  // commands here and delete them once everything is processed
+  std::vector<int> completed{};
+
+  for (auto &[clientNum, cmd] : countdownCommands) {
+    if (level.time > cmd.nextMessageTime) {
+      sendCountdownMessage(clientNum);
+      cmd.seconds--;
+      cmd.nextMessageTime += 1000;
+
+      if (cmd.seconds < 0) {
+        completed.push_back(clientNum);
+      }
+    }
+  }
+
+  for (const auto &cmd : completed) {
+    countdownCommands.erase(cmd);
+  }
+}
+
+void FireteamCountdown::addCountdown(const int clientNum,
+                                     const int8_t seconds) {
+  // erase any pending countdowns for this client
+  if (countdownCommands.find(clientNum) != countdownCommands.cend()) {
+    countdownCommands.erase(clientNum);
+  }
+
+  countdownCommands[clientNum].seconds = seconds;
+  countdownCommands[clientNum].nextMessageTime = level.time + level.frameTime;
+}
+
+void FireteamCountdown::removeCountdown(const int clientNum) {
+  countdownCommands.erase(clientNum);
+}
+
+void FireteamCountdown::sendCountdownMessage(const int clientNum) {
+  gentity_t *ent = g_entities + clientNum;
+  char message[MAX_SAY_TEXT]{};
+
+  Com_sprintf(message, sizeof(message),
+              countdownCommands[clientNum].seconds > 0
+                  ? std::to_string(countdownCommands[clientNum].seconds).c_str()
+                  : "GO!");
+  G_Say(ent, nullptr, SAY_BUDDY, qtrue, message);
+}
+} // namespace ETJump

--- a/src/game/etj_fireteam_countdown.cpp
+++ b/src/game/etj_fireteam_countdown.cpp
@@ -51,11 +51,6 @@ void FireteamCountdown::runFrame() {
 
 void FireteamCountdown::addCountdown(const int clientNum,
                                      const int8_t seconds) {
-  // erase any pending countdowns for this client
-  if (countdownCommands.find(clientNum) != countdownCommands.cend()) {
-    countdownCommands.erase(clientNum);
-  }
-
   countdownCommands[clientNum].seconds = seconds;
   countdownCommands[clientNum].nextMessageTime = level.time + level.frameTime;
 }

--- a/src/game/etj_fireteam_countdown.h
+++ b/src/game/etj_fireteam_countdown.h
@@ -24,35 +24,25 @@
 
 #pragma once
 
-#include <memory>
+#include <cstdint>
+#include <unordered_map>
 
 namespace ETJump {
-class TimerunV2;
-class RockTheVote;
-class Tokens;
-class ChatReplay;
-class Motd;
-class CustomMapVotes;
-class MapStatistics;
-class FireteamCountdown;
-} // namespace ETJump
+class FireteamCountdown {
+public:
+  void runFrame();
+  void addCountdown(int clientNum, int8_t seconds);
+  // called on client disconnect and on leaving fireteam
+  void removeCountdown(int clientNum);
 
-class Levels;
-class Commands;
-class Timerun;
+private:
+  struct CountdownCommand {
+    int32_t nextMessageTime;
+    int8_t seconds;
+  };
 
-struct Game {
-  Game() = default;
+  std::unordered_map<int, CountdownCommand> countdownCommands;
 
-  std::shared_ptr<Levels> levels;
-  std::shared_ptr<Commands> commands;
-  std::shared_ptr<ETJump::MapStatistics> mapStatistics;
-  std::shared_ptr<ETJump::TimerunV2> timerunV2;
-  std::shared_ptr<ETJump::RockTheVote> rtv;
-
-  std::unique_ptr<ETJump::CustomMapVotes> customMapVotes;
-  std::unique_ptr<ETJump::Motd> motd;
-  std::unique_ptr<ETJump::Tokens> tokens;
-  std::unique_ptr<ETJump::ChatReplay> chatReplay;
-  std::unique_ptr<ETJump::FireteamCountdown> fireteamCountdown;
+  void sendCountdownMessage(int clientNum);
 };
+} // namespace ETJump

--- a/src/game/g_fireteams.cpp
+++ b/src/game/g_fireteams.cpp
@@ -52,7 +52,7 @@
 
 #define G_ClientPrintAndReturn(entityNum, text)                                \
   trap_SendServerCommand(entityNum, "cpm \"" text "\"\n");                     \
-  return;
+  return
 
 // Utility functions
 fireteamData_t *G_FindFreeFireteam() {
@@ -998,6 +998,46 @@ void setupTeamJumpMode(const int &clientNum) {
 
   G_UpdateFireteamConfigString(ft);
 }
+
+static void startFireteamCountdown(gentity_t *ent) {
+  const int argc = trap_Argc();
+
+  // the client should always produce a countdown command with duration,
+  // even if it's not manually specified
+  if (argc < 3) {
+    Printer::console(
+        ent, "Malformed 'countdown' command - no duration specified!\n");
+    return;
+  }
+
+  if (ent->client->sess.muted) {
+    Printer::console(ent, "You are muted.\n");
+    return;
+  }
+
+  const int clientNum = ClientNum(ent);
+
+  // sanity check
+  if (clientNum < 0 || clientNum >= MAX_CLIENTS) {
+    Printer::console(ent,
+                     "Malformed 'countdown' command - invalid clientNum!\n");
+    return;
+  }
+
+  fireteamData_t *ft = nullptr;
+
+  if (!G_IsOnFireteam(clientNum, &ft)) {
+    Printer::console(ent, "You are not in a fireteam.\n");
+    return;
+  }
+
+  // max 10s countdown, minimum 1s
+  // if the client side cvar is <= 0, the default value (3s) will be used
+  char buf[8];
+  trap_Argv(2, buf, sizeof(buf));
+  const auto seconds = static_cast<int8_t>(std::clamp(Q_atoi(buf), 1, 10));
+  game.fireteamCountdown->addCountdown(clientNum, seconds);
+}
 } // namespace ETJump
 
 // Checks if given command buffer matches a valid client on the server
@@ -1021,12 +1061,13 @@ bool validClientForFireteam(gentity_t *ent, int *targetNum, char *numbuffer) {
 // Command handler
 void Cmd_FireTeam_MP_f(gentity_t *ent) {
   char command[MAX_NAME_LENGTH]; // more than enough to hold the commands
-  auto selfNum = ClientNum(ent);
+  const int selfNum = ClientNum(ent);
   int targetNum = -1;
 
   if (trap_Argc() < 2) {
-    G_ClientPrintAndReturn(selfNum,
-                           "usage: fireteam <create|leave|apply|invite|rules>");
+    G_ClientPrintAndReturn(
+        selfNum,
+        "usage: fireteam <create|leave|apply|invite|rules|teamjump|countdown>");
   }
 
   trap_Argv(1, command, sizeof(command));
@@ -1125,5 +1166,7 @@ void Cmd_FireTeam_MP_f(gentity_t *ent) {
     ETJump::setupTeamJumpMode(selfNum);
   } else if (!Q_stricmp(command, "race")) {
     G_FireteamRace(selfNum);
+  } else if (!Q_stricmp(command, "countdown")) {
+    ETJump::startFireteamCountdown(ent);
   }
 }

--- a/src/game/g_fireteams.cpp
+++ b/src/game/g_fireteams.cpp
@@ -2,6 +2,8 @@
 #include "etj_printer.h"
 #include "etj_string_utilities.h"
 #include "etj_entity_utilities.h"
+#include "etj_local.h"
+#include "etj_fireteam_countdown.h"
 
 // Gordon
 // What we need....
@@ -360,6 +362,8 @@ void G_RemoveClientFromFireteams(int entityNum, qboolean update,
         break;
       }
     }
+
+    game.fireteamCountdown->removeCountdown(entityNum);
   } else {
     return;
   }

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1841,6 +1841,8 @@ void G_SendScore(gentity_t *client);
 //
 // g_cmds.c
 //
+void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
+           char *chatText);
 void G_SayTo(
     gentity_t *ent, gentity_t *other, int mode, int color, const char *name,
     const char *message, qboolean localize,


### PR DESCRIPTION
A simple `countdown` command for fireteams that prints a countdown to fireteam chat. This can be used to easily coordinate timings on teamjumps, without having to be in voice chat or write scripts yourself.

If given an argument, the countdown will last for the specified amount of seconds. If no arguments are given, the default time will be taken from `etj_fireteamCountdownLength` cvar value. The countdown is capped to 1-10s. If the cvar is <= 0, a default timer of 3s will be used.

The countdown can also be started via the fireteam menu.

<img width="215" height="196" alt="image" src="https://github.com/user-attachments/assets/5f7365b8-c069-42db-9346-918285ab9e7b" />

