### PR TITLE
Fix exploits with projectiles on timerun start

### DIFF
--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -1172,6 +1172,10 @@ void ETJump::TimerunV2::deleteSeason(int clientNum, const std::string &name) {
       });
 }
 
+int32_t ETJump::TimerunV2::getRunStartTime(const int32_t clientNum) const {
+  return _players[clientNum]->startTime.valueOr(0);
+}
+
 void ETJump::TimerunV2::startNotify(Player *player) const {
   auto previousRecord =
       player->getRecord(defaultSeasonId, player->activeRunName);

--- a/src/game/etj_timerun_v2.h
+++ b/src/game/etj_timerun_v2.h
@@ -115,6 +115,8 @@ public:
   void printSeasons(int clientNum);
   void deleteSeason(int clientNum, const std::string &name);
 
+  [[nodiscard]] int32_t getRunStartTime(int32_t clientNum) const;
+
   static void removeDisallowedWeapons(gentity_t *ent);
   static void removePlayerProjectiles(gentity_t *ent);
 


### PR DESCRIPTION
* Fix projectiles not getting deleted on timerun start (was accidentally broken in 329158a4c684addd5d84d2bf6d11b513a254ba9a)
* Fix frame-perfect exploit with spawning projectiles on timerun start.

refs #1515 