### PR TITLE
Fix rank 1 time displaying diff when player has no record

### DIFF
--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -667,7 +667,11 @@ void ETJump::TimerunV2::printRecords(
               const auto &runName = rkvp.first;
               int rank = 1;
               int rank1Time = !rkvp.second.empty() ? rkvp.second[0]->time : 0;
-              int ownTime = ownRecords[season->id][mapName].count(runName) > 0
+              const bool haveOwnTime =
+                  ownRecords[season->id][mapName].count(runName) > 0;
+              // FIXME: this is a terribly named variable,
+              // it's not necessarily our own time...
+              int ownTime = haveOwnTime
                                 ? ownRecords[season->id][mapName][runName]
                                 : rank1Time;
 
@@ -728,7 +732,9 @@ void ETJump::TimerunV2::printRecords(
                   auto millisString = millisToString(r->time);
 
                   const std::string diffString =
-                      ownRecord ? "" : diffToString(ownTime, r->time);
+                      ownRecord || !haveOwnTime && rank == 1
+                          ? ""
+                          : diffToString(ownTime, r->time);
 
                   auto playerNameString =
                       ownRecord ? r->playerName + " ^g(You)" : r->playerName;


### PR DESCRIPTION
I really need to blow up this whole function and chop it into smaller pieces, it's way too complex and error prone.

refs #1586 