### PR TITLE
Speed up macOS build pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,12 +110,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [x64]
+        arch: [x86_64, arm64]
         config: [Release]
         include:
-          - arch: x64
-            platforms: "\"x86_64;arm64\""
-            osx-target: "10.13"
+          - osx-target: "10.13"
 
     steps:
     - uses: actions/checkout@v4
@@ -123,7 +121,7 @@ jobs:
         fetch-depth: 0
 
     - name: Configure CMake
-      run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_OSX_ARCHITECTURES=${{ matrix.platforms }} -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.osx-target }}
+      run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.osx-target }}
 
     - name: Build
       run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.config }} --parallel
@@ -138,10 +136,48 @@ jobs:
         name: etjump-artifacts-macos-${{ matrix.arch }}
         path: ${{ github.workspace }}/build/etjump
 
+  macOS-universal:
+    name: macOS Universal Binary
+    runs-on: macos-14
+    needs: [macOS]
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: etjump-artifacts-macos-*
+        path: artifacts
+
+    - name: Create universal binary
+      run: |
+        mkdir -p build-universal
+        cp -R artifacts/etjump-artifacts-macos-arm64/* build-universal
+        lipo -create artifacts/etjump-artifacts-macos-x86_64/cgame_mac \
+                     artifacts/etjump-artifacts-macos-arm64/cgame_mac \
+              -output build-universal/cgame_mac
+        lipo -create artifacts/etjump-artifacts-macos-x86_64/ui_mac \
+                     artifacts/etjump-artifacts-macos-arm64/ui_mac \
+              -output build-universal/ui_mac
+        lipo -create artifacts/etjump-artifacts-macos-x86_64/qagame_mac \
+                     artifacts/etjump-artifacts-macos-arm64/qagame_mac \
+              -output build-universal/qagame_mac
+
+    - name: Upload universal artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: etjump-artifacts-macos-universal
+        path: ${{ github.workspace }}/build-universal
+
+    # cleanup the individual builds so package doesn't download them
+    - name: Cleanup
+      uses: geekyeggo/delete-artifact@v5
+      with:
+        name: |
+          etjump-artifacts-macos-arm64
+          etjump-artifacts-macos-x86_64
+
   package:
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     runs-on: ubuntu-22.04
-    needs: [Windows, Linux, macOS]
+    needs: [Windows, Linux, macOS-universal]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,21 +92,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [x64]
+        arch: [x86_64, arm64]
         config: [Release]
         include:
-          - arch: x64
-            platforms: "\"x86_64;arm64\""
-            osx-target: "10.13"
+          - osx-target: "10.13"
 
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        ref: master
 
     - name: Configure CMake
-      run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_OSX_ARCHITECTURES=${{ matrix.platforms }} -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.osx-target }}
+      run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.osx-target }}
 
     - name: Build
       run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.config }} --parallel
@@ -121,9 +118,47 @@ jobs:
         name: etjump-artifacts-macos-${{ matrix.arch }}
         path: ${{ github.workspace }}/build/etjump
 
+  macOS-universal:
+    name: macOS Universal Binary
+    runs-on: macos-14
+    needs: [macOS]
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: etjump-artifacts-macos-*
+        path: artifacts
+
+    - name: Create universal binary
+      run: |
+        mkdir -p build-universal
+        cp -R artifacts/etjump-artifacts-macos-arm64/* build-universal
+        lipo -create artifacts/etjump-artifacts-macos-x86_64/cgame_mac \
+                     artifacts/etjump-artifacts-macos-arm64/cgame_mac \
+              -output build-universal/cgame_mac
+        lipo -create artifacts/etjump-artifacts-macos-x86_64/ui_mac \
+                     artifacts/etjump-artifacts-macos-arm64/ui_mac \
+              -output build-universal/ui_mac
+        lipo -create artifacts/etjump-artifacts-macos-x86_64/qagame_mac \
+                     artifacts/etjump-artifacts-macos-arm64/qagame_mac \
+              -output build-universal/qagame_mac
+
+    - name: Upload universal artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: etjump-artifacts-macos-universal
+        path: ${{ github.workspace }}/build-universal
+
+    # cleanup the individual builds so package doesn't download them
+    - name: Cleanup
+      uses: geekyeggo/delete-artifact@v5
+      with:
+        name: |
+          etjump-artifacts-macos-arm64
+          etjump-artifacts-macos-x86_64
+
   package:
     runs-on: ubuntu-22.04
-    needs: [Windows, Linux, macOS]
+    needs: [Windows, Linux, macOS-universal]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Build `x86_64` and `arm64` in parallel, and combine to a universal binary using `lipo` in a separate step. It's still pretty slow because Apple is incapable of writing a performant C++ linker, but at least it shouldn't take 20 minutes anymore.