### PR TITLE
Spectator info list improvements

### DIFF
--- a/assets/ui/etjump_settings_hud1_specinfo.menu
+++ b/assets/ui/etjump_settings_hud1_specinfo.menu
@@ -65,6 +65,7 @@ menuDef {
         SLIDER              (SETTINGS_ITEM_POS(5), "Spec list scale:", 0.2, SETTINGS_ITEM_H, etj_spectatorInfoScale 1.0 0 5 0.1, "Scale of spectator list\netj_spectatorInfoSize")
         CVARINTLABEL        (SETTINGS_ITEM_POS(6), "etj_spectatorInfoMaxClients", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(6), "Max clients:", 0.2, SETTINGS_ITEM_H, etj_spectatorInfoMaxClients -1 -1 63 1, "Maximum number of clients to draw on the list, -1 for unlimited\netj_spectatorInfoMaxClients")
+        YESNO               (SETTINGS_ITEM_POS(7), "Bottom-up direction:", 0.2, SETTINGS_ITEM_H, "etj_spectatorInfoDirection", "Draw the list in bottom-up direction\netj_spectatorInfoDirection")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/assets/ui/etjump_settings_hud1_specinfo.menu
+++ b/assets/ui/etjump_settings_hud1_specinfo.menu
@@ -63,6 +63,8 @@ menuDef {
         YESNO               (SETTINGS_ITEM_POS(4), "Spec list shadow:", 0.2, SETTINGS_ITEM_H, "etj_spectatorInfoShadow", "Draw shadow on spectator list\netj_spectatorInfoShadow")
         CVARFLOATLABEL      (SETTINGS_ITEM_POS(5), "etj_spectatorInfoScale", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(5), "Spec list scale:", 0.2, SETTINGS_ITEM_H, etj_spectatorInfoScale 1.0 0 5 0.1, "Scale of spectator list\netj_spectatorInfoSize")
+        CVARINTLABEL        (SETTINGS_ITEM_POS(6), "etj_spectatorInfoMaxClients", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(6), "Max clients:", 0.2, SETTINGS_ITEM_H, etj_spectatorInfoMaxClients -1 -1 63 1, "Maximum number of clients to draw on the list, -1 for unlimited\netj_spectatorInfoMaxClients")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -85,6 +85,7 @@ add_library(cgame MODULE
 	"etj_savepos.cpp"
 	"etj_snaphud.cpp"
 	"etj_speed_drawable.cpp"
+	"etj_spectatorinfo_data.cpp"
 	"etj_spectatorinfo_drawable.cpp"
 	"etj_strafe_quality_drawable.cpp"
 	"etj_upper_right_drawable.cpp"

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2541,6 +2541,7 @@ extern vmCvar_t etj_spectatorInfoX;
 extern vmCvar_t etj_spectatorInfoY;
 extern vmCvar_t etj_spectatorInfoScale;
 extern vmCvar_t etj_spectatorInfoShadow;
+extern vmCvar_t etj_spectatorInfoMaxClients;
 
 extern vmCvar_t etj_drawRunTimer;
 extern vmCvar_t etj_runTimerX;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2542,6 +2542,7 @@ extern vmCvar_t etj_spectatorInfoY;
 extern vmCvar_t etj_spectatorInfoScale;
 extern vmCvar_t etj_spectatorInfoShadow;
 extern vmCvar_t etj_spectatorInfoMaxClients;
+extern vmCvar_t etj_spectatorInfoDirection;
 
 extern vmCvar_t etj_drawRunTimer;
 extern vmCvar_t etj_runTimerX;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -443,6 +443,7 @@ vmCvar_t etj_spectatorInfoX;
 vmCvar_t etj_spectatorInfoY;
 vmCvar_t etj_spectatorInfoScale;
 vmCvar_t etj_spectatorInfoShadow;
+vmCvar_t etj_spectatorInfoMaxClients;
 
 vmCvar_t etj_drawRunTimer;
 vmCvar_t etj_runTimerX;
@@ -1025,6 +1026,8 @@ cvarTable_t cvarTable[] = {
     {&etj_spectatorInfoY, "etj_spectatorInfoY", "30", CVAR_ARCHIVE},
     {&etj_spectatorInfoScale, "etj_spectatorInfoScale", "1.0", CVAR_ARCHIVE},
     {&etj_spectatorInfoShadow, "etj_spectatorInfoShadow", "1", CVAR_ARCHIVE},
+    {&etj_spectatorInfoMaxClients, "etj_spectatorInfoMaxClients", "-1",
+     CVAR_ARCHIVE},
     {&etj_drawRunTimer, "etj_drawRunTimer", "1", CVAR_ARCHIVE},
     {&etj_runTimerX, "etj_runTimerX", "320", CVAR_ARCHIVE},
     {&etj_runTimerY, "etj_runTimerY", "360", CVAR_ARCHIVE},

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -444,6 +444,7 @@ vmCvar_t etj_spectatorInfoY;
 vmCvar_t etj_spectatorInfoScale;
 vmCvar_t etj_spectatorInfoShadow;
 vmCvar_t etj_spectatorInfoMaxClients;
+vmCvar_t etj_spectatorInfoDirection;
 
 vmCvar_t etj_drawRunTimer;
 vmCvar_t etj_runTimerX;
@@ -1027,6 +1028,8 @@ cvarTable_t cvarTable[] = {
     {&etj_spectatorInfoScale, "etj_spectatorInfoScale", "1.0", CVAR_ARCHIVE},
     {&etj_spectatorInfoShadow, "etj_spectatorInfoShadow", "1", CVAR_ARCHIVE},
     {&etj_spectatorInfoMaxClients, "etj_spectatorInfoMaxClients", "-1",
+     CVAR_ARCHIVE},
+    {&etj_spectatorInfoDirection, "etj_spectatorInfoDirection", "0",
      CVAR_ARCHIVE},
     {&etj_drawRunTimer, "etj_drawRunTimer", "1", CVAR_ARCHIVE},
     {&etj_runTimerX, "etj_runTimerX", "320", CVAR_ARCHIVE},

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -10,6 +10,7 @@
 #include "etj_init.h"
 #include "etj_client_commands_handler.h"
 #include "etj_client_rtv_handler.h"
+#include "etj_spectatorinfo_data.h"
 
 #include "../game/etj_string_utilities.h"
 #include "../game/etj_syscall_ext_shared.h"
@@ -710,6 +711,7 @@ static void CG_ConfigStringModified(void) {
     }
   } else if (num >= CS_PLAYERS && num < CS_PLAYERS + MAX_CLIENTS) {
     CG_NewClientInfo(num - CS_PLAYERS);
+    ETJump::SpectatorInfoData::updateSpectatorData(num - CS_PLAYERS);
   } else if (num >= CS_DLIGHTS && num < CS_DLIGHTS + MAX_DLIGHT_CONFIGSTRINGS) {
     CG_SetupDlightstyles();
   } else if (num == CS_SHADERSTATE) {
@@ -2259,9 +2261,11 @@ static void CG_ServerCommand(void) {
   }
   if (!strcmp(cmd, "sc0")) {
     CG_ParseScore(TEAM_AXIS);
+    ETJump::SpectatorInfoData::updateSpectatorData(std::nullopt);
     return;
   } else if (!strcmp(cmd, "sc1")) {
     CG_ParseScore(TEAM_ALLIES);
+    ETJump::SpectatorInfoData::updateSpectatorData(std::nullopt);
     return;
   }
 

--- a/src/cgame/etj_spectatorinfo_data.cpp
+++ b/src/cgame/etj_spectatorinfo_data.cpp
@@ -1,0 +1,95 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <algorithm>
+
+#include "etj_spectatorinfo_data.h"
+
+namespace ETJump {
+std::vector<int32_t> SpectatorInfoData::activeSpectators;
+std::vector<int32_t> SpectatorInfoData::inactiveSpectators;
+
+void SpectatorInfoData::updateSpectatorData(std::optional<int32_t> clientNum) {
+  if (clientNum.has_value()) {
+    const int32_t cnum = clientNum.value();
+    const char *cs = CG_ConfigString(CS_PLAYERS + cnum);
+
+    // the client we got an update from disconnected,
+    // remove them from the lists if present
+    if (cs[0] == '\0') {
+      removeClientFromList(activeSpectators, cnum);
+      removeClientFromList(inactiveSpectators, cnum);
+    }
+
+    return;
+  }
+
+  for (int32_t i = 0; i < cg.numScores; i++) {
+    if (skipClient(cg.scores[i])) {
+      continue;
+    }
+
+    if (cg.scores[i].followedClient != cg.snap->ps.clientNum) {
+      removeClientFromList(activeSpectators, cg.scores[i].client);
+      removeClientFromList(inactiveSpectators, cg.scores[i].client);
+      continue;
+    }
+
+    const clientInfo_t *ci = &cgs.clientinfo[cg.scores[i].client];
+
+    if (ci->clientIsInactive) {
+      removeClientFromList(activeSpectators, cg.scores[i].client);
+
+      if (std::find(inactiveSpectators.cbegin(), inactiveSpectators.cend(),
+                    cg.scores[i].client) == inactiveSpectators.cend()) {
+        inactiveSpectators.emplace_back(cg.scores[i].client);
+      }
+    } else {
+      removeClientFromList(inactiveSpectators, cg.scores[i].client);
+
+      if (std::find(activeSpectators.cbegin(), activeSpectators.cend(),
+                    cg.scores[i].client) == activeSpectators.cend()) {
+        activeSpectators.emplace_back(cg.scores[i].client);
+      }
+    }
+  }
+}
+
+void SpectatorInfoData::removeClientFromList(std::vector<int32_t> &v,
+                                             const int32_t clientNum) {
+  v.erase(std::remove(v.begin(), v.end(), clientNum), v.end());
+}
+
+bool SpectatorInfoData::skipClient(const score_t &score) {
+  if (score.client == cg.snap->ps.clientNum) {
+    return true;
+  }
+
+  if (score.team != TEAM_SPECTATOR) {
+    return true;
+  }
+
+  return false;
+}
+} // namespace ETJump

--- a/src/cgame/etj_spectatorinfo_data.h
+++ b/src/cgame/etj_spectatorinfo_data.h
@@ -24,36 +24,24 @@
 
 #pragma once
 
-#include "etj_irenderable.h"
-#include "etj_cvar_parser.h"
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "cg_local.h"
 
 namespace ETJump {
-class SpectatorInfo : public IRenderable {
-  CvarValue::Scale scale{};
-  int32_t textStyle{};
-  float sizeX{};
-  float sizeY{};
-  float rowHeight{};
-
-  enum class DrawDirection {
-    DOWN = 0,
-    UP = 1,
-  };
-
-  static constexpr vec4_t inactiveColor = {1.0f, 1.0f, 1.0f, 0.33f};
-
-  static bool canSkipDraw();
-  void startListeners();
-
-  void setTextSize(const vmCvar_t &cvar);
-  void setRowHeight();
-  void setTextStyle(const vmCvar_t &cvar);
-  static float getTextOffset(const char *name, float fontWidth);
-
+class SpectatorInfoData {
 public:
-  SpectatorInfo();
+  static std::vector<int32_t> activeSpectators;
+  static std::vector<int32_t> inactiveSpectators;
 
-  bool beforeRender() override;
-  void render() const override;
+  // If 'clientNum' has value, then this is a 'CS_PLAYERS' update.
+  // This handles removing client from the lists if they disconnected.
+  static void updateSpectatorData(std::optional<int32_t> clientNum);
+
+private:
+  static void removeClientFromList(std::vector<int32_t> &v, int32_t clientNum);
+  static bool skipClient(const score_t &score);
 };
 } // namespace ETJump

--- a/src/cgame/etj_spectatorinfo_drawable.cpp
+++ b/src/cgame/etj_spectatorinfo_drawable.cpp
@@ -123,9 +123,19 @@ void SpectatorInfo::render() const {
 
   const auto drawRow = [this, x, &y](const char *name, const vec4_t color) {
     const float offset = getTextOffset(name, sizeX);
-    y += rowHeight;
 
-    DrawString(x - offset, y, sizeX, sizeY, color, qfalse, name, 0, textStyle);
+    if (static_cast<DrawDirection>(etj_spectatorInfoDirection.integer) ==
+        DrawDirection::DOWN) {
+      y += rowHeight;
+      DrawString(x - offset, y, sizeX, sizeY, color, qfalse, name, 0,
+                 textStyle);
+    } else {
+      // if we're drawing bottom-up, draw first before changing the y pos,
+      // because 'DrawString' draws from the bottom left vertex
+      DrawString(x - offset, y, sizeX, sizeY, color, qfalse, name, 0,
+                 textStyle);
+      y -= rowHeight;
+    }
   };
 
   const size_t max =

--- a/src/cgame/etj_spectatorinfo_drawable.h
+++ b/src/cgame/etj_spectatorinfo_drawable.h
@@ -36,6 +36,11 @@ class SpectatorInfo : public IRenderable {
   float rowHeight{};
   std::vector<std::pair<int32_t, bool>> spectators;
 
+  enum class DrawDirection {
+    DOWN = 0,
+    UP = 1,
+  };
+
   static constexpr vec4_t inactiveColor = {1.0f, 1.0f, 1.0f, 0.33f};
 
   static bool canSkipDraw();

--- a/src/cgame/etj_spectatorinfo_drawable.h
+++ b/src/cgame/etj_spectatorinfo_drawable.h
@@ -30,11 +30,21 @@
 namespace ETJump {
 class SpectatorInfo : public IRenderable {
   CvarValue::Scale scale{};
+  int32_t textStyle{};
+  float sizeX{};
+  float sizeY{};
+  float rowHeight{};
+  std::vector<std::pair<int32_t, bool>> spectators;
+
+  static constexpr vec4_t inactiveColor = {1.0f, 1.0f, 1.0f, 0.33f};
 
   static bool canSkipDraw();
   void startListeners();
 
-  void setScale();
+  void setTextSize(const vmCvar_t &cvar);
+  void setRowHeight();
+  void setTextStyle(const vmCvar_t &cvar);
+  static float getTextOffset(const char *name, float fontWidth);
 
 public:
   SpectatorInfo();


### PR DESCRIPTION
* Number of listed clients can now be limited with `etj_spectatorInfoMaxClients`, -1 for unlimited (default).
  * If the number of spectators is greater than the specified amount, an additoonal row will be drawn indicating how many spectators are hidden from the list.
  * If the value is 0, only the number of spectators is drawn.
* Spectator list drawing now draws active clients before inactive clients.
* Spectator list can now draw in bottom-up direction with `etj_spectatorInfoDirection 1`.

fixes #1716 