### PR TITLE
Fix disabled spawnpoints drawing on command map

### DIFF
--- a/src/cgame/cg_commandmap.cpp
+++ b/src/cgame/cg_commandmap.cpp
@@ -1148,7 +1148,7 @@ int CG_DrawSpawnPointInfo(int px, int py, int pw, int ph, qboolean draw,
     // rain - added parens around ambiguity
     if (((cgs.clientinfo[cg.clientNum].team != TEAM_SPECTATOR) &&
          (cg.spawnTeams[i] != team)) ||
-        ((cg.spawnTeams[i] & 256) && !changetime)) {
+        ((cg.spawnTeams[i] & SPAWN_DISABLED) && !changetime)) {
 
       continue;
     }
@@ -1541,7 +1541,7 @@ qboolean CG_CommandCentreSpawnPointClick(void) {
       continue;
     }
 
-    if (cg.spawnTeams[i] & 256) {
+    if (cg.spawnTeams[i] & SPAWN_DISABLED) {
       continue;
     }
 

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -1527,7 +1527,6 @@ typedef struct headAnimation_s {
 // changes so a restart of the same anim can be detected
 inline constexpr int ANIM_TOGGLEBIT = 1 << (ANIM_BITS - 1);
 
-// Gordon: renamed these to team_axis/allies, it really was awful....
 enum team_t : int32_t {
   TEAM_FREE,
   TEAM_AXIS,
@@ -1536,6 +1535,10 @@ enum team_t : int32_t {
 
   TEAM_NUM_TEAMS
 };
+
+// set by the server along with the team number for spawns,
+// to indicate that a spawn is currently disabled
+inline constexpr int32_t SPAWN_DISABLED = 1 << 8;
 
 // OSP - weapon stat info: mapping between MOD_ and WP_ types (FIXME for new ET
 // weapons)

--- a/src/game/g_team.cpp
+++ b/src/game/g_team.cpp
@@ -1079,11 +1079,10 @@ void team_wolf_objective_use(gentity_t *self, gentity_t *other,
                              gentity_t *activator) {
   char cs[MAX_STRING_CHARS];
 
-  // Gordon 256 is a disabled flag
-  if ((self->count2 & ~256) == TEAM_AXIS) {
-    self->count2 = (self->count2 & 256) + TEAM_ALLIES;
-  } else if ((self->count2 & ~256) == TEAM_ALLIES) {
-    self->count2 = (self->count2 & 256) + TEAM_AXIS;
+  if ((self->count2 & ~SPAWN_DISABLED) == TEAM_AXIS) {
+    self->count2 = (self->count2 & SPAWN_DISABLED) + TEAM_ALLIES;
+  } else if ((self->count2 & ~SPAWN_DISABLED) == TEAM_ALLIES) {
+    self->count2 = (self->count2 & SPAWN_DISABLED) + TEAM_AXIS;
   }
 
   // And update configstring


### PR DESCRIPTION
The `team_t` enum was changed to be `char` type in https://github.com/etjump/etjump/commit/e4abfe27778adb5006bbae3e04f4d83cf4e838fd (and later to `int8_t` in https://github.com/etjump/etjump/commit/2ff4e7ce4e451ae38086166fdd61398ca2dac9b4). This broke the functionality for hiding disabled spawns, because they have the 8th bit set to indicate being disabled. This caused a wraparound bug with the spawn parsing, where the client parsed all spawns as if the disabled bit was never set, causing all spawns to be visible at all times.

refs #667