### PR TITLE
Update macOS runner to macos-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
 
   macOS:
     name: macOS ${{ matrix.arch }}
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
 
   macOS:
     name: macOS ${{ matrix.arch }}
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We are still fine targeting 10.13 as the oldest release, when it comes to SDK support.