### PR TITLE
Add demo compatibility for jump speeds on old demos

### DIFF
--- a/src/cgame/etj_demo_compatibility.cpp
+++ b/src/cgame/etj_demo_compatibility.cpp
@@ -126,6 +126,12 @@ void DemoCompatibility::setupCompatibilityFlags() {
         "- Adjusted event indices for ET_VELOCITY_PUSH_TRIGGER");
   }
 
+  if (!isCompatible({2, 5, 0})) {
+    flags.predictedJumpSpeeds = true;
+    compatibilityStrings.emplace_back(
+        "- Using predicted speeds for jump speeds display");
+  }
+
   if (!isCompatible({3, 2, 0})) {
     flags.serverSideCoronas = true;
     compatibilityStrings.emplace_back("- Using fully server-side coronas");

--- a/src/cgame/etj_demo_compatibility.h
+++ b/src/cgame/etj_demo_compatibility.h
@@ -67,6 +67,7 @@ public:
     bool serverSideDlights = false;
     bool setAttack2FiringFlag = false;
     bool adjustItemlistIndex = false;
+    bool predictedJumpSpeeds = false;
   };
 
   // everything in here will be set to false unless we're on demo playback

--- a/src/cgame/etj_jump_speeds.cpp
+++ b/src/cgame/etj_jump_speeds.cpp
@@ -26,6 +26,7 @@
 #include "etj_utilities.h"
 #include "etj_client_commands_handler.h"
 #include "etj_player_events_handler.h"
+#include "etj_demo_compatibility.h"
 
 namespace ETJump {
 JumpSpeeds::JumpSpeeds(EntityEventsHandler *entityEventsHandler)
@@ -163,7 +164,12 @@ void JumpSpeeds::updateJumpSpeeds() {
 
   team = ps->persistant[PERS_TEAM];
   baseColorStr = etj_jumpSpeedsColor.string;
-  jumpSpeeds.emplace_back(ps->persistant[PERS_JUMP_SPEED], baseColorStr);
+
+  if (demoCompatibility->flags.predictedJumpSpeeds) {
+    jumpSpeeds.emplace_back(VectorLength2(ps->velocity), baseColorStr);
+  } else {
+    jumpSpeeds.emplace_back(ps->persistant[PERS_JUMP_SPEED], baseColorStr);
+  }
 
   // we only want to keep last 10 jumps, so remove first value if we go
   // over that


### PR DESCRIPTION
Use velocity from `ps->velocity` to display a predicted velocity since `ps->persistant` does not contain the jump speed data prior to 2.5.0.