### PR TITLE
Remove unnecessary moves from timerun commands

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -198,7 +198,7 @@ bool Rankings(gentity_t *ent, Arguments argv) {
   ETJump::Timerun::PrintRankingsParams params{
       ClientNum(ent), userId, std::move(season), page, pageSize};
 
-  game.timerunV2->printRankings(std::move(params));
+  game.timerunV2->printRankings(params);
   return true;
 }
 
@@ -317,7 +317,7 @@ bool Records(gentity_t *ent, Arguments argv) {
   }
   params.userId = ETJump::session->GetId(ent);
 
-  game.timerunV2->printRecords(std::move(params));
+  game.timerunV2->printRecords(params);
 
   return true;
 }
@@ -2287,7 +2287,7 @@ bool TimerunAddSeason(gentity_t *ent, Arguments argv) {
   params.endTime = end;
   params.name = name;
 
-  game.timerunV2->addSeason(std::move(params));
+  game.timerunV2->addSeason(params);
 
   return true;
 }


### PR DESCRIPTION
Since c4d93aa0aaecc94b825b568e17624e27f03be547, these moves are no longer necessary as we pass const references to the functions.