### PR TITLE
Fix client side coronas using over 10 bits for scale

### DIFF
--- a/src/cgame/cg_spawn.cpp
+++ b/src/cgame/cg_spawn.cpp
@@ -242,7 +242,9 @@ void SP_corona() {
 
   float scale;
   CG_SpawnFloat("scale", "1", &scale);
-  corona->currentState.density = static_cast<int>(scale * 255);
+  // es->density is networked as uint10_t, so use only the lower 10 bits here
+  // to match the the actual value with server-side coronas
+  corona->currentState.density = static_cast<int>(scale * 255) & 0x3FF;
 }
 
 void SP_trigger_objective_info(void) {


### PR DESCRIPTION
Server-side coronas network the value for `scale` as 10-bit unsigned integer, but client-side coronas were using the full 32-bit integer range, which caused coronas with scale values of > 1023 to display at bigger size if the corona was client sided.

refs #1201