### PR TITLE
Enforce LF line endings for .menu files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 * text=auto
 
 *.sh text eol=lf
+
+# enforce lf line endings for menu files, so Windows menu integrity checks
+# won't fail due to different line endings, when the mod is packaged on Linux
+*.menu text eol=lf


### PR DESCRIPTION
The menu integrity check currently fails on Windows, because the mod is packaged on Linux. The Windows build reads and generates the hashes with CRLF line endings, which in itself works fine when testing locally, but when the CI builds the mod, the package step checks out the repo, and changes the line endings to be LF instead of CRLF. Rather than e.g. normalizing the line endings in the hash generation step, just enforce LF all the time, so if the mod is ever packaged on Windows, the hash comparison still works.

refs #1759 