### PR TITLE
Remove some magic number from demo compatibility checks

### DIFF
--- a/src/cgame/cg_snapshot.cpp
+++ b/src/cgame/cg_snapshot.cpp
@@ -431,20 +431,21 @@ static snapshot_t *CG_ReadNextSnapshot(void) {
           if (ETJump::demoCompatibility->flags.adjustEntityTypes) {
             // ET_VELOCITY_PUSH_TRIGGER = 9 in 2.3.0,
             // so we should remap it to the current position
-            if (es->eType == 9) {
+            if (es->eType == ETJump::COMPAT_ET_VELOCITY_PUSH_TRIGGER_NUM) {
               es->eType = ET_VELOCITY_PUSH_TRIGGER;
             }
 
             // shifting back all eTypes in demo,
             // so it would match the current enum order
-            else if (es->eType > 9) {
+            else if (es->eType > ETJump::COMPAT_ET_VELOCITY_PUSH_TRIGGER_NUM) {
               --es->eType;
             }
           }
 
           // adjust itemlist index for removal of duplicate 'weapon_medic_heal'
           if (ETJump::demoCompatibility->flags.adjustItemlistIndex &&
-              es->eType == ET_ITEM && es->modelindex > 56) {
+              es->eType == ET_ITEM &&
+              es->modelindex > ETJump::COMPAT_WEAPON_MEDIC_HEAL_INDEX) {
             es->modelindex--;
           }
         }

--- a/src/cgame/etj_demo_compatibility.cpp
+++ b/src/cgame/etj_demo_compatibility.cpp
@@ -22,10 +22,7 @@
  * SOFTWARE.
  */
 
-#include <string>
-
 #include "etj_demo_compatibility.h"
-#include "cg_local.h"
 #include "../game/etj_string_utilities.h"
 
 namespace ETJump {

--- a/src/cgame/etj_demo_compatibility.h
+++ b/src/cgame/etj_demo_compatibility.h
@@ -24,9 +24,14 @@
 
 #pragma once
 
-#include <vector>
+#include "cg_local.h"
 
 namespace ETJump {
+// 2.3.0 (+ RC4) ET_VELOCITY_PUSH_TRIGGER eType number
+inline constexpr int32_t COMPAT_ET_VELOCITY_PUSH_TRIGGER_NUM = 9;
+// old array index of removed 'weapon_medic_heal' item
+inline constexpr int32_t COMPAT_WEAPON_MEDIC_HEAL_INDEX = 56;
+
 class DemoCompatibility {
   struct Version {
     int major;
@@ -41,10 +46,10 @@ class DemoCompatibility {
   void setupCompatibilityFlags();
 
   // returns true if the demo version is newer or same as 'minimum'
-  bool isCompatible(const Version &minimum) const;
+  [[nodiscard]] bool isCompatible(const Version &minimum) const;
 
   // returns true if 'version' is the exact same as demo version
-  bool isExactVersion(const Version &version) const;
+  [[nodiscard]] bool isExactVersion(const Version &version) const;
 
   Version demoVersion{};
 
@@ -68,11 +73,11 @@ public:
   CompatibilityFlags flags{};
 
   // stores the strings to print for compatibility info
-  std::vector<std::string> compatibilityStrings{};
+  std::vector<std::string> compatibilityStrings;
 
   // performs event number adjustments for events that are added freestanding
   // by setting event num to ET_EVENTS + event due to additional entity types
-  int adjustedEventNum(int event) const;
+  [[nodiscard]] int adjustedEventNum(int event) const;
 
   void printDemoInformation() const;
 


### PR DESCRIPTION
Use named constants for old `ET_VELOCITY_PUSH_TRIGGER` eType and `weapon_medic_heal` item.