### PR TITLE
Fix chat not clearing inactivity status from clients

### DIFF
--- a/src/game/etj_inactivity_timer.cpp
+++ b/src/game/etj_inactivity_timer.cpp
@@ -27,14 +27,18 @@
 namespace ETJump {
 void InactivityTimer::updateClientInactivityStatus(const gentity_t *ent) {
   if (ent->client->pers.cmd.buttons & BUTTON_ANY) {
-    ent->client->sess.inactive = false;
-    ent->client->sess.clientLastActive = level.time;
-    UpdateClientConfigString(*ent);
+    clearClientInactivity(ent);
   } else if (!ent->client->sess.inactive &&
              level.time >=
                  ent->client->sess.clientLastActive + CLIENT_INACTIVITY_TIMER) {
     ent->client->sess.inactive = true;
     UpdateClientConfigString(*ent);
   }
+}
+
+void InactivityTimer::clearClientInactivity(const gentity_t *ent) {
+  ent->client->sess.inactive = false;
+  ent->client->sess.clientLastActive = level.time;
+  UpdateClientConfigString(*ent);
 }
 } // namespace ETJump

--- a/src/game/etj_inactivity_timer.h
+++ b/src/game/etj_inactivity_timer.h
@@ -32,5 +32,6 @@ inline constexpr int CLIENT_INACTIVITY_TIMER = 180 * 1000; // in ms
 class InactivityTimer {
 public:
   static void updateClientInactivityStatus(const gentity_t *ent);
+  static void clearClientInactivity(const gentity_t *ent);
 };
 } // namespace ETJump


### PR DESCRIPTION
The inactivity timer cannot monitor `BUTTON_TALK` directly to clear the inactivity status, as that is also set when the console is open, which would cause clients to never go inactive if the console is down. Instead, monitor the chat commands themselves, and clear the inactivity flag there.

refs #568 