### PR TITLE
Fix infinite loop in changelog formatting

### DIFF
--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -830,8 +830,16 @@ fitChangelogLinesToWidth(std::vector<std::string> &lines, const int maxW,
 
       if (width > maxW) {
         if (lastWhitespace != 0) {
-          fmtLines.emplace_back(tmp.substr(0, lastWhitespace));
-          line.erase(0, lastWhitespace + 1); // consume the whitespace too
+          // we have a line with single word that is over max width,
+          // just split at the line end
+          if (lastWhitespace < indent) {
+            fmtLines.emplace_back(tmp.substr(0, i));
+            line.erase(0, i);
+          } else {
+            fmtLines.emplace_back(tmp.substr(0, lastWhitespace));
+            line.erase(0, lastWhitespace + 1); // consume the whitespace too
+          }
+
           lastWhitespace = 0;
         } else {
           // this should never happen, but it protects against an infinite loop


### PR DESCRIPTION
If there was a line which started with a word that would exceed the max width of a line, the parser would get stuck on infinite loop, as it was constantly trying to split the line from the previous whitespace, without ever consuming the line further. In such cases, just split at the line end and break a word in the middle.

This likely happened as part of https://github.com/etjump/etjump/commit/c54d3fcb3702d60377c58821ec4db351e4e1d35c, since I do remember testing every single changelog while implementing this, but the size decrease caused the parser to fail in some scenarios, like in 3.1.0 and 2.3.0 changelogs.

refs #1532