### PR TITLE
Revert "Smooth step transitions in spec/demo playback"

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -1795,27 +1795,37 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
     case EV_STEP_12:
     case EV_STEP_16: // smooth out step up transitions
     {
+      float oldStep;
+      int delta;
+      int step;
+
       if (clientNum != cg.predictedPlayerState.clientNum) {
         break;
       }
-
+      // if we are interpolating, we don't need to smooth steps
+      if (cg.demoPlayback || (cg.snap->ps.pm_flags & PMF_FOLLOW) ||
+          cg_nopredict.integer
+#ifdef ALLOW_GSYNC
+          || cgs.synchronousClients
+#endif // ALLOW_GSYNC
+      ) {
+        break;
+      }
       // check for stepping up before a previous step is completed
-      float oldStep = 0.0f;
-      const int delta = cg.time - cg.stepTime;
-
+      delta = cg.time - cg.stepTime;
       if (delta < STEP_TIME) {
         oldStep =
             cg.stepChange * (static_cast<float>(STEP_TIME - delta)) / STEP_TIME;
+      } else {
+        oldStep = 0;
       }
 
       // add this amount
-      const int step = 4 * (event - EV_STEP_4 + 1);
+      step = 4 * (event - EV_STEP_4 + 1);
       cg.stepChange = oldStep + static_cast<float>(step);
-
       if (cg.stepChange > MAX_STEP_CHANGE) {
         cg.stepChange = MAX_STEP_CHANGE;
       }
-
       cg.stepTime = cg.time;
       break;
     }


### PR DESCRIPTION
This reverts commit 6dc0617cf8efdf5ba2aeda36ea97ae8247d746c8.

This breaks stepup view quite bad in certain types of stairs, which my initial testing did not catch. Might be fixable, but I'll just revert for now and come back to this later.