### PR TITLE
Fix client inactivity persistence breaking with level time reset

### DIFF
--- a/src/game/etj_inactivity_timer.cpp
+++ b/src/game/etj_inactivity_timer.cpp
@@ -25,15 +25,15 @@
 #include "etj_inactivity_timer.h"
 
 namespace ETJump {
-void InactivityTimer::checkClientInactivity(gentity_t *ent) {
+void InactivityTimer::updateClientInactivityStatus(const gentity_t *ent) {
   if (ent->client->pers.cmd.buttons & BUTTON_ANY) {
-    ent->client->inactive = false;
+    ent->client->sess.inactive = false;
     ent->client->sess.clientLastActive = level.time;
     UpdateClientConfigString(*ent);
-  } else if (!ent->client->inactive &&
-             level.time >= ent->client->sess.clientLastActive +
-                               1000 * clientInactivityTimer) {
-    ent->client->inactive = true;
+  } else if (!ent->client->sess.inactive &&
+             level.time >=
+                 ent->client->sess.clientLastActive + CLIENT_INACTIVITY_TIMER) {
+    ent->client->sess.inactive = true;
     UpdateClientConfigString(*ent);
   }
 }

--- a/src/game/etj_inactivity_timer.h
+++ b/src/game/etj_inactivity_timer.h
@@ -27,10 +27,10 @@
 #include "g_local.h"
 
 namespace ETJump {
-constexpr int clientInactivityTimer = 180; // in seconds
+inline constexpr int CLIENT_INACTIVITY_TIMER = 180 * 1000; // in ms
 
 class InactivityTimer {
 public:
-  static void checkClientInactivity(gentity_t *ent);
+  static void updateClientInactivityStatus(const gentity_t *ent);
 };
 } // namespace ETJump

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1032,7 +1032,7 @@ void ClientThink_real(gentity_t *ent) {
     return;
   }
 
-  ETJump::InactivityTimer::checkClientInactivity(ent);
+  ETJump::InactivityTimer::updateClientInactivityStatus(ent);
 
   if (!(ent->r.svFlags & SVF_BOT) &&
       level.time - client->pers.lastCCPulseTime > 2000) {

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -1717,7 +1717,7 @@ const char *GetParsedIP(const char *ipadd) {
 }
 
 namespace ETJump {
-bool UpdateClientConfigString(gentity_t &gent) {
+bool UpdateClientConfigString(const gentity_t &gent) {
   if (!gent.client) {
     return false;
   }
@@ -1756,7 +1756,7 @@ bool UpdateClientConfigString(gentity_t &gent) {
          gent.client->pers.hideMe > 0 ? gent.client->pers.hideMe : 0,
          gent.client->sess.specLocked ? 1 : 0,
          gent.client->sess.timerunActive ? 1 : 0,
-         gent.client->pers.snaphud ? 1 : 0, gent.client->inactive ? 1 : 0);
+         gent.client->pers.snaphud ? 1 : 0, gent.client->sess.inactive ? 1 : 0);
 
   trap_GetConfigstring(CS_PLAYERS + ClientNum(&gent), oldcs, sizeof(oldcs));
 
@@ -2050,7 +2050,7 @@ const char *ClientConnect(int clientNum, qboolean firstTime, qboolean isBot) {
     client->sess.loadedPosBeforeInactivity = qtrue;
     client->sess.motdPrinted = qfalse;
     client->sess.timerunActive = qfalse;
-    client->inactive = false;
+    client->sess.inactive = false;
     client->sess.clientLastActive = level.time;
   } else {
     client->sess.gotoAllowed = qtrue; // Feen: TEMP FIX! - Also added these two

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -828,6 +828,9 @@ typedef struct {
   int deathrunFlags;
 
   float velocityScale;
+
+  // level.time >= clientLastActive + CLIENT_INACTIVITY_TIMER
+  bool inactive;
   int clientLastActive;
 
   int weaponsOnSpawn[MAX_WEAPONS /
@@ -1082,8 +1085,6 @@ struct gclient_s {
   int respawnTime;            // can respawn when time > this, force after
                               // g_forcerespwan
   int inactivityTime;         // kick players when time > this
-  bool inactive;              // level.time >= clientLastActive
-                              // + 1000 * clientInactivityTimer
   qboolean inactivityWarning; // qtrue if the five seoond warning has
                               // been given
   int rewardTime; // clear the EF_AWARD_IMPRESSIVE, etc when time > this
@@ -1875,7 +1876,7 @@ void ClientDisconnect(int clientNum);
 void ClientBegin(int clientNum);
 void ClientCommand(int clientNum);
 namespace ETJump {
-bool UpdateClientConfigString(gentity_t &gent);
+bool UpdateClientConfigString(const gentity_t &gent);
 }
 
 //

--- a/src/game/g_session.cpp
+++ b/src/game/g_session.cpp
@@ -37,7 +37,7 @@ void G_WriteClientSessionData(gclient_t *client, qboolean restart) {
          client->sess.playerWeapon2,
          client->sess.latchPlayerType,   // DHM - Nerve
          client->sess.latchPlayerWeapon, // DHM - Nerve
-         client->sess.latchPlayerWeapon2, client->sess.clientLastActive,
+         client->sess.latchPlayerWeapon2, client->sess.inactive ? 1 : 0,
 
          // OSP
          client->sess.coach_team, client->sess.deaths, client->sess.game_points,
@@ -175,7 +175,7 @@ void G_ReadSessionData(gclient_t *client) {
       &client->sess.playerWeapon2,
       &client->sess.latchPlayerType,   // DHM - Nerve
       &client->sess.latchPlayerWeapon, // DHM - Nerve
-      &client->sess.latchPlayerWeapon2, &client->sess.clientLastActive,
+      &client->sess.latchPlayerWeapon2, &client->sess.inactive,
 
       // OSP
       &client->sess.coach_team, &client->sess.deaths, &client->sess.game_points,


### PR DESCRIPTION
Client inactivity status persistence relied on the last activity timestamp, which broke upon map change if the server was using `sv_level/serverTimeReset`. We don't actually need to store the timestamp at all, we can simply store the state of client, as the timestamp is only used to determine whether the client should be set to inactive.

refs #568 