### PR TITLE
Fix portal predict vote UI, announce cvar change always

### DIFF
--- a/assets/ui/ingame_vote.menu
+++ b/assets/ui/ingame_vote.menu
@@ -25,7 +25,7 @@ menuDef {
 	onOpen {
 		uiScript voteInitToggles
 
-    conditionalScript g_portalPredict 0
+    conditionalScript ui_VotePortalPredict 0
       ( "hide bttn_vote_portalpredict_on ; show bttn_vote_portalpredict_off" )
       ( "hide bttn_vote_portalpredict_off ; show bttn_vote_portalpredict_on" )
 	}
@@ -81,8 +81,8 @@ menuDef {
 	NAMEDBUTTONEXT        ( "bttnextAutoRtv", ITEM_POS_QUARTER_3(4), "OK", .25, 12, uiScript voteAutoRtv; uiScript closeingame, voteFlag CV_SVF_AUTORTV )
 	NAMEDBUTTONEXT        ( "bttnextAutoRtvOff", ITEM_POS_QUARTER_4(4), "OFF", .25, 12, exec "cmd callvote autoRtv 0"; uiScript closeingame, voteFlag CV_SVF_AUTORTV )
 
-	NAMEDBUTTONEXT        ( "bttn_vote_portalpredict_on", ITEM_POS(5), "PREDICTED PORTALS ON", .25, 12, exec "cmd callvote portalPredict 1"; uiScript closeingame, voteFlag CV_SVF_PORTALPREDICT )
-	NAMEDBUTTONEXT        ( "bttn_vote_portalpredict_off", ITEM_POS(5), "PREDICTED PORTALS OFF", .25, 12, exec "cmd callvote portalPredict 0"; uiScript closeingame, voteFlag CV_SVF_PORTALPREDICT )
+	NAMEDBUTTONEXT        ( "bttn_vote_portalpredict_on", ITEM_POS(5), "PREDICTED PORTALS ON", .25, 12, uiScript votePortalPredict; uiScript closeingame, voteFlag CV_SVF_PORTALPREDICT )
+	NAMEDBUTTONEXT        ( "bttn_vote_portalpredict_off", ITEM_POS(5), "PREDICTED PORTALS OFF", .25, 12, uiScript votePortalPredict; uiScript closeingame, voteFlag CV_SVF_PORTALPREDICT )
 
 	BUTTON                ( ITEM_POS(6), "BACK", .25, 12, close ingame_vote ; open ingame_main )
 }

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -485,7 +485,8 @@ cvarTable_t gameCvarTable[] = {
     // Feen: PGM
     // 0 - freestyle, 1 - restricted
     {&g_portalMode, "g_portalMode", "1", CVAR_ARCHIVE},
-    {&g_portalPredict, "g_portalPredict", "0", CVAR_ARCHIVE | CVAR_SERVERINFO},
+    {&g_portalPredict, "g_portalPredict", "0", CVAR_ARCHIVE | CVAR_SERVERINFO,
+     0, qtrue},
     {&g_portalTeam, "g_portalTeam", "0", CVAR_ROM | CVAR_SERVERINFO},
 
     {&g_maxConnsPerIP, "g_maxConnsPerIP", "2", CVAR_ARCHIVE},

--- a/src/game/g_vote.cpp
+++ b/src/game/g_vote.cpp
@@ -686,9 +686,6 @@ int G_PortalPredict_v(gentity_t *ent, unsigned dwVoteIndex, char *arg,
                 val == 0 ? "0" : "1");
   } else {
     trap_Cvar_Set("g_portalPredict", level.voteInfo.vote_value);
-    Printer::popupAll(stringFormat(
-        "Predicted portalgun teleports are now ^3%s^7!",
-        Q_atoi(level.voteInfo.vote_value) ? "enabled" : "disabled"));
   }
 
   return G_OK;

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -4013,6 +4013,9 @@ void UI_RunMenuScript(const char **args) {
                     va("%i", Q_atoi(Info_ValueForKey(info, "timelimit"))));
       trap_Cvar_Set("ui_voteAutoRtv",
                     va("%i", Q_atoi(Info_ValueForKey(info, "g_autoRtv"))));
+      trap_Cvar_Set(
+          "ui_votePortalPredict",
+          va("%i", Q_atoi(Info_ValueForKey(info, "g_portalPredict"))));
 
       return;
     }
@@ -5136,6 +5139,18 @@ void UI_RunMenuScript(const char **args) {
       for (int i = 0; i < count; i++) {
         toggleButtonState(i, qtrue);
       }
+
+      return;
+    }
+
+    if (!Q_stricmp(name, "votePortalPredict")) {
+      const auto value =
+          static_cast<int32_t>(trap_Cvar_VariableValue("ui_votePortalPredict"));
+
+      // the cvar is the current value of 'g_portalPredict',
+      // so we wanna vote the opposing value here to toggle the setting
+      trap_Cmd_ExecuteText(
+          EXEC_APPEND, va("callvote portalpredict %i\n", value == 0 ? 1 : 0));
 
       return;
     }


### PR DESCRIPTION
* Fix the vote UI not updating correctly when `g_portalPredict` was updated due to the menu reading the cvar value directly, which made it only work on localhost
* Add `trackChange` flag to `g_portalPredict` so any changes are always announced to clients, even if the change is done outside of vote.

refs #1689 