### PR TITLE
Fix EF_FIRING not being set when firing weapons with +attack2

### DIFF
--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -5920,7 +5920,8 @@ void PmoveSingle(pmove_t *pmove) {
               pm->ps->weaponstate == WEAPON_FIRING) {
 
             // all clear, fire!
-            if (pm->cmd.buttons & BUTTON_ATTACK &&
+            if ((pm->cmd.buttons & BUTTON_ATTACK ||
+                 pm->cmd.wbuttons & WBUTTON_ATTACK2) &&
                 !(pm->cmd.buttons & BUTTON_TALK)) {
               pm->ps->eFlags |= EF_FIRING;
             }


### PR DESCRIPTION
This mainly fixes flamethrower flames being invisible if the weapon was fired with '+attack2', it's possible that this caused other issues too since due to this, cgame never registered that you fired a weapon for viewmodel drawing purposes.