### PR TITLE
Fix client inactivity drop position restore not working

### DIFF
--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2045,9 +2045,6 @@ const char *ClientConnect(int clientNum, qboolean firstTime, qboolean isBot) {
     client->last8BallTime = 0;
     client->lastVoteTime = 0;
     client->cheatDetected = qfalse;
-    // Client has loaded position after inactivity putspec
-    // -> don't do anything anymore
-    client->sess.loadedPosBeforeInactivity = qtrue;
     client->sess.motdPrinted = qfalse;
     client->sess.timerunActive = qfalse;
     client->sess.inactive = false;
@@ -2379,6 +2376,8 @@ void ClientSpawn(gentity_t *ent, qboolean revived) {
     persistant[i] = client->ps.persistant[i];
   }
 
+  const ETJump::InactivityPos savedInactivityPos = client->inactivityPos;
+
   {
     qboolean set = client->maxlivescalced;
 
@@ -2398,6 +2397,8 @@ void ClientSpawn(gentity_t *ent, qboolean revived) {
   for (i = 0; i < MAX_PERSISTANT; i++) {
     client->ps.persistant[i] = persistant[i];
   }
+
+  client->inactivityPos = savedInactivityPos;
 
   // increment the spawncount so the client will detect the respawn
   client->ps.persistant[PERS_SPAWN_COUNT]++;
@@ -2655,14 +2656,6 @@ void ClientSpawn(gentity_t *ent, qboolean revived) {
   if (!revived && client->sess.sessionTeam == TEAM_SPECTATOR &&
       level.spawnRelayEntities.spectatorRelay) {
     G_UseEntity(level.spawnRelayEntities.spectatorRelay, nullptr, ent);
-  }
-
-  // FIXME: doesn't load pos????
-  if (!client->sess.loadedPosBeforeInactivity &&
-      client->sess.sessionTeam == client->sess.teamBeforeInactivitySpec) {
-    VectorCopy(client->sess.posBeforeInactivity, client->ps.origin);
-    VectorCopy(client->sess.posBeforeInactivity, ent->r.currentOrigin);
-    client->sess.loadedPosBeforeInactivity = qtrue;
   }
 
   client->sess.velocityScale = 1;

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -804,12 +804,6 @@ typedef struct {
   int lastListmapsTime;
   int lastMostPlayedListTime;
 
-  // Position of user before inactivity
-  vec3_t posBeforeInactivity;
-  // Did the client join back to team already (after inactivity)?
-  qboolean loadedPosBeforeInactivity;
-  team_t teamBeforeInactivitySpec;
-
   qboolean firstTime;
 
   qboolean versionOK;
@@ -887,6 +881,12 @@ struct votingInfo_t {
                    // allow yet, notification will be sent
 
   int lastRtvMapVoted; // used for re-votes, the last map number we voted on
+};
+
+struct InactivityPos {
+  vec3_t savedPos;
+  vec3_t savedAngles;
+  team_t team; // TEAM_FREE if the position is invalid
 };
 
 inline constexpr int MAX_TOKENS_PER_DIFFICULTY = 32;
@@ -1191,6 +1191,8 @@ struct gclient_s {
   bool forceRename;
 
   int lastRevivePushTime;
+
+  ETJump::InactivityPos inactivityPos;
 };
 
 typedef struct {


### PR DESCRIPTION
This code has been in the mod since 2013 (2.0.3 RC1), but it has never worked because the position restore was made in an incorrect location. Clients are now correctly placed back to the position they were moved to spectators from due to inactivity. This persist for one spawn for a team (you're allowed to join wrong team initially, it won't invalidate the position - only joining the team you were at the time of drop uses up the position and invalidates it) and takes precedence over a position from `etj_autoLoad`. In addition to the original implementation, it also now saves and restores your viewangles.