### PR TITLE
Fix 1 frame lag on setting portal destination origin/angles

### DIFF
--- a/src/game/etj_portalgun.cpp
+++ b/src/game/etj_portalgun.cpp
@@ -88,8 +88,16 @@ void Portal::spawn(gentity_t *ent, const float scale, const Type type,
   };
 
   portal->think = think;
-  // we need fast thinks to update dest origin/angles for clients
-  portal->nextthink = level.time + level.frameTime;
+
+  // think once immediately, and also force the linked portal to think
+  // this is so that we have valid origin2/angles2 set immediately
+  // when we spawn the portal, otherwise there will be a single server
+  // frame where the portal destination is at 0 0 0
+  think(portal);
+
+  if (portal->linkedPortal) {
+    portal->linkedPortal->think(portal->linkedPortal);
+  }
 
   portal->r.ownerNum = ent->s.number;
   portal->parent = ent;


### PR DESCRIPTION
Force portals and the linked portal to think once when a portal is spawned, to ensure we have valid origin2/angles2 set immediately for the destination. Without this, there is a 1 frame delay on setting them, during which players who activate a portal will be teleported to invalid location.

refs #1689 