### PR TITLE
Fix server crash if target_spawn_relay entity was removed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+# ETJump 3.4.1
+
+* fixed an old bug where disabled spawnpoints were always drawn on the map regardless of whether the spawn was active or not [#1743](https://github.com/etjump/etjump/pull/1743)
+* `func_static` entities with `PAIN` spawnflag now restore their health when taking damage, making them effectively unkillable under normal gameplay circumstances [#1744](https://github.com/etjump/etjump/pull/1744)
+* fixed UI changelog parsing entering an infinite loop when encountering a word which was longer that the maximum width of the entire row [#1745](https://github.com/etjump/etjump/pull/1745)
+  * this caused the game to hang when viewing ETJump 2.3.0 and 3.1.0 changelogs - these are now viewable in-game again
+* fixes to flamethrower interactions with water [#1746](https://github.com/etjump/etjump/pull/1746)
+  * flamethrower no longer produces dlights when trying to fire it underwater
+  * flamethrower no longer plays an idle sound while underwater, as the flame is shut off anyway
+* fixed chatting not clearing inactivity status from clients [#1747](https://github.com/etjump/etjump/pull/1747)
+* moving a player to spectators due to `g_inactivity` now stores the players position, and spawns the player back to that position when re-joining the team the player was at the time of the inactivity drop [#1748](https://github.com/etjump/etjump/pull/1748)
+* map progression tracked by `target/trigger_tracker` entities is now saved and restored if a client disconnects and reconnects during a map [#1749](https://github.com/etjump/etjump/pull/1749)
+* fixed crash when `target_spawn_relay` was deleted from the map on runtime [#1752](https://github.com/etjump/etjump/pull/1752)
+* fixed some HUD elements breaking spec/demo playback view by altering the data received from the server [#1753](https://github.com/etjump/etjump/pull/1753)
+
 # ETJump 3.4.0
 
 * improvements to `records` output [#1603](https://github.com/etjump/etjump/pull/1603) [#1739](https://github.com/etjump/etjump/pull/1739)

--- a/src/game/etj_target_spawn_relay.cpp
+++ b/src/game/etj_target_spawn_relay.cpp
@@ -143,4 +143,24 @@ void TargetSpawnRelay::validateSpawnRelayEntities() {
   spawnRelayEntities.erase(spawnRelayEntities.begin(),
                            spawnRelayEntities.end());
 }
+
+void TargetSpawnRelay::invalidateSpawnRelayPointers(const gentity_t *ent) {
+  if (!ent->team) {
+    level.spawnRelayEntities.alliesRelay = nullptr;
+    level.spawnRelayEntities.axisRelay = nullptr;
+    level.spawnRelayEntities.spectatorRelay = nullptr;
+  } else {
+    const auto teams = StringUtil::split(ent->team, ",");
+
+    for (const auto &team : teams) {
+      if (StringUtil::iEqual(team, "allies")) {
+        level.spawnRelayEntities.alliesRelay = nullptr;
+      } else if (StringUtil::iEqual(team, "axis")) {
+        level.spawnRelayEntities.axisRelay = nullptr;
+      } else if (StringUtil::iEqual(team, "spectator")) {
+        level.spawnRelayEntities.spectatorRelay = nullptr;
+      }
+    }
+  }
+}
 } // namespace ETJump

--- a/src/game/etj_target_spawn_relay.h
+++ b/src/game/etj_target_spawn_relay.h
@@ -36,6 +36,9 @@ public:
 
   static void spawn(gentity_t *ent);
   static void validateSpawnRelayEntities();
+  // handles invalidating the pointers to the spawn relay entities,
+  // if they are deleted by the game by some means
+  static void invalidateSpawnRelayPointers(const gentity_t *ent);
 
 private:
   static void use(gentity_t *self, gentity_t *activator);

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -12,6 +12,7 @@
 #include "etj_printer.h"
 #include "etj_string_utilities.h"
 #include "etj_progression_tracker.h"
+#include "etj_target_spawn_relay.h"
 
 /*
 Contains the code to handle the various commands available with an event script.
@@ -3550,6 +3551,10 @@ qboolean G_ScriptAction_RemoveEntity(gentity_t *ent, char *params) {
     level.numRemovedBModels++;
   }
 
+  if (!Q_stricmp(ent->classname, "target_spawn_relay")) {
+    ETJump::TargetSpawnRelay::invalidateSpawnRelayPointers(ent);
+  }
+
   ent->think = G_FreeEntity;
   ent->nextthink = level.time + FRAMETIME;
 
@@ -4827,6 +4832,12 @@ qboolean G_ScriptAction_Delete(gentity_t *ent, char *params) {
           ETJump::StringUtil::join(pass[i].second, ", ");
       G_Printf("%s: deleted entity %i [^z%s^7], matched params: ^3'%s'\n",
                __func__, i, g_entities[i].classname, paramsMatched.c_str());
+
+      if (ETJump::StringUtil::iEqual(g_entities[i].classname,
+                                     "target_spawn_relay")) {
+        ETJump::TargetSpawnRelay::invalidateSpawnRelayPointers(&g_entities[i]);
+      }
+
       G_FreeEntity(&g_entities[i]);
     }
   }

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -11,6 +11,7 @@
 #include "etj_save_system.h"
 #include "etj_printer.h"
 #include "etj_string_utilities.h"
+#include "etj_target_spawn_relay.h"
 
 //==========================================================
 
@@ -842,11 +843,15 @@ void G_KillEnts(const char *target, gentity_t *ignore, gentity_t *killer,
       continue;
     }
 
+    if (!(Q_stricmp(targ->classname, "target_spawn_relay"))) {
+      ETJump::TargetSpawnRelay::invalidateSpawnRelayPointers(targ);
+    }
+
     trap_UnlinkEntity(targ);
     targ->nextthink = level.time + FRAMETIME;
 
-    targ->use = NULL;
-    targ->touch = NULL;
+    targ->use = nullptr;
+    targ->touch = nullptr;
     targ->think = G_FreeEntity;
   }
 }


### PR DESCRIPTION
The pointers which pointed to the spawn relay entities were not invalidated when a `target_spawn_relay` entity was removed, which caused a crash as it was now a null pointer.

This now handled for `delete`, `kill` and `remove` script actions, as well as `target_kill`. I can't think of any other ways to delete entities from the top of my head.

refs #1636
refs #1751 