### PR TITLE
Fix incorrect spectatorinfo data upon team switches

### DIFF
--- a/src/cgame/cg_playerstate.cpp
+++ b/src/cgame/cg_playerstate.cpp
@@ -7,6 +7,7 @@
 
 #include "cg_local.h"
 #include "etj_utilities.h"
+#include "etj_spectatorinfo_data.h"
 
 /*
 ==============
@@ -274,6 +275,12 @@ void CG_Respawn(qboolean revived) {
         "autoexec_%s", BG_TeamnameForNumber(cgs.clientinfo[cg.clientNum].team));
     if (ETJump::configFileExists(teamConfig)) {
       ETJump::execFile(teamConfig, ETJump::ExecFileType::TEAM_AUTOEXEC);
+    }
+
+    // clear spectatorinfo lists on team switch, so we don't carry over
+    // the data from the client we just spectated, if switching from spec
+    if (oldTeam == TEAM_SPECTATOR) {
+      ETJump::SpectatorInfoData::clearData();
     }
 
     oldTeam = cgs.clientinfo[cg.clientNum].team;

--- a/src/cgame/etj_spectatorinfo_data.cpp
+++ b/src/cgame/etj_spectatorinfo_data.cpp
@@ -41,16 +41,16 @@ void SpectatorInfoData::updateSpectatorData(std::optional<int32_t> clientNum) {
       removeClientFromList(activeSpectators, cnum);
       removeClientFromList(inactiveSpectators, cnum);
     }
-
-    return;
   }
 
   for (int32_t i = 0; i < cg.numScores; i++) {
-    if (skipClient(cg.scores[i])) {
+    if (cg.scores[i].client == cg.snap->ps.clientNum) {
       continue;
     }
 
-    if (cg.scores[i].followedClient != cg.snap->ps.clientNum) {
+    // remove any clients that aren't spectating us
+    if (cg.scores[i].followedClient != cg.snap->ps.clientNum ||
+        cgs.clientinfo[cg.scores[i].client].team != TEAM_SPECTATOR) {
       removeClientFromList(activeSpectators, cg.scores[i].client);
       removeClientFromList(inactiveSpectators, cg.scores[i].client);
       continue;
@@ -81,15 +81,8 @@ void SpectatorInfoData::removeClientFromList(std::vector<int32_t> &v,
   v.erase(std::remove(v.begin(), v.end(), clientNum), v.end());
 }
 
-bool SpectatorInfoData::skipClient(const score_t &score) {
-  if (score.client == cg.snap->ps.clientNum) {
-    return true;
-  }
-
-  if (score.team != TEAM_SPECTATOR) {
-    return true;
-  }
-
-  return false;
+void SpectatorInfoData::clearData() {
+  activeSpectators.clear();
+  inactiveSpectators.clear();
 }
 } // namespace ETJump

--- a/src/cgame/etj_spectatorinfo_data.h
+++ b/src/cgame/etj_spectatorinfo_data.h
@@ -39,9 +39,9 @@ public:
   // If 'clientNum' has value, then this is a 'CS_PLAYERS' update.
   // This handles removing client from the lists if they disconnected.
   static void updateSpectatorData(std::optional<int32_t> clientNum);
+  static void clearData();
 
 private:
   static void removeClientFromList(std::vector<int32_t> &v, int32_t clientNum);
-  static bool skipClient(const score_t &score);
 };
 } // namespace ETJump


### PR DESCRIPTION
* Fix spectator info data carrying over from the spectated player to ourself, the data is now cleared on team switches, if joining to a team from spectators
* Fix players getting cleared from spectator info lists only when switching spectated target, which caused players who joined a team from spectators to stay as a spectating client on the lists

refs #1718 