### PR TITLE
Add etj_onDemoPlaybackEnd cvar

### DIFF
--- a/assets/ui/etjump_settings_demos_playback.menu
+++ b/assets/ui/etjump_settings_demos_playback.menu
@@ -59,6 +59,7 @@ menuDef {
         EDITFIELD_EXT       (SETTINGS_EF_POS(8), "Freecam camera lock:", 0.2, SETTINGS_ITEM_H, "b_demo_lookat", 5, 5, "Entity number to lock viewangles towards to when in freecam mode, -1 to disable\nb_demo_lookat")
         EDITFIELD_EXT       (SETTINGS_EF_POS(9), "Demo queue directory:", 0.2, SETTINGS_ITEM_H, "etj_demoQueueDir", SETTINGS_EF_MAXCHARS, SETTINGS_EF_MAXPAINTCHARS, "Directory inside 'demos' to playback demo queue from\nLeave empty to playback from the root of 'demos' directory\netj_demoQueueDir")
         EDITFIELD_EXT       (SETTINGS_EF_POS(10), "On playback start:", 0.2, SETTINGS_ITEM_H, "etj_onDemoPlaybackStart", SETTINGS_EF_MAXCHARS, SETTINGS_EF_MAXPAINTCHARS, "Command(s) to execute on the first frame of demo playback\nThis also gets re-executed if 'vid_restart' is used during playback\netj_onDemoPlaybackStart")
+        EDITFIELD_EXT       (SETTINGS_EF_POS(11), "On playback end:", 0.2, SETTINGS_ITEM_H, "etj_onDemoPlaybackEnd", SETTINGS_EF_MAXCHARS, SETTINGS_EF_MAXPAINTCHARS, "Command(s) to execute when demo playback finishes\nThis also gets re-executed if 'vid_restart' is used during playback\netj_onDemoPlaybackStart")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2784,6 +2784,7 @@ extern vmCvar_t etj_autoSprint;
 extern vmCvar_t etj_logCenterPrint;
 
 extern vmCvar_t etj_onDemoPlaybackStart;
+extern vmCvar_t etj_onDemoPlaybackEnd;
 
 extern vmCvar_t etj_HUD_noLerp;
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -685,6 +685,7 @@ vmCvar_t etj_autoSprint;
 vmCvar_t etj_logCenterPrint;
 
 vmCvar_t etj_onDemoPlaybackStart;
+vmCvar_t etj_onDemoPlaybackEnd;
 
 vmCvar_t etj_HUD_noLerp;
 
@@ -1298,6 +1299,7 @@ cvarTable_t cvarTable[] = {
     {&etj_logCenterPrint, "etj_logCenterPrint", "0", CVAR_ARCHIVE},
 
     {&etj_onDemoPlaybackStart, "etj_onDemoPlaybackStart", "", CVAR_ARCHIVE},
+    {&etj_onDemoPlaybackEnd, "etj_onDemoPlaybackEnd", "", CVAR_ARCHIVE},
 
     {&etj_HUD_noLerp, "etj_HUD_noLerp", "0", CVAR_ARCHIVE},
     {&etj_useExecQuiet, "etj_useExecQuiet", "0", CVAR_ARCHIVE},
@@ -4076,6 +4078,10 @@ void CG_Shutdown(void) {
   // like closing files or archiving session data
 
   CG_EventHandling(CGAME_EVENT_NONE, qtrue);
+
+  if (cg.demoPlayback && etj_onDemoPlaybackEnd.string[0] != '\0') {
+    trap_SendConsoleCommand(etj_onDemoPlaybackEnd.string);
+  }
 
   ETJump::shutdown();
 


### PR DESCRIPTION
Combined with `etj_onDemoPlaybackStart`, can be used to have specific settings apply only for demo playback, e.g. completely different set of keybindings. Using a special autoexec for this, like `autoexec_demo` isn't really a good idea because the settings would linger on after the playback ends.