### PR TITLE
Add cvar to hide flamethrower effects

### DIFF
--- a/assets/ui/etjump_settings_graphics_gun.menu
+++ b/assets/ui/etjump_settings_graphics_gun.menu
@@ -54,6 +54,7 @@ menuDef {
         SLIDER              (SETTINGS_ITEM_POS(4), "Gun Z:", 0.2, SETTINGS_ITEM_H, cg_gunZ 0 -30 30 0.5, "Sets Z position of gun\ncg_gunz")
         YESNO               (SETTINGS_ITEM_POS(5), "Gun sway:", 0.2, SETTINGS_ITEM_H, "etj_gunSway", "Enable gun sway/bobbing\netj_gunSway")
         MULTI               (SETTINGS_ITEM_POS(6), "Muzzleflash:", 0.2, SETTINGS_ITEM_H, "etj_muzzleFlash", cvarFloatList { "Off" 0 "On" 1 "Only for others" 2 "Only for self" 3 }, "Enable muzzleflash\netj_muzzleFlash")
+        COMBO_BIT           (SETTINGS_COMBO_POS(7), "Hide flamethrower effects:", 0.2, SETTINGS_ITEM_H, "etj_hideFlamethrowerEffects", cvarFloatList { "Hide own effects" 1 "Hide others' effects" 2 }, none, "Hide effects produces by flamethrower\netj_hideFlamethrower")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/src/cgame/cg_flamethrower.cpp
+++ b/src/cgame/cg_flamethrower.cpp
@@ -139,8 +139,8 @@ inline constexpr int FLAME_BLUE_LIFE =
 int rotatingFlames = qtrue;
 
 namespace ETJump {
-void flamechunkTrace(trace_t *trace, vec3_t start, vec3_t end,
-                     const int skipNumber, const int mask) {
+static void flamechunkTrace(trace_t *trace, vec3_t start, vec3_t end,
+                            const int skipNumber, const int mask) {
   CG_Trace(trace, start, flameChunkMins, flameChunkMaxs, end, skipNumber, mask);
 
   // a flamechunk might be spawned by an entity in the map (props_flamethrower)
@@ -160,6 +160,22 @@ void flamechunkTrace(trace_t *trace, vec3_t start, vec3_t end,
   }
 
   resetTempTraceIgnoredClients();
+}
+
+static bool drawFlamethrowerEffect(const flameChunk_t *f) {
+  if (f->ownerCent == cg.snap->ps.clientNum) {
+    if (etj_hideFlamethrowerEffects.integer &
+        static_cast<int>(ETJump::HideFlamethrowerFlags::HIDE_SELF)) {
+      return false;
+    }
+  } else {
+    if (etj_hideFlamethrowerEffects.integer &
+        static_cast<int>(ETJump::HideFlamethrowerFlags::HIDE_OTHERS)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 } // namespace ETJump
 
@@ -746,6 +762,10 @@ void CG_AddFlameSpriteToScene(flameChunk_t *f, float lifeFrac, float alpha) {
     return; // we dont want to see this
   }
 
+  if (!ETJump::drawFlamethrowerEffect(f)) {
+    return;
+  }
+
   radius = (f->size / 2.0);
   if (radius < 6) {
     radius = 6;
@@ -869,7 +889,6 @@ void CG_AddFlameToScene(flameChunk_t *fHead) {
   int headTimeStart;
   float vdist, bdot;
   flameChunk_t *lastBlowChunk = nullptr;
-  qboolean isClientFlame;
   int shader;
   flameChunk_t *lastBlueChunk = nullptr;
   qboolean skip = qfalse, droppedTrail;
@@ -879,9 +898,9 @@ void CG_AddFlameToScene(flameChunk_t *fHead) {
   float lightFlameCount;
   float lastFuelAlpha;
 
-  isClientFlame = (fHead == centFlameInfo[fHead->ownerCent].lastFlameChunk)
-                      ? qtrue
-                      : qfalse;
+  // is this our flame?
+  const bool isClientFlame =
+      fHead == centFlameInfo[fHead->ownerCent].lastFlameChunk;
 
   if ((cg_entities[fHead->ownerCent].currentState.eFlags & EF_FIRING) &&
       (centFlameInfo[fHead->ownerCent].lastFlameChunk == fHead)) {
@@ -1015,19 +1034,21 @@ void CG_AddFlameToScene(flameChunk_t *fHead) {
 
           if (!fskip) {
             lastFuelAlpha = alpha;
-
             VectorScale(whiteColor, alpha, c);
-
             droppedTrail = qtrue;
 
-            fuelTrailHead = CG_AddTrailJunc(
-                fuelTrailHead, nullptr,
-                /* rain - zinx's trail fix */ cgs.media.flamethrowerFireStream,
-                cg.time, (f->ignitionOnly ? STYPE_STRETCH : STYPE_REPEAT),
-                f->org, 1, alpha, alpha,
-                (f->size / 2 < f->sizeMax / 4 ? f->size / 2 : f->sizeMax / 4),
-                FLAME_MAX_SIZE, TJFL_NOCULL | TJFL_FIXDISTORT | TJFL_CROSSOVER,
-                c, c, 0.5, 1.5);
+            if (ETJump::drawFlamethrowerEffect(f)) {
+              fuelTrailHead = CG_AddTrailJunc(
+                  fuelTrailHead, nullptr,
+                  /* rain - zinx's trail fix */
+                  cgs.media.flamethrowerFireStream, cg.time,
+                  (f->ignitionOnly ? STYPE_STRETCH : STYPE_REPEAT), f->org, 1,
+                  alpha, alpha,
+                  (f->size / 2 < f->sizeMax / 4 ? f->size / 2 : f->sizeMax / 4),
+                  FLAME_MAX_SIZE,
+                  TJFL_NOCULL | TJFL_FIXDISTORT | TJFL_CROSSOVER, c, c, 0.5,
+                  1.5);
+            }
           }
         }
       }
@@ -1100,7 +1121,7 @@ void CG_AddFlameToScene(flameChunk_t *fHead) {
       lightSize = 80;
     }
     trap_R_AddLightToScene(lightOrg, 80, alpha, 0.2, 0.21, 0.5, 0, 0);
-  } else if (isClientFlame || (fHead->ownerCent == cg.snap->ps.clientNum)) {
+  } else if (ETJump::drawFlamethrowerEffect(fHead)) {
     trap_R_AddLightToScene(lightOrg, 320, alpha, 1.000000, 0.603922, 0.207843,
                            0, 0);
   }

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2783,6 +2783,8 @@ extern vmCvar_t etj_HUD_noLerp;
 
 extern vmCvar_t etj_useExecQuiet;
 
+extern vmCvar_t etj_hideFlamethrowerEffects;
+
 //
 // cg_main.c
 //
@@ -4256,6 +4258,11 @@ enum class ExecFileType {
   NONE = 0,
   MAP_AUTOEXEC = 1 << 0,
   TEAM_AUTOEXEC = 1 << 1,
+};
+
+enum class HideFlamethrowerFlags {
+  HIDE_SELF = 1 << 0,
+  HIDE_OTHERS = 1 << 1,
 };
 } // namespace ETJump
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -687,6 +687,8 @@ vmCvar_t etj_HUD_noLerp;
 
 vmCvar_t etj_useExecQuiet;
 
+vmCvar_t etj_hideFlamethrowerEffects;
+
 typedef struct {
   vmCvar_t *vmCvar;
   const char *cvarName;
@@ -1290,6 +1292,9 @@ cvarTable_t cvarTable[] = {
 
     {&etj_HUD_noLerp, "etj_HUD_noLerp", "0", CVAR_ARCHIVE},
     {&etj_useExecQuiet, "etj_useExecQuiet", "0", CVAR_ARCHIVE},
+
+    {&etj_hideFlamethrowerEffects, "etj_hideFlamethrowerEffects", "0",
+     CVAR_ARCHIVE},
 };
 
 int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);


### PR DESCRIPTION
`etj_hideFlamethrowerEffects` allows hiding flamethrower effects (flame sprites, flame stream, dlights).

Bitflag cvar:
* 1 = hide effects produced by the player
* 2 = hide effects produced by others