### PR TITLE
Add warning about loose files to menu integrity checker

### DIFF
--- a/src/ui/etj_menu_integrity_checker.cpp
+++ b/src/ui/etj_menu_integrity_checker.cpp
@@ -115,10 +115,15 @@ void MenuIntegrityChecker::printIntegrityViolation() {
   const auto badPaks = getBadPaks();
 
   if (badPaks.empty()) {
+    msg = "^1Make sure '" + uiInfo.fsGame +
+          "' directory does not contain any '.menu' files outside of pk3 files "
+          "(usually inside 'ui' directory).\n";
+    msg += "^1If any are present, try removing them to restore menu integrity "
+           "and remove this warning.\n\n";
+    uiInfo.uiDC.Print(msg.c_str());
     return;
   }
 
-  msg.clear();
   msg = "^1The following paks may contain potentially unwanted files:\n\n";
 
   for (const auto &pak : badPaks) {


### PR DESCRIPTION
If no pk3s are found, but the menu integrity check fails, let the user know that they should look for any loose `.menu` files in the `fs_game` directory.

#1759 