### PR TITLE
Fix portalgun trail/railbox colors for other's portals

### DIFF
--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -9,6 +9,7 @@
 
 #include "cg_local.h"
 #include "etj_utilities.h"
+#include "../game/etj_portalgun_shared.h"
 
 /*
 ======================

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -7,6 +7,7 @@
 #include "etj_player_events_handler.h"
 #include "../game/etj_string_utilities.h"
 #include "etj_utilities.h"
+#include "../game/etj_portalgun_shared.h"
 
 extern void CG_StartShakeCamera(float param, entityState_t *es);
 extern void CG_Tracer(vec3_t source, vec3_t dest, int sparks);
@@ -2752,9 +2753,17 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       CG_ResetTransitionEffects();
       break;
     case EV_PORTAL_TRAIL:
-      if (!ETJump::skipPortalDraw(cg.snap->ps.clientNum, es->otherEntityNum)) {
+      if (ETJump::skipPortalDraw(cg.snap->ps.clientNum, es->otherEntityNum)) {
+        break;
+      }
+
+      if (cg.snap->ps.clientNum == es->otherEntityNum2) {
+        CG_RailTrail(es->origin2, es->pos.trBase, es->dmgFlags, es->angles);
+      } else {
         CG_RailTrail(es->origin2, es->pos.trBase, es->dmgFlags,
-                     tv(es->angles[0], es->angles[1], es->angles[2]));
+                     VectorCompare(es->angles, ETJump::portalBlueTrail)
+                         ? ETJump::portalGreenTrail
+                         : ETJump::portalYellowTrail);
       }
 
       break;

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -9,6 +9,7 @@
 #include "cg_local.h"
 #include "etj_utilities.h"
 #include "../game/etj_entity_utilities_shared.h"
+#include "../game/etj_portalgun_shared.h"
 
 /*static*/ pmove_t cg_pmove;
 
@@ -600,9 +601,22 @@ static void CG_TouchTriggerPrediction() {
                                     cent->currentState.otherEntityNum) &&
             etj_portalDebug.integer &&
             cg.time > cent->lastRailboxTime + cg_railTrailTime.integer) {
-          CG_RailTrail(mins, maxs, true,
-                       ent->eType == ET_PORTAL_BLUE ? tv(0, 0, 1)
-                                                    : tv(1, 0, 0));
+
+          vec3_t boxColor{};
+
+          if (cg.snap->ps.clientNum == cent->currentState.otherEntityNum) {
+            VectorCopy(cent->currentState.eType == ET_PORTAL_BLUE
+                           ? ETJump::portalBlueTrail
+                           : ETJump::portalRedTrail,
+                       boxColor);
+          } else {
+            VectorCopy(cent->currentState.eType == ET_PORTAL_BLUE
+                           ? ETJump::portalGreenTrail
+                           : ETJump::portalYellowTrail,
+                       boxColor);
+          }
+
+          CG_RailTrail(mins, maxs, true, boxColor);
           cent->lastRailboxTime = cg.time;
         }
       } else {

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -31,9 +31,10 @@
 
 #include "etj_utilities.h"
 #include "etj_event_loop.h"
-#include "../game/etj_string_utilities.h"
 #include "cg_local.h"
 #include "etj_demo_compatibility.h"
+#include "../game/etj_string_utilities.h"
+#include "../game/etj_portalgun_shared.h"
 
 namespace ETJump {
 extern std::shared_ptr<EventLoop> eventLoop;

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2879,27 +2879,6 @@ enum class PlayerStance {
   Crouch = 1,
   Prone = 2,
 };
-
-// portalteam
-inline constexpr int PORTAL_TEAM_NONE = 0;
-inline constexpr int PORTAL_TEAM_FT = 1;
-inline constexpr int PORTAL_TEAM_ALL = 2;
-
-// cooldown between portal touch events (ms)
-inline constexpr int PORTAL_TOUCH_COOLDOWN = 100;
-
-// radius of portal bbox
-inline constexpr float PORTAL_BBOX_RADIUS = 30.0f;
-// depth for horizontal portals
-inline constexpr float PORTAL_BBOX_HOR_DEPTH = 15.0f;
-// depth for vertical portals
-inline constexpr float PORTAL_BBOX_VERT_DEPTH = 5.0f;
-
-// radius for portal shader drawing
-inline constexpr float PORTAL_DRAW_RADIUS = 48.0f;
-// scalar for drawing the portal shader proportional to the portal size
-inline constexpr float PORTAL_DRAW_SCALAR =
-    PORTAL_DRAW_RADIUS / (PORTAL_BBOX_RADIUS * 2);
 } // namespace ETJump
 
 inline constexpr int JUMP_VELOCITY = 270;

--- a/src/game/etj_entity_utilities_shared.cpp
+++ b/src/game/etj_entity_utilities_shared.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "etj_entity_utilities_shared.h"
+#include "etj_portalgun_shared.h"
 
 // Entity helper functions used by both games (client side predicted entities)
 

--- a/src/game/etj_portalgun.cpp
+++ b/src/game/etj_portalgun.cpp
@@ -27,6 +27,7 @@
 #include "etj_portalgun.h"
 #include "etj_entity_utilities.h"
 #include "etj_entity_utilities_shared.h"
+#include "etj_portalgun_shared.h"
 
 namespace ETJump {
 // max range where you can place next portal gate
@@ -276,9 +277,6 @@ void Portalgun::fire(gentity_t *ent, const Portal::Type type, vec3_t forward,
   // BBox info
   vec3_t t_portalAngles; // Could be used for all angles conversions...
 
-  constexpr vec3_t blueTrail = {0.0f, 0.0f, 1.0f};
-  constexpr vec3_t redTrail = {1.0f, 0.0f, 0.0f};
-
   // NOTE: NEW trace setup.... pulled from flamethrower
   // NOTE: Need this for +attack2 call...
   AngleVectors(ent->client->ps.viewangles, forward, right, up);
@@ -364,8 +362,9 @@ void Portalgun::fire(gentity_t *ent, const Portal::Type type, vec3_t forward,
   // close enough for the barrel on most cases, realistically we should
   // grab the starting point from the weapon tags
   gentity_t *tent = G_TempEntity(muzzleEffect, EV_PORTAL_TRAIL);
-  type == Portal::Type::PORTAL_BLUE ? VectorCopy(blueTrail, tent->s.angles)
-                                    : VectorCopy(redTrail, tent->s.angles);
+  type == Portal::Type::PORTAL_BLUE
+      ? VectorCopy(portalBlueTrail, tent->s.angles)
+      : VectorCopy(portalRedTrail, tent->s.angles);
 
   SnapVectorTowards(tr_end, start);
   VectorCopy(tr_end, tent->s.origin2);

--- a/src/game/etj_portalgun_shared.h
+++ b/src/game/etj_portalgun_shared.h
@@ -1,0 +1,56 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "q_shared.h"
+
+namespace ETJump {
+// portal trail colors
+inline constexpr vec3_t portalBlueTrail = {0.0f, 0.0f, 1.0f};
+inline constexpr vec3_t portalRedTrail = {1.0f, 0.0f, 0.0f};
+inline constexpr vec3_t portalGreenTrail = {0.2f, 1.0f, 0.5f};
+inline constexpr vec3_t portalYellowTrail = {1.0f, 1.0f, 0.0f};
+
+// portalteam
+inline constexpr int PORTAL_TEAM_NONE = 0;
+inline constexpr int PORTAL_TEAM_FT = 1;
+inline constexpr int PORTAL_TEAM_ALL = 2;
+
+// cooldown between portal touch events (ms)
+inline constexpr int PORTAL_TOUCH_COOLDOWN = 100;
+
+// radius of portal bbox
+inline constexpr float PORTAL_BBOX_RADIUS = 30.0f;
+// depth for horizontal portals
+inline constexpr float PORTAL_BBOX_HOR_DEPTH = 15.0f;
+// depth for vertical portals
+inline constexpr float PORTAL_BBOX_VERT_DEPTH = 5.0f;
+
+// radius for portal shader drawing
+inline constexpr float PORTAL_DRAW_RADIUS = 48.0f;
+// scalar for drawing the portal shader proportional to the portal size
+inline constexpr float PORTAL_DRAW_SCALAR =
+    PORTAL_DRAW_RADIUS / (PORTAL_BBOX_RADIUS * 2);
+} // namespace ETJump

--- a/src/game/g_fireteams.cpp
+++ b/src/game/g_fireteams.cpp
@@ -4,6 +4,7 @@
 #include "etj_entity_utilities.h"
 #include "etj_local.h"
 #include "etj_fireteam_countdown.h"
+#include "etj_portalgun_shared.h"
 
 // Gordon
 // What we need....

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -20,6 +20,7 @@
 #include "etj_target_ft_setrules.h"
 #include "etj_target_spawn_relay.h"
 #include "etj_portalgun.h"
+#include "etj_portalgun_shared.h"
 
 qboolean G_SpawnStringExt(const char *key, const char *defaultString,
                           char **out, const char *file, int line) {


### PR DESCRIPTION
Blue & red portal trails/railboxes now correctly draw as green/yellow for portals shot by others, respectively.