### PR TITLE
Don't skip diff drawing for rank 1 times if own record is tied

### DIFF
--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -727,13 +727,8 @@ void ETJump::TimerunV2::printRecords(
 
                   auto millisString = millisToString(r->time);
 
-                  std::string diffString;
-
-                  if (ownRecord || rank == 1 && ownTime == r->time) {
-                    diffString = "";
-                  } else {
-                    diffString = diffToString(ownTime, r->time);
-                  }
+                  const std::string diffString =
+                      ownRecord ? "" : diffToString(ownTime, r->time);
 
                   auto playerNameString =
                       ownRecord ? r->playerName + " ^g(You)" : r->playerName;


### PR DESCRIPTION
I'm not sure what the intention behind this was, I can't think of a reason why we would not want to draw the diff in this scenario.

fixes #1586 