### PR TITLE
Fix buffer overflow with autortv

### DIFF
--- a/src/game/etj_rtv.cpp
+++ b/src/game/etj_rtv.cpp
@@ -158,11 +158,10 @@ bool RockTheVote::checkAutoRtv() {
 }
 
 void RockTheVote::callAutoRtv() {
-  int i;
   char voteArg[MAX_STRING_TOKENS];
   // send an empty secondary arg to G_voteCmdCheck rather than nullptr,
   // so we don't need to dance around nullptr dereferences in the vote cmd
-  char arg2[2] = "\0";
+  char arg2[MAX_STRING_TOKENS] = "";
 
   Q_strncpyz(voteArg, "rtv", sizeof(voteArg));
 
@@ -170,7 +169,9 @@ void RockTheVote::callAutoRtv() {
   // if vote_allow_rtv is set to 0
   level.voteInfo.isAutoRtvVote = true;
 
-  if ((i = G_voteCmdCheck(nullptr, voteArg, arg2)) != G_OK) {
+  int32_t i = G_voteCmdCheck(nullptr, voteArg, arg2);
+
+  if (i != G_OK) {
     if (i == G_NOTFOUND) {
       G_LogPrintf(
           "callAutoRtv: Could not find vote command for '%s'. This should not "

--- a/src/game/g_vote.cpp
+++ b/src/game/g_vote.cpp
@@ -567,9 +567,11 @@ int G_RockTheVote_v(gentity_t *ent, unsigned dwVoteIndex, char *arg,
                          i == maxMaps - 1 ? "" : "\\");
     }
 
-    const char *mapTypeDesc = CustomMapTypeExists(arg2);
-    // array size is set in Cmd_CallVote_f
-    Q_strncpyz(arg2, mapTypeDesc ? mapTypeDesc : "", MAX_STRING_TOKENS);
+    if (arg2[0] != '\0') {
+      const char *mapTypeDesc = CustomMapTypeExists(arg2);
+      // array size is set in Cmd_CallVote_f
+      Q_strncpyz(arg2, mapTypeDesc ? mapTypeDesc : "", MAX_STRING_TOKENS);
+    }
 
     // this will never overflow as MAX_QPATH is 64 and rtv supports max 9 maps
     trap_SetConfigstring(CS_VOTE_YES, cs.c_str());


### PR DESCRIPTION
Autortv sent a 2-byte buffer as `arg2` to the callvote function, which would cause a buffer overflow because the code that should copy the name of a custom vote list to `arg2` wasn't checking whether `arg2` actually contained the list name we wanted to vote for. If `arg2` is empty, nothing should be copied to it, but for safety, send a 256-byte buffer from auto-rtv too, as the rest of the code path expects it to be that size.

refs #1215 