### PR TITLE
Fix incorrect variable check for portal trails

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -2753,7 +2753,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       CG_ResetTransitionEffects();
       break;
     case EV_PORTAL_TRAIL:
-      if (ETJump::skipPortalDraw(cg.snap->ps.clientNum, es->otherEntityNum)) {
+      if (ETJump::skipPortalDraw(cg.snap->ps.clientNum, es->otherEntityNum2)) {
         break;
       }
 


### PR DESCRIPTION
Trails use `otherEntityNum2` for the owner info, not `otherEntityNum`.

refs #1707 