### PR TITLE
Fixes to knife and binocular events

### DIFF
--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -4650,7 +4650,7 @@ static void PM_Weapon(void) {
     } else {
       PM_AddEvent(EV_FIRE_WEAPONB);
     }
-  } else {
+  } else if (pm->ps->weapon != WP_BINOCULARS || pm->ps->eFlags & EF_ZOOMING) {
     if (PM_WeaponClipEmpty(pm->ps->weapon)) {
       PM_AddEvent(EV_FIRE_WEAPON_LASTSHOT);
     } else {

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -848,7 +848,7 @@ void SetWolfSpawnWeapons(gclient_t *client) {
 
   // Zero: CTF: if CTF give no other weapons than knife
   if (g_weapons.integer) {
-    if (AddWeaponToPlayer(client, WP_BINOCULARS, 1, 0, qfalse)) {
+    if (AddWeaponToPlayer(client, WP_BINOCULARS, 0, 1, qfalse)) {
       client->ps.stats[STAT_KEYS] |= (1 << INV_BINOCS);
     }
     // Engineer gets dynamite

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -842,7 +842,7 @@ void SetWolfSpawnWeapons(gclient_t *client) {
   client->ps.weapons[0] = 0;
   client->ps.weapons[1] = 0;
 
-  AddWeaponToPlayer(client, WP_KNIFE, 1, 0, qtrue);
+  AddWeaponToPlayer(client, WP_KNIFE, 0, 1, qtrue);
 
   client->ps.weaponstate = WEAPON_READY;
 


### PR DESCRIPTION
* Fix knife starting with 0 ammo in clip, which caused a reload event to happen on first switch to it after spawn
* Fix binoculars starting with 0 ammo in clip, which made it fire "last shot" every time
* Fix firing with unzoomed binoculars producing `EV_FIRE_WEAPON` events