### PR TITLE
Rework timerun high ping interrupt

### DIFF
--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -931,8 +931,7 @@ void CheckForEvents(gentity_t *ent) {
   }
 }
 
-inline constexpr int TIMERUN_HIGH_PING_LIMIT = 400;
-inline constexpr int MAX_TIMERUN_LAG_TIME = 300;
+inline constexpr int32_t MAX_TIMERUN_LAG_TIME = 600;
 
 /*
 ==============
@@ -1111,17 +1110,11 @@ void ClientThink_real(gentity_t *ent) {
 
   // Stop lagging through triggers in timeruns
   if (client->sess.timerunActive) {
-    if (client->ps.ping > TIMERUN_HIGH_PING_LIMIT) {
-      client->numLagFrames++;
-
-      if (client->numLagFrames * level.frameTime >= MAX_TIMERUN_LAG_TIME) {
-        Printer::center(clientNum,
-                        "^3WARNING: ^7Timerun stopped due to high ping!");
-        InterruptRun(ent);
-        client->numLagFrames = 0;
-      }
-    } else {
-      client->numLagFrames = 0;
+    if (ucmd->serverTime - client->ps.commandTime > MAX_TIMERUN_LAG_TIME) {
+      Printer::center(
+          clientNum,
+          "^3WARNING: ^7Timerun stopped due to high command time delta!");
+      InterruptRun(ent);
     }
 
     if (client->pers.maxFPS > 0 && client->pers.maxFPS < 25) {

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1191,8 +1191,6 @@ struct gclient_s {
   bool forceRename;
 
   int lastRevivePushTime;
-
-  int numLagFrames; // for tracking high ping on timeruns to counter lag abuse
 };
 
 typedef struct {


### PR DESCRIPTION
`ps.ping` is a completely made up number that has no actual relevance to the client's connection on the current frame, therefore we can't use it to reliably determine the threshold on whether the client is lagging or not. Instead, check the `usercmd->serverTime - ps.commandTime` delta, and determine the amount of lag from that. If we have over 600ms of delta, interrupt the run.

Might need to tweak this again in the future once I get some real world testing from high ping players with unstable connections, but for now this seems like a reasonable value from my own testing with artificial lag.