### PR TITLE
Adjust timerun high ping threshold to 300ms

### DIFF
--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -931,8 +931,8 @@ void CheckForEvents(gentity_t *ent) {
   }
 }
 
-// void ClientDamage( gentity_t *clent, int entnum, int enemynum, int id );
-// // NERVE - SMF
+inline constexpr int TIMERUN_HIGH_PING_LIMIT = 400;
+inline constexpr int MAX_TIMERUN_LAG_TIME = 300;
 
 /*
 ==============
@@ -1111,11 +1111,10 @@ void ClientThink_real(gentity_t *ent) {
 
   // Stop lagging through triggers in timeruns
   if (client->sess.timerunActive) {
-    if (client->ps.ping > 400) {
+    if (client->ps.ping > TIMERUN_HIGH_PING_LIMIT) {
       client->numLagFrames++;
 
-      // allow 100ms of sustained lag
-      if (client->numLagFrames * level.frameTime >= FRAMETIME) {
+      if (client->numLagFrames * level.frameTime >= MAX_TIMERUN_LAG_TIME) {
         Printer::center(clientNum,
                         "^3WARNING: ^7Timerun stopped due to high ping!");
         InterruptRun(ent);


### PR DESCRIPTION
Up from 100ms, hopefully helps high ping players to not get interrupted so easily while doing timeruns.