### PR TITLE
Fix demo compatibility for pre-2.0.6 bg_itemList

### DIFF
--- a/src/cgame/cg_snapshot.cpp
+++ b/src/cgame/cg_snapshot.cpp
@@ -421,19 +421,31 @@ static snapshot_t *CG_ReadNextSnapshot(void) {
         CG_ResetTransitionEffects();
       }
 
-      // adjust entity types to be compatible with 2.3.0/2.3.0 RC4
-      if (ETJump::demoCompatibility->flags.adjustEntityTypes) {
+      // adjust entity types to be compatible with 2.3.0/2.3.0 RC4,
+      // or modelindices for pre-2.0.6
+      if (ETJump::demoCompatibility->flags.adjustEntityTypes ||
+          ETJump::demoCompatibility->flags.adjustItemlistIndex) {
         for (int i = 0; i < dest->numEntities; i++) {
           entityState_t *es = &dest->entities[i];
-          // ET_VELOCITY_PUSH_TRIGGER = 9 in 2.3.0,
-          // so we should remap it to the current position
-          if (es->eType == 9) {
-            es->eType = ET_VELOCITY_PUSH_TRIGGER;
+
+          if (ETJump::demoCompatibility->flags.adjustEntityTypes) {
+            // ET_VELOCITY_PUSH_TRIGGER = 9 in 2.3.0,
+            // so we should remap it to the current position
+            if (es->eType == 9) {
+              es->eType = ET_VELOCITY_PUSH_TRIGGER;
+            }
+
+            // shifting back all eTypes in demo,
+            // so it would match the current enum order
+            else if (es->eType > 9) {
+              --es->eType;
+            }
           }
-          // shifting back all eTypes in demo,
-          // so it would match the current enum order
-          else if (es->eType > 9) {
-            --es->eType;
+
+          // adjust itemlist index for removal of duplicate 'weapon_medic_heal'
+          if (ETJump::demoCompatibility->flags.adjustItemlistIndex &&
+              es->eType == ET_ITEM && es->modelindex > 56) {
+            es->modelindex--;
           }
         }
       }

--- a/src/cgame/etj_demo_compatibility.cpp
+++ b/src/cgame/etj_demo_compatibility.cpp
@@ -113,6 +113,10 @@ void DemoCompatibility::setupCompatibilityFlags() {
     flags.adjustEvTokens = true;
     compatibilityStrings.emplace_back(
         "- Adjusted event indices for ET_TOKEN_ entities");
+
+    flags.adjustItemlistIndex = true;
+    compatibilityStrings.emplace_back(
+        "- Adjusted item indices for removal of duplicate 'weapon_medic_heal'");
   }
 
   if (!isCompatible({2, 3, 0})) {

--- a/src/cgame/etj_demo_compatibility.h
+++ b/src/cgame/etj_demo_compatibility.h
@@ -61,6 +61,7 @@ public:
     bool adjustEvFakebrushAndClientTeleporter = false;
     bool serverSideDlights = false;
     bool setAttack2FiringFlag = false;
+    bool adjustItemlistIndex = false;
   };
 
   // everything in here will be set to false unless we're on demo playback


### PR DESCRIPTION
In 339bede1c1efe60ae578472372ca9d249366c27d, a duplicate entry for `weapon_medic_heal` (present in ETMain) was removed from `bg_itemList`, which shifted all item numbers > 56 down by one. This would display wrong models for certain items, and crash playback for any demo containing a snapshot with `team_CTF_blueflag`. Take this into account in demo playback, and shift down `modelindex` accordingly for `ET_ITEM` entities.