### PR TITLE
Records print improvements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # ETJump 3.4.0
 
-* `records` output no longer shows duplicate rank strings for tied times [#1603](https://github.com/etjump/etjump/pull/1603)
+* improvements to `records` output [#1603](https://github.com/etjump/etjump/pull/1603) [#1739](https://github.com/etjump/etjump/pull/1739)
+  * duplicate rank strings are no longer shown for tied times
+  * `page` parameter is now correctly capped - it's no longer possible to request a page without any records on it
+  * the total amount of records on a run is now displayed if the number of records is higher than the page size
 * added `tracker_not_eq_any` and `tracker_not_eq_all` keys to `target/trigger_tracker` [#1614](https://github.com/etjump/etjump/pull/1614)
   * this allows mappers to pick desired behavior for "not equal" trackers - either all values or one of the values
   * old `tracker_not_eq` is now deprecated and functionality is provided by `tracker_not_eq_any`
@@ -104,7 +107,6 @@
     * `portalteam` is set to 2 (anyone can use anyone's portals)
 * portalgun trails and debug bboxes are now correctly colored green/yellow for other's portals [#1707](https://github.com/etjump/etjump/pull/1707)
 * overbounce detector now correctly shows overbounces on top of other solid players [#1710](https://github.com/etjump/etjump/pull/1710)
-* stepup view transitions are now interpolated on spec/demo playback [#1712](https://github.com/etjump/etjump/pull/1712)
 * added `dumpEntities` command to dump entities from the current map to a file [#1713](https://github.com/etjump/etjump/pull/1713)
   * `dumpEntities [optional name]`, if name isn't given, defaults to current map name
   * requires `developer 1`
@@ -125,6 +127,7 @@
     * 1 = hide for self
     * 2 = hide for others
 * added a short animation when portalgun portals are spawned [#1727](https://github.com/etjump/etjump/pull/1727)
+* bundled fixed `.arena` files for certain maps with the mod pk3 [#1690](https://github.com/etjump/etjump/pull/1690)
 
 # ETJump 3.3.4
 
@@ -620,7 +623,7 @@
 * fixed double footsteps and prediction errors on `surfaceparm nodamage` [#1166](https://github.com/etjump/etjump/pull/1166)
 * fixed rtv menu not drawing if client connected after rtv had already been called previously during the map, or an rtv vote was active while connecting [#1167](https://github.com/etjump/etjump/pull/1167)
 * timeruns which don't reset on team change are now reset if a client goes to spec, only allies <-> axis switches don't interrupt [#1168](https://github.com/etjump/etjump/pull/1168)
-* fixed (globa)accum indices 8 and 9 working unreliably [#1170](https://github.com/etjump/etjump/pull/1170)
+* fixed (global)accum indices 8 and 9 working unreliably [#1170](https://github.com/etjump/etjump/pull/1170)
 * fixed potential div by 0 in accum and playanim script functions [#1173](https://github.com/etjump/etjump/pull/1173)
 * updated `g_oss` value to reflect correct macOS support - only x86_64 is supported [#1177](https://github.com/etjump/etjump/pull/1177)
 * using `setoffset` now requires `/kill` like `noclip` before a timerun can be started [#1178](https://github.com/etjump/etjump/pull/1178)

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -302,15 +302,18 @@ bool Records(gentity_t *ent, Arguments argv) {
   // use exact map search if user did not specify the map
   params.exactMap = exactMap;
   params.run = std::move(run);
-  params.page = optPage.hasValue() ? optPage.value().integer : 1;
+  params.page = optPage.hasValue() ? std::max(optPage.value().integer, 1) : 1;
   if (!params.run.hasValue()) {
     params.pageSize = optPageSize.hasValue()
-                          ? std::clamp(optPageSize.value().integer, 1, 10)
-                          : 3;
+                          ? std::clamp(optPageSize.value().integer, 1,
+                                       ETJump::Timerun::MAX_PAGE_SIZE_ALL_RUNS)
+                          : ETJump::Timerun::DEFAULT_PAGE_SIZE_ALL_RUNS;
   } else {
-    params.pageSize = optPageSize.hasValue()
-                          ? std::clamp(optPageSize.value().integer, 1, 100)
-                          : 20;
+    params.pageSize =
+        optPageSize.hasValue()
+            ? std::clamp(optPageSize.value().integer, 1,
+                         ETJump::Timerun::MAX_PAGE_SIZE_SINGLE_RUN)
+            : ETJump::Timerun::DEFAULT_PAGE_SIZE_SINGLE_RUN;
   }
   params.userId = ETJump::session->GetId(ent);
 

--- a/src/game/etj_timerun_models.h
+++ b/src/game/etj_timerun_models.h
@@ -31,6 +31,12 @@
 
 namespace ETJump {
 namespace Timerun {
+
+inline constexpr int32_t DEFAULT_PAGE_SIZE_ALL_RUNS = 3;
+inline constexpr int32_t DEFAULT_PAGE_SIZE_SINGLE_RUN = 20;
+inline constexpr int32_t MAX_PAGE_SIZE_SINGLE_RUN = 100;
+inline constexpr int32_t MAX_PAGE_SIZE_ALL_RUNS = 10;
+
 struct Season {
   int id;
   std::string name;

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 
+#include <cstddef>
 #include <utility>
 #include <chrono>
 
@@ -669,21 +670,27 @@ void ETJump::TimerunV2::printRecords(
               int ownTime = ownRecords[season->id][mapName].count(runName) > 0
                                 ? ownRecords[season->id][mapName][runName]
                                 : rank1Time;
+
+              const auto numPages = static_cast<int32_t>(
+                  std::ceil(static_cast<float>(rkvp.second.size()) /
+                            static_cast<float>(params.pageSize)));
+              // cap the page paramater so we don't print empty pages
+              const int32_t page = std::min(params.page, numPages);
+
               // clang-format off
               message += "^g-------------------------------------------------------------\n";
               // clang-format on
               message += stringFormat(" ^2Run: ^7%s\n\n", rkvp.first);
 
-              const int rankWidth = 4;
-              const int timeWidth = 10;
-              const int diffWidth = 11;
+              constexpr int rankWidth = 4;
+              constexpr int timeWidth = 10;
+              constexpr int diffWidth = 11;
 
               message += "^g Rank Time       Difference  Player\n";
               std::string ownRecordString;
               for (const auto &r : rkvp.second) {
-                auto isOnVisiblePage =
-                    rank > (params.page - 1) * params.pageSize &&
-                    rank <= (params.page) * params.pageSize;
+                auto isOnVisiblePage = rank > (page - 1) * params.pageSize &&
+                                       rank <= (page)*params.pageSize;
                 auto isOwnRecord = r->userId == params.userId;
 
                 if (isOnVisiblePage || isOwnRecord) {

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -768,6 +768,24 @@ void ETJump::TimerunV2::printRecords(
                 message += "\n" + ownRecordString;
               }
 
+              // display the total amount of records if querying records
+              // for a single run, and they don't fit on a single page
+              const auto numRecords = static_cast<int32_t>(rkvp.second.size());
+
+              if (params.run.hasValue() && numRecords > params.pageSize) {
+                const int32_t start =
+                    (page * params.pageSize) - params.pageSize + 1;
+                const int32_t end =
+                    std::min(start + params.pageSize - 1, numRecords);
+
+                message += stringFormat(
+                    "\n ^7Showing ^2%i-%i ^7of ^2%i ^7total records\n", start,
+                    end, numRecords);
+
+              } else {
+                message += '\n';
+              }
+
               if (processedRecords.size() > 1 &&
                   skvp.first != std::prev(processedRecords.end())->first) {
                 message += "\n";


### PR DESCRIPTION
* `page` parameter is now capped appropriately, and it's no longer possible to print empty pages by using a bogus page number
* If querying records for a specific run, the total number of records will now be displayed underneath the records, if the total number of records is higher than the specified page size.

<img width="517" height="508" alt="image" src="https://github.com/user-attachments/assets/38587dcb-a67c-4279-9210-6551107efe1e" />
<img width="513" height="320" alt="image" src="https://github.com/user-attachments/assets/86edc1c9-2c17-4aa1-95fc-495c6f9d689e" />

