### PR TITLE
Add overbounce_players worldspawn key

### DIFF
--- a/src/cgame/etj_overbounce_shared.cpp
+++ b/src/cgame/etj_overbounce_shared.cpp
@@ -68,11 +68,29 @@ bool Overbounce::isOverbounce(float zVel, float startHeight, float endHeight,
   return false;
 }
 
-bool Overbounce::surfaceAllowsOverbounce(trace_t *trace) {
-  if (cgs.shared & BG_LEVEL_NO_OVERBOUNCE) {
-    return ((trace->surfaceFlags & SURF_OVERBOUNCE) != 0);
-  } else {
-    return (trace->surfaceFlags & SURF_OVERBOUNCE) == 0;
+bool Overbounce::surfaceAllowsOverbounce(const trace_t *trace) {
+  const bool onPlayer = trace->entityNum >= 0 && trace->entityNum < MAX_CLIENTS;
+
+  if (onPlayer) {
+    if (cgs.shared & BG_LEVEL_BODY_OB_NEVER) {
+      return false;
+    }
+
+    if (cgs.shared & BG_LEVEL_BODY_OB_ALWAYS) {
+      return true;
+    }
   }
+
+  if (cgs.shared & BG_LEVEL_NO_OVERBOUNCE) {
+    if (!(trace->surfaceFlags & SURF_OVERBOUNCE)) {
+      return false;
+    }
+  } else {
+    if (trace->surfaceFlags & SURF_OVERBOUNCE) {
+      return false;
+    }
+  }
+
+  return true;
 }
 } // namespace ETJump

--- a/src/cgame/etj_overbounce_shared.h
+++ b/src/cgame/etj_overbounce_shared.h
@@ -31,7 +31,7 @@ class Overbounce {
 public:
   static bool isOverbounce(float zVel, float startHeight, float endHeight,
                            float zVelSnapped, float pmoveSec, int gravity);
-  static bool surfaceAllowsOverbounce(trace_t *trace);
+  static bool surfaceAllowsOverbounce(const trace_t *trace);
 
   static constexpr float stickyOffset = 0.25f;
   static constexpr int MAX_TRACE_DIST = MAX_MAP_SIZE * 2;

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2831,6 +2831,10 @@ inline constexpr int BG_LEVEL_NO_WALLBUG = 1 << 7;
 inline constexpr int BG_LEVEL_NO_NOCLIP = 1 << 8;
 // portalgun prediction is force-enabled
 inline constexpr int BG_LEVEL_PORTAL_PREDICT = 1 << 9;
+// overbounces are always allowed on CONTENTS_BODY
+inline constexpr int32_t BG_LEVEL_BODY_OB_ALWAYS = 1 << 10;
+// overbounces are never allowed on CONTENTS_BODY
+inline constexpr int32_t BG_LEVEL_BODY_OB_NEVER = 1 << 11;
 
 namespace ETJump {
 inline constexpr char CUSTOMVOTE_TYPE[] = "type";

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1454,6 +1454,7 @@ typedef struct {
   bool noFTSaveLimit;
   bool noFTTeamjumpMode;
   bool portalPredict;
+  int32_t bodyOverbounce;
 
   int portalEnabled; // Feen: PGM - Enabled/Disabled by map key
   qboolean portalSurfaces;

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -1178,6 +1178,32 @@ static void initPortalPredict() {
   G_Printf("Predicted portal teleports are %sforced.\n",
            level.portalPredict ? "" : "not ");
 }
+
+static void initBodyOverbounce() {
+  int32_t value = 0;
+  G_SpawnInt("overbounce_players", "0", &value);
+
+  level.bodyOverbounce = value;
+
+  shared.integer &= ~BG_LEVEL_BODY_OB_ALWAYS;
+  shared.integer &= ~BG_LEVEL_BODY_OB_NEVER;
+
+  if (level.bodyOverbounce == 1) {
+    shared.integer |= BG_LEVEL_BODY_OB_ALWAYS;
+  } else if (level.bodyOverbounce == 2) {
+    shared.integer |= BG_LEVEL_BODY_OB_NEVER;
+  }
+
+  trap_Cvar_Set("shared", va("%d", shared.integer));
+
+  if (!level.bodyOverbounce) {
+    G_Printf("Overbounces on top of players are controlled by 'nooverbounce' "
+             "key.\n");
+  } else {
+    G_Printf("Overbounces on top of players are %s allowed.\n",
+             level.bodyOverbounce == 1 ? "always" : "never");
+  }
+}
 } // namespace ETJump
 
 /*QUAKED worldspawn (0 0 0) ? NO_GT_WOLF NO_GT_STOPWATCH NO_GT_CHECKPOINT NO_LMS
@@ -1328,6 +1354,7 @@ void SP_worldspawn(void) {
   ETJump::initNoFTSaveLimit();
   ETJump::initNoFTTeamjumpMode();
   ETJump::initPortalPredict();
+  ETJump::initBodyOverbounce();
 
   level.mapcoordsValid = qfalse;
   if (G_SpawnVector2D("mapcoordsmins", "-128 128",


### PR DESCRIPTION
This key provides additional control for overbounces performed from top of other players. Prior to this, if a map wanted to allow performing overbounces by landing on top of players, they would have to leave `nooverbounce 0` and carefully disable overbounces everywhere in the map where required. This allows mappers to use `nooverbounce 1` and only add OB surfaces where required, while still allowing players to perform overbounces atop other players. In reverse, this also allows mappers to leave overbounces enabled everywhere in the map, but explicitly disallow performing them on top of other players.

* `overbounce_players 0` = default, overbounces from top of players are controlled by `nooverbounce` worldspawn key (0 = allowed, 1 = disallowed)
* `overbounce_players 1` = overbounces from top of players are always allowed, even if OB is disabled otherwise
* `overbounce_players 2` = overbounces from top of players are never allowed, even if OB is enabled otherwise