### PR TITLE
Fix etj_hideMe not hiding portals

### DIFF
--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -281,7 +281,7 @@ bool ETJump::skipPortalDraw(const int selfNum, const int otherNum) {
   }
 
   if (etj_portalTeam.integer == PORTAL_TEAM_ALL ||
-      etj_viewPlayerPortals.integer) {
+      (etj_viewPlayerPortals.integer && !cgs.clientinfo[otherNum].hideMe)) {
     return false;
   }
 


### PR DESCRIPTION
Players' portals are now hidden if `etj_hideMe` is enabled, except in the following scenarios:

* `portalteam` is set to 2
* `portalteam` is set to 1, and the player using hideme is in a fireteam, in which case the portal isn't hidden for the fireteam members