### PR TITLE
Add animation to portal spawning

### DIFF
--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -2378,11 +2378,6 @@ static void CG_PortalGate(const centity_t *cent) {
   vec3_t verts[4];
   vec3_t pushedOrigin, angleInverse;
   vec3_t axis[3];
-  const float radius =
-      !cent->currentState.onFireStart
-          ? ETJump::PORTAL_DRAW_RADIUS
-          : static_cast<float>(cent->currentState.onFireStart) *
-                ETJump::PORTAL_DRAW_SCALAR;
 
   if (ETJump::skipPortalDraw(cg.snap->ps.clientNum,
                              cent->currentState.otherEntityNum)) {
@@ -2396,6 +2391,24 @@ static void CG_PortalGate(const centity_t *cent) {
   /* push the origin out a bit */
   VectorMA(cent->currentState.origin, (-5.0f + 1.0f) /*(-12.0f + 1)*/, axis[0],
            pushedOrigin);
+
+  float radius = !cent->currentState.onFireStart
+                     ? ETJump::PORTAL_DRAW_RADIUS
+                     : static_cast<float>(cent->currentState.onFireStart) *
+                           ETJump::PORTAL_DRAW_SCALAR;
+
+  if (cent->currentState.effect1Time &&
+      cent->currentState.effect1Time + ETJump::PORTAL_SPAWN_ANIM_DURATION >=
+          cg.time) {
+    const auto elapsedTime =
+        static_cast<float>(cg.time - cent->currentState.effect1Time);
+    float progress = std::clamp(
+        elapsedTime / ETJump::PORTAL_SPAWN_ANIM_DURATION, 0.0f, 1.0f);
+
+    // ease-out the growth
+    progress = 1.0f - std::pow(1.0f - progress, 2.0f);
+    radius *= progress;
+  }
 
   /* create the full polygon */
   for (int i = 0; i < 3; i++) {

--- a/src/game/etj_portalgun.cpp
+++ b/src/game/etj_portalgun.cpp
@@ -43,6 +43,9 @@ void Portal::spawn(gentity_t *ent, const float scale, const Type type,
   portal->classname = "portal_gate";
   portal->s.onFireStart = static_cast<int>(PORTAL_BBOX_RADIUS * 2 * scale);
 
+  // save the spawn timestamp so client can animate the spawning
+  portal->s.effect1Time = level.time;
+
   // Assign ent to player as well as the portal type..
   if (type == Type::PORTAL_BLUE) {
     portal->s.eType = ET_PORTAL_BLUE; // Portal 1

--- a/src/game/etj_portalgun_shared.h
+++ b/src/game/etj_portalgun_shared.h
@@ -53,4 +53,6 @@ inline constexpr float PORTAL_DRAW_RADIUS = 48.0f;
 // scalar for drawing the portal shader proportional to the portal size
 inline constexpr float PORTAL_DRAW_SCALAR =
     PORTAL_DRAW_RADIUS / (PORTAL_BBOX_RADIUS * 2);
+// animation duration for portal spawning
+inline constexpr int32_t PORTAL_SPAWN_ANIM_DURATION = 200;
 } // namespace ETJump


### PR DESCRIPTION
Portals now spawn with a 200ms long quadratic ease-out animation. This is only for drawing purposes, the actual portal bbox is instantly spawned at maximum size.

This won't work for old demos, as we don't have the timestamp when the portal was spawned. We can't use the client-sided spawntime (e.g. when the entity appeared in a snapshot) because it can cause animations to draw incorrectly in some scenarios, like when teleporting to a new area which has portals already spawned.

https://streamable.com/8cqw3a