### PR TITLE
Prevent teleport bit from getting flipped multiple times per frame

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,8 @@
 * map progression tracked by `target/trigger_tracker` entities is now saved and restored if a client disconnects and reconnects during a map [#1749](https://github.com/etjump/etjump/pull/1749)
 * fixed crash when `target_spawn_relay` was deleted from the map on runtime [#1752](https://github.com/etjump/etjump/pull/1752)
 * fixed some HUD elements breaking spec/demo playback view by altering the data received from the server [#1753](https://github.com/etjump/etjump/pull/1753)
+* `etj_hideMe` now hides players' portals from other players, unless those players are able to use your portals [#1756](https://github.com/etjump/etjump/pull/1756)
+* fixed teleportation events getting interpolated if the player triggered multiple teleportation events during the same frame [#1758](https://github.com/etjump/etjump/pull/1758)
 
 # ETJump 3.4.0
 
@@ -141,6 +143,7 @@
   * bitflag value
     * 1 = hide for self
     * 2 = hide for others
+* scoreboard inactivity now correctly works if the server is using `sv_level/serverTimeReset` [#1731](https://github.com/etjump/etjump/pull/1731) [#1734](https://github.com/etjump/etjump/pull/1734)
 * added a short animation when portalgun portals are spawned [#1727](https://github.com/etjump/etjump/pull/1727)
 * bundled fixed `.arena` files for certain maps with the mod pk3 [#1690](https://github.com/etjump/etjump/pull/1690)
 * reworked timerun high ping interrupt to work based off command time delta rather than ping [#1741](https://github.com/etjump/etjump/pull/1741)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1278,6 +1278,9 @@ typedef struct {
   bool jumpDelayBug;
 
   bool chatMenuOpen;
+
+  // to prevent teleport bit getting flipped multiple times per frame
+  bool teleportBitFlipped;
 } cg_t;
 
 inline constexpr int NUM_FUNNEL_SPRITES = 21;

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -540,6 +540,8 @@ static void CG_TouchTriggerPrediction() {
     return;
   }
 
+  cg.teleportBitFlipped = false;
+
   for (i = 0; i < cg_numTriggerEntities; i++) {
     cent = cg_triggerEntities[i];
     ent = &cent->currentState;
@@ -690,7 +692,7 @@ static void CG_TouchTriggerPrediction() {
               &cg_entities[cg.snap->ps.clientNum].currentState;
           ETJump::EntityUtilsShared::teleportPlayer(
               &cg.predictedPlayerState, playerEs, ent, &cg_pmove.cmd,
-              ent->origin2, ent->angles2);
+              ent->origin2, ent->angles2, cg.teleportBitFlipped);
         } else {
           ETJump::EntityUtilsShared::touchPusher(&cg.predictedPlayerState,
                                                  cg.physicsTime, ent);
@@ -714,9 +716,9 @@ static void CG_TouchTriggerPrediction() {
 
         entityState_t *playerEs =
             &cg_entities[cg.snap->ps.clientNum].currentState;
-        ETJump::EntityUtilsShared::portalTeleport(&cg.predictedPlayerState,
-                                                  playerEs, ent, &cg_pmove.cmd,
-                                                  cg.physicsTime);
+        ETJump::EntityUtilsShared::portalTeleport(
+            &cg.predictedPlayerState, playerEs, ent, &cg_pmove.cmd,
+            cg.physicsTime, cg.teleportBitFlipped);
       }
     }
   }

--- a/src/game/etj_entity_utilities_shared.cpp
+++ b/src/game/etj_entity_utilities_shared.cpp
@@ -93,7 +93,8 @@ void EntityUtilsShared::setPushVelocity(const playerState_t *ps,
 void EntityUtilsShared::teleportPlayer(playerState_t *ps, entityState_t *player,
                                        entityState_t *teleporter,
                                        usercmd_t *cmd, const vec3_t origin,
-                                       vec3_t angles) {
+                                       vec3_t angles,
+                                       bool &teleportBitFlipped) {
   // bits 8-31 contain the spawnflags
   const int spawnflags = (teleporter->constantLight >> 8) & 0xffffff;
 
@@ -136,7 +137,10 @@ void EntityUtilsShared::teleportPlayer(playerState_t *ps, entityState_t *player,
   }
 
   // toggle the teleport bit so the client knows to not lerp
-  ps->eFlags ^= EF_TELEPORT_BIT;
+  if (!teleportBitFlipped) {
+    ps->eFlags ^= EF_TELEPORT_BIT;
+    teleportBitFlipped = true;
+  }
 
   // set angles
   setViewAngles(ps, player, cmd, angles);
@@ -172,7 +176,8 @@ void EntityUtilsShared::setViewAngles(playerState_t *ps, entityState_t *es,
 
 void EntityUtilsShared::portalTeleport(playerState_t *ps, entityState_t *player,
                                        const entityState_t *portal,
-                                       usercmd_t *cmd, const int time) {
+                                       usercmd_t *cmd, const int time,
+                                       bool &teleportBitFlipped) {
   if (ps->powerups[PW_PORTALPREDICT] + PORTAL_TOUCH_COOLDOWN > time) {
     return;
   }
@@ -199,7 +204,10 @@ void EntityUtilsShared::portalTeleport(playerState_t *ps, entityState_t *player,
   VectorScale(ps->velocity, velocityLength + PORTAL_NUDGE, ps->velocity);
 
   // toggle the teleport bit so the client knows to not lerp
-  ps->eFlags ^= EF_TELEPORT_BIT;
+  if (!teleportBitFlipped) {
+    ps->eFlags ^= EF_TELEPORT_BIT;
+    teleportBitFlipped = true;
+  }
 
   // Adjust view angles so portals don't have you looking straight up or
   // down...

--- a/src/game/etj_entity_utilities_shared.h
+++ b/src/game/etj_entity_utilities_shared.h
@@ -41,14 +41,15 @@ public:
 
   static void teleportPlayer(playerState_t *ps, entityState_t *player,
                              entityState_t *teleporter, usercmd_t *cmd,
-                             const vec3_t origin, vec3_t angles);
+                             const vec3_t origin, vec3_t angles,
+                             bool &teleportBitFlipped);
 
   static void setViewAngles(playerState_t *ps, entityState_t *es,
                             usercmd_t *cmd, const vec3_t angle);
 
   static void portalTeleport(playerState_t *ps, entityState_t *player,
                              const entityState_t *portal, usercmd_t *cmd,
-                             int time);
+                             int time, bool &teleportBitFlipped);
 
   static void setPortalBBox(vec3_t mins, vec3_t maxs, const vec3_t angles,
                             float scale);

--- a/src/game/etj_portalgun.cpp
+++ b/src/game/etj_portalgun.cpp
@@ -205,7 +205,8 @@ void Portal::touch(gentity_t *self, gentity_t *other) {
   }
 
   EntityUtilsShared::portalTeleport(&other->client->ps, &other->s, &self->s,
-                                    &other->client->pers.cmd, level.time);
+                                    &other->client->pers.cmd, level.time,
+                                    other->client->teleportBitFlipped);
 }
 
 void Portalgun::spawn(gentity_t *ent) {

--- a/src/game/etj_trigger_teleport_client.cpp
+++ b/src/game/etj_trigger_teleport_client.cpp
@@ -34,9 +34,9 @@ void TriggerTeleportClient::touch(gentity_t *self, gentity_t *other) {
     return;
   }
 
-  EntityUtilsShared::teleportPlayer(&other->client->ps, &other->s, &self->s,
-                                    &other->client->pers.cmd, self->s.origin2,
-                                    self->s.angles2);
+  EntityUtilsShared::teleportPlayer(
+      &other->client->ps, &other->s, &self->s, &other->client->pers.cmd,
+      self->s.origin2, self->s.angles2, other->client->teleportBitFlipped);
 }
 
 void TriggerTeleportClient::think(gentity_t *self) {

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1019,6 +1019,8 @@ void ClientThink_real(gentity_t *ent) {
     client->wantsscore = qfalse;
   }
 
+  ent->client->teleportBitFlipped = false;
+
   //
   // check for exiting intermission
   //

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1194,6 +1194,9 @@ struct gclient_s {
   int lastRevivePushTime;
 
   ETJump::InactivityPos inactivityPos;
+
+  // to prevent teleport bit getting flipped multiple times per frame
+  bool teleportBitFlipped;
 };
 
 typedef struct {

--- a/src/game/g_misc.cpp
+++ b/src/game/g_misc.cpp
@@ -83,7 +83,10 @@ void TeleportPlayer(gentity_t *player, const vec3_t origin, vec3_t angles) {
   player->client->ps.origin[2] += 1;
 
   // toggle the teleport bit so the client knows to not lerp
-  player->client->ps.eFlags ^= EF_TELEPORT_BIT;
+  if (!player->client->teleportBitFlipped) {
+    player->client->ps.eFlags ^= EF_TELEPORT_BIT;
+    player->client->teleportBitFlipped = true;
+  }
 
   // set angles
   SetClientViewAngle(player, angles);
@@ -317,7 +320,10 @@ void teleportPlayer(gentity_t *self, gentity_t *other, const vec3_t origin,
   }
 
   // toggle the teleport bit so the client knows to not lerp
-  self->client->ps.eFlags ^= EF_TELEPORT_BIT;
+  if (!self->client->teleportBitFlipped) {
+    self->client->ps.eFlags ^= EF_TELEPORT_BIT;
+    self->client->teleportBitFlipped = true;
+  }
 
   SetClientViewAngle(self, teleAngles);
   BG_PlayerStateToEntityState(&self->client->ps, &self->s, qtrue);
@@ -336,7 +342,10 @@ void DirectTeleport(gentity_t *player, const vec3_t origin, vec3_t angles) {
   VectorCopy(origin, player->client->ps.origin);
 
   // toggle the teleport bit so the client knows to not lerp
-  player->client->ps.eFlags ^= EF_TELEPORT_BIT;
+  if (!player->client->teleportBitFlipped) {
+    player->client->ps.eFlags ^= EF_TELEPORT_BIT;
+    player->client->teleportBitFlipped = true;
+  }
 
   // set angles
   SetClientViewAngle(player, angles);


### PR DESCRIPTION
In scenarios where a client would trigger multiple teleportation events per frame, the `EF_TELEPORT_BIT` would get flipped multiple times, which could cause the teleportation event to get interpolated. This is now prevented for teleport entities and the portal gun. Client spawn and load/loadpos are not handled - dead players don't use teleporters, so a client spawn and teleportation will never happen on a same frame, and client commands are processed separately from ClientThinks, which should make the latter a non-issue.