### PR TITLE
Adjust etj_viewPlayerPortals behavior

### DIFF
--- a/assets/ui/etjump_settings_graphics_visuals.menu
+++ b/assets/ui/etjump_settings_graphics_visuals.menu
@@ -46,7 +46,7 @@ menuDef {
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "VISUALS")
 
         YESNO               (SETTINGS_ITEM_POS(1), "Hor+ FOV:", 0.2, SETTINGS_ITEM_H, "etj_realFov", "Use hor+ FOV calculation instead of vert-\netj_realFov")
-        MULTI               (SETTINGS_ITEM_POS(2), "Draw other players' portals:", 0.2, SETTINGS_ITEM_H, "etj_viewPlayerPortals", cvarFloatList { "No" 0 "Yes" 1 "Only when spectating" 2 }, "Draw other players' portalgun portals\netj_viewPlayerPortals")
+        YESNO               (SETTINGS_ITEM_POS(2), "Draw non-interactable portals", 0.2, SETTINGS_ITEM_H, "etj_viewPlayerPortals", "Draw other player's portals even if they cannot be interacted with\netj_viewPlayerPortals")
         MULTI               (SETTINGS_ITEM_POS(3), "Explosion screenshake:", 0.2, SETTINGS_ITEM_H, "etj_explosivesShake", cvarFloatList { "No" 0 "From others" 1 "From own" 2 "Yes" 3 }, "Shake screen from explosions\netj_explosivesShake")
         YESNO               (SETTINGS_ITEM_POS(4), "Draw tokens:", 0.2, SETTINGS_ITEM_H, "etj_drawTokens", "Draw collectible tokens placed by server admins\netj_drawTokens")
 

--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 
 #include "cg_local.h"
+#include "etj_utilities.h"
 
 /*
 ======================
@@ -2382,15 +2383,8 @@ static void CG_PortalGate(const centity_t *cent) {
           : static_cast<float>(cent->currentState.onFireStart) *
                 ETJump::PORTAL_DRAW_SCALAR;
 
-  // not our portal
-  if (!etj_viewPlayerPortals.integer &&
-      cent->currentState.otherEntityNum != cg.clientNum) {
-    return;
-  }
-  // not our portal, not spectating
-  if (etj_viewPlayerPortals.integer == 2 &&
-      cgs.clientinfo[cg.clientNum].team != TEAM_SPECTATOR &&
-      cent->currentState.otherEntityNum != cg.clientNum) {
+  if (ETJump::skipPortalDraw(cg.snap->ps.clientNum,
+                             cent->currentState.otherEntityNum)) {
     return;
   }
 

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include "etj_player_events_handler.h"
 #include "../game/etj_string_utilities.h"
+#include "etj_utilities.h"
 
 extern void CG_StartShakeCamera(float param, entityState_t *es);
 extern void CG_Tracer(vec3_t source, vec3_t dest, int sparks);
@@ -2751,20 +2752,11 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       CG_ResetTransitionEffects();
       break;
     case EV_PORTAL_TRAIL:
-      // not our portal trail
-      if (!etj_viewPlayerPortals.integer &&
-          es->otherEntityNum2 != cg.clientNum) {
-        return;
-      }
-      // not our portal trail, not spectating
-      if (etj_viewPlayerPortals.integer == 2 &&
-          cgs.clientinfo[cg.clientNum].team != TEAM_SPECTATOR &&
-          es->otherEntityNum2 != cg.clientNum) {
-        return;
+      if (!ETJump::skipPortalDraw(cg.snap->ps.clientNum, es->otherEntityNum)) {
+        CG_RailTrail(es->origin2, es->pos.trBase, es->dmgFlags,
+                     tv(es->angles[0], es->angles[1], es->angles[2]));
       }
 
-      CG_RailTrail(es->origin2, es->pos.trBase, es->dmgFlags,
-                   tv(es->angles[0], es->angles[1], es->angles[2]));
       break;
     default:
       break;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2465,6 +2465,7 @@ extern vmCvar_t etj_popupPosY;
 extern vmCvar_t etj_viewPlayerPortals;
 extern vmCvar_t etj_portalDebug;
 extern vmCvar_t etj_portalPredict;
+extern vmCvar_t etj_portalTeam;
 
 extern vmCvar_t etj_expandedMapAlpha;
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -371,6 +371,7 @@ vmCvar_t etj_popupPosY;
 vmCvar_t etj_viewPlayerPortals; // Enable/Disable viewing other player portals
 vmCvar_t etj_portalDebug;
 vmCvar_t etj_portalPredict;
+vmCvar_t etj_portalTeam;
 
 vmCvar_t etj_expandedMapAlpha;
 
@@ -953,10 +954,11 @@ cvarTable_t cvarTable[] = {
     {&etj_popupPosX, "etj_popupPosX", "0", CVAR_ARCHIVE},
     {&etj_popupPosY, "etj_popupPosY", "0", CVAR_ARCHIVE},
 
-    {&etj_viewPlayerPortals, "etj_viewPlayerPortals", "1",
+    {&etj_viewPlayerPortals, "etj_viewPlayerPortals", "0",
      CVAR_ARCHIVE}, // Feen: PGM - View other player portals
     {&etj_portalDebug, "etj_portalDebug", "0", CVAR_ARCHIVE | CVAR_CHEAT},
     {&etj_portalPredict, "", "0", 0},
+    {&etj_portalTeam, "", "0", 0},
 
     {&etj_expandedMapAlpha, "etj_expandedMapAlpha", "0.7", CVAR_ARCHIVE},
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -132,6 +132,7 @@ void CG_ParseServerinfo(void) {
   etj_spectatorVote.integer = Q_atoi(Info_ValueForKey(info, "g_spectatorVote"));
 
   etj_portalPredict.integer = Q_atoi(Info_ValueForKey(info, "g_portalPredict"));
+  etj_portalTeam.integer = Q_atoi(Info_ValueForKey(info, "g_portalTeam"));
 
   cgs.minclients = Q_atoi(Info_ValueForKey(
       info, "g_minGameClients")); // NERVE - SMF -- OSP:

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -274,4 +274,22 @@ void ETJump::resetTempTraceIgnoredClients() {
   std::fill_n(tempTraceIgnoredClients.begin(), MAX_CLIENTS, false);
 }
 
+bool ETJump::skipPortalDraw(const int selfNum, const int otherNum) {
+  if (selfNum == otherNum) {
+    return false;
+  }
+
+  if (etj_portalTeam.integer == PORTAL_TEAM_ALL ||
+      etj_viewPlayerPortals.integer) {
+    return false;
+  }
+
+  if (etj_portalTeam.integer == PORTAL_TEAM_FT &&
+      CG_IsOnSameFireteam(selfNum, otherNum)) {
+    return false;
+  }
+
+  return true;
+}
+
 #endif

--- a/src/cgame/etj_utilities.h
+++ b/src/cgame/etj_utilities.h
@@ -86,5 +86,7 @@ void tempTraceIgnoreClient(int clientNum);
 
 void resetTempTraceIgnoredClients();
 
+bool skipPortalDraw(int selfNum, int otherNum);
+
 #endif
 } // namespace ETJump

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -225,6 +225,7 @@ vmCvar_t g_banners;
 // 0 = Freestyle, 1 = Standard,  2 = team (possible future)
 vmCvar_t g_portalMode;
 vmCvar_t g_portalPredict;
+vmCvar_t g_portalTeam;
 
 // Bugfixes
 vmCvar_t g_maxConnsPerIP;
@@ -485,6 +486,7 @@ cvarTable_t gameCvarTable[] = {
     // 0 - freestyle, 1 - restricted
     {&g_portalMode, "g_portalMode", "1", CVAR_ARCHIVE},
     {&g_portalPredict, "g_portalPredict", "0", CVAR_ARCHIVE | CVAR_SERVERINFO},
+    {&g_portalTeam, "g_portalTeam", "0", CVAR_ROM | CVAR_SERVERINFO},
 
     {&g_maxConnsPerIP, "g_maxConnsPerIP", "2", CVAR_ARCHIVE},
     {&g_mute, "g_mute", "0", CVAR_ARCHIVE},

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -1300,6 +1300,8 @@ void SP_worldspawn(void) {
       level.portalTeam = ETJump::PORTAL_TEAM_ALL;
     }
   }
+
+  trap_Cvar_Set("g_portaLTeam", s);
   G_Printf("Portal team is set to %d.\n", val);
 
   ETJump::initNoSave();


### PR DESCRIPTION
This cvar is now a toggle, which controls drawing of non-interactable portals. If a portal is not interactable, it will only be drawn if the cvar value is 1. New default value is 0, which draws only interactable portals.

A portal is interactable in the following scenarios:
* the portal is yours
* `portalteam` is set to 1 and the portal is yours or from a fireteam member
* `portalteam` is set to 2 (anyone can use anyone's portals)