### PR TITLE
Fix replay menu not handling ending carets properly

### DIFF
--- a/src/game/etj_string_utilities.cpp
+++ b/src/game/etj_string_utilities.cpp
@@ -395,3 +395,11 @@ std::string ETJump::StringUtil::truncate(const std::string &str,
   std::string out = str.substr(0, outLen);
   return out;
 }
+
+void ETJump::StringUtil::stripExtension(std::string &str) {
+  const auto pos = str.rfind('.');
+
+  if (pos != std::string::npos) {
+    str.erase(pos);
+  }
+}

--- a/src/game/etj_string_utilities.h
+++ b/src/game/etj_string_utilities.h
@@ -139,6 +139,10 @@ bool isColorString(std::string_view str, size_t idx);
 // e.g. truncate("^1foo^2bar", 3) -> "^1foo"
 std::string truncate(const std::string &str, size_t len);
 
+// removes a file extension from the string
+// if string contains no file extenstion, no modification is made
+void stripExtension(std::string &str);
+
 // sorts strings either with case sensitivity or insensitivity
 // identical strings are kept in order
 template <typename T>

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -3281,7 +3281,10 @@ static void UI_LoadDemos() {
     FileSystemObjectInfo objectInfo;
     objectInfo.type = FileSystemObjectType::Item;
     objectInfo.name = demo;
-    objectInfo.displayName = ETJump::sanitize(objectInfo.name, false);
+    objectInfo.displayName = demo;
+    ETJump::StringUtil::stripExtension(objectInfo.displayName);
+    objectInfo.displayName =
+        ETJump::sanitize(objectInfo.displayName) + "^*." + ext;
     files.emplace_back(objectInfo);
   }
 

--- a/tests/string_utilities_tests.cpp
+++ b/tests/string_utilities_tests.cpp
@@ -350,3 +350,31 @@ TEST_F(StringUtilitiesTests, sanitize_handlesEndingCarets) {
   ASSERT_EQ(sanitize("test test^"), "test test^");
   ASSERT_EQ(sanitize("test test^^"), "test test^^");
 }
+
+TEST_F(StringUtilitiesTests, stripExtension_stripsCorrectly) {
+  std::string in = "test.dat";
+  StringUtil::stripExtension(in);
+
+  ASSERT_EQ(in, "test");
+}
+
+TEST_F(StringUtilitiesTests, stripExtension_handlesEmptyString) {
+  std::string in = "";
+  StringUtil::stripExtension(in);
+
+  ASSERT_EQ(in, "");
+}
+
+TEST_F(StringUtilitiesTests, stripExtension_stripsOnlyLastExt) {
+  std::string in = "test.dat.dat";
+  StringUtil::stripExtension(in);
+
+  ASSERT_EQ(in, "test.dat");
+}
+
+TEST_F(StringUtilitiesTests, stripExtension_noExtIsUnmodified) {
+  std::string in = "test";
+  StringUtil::stripExtension(in);
+
+  ASSERT_EQ(in, "test");
+}


### PR DESCRIPTION
If a demo filename ended with a `^`, the list would strip that + the dot separating the file extension, because `sanitize()` was called on the entire string. Instead, strip the extension from the filename, sanitize and then add a color-escaped extension back to the display name.