### PR TITLE
Add target_random entity

### DIFF
--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -88,6 +88,7 @@ add_library(qagame MODULE
 	"etj_string_utilities.cpp"
 	"etj_target_ft_setrules.cpp"
 	"etj_target_init.cpp"
+	"etj_target_random.cpp"
 	"etj_target_spawn_relay.cpp"
 	"etj_time_utilities.cpp"
 	"etj_timerun_repository.cpp"

--- a/src/game/etj_target_random.cpp
+++ b/src/game/etj_target_random.cpp
@@ -1,0 +1,77 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <random>
+
+#include "etj_target_random.h"
+
+namespace ETJump {
+void TargetRandom::spawn(gentity_t *ent) {
+  G_SpawnInt("chance", "1", &ent->count);
+  G_SpawnInt("total", "1", &ent->count2);
+
+  if (ent->count < 1) {
+    G_Error("target_random: 'chance' must be over 1.\n");
+  }
+
+  if (ent->count2 < 1) {
+    G_Error("target_random: 'total' must be over 1.\n");
+  }
+
+  if (ent->count2 < ent->count) {
+    G_Error("target_random: 'total' (%i) must be higher than 'chance' (%i).",
+            ent->count2, ent->count);
+  }
+
+  ent->use = [](gentity_t *self, gentity_t *other, gentity_t *activator) {
+    use(self, activator);
+  };
+}
+
+void TargetRandom::use(gentity_t *self, gentity_t *activator) {
+  std::random_device dev;
+  std::mt19937 rng(dev());
+  std::uniform_int_distribution<int32_t> dist(1, self->count2);
+
+  if (dist(rng) <= self->count) {
+    // if scriptname is set, call the 'activate' script trigger
+    if (self->scriptName) {
+      const team_t team = activator->client->sess.sessionTeam;
+      self->activator = activator;
+
+      // send team to script too to support 'activate axis/allies'
+      // this simplifies usage for mappers so they don't have to create
+      // separate entities to fire individual script triggers for either team
+      if (team == TEAM_AXIS || team == TEAM_ALLIES) {
+        G_Script_ScriptEvent(self, "activate",
+                             team == TEAM_AXIS ? "axis" : "allies");
+      } else {
+        G_Script_ScriptEvent(self, "activate", nullptr);
+      }
+    }
+
+    G_UseTargets(self, activator);
+  }
+}
+} // namespace ETJump

--- a/src/game/etj_target_random.h
+++ b/src/game/etj_target_random.h
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "g_local.h"
+
+namespace ETJump {
+class TargetRandom {
+public:
+  static void spawn(gentity_t *ent);
+  static void use(gentity_t *self, gentity_t *activator);
+};
+}; // namespace ETJump

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -22,6 +22,7 @@
 #include "etj_portalgun_shared.h"
 #include "etj_entity_utilities.h"
 #include "etj_progression_tracker.h"
+#include "etj_target_random.h"
 
 qboolean G_SpawnStringExt(const char *key, const char *defaultString,
                           char **out, const char *file, int line) {
@@ -185,6 +186,9 @@ field_t fields[] = {
     {"noghost", FOFS(damage), F_INT},
     {"teamjumpmode", FOFS(health), F_INT},
     {"leader_only_message", FOFS(message), F_LSTRING},
+
+    {"chance", FOFS(count), F_INT},
+    {"total", FOFS(count2), F_INT},
 
     {nullptr}};
 
@@ -724,6 +728,7 @@ spawn_t spawns[] = {
     {"trigger_teleport_client", ETJump::TriggerTeleportClient::spawn},
     {"target_ft_setrules", ETJump::TargetFtSetRules::spawn},
     {"target_spawn_relay", ETJump::TargetSpawnRelay::spawn},
+    {"target_random", ETJump::TargetRandom::spawn},
     {nullptr, nullptr},
 };
 


### PR DESCRIPTION
Allows per-client random number generation. Generates a number from 1 - 'total', and fires targets if the generated number is less than or equal to 'chance'. Supports mapscriping via 'activate (axis/allies)' trigger, and passes activator to the mapscript.