### PR TITLE
Improve perceived smoothness of mouse cursor

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -4414,16 +4414,9 @@ static void CG_Draw2D() {
     CG_DrawCHS();
   } else {
     if (cgs.eventHandling != CGAME_EVENT_NONE) {
-      //			qboolean old =
-      // cg.showGameView;
-
-      //			cg.showGameView =
-      // qfalse;
       // draw cursor
-      trap_R_SetColor(NULL);
-      CG_DrawPic(cgDC.cursorx - 14, cgDC.cursory - 14, 32, 32,
-                 cgs.media.cursorIcon);
-      //			cg.showGameView = old;
+      trap_R_SetColor(nullptr);
+      cgDC.drawCursor(CURSOR_SIZE, CURSOR_SIZE, cgs.media.cursorIcon);
     }
   }
 

--- a/src/cgame/cg_limbopanel.cpp
+++ b/src/cgame/cg_limbopanel.cpp
@@ -2504,7 +2504,7 @@ qboolean CG_LimboPanel_Draw(void) {
   BG_PanelButtonsRender(limboPanelButtonsLayout);
 
   trap_R_SetColor(NULL);
-  CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
+  cgDC.drawCursor(CURSOR_SIZE, CURSOR_SIZE, cgs.media.cursorIcon);
 
   if (cgs.ccRequestedObjective != -1) {
     if (cg.time - cgs.ccLastObjectiveRequestTime > 1000) {

--- a/src/cgame/cg_loadpanel.cpp
+++ b/src/cgame/cg_loadpanel.cpp
@@ -248,9 +248,7 @@ void CG_DrawConnectScreen(qboolean interactive, qboolean forcerefresh) {
   BG_PanelButtonsRender(loadpanelButtonsLayout);
 
   if (interactive) {
-    DC->drawHandlePic(static_cast<float>(DC->cursorx),
-                      static_cast<float>(DC->cursory), 32, 32,
-                      DC->Assets.cursor);
+    DC->drawCursor(CURSOR_SIZE, CURSOR_SIZE, DC->Assets.cursor);
   }
 
   DC->getConfigString(CS_SERVERINFO, buffer, sizeof(buffer));

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2021,6 +2021,8 @@ typedef struct {
 
   int cursorX;
   int cursorY;
+  int32_t realCursorX; // real X coordinate as per resolution
+  int32_t realCursorY; // real Y coordinate as per resolution
   int eventHandling;
   qboolean mouseCaptured;
   qboolean sizingHud;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -61,7 +61,9 @@ extern "C" FN_PUBLIC intptr_t vmMain(int command, intptr_t arg0, intptr_t arg1,
     case CG_MOUSE_EVENT:
       cgDC.cursorx = cgs.cursorX;
       cgDC.cursory = cgs.cursorY;
-      CG_MouseEvent(arg0, arg1);
+      cgDC.realCursorX = cgs.realCursorX;
+      cgDC.realCursorY = cgs.realCursorY;
+      CG_MouseEvent(static_cast<int32_t>(arg0), static_cast<int32_t>(arg1));
       return 0;
     case CG_EVENT_HANDLING:
       CG_EventHandling(arg0, qtrue);
@@ -3689,6 +3691,7 @@ void CG_LoadHudMenu() {
   cgDC.setColor = &trap_R_SetColor;
   cgDC.drawHandlePic = &CG_DrawPic;
   cgDC.drawStretchPic = &trap_R_DrawStretchPic;
+  cgDC.drawCursor = &ETJump::drawCursor;
   cgDC.drawText = &CG_Text_Paint;
   cgDC.drawTextExt = &CG_Text_Paint_Ext;
   cgDC.textWidth = &CG_Text_Width;
@@ -3753,6 +3756,8 @@ void CG_LoadHudMenu() {
       ceil(cgs.glconfig.vidWidth * 480.0 / cgs.glconfig.vidHeight));
   cgDC.screenWidth = width > 640 ? width : 640;
   cgDC.screenHeight = 480;
+
+  cgDC.glconfig = cgs.glconfig;
 
   Init_Display(&cgDC);
 

--- a/src/cgame/cg_newDraw.cpp
+++ b/src/cgame/cg_newDraw.cpp
@@ -550,24 +550,12 @@ void CG_MouseEvent(int x, int y) {
     case CGAME_EVENT_FIRETEAMMSG:
     case CGAME_EVENT_RTV:
       if (!cgs.demoCam.renderingFreeCam) {
-        float mdx, mdy;
-        ETJump::scaleMenuSensitivity(x, y, &mdx, &mdy);
-        x = static_cast<int>(mdx);
-        y = static_cast<int>(mdy);
+        ETJump::computeCursorPosition(x, y);
 
-        cgs.cursorX += x;
-        if (cgs.cursorX < 0) {
-          cgs.cursorX = 0;
-        } else if (cgs.cursorX > SCREEN_WIDTH) {
-          cgs.cursorX = SCREEN_WIDTH;
-        }
-
-        cgs.cursorY += y;
-        if (cgs.cursorY < 0) {
-          cgs.cursorY = 0;
-        } else if (cgs.cursorY > 480) {
-          cgs.cursorY = 480;
-        }
+        cgs.cursorX = cgDC.cursorx;
+        cgs.cursorY = cgDC.cursory;
+        cgs.realCursorX = cgDC.realCursorX;
+        cgs.realCursorY = cgDC.realCursorY;
 
         if (cgs.eventHandling == CGAME_EVENT_SPEAKEREDITOR) {
           CG_SpeakerEditorMouseMove_Handling(x, y);

--- a/src/cgame/cg_sound.cpp
+++ b/src/cgame/cg_sound.cpp
@@ -1820,7 +1820,7 @@ void CG_SpeakerEditorDraw(void) {
 
     // render cursor
     trap_R_SetColor(NULL);
-    CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
+    cgDC.drawCursor(CURSOR_SIZE, CURSOR_SIZE, cgs.media.cursorIcon);
   }
 }
 

--- a/src/cgame/cg_window.cpp
+++ b/src/cgame/cg_window.cpp
@@ -338,9 +338,7 @@ void CG_windowDraw(void) {
 
   // Mouse cursor lays on top of everything
   if (cg.mvTotalClients > 0 && cg.time < cgs.cursorUpdate && fAllowMV) {
-    // CG_DrawPic(cgs.cursorX - CURSOR_OFFSETX, cgs.cursorY -
-    // CURSOR_OFFSETY, 32, 32, cgs.media.cursor);
-    CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
+    cgDC.drawCursor(CURSOR_SIZE, CURSOR_SIZE, cgs.media.cursorIcon);
   }
 
   if (fCleanup) {

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -969,8 +969,8 @@ void _UI_Refresh(int realtime) {
     uiClientState_t cstate;
     trap_GetClientState(&cstate);
     if (cstate.connState <= CA_DISCONNECTED || cstate.connState >= CA_ACTIVE) {
-      UI_DrawHandlePic(uiInfo.uiDC.cursorx, uiInfo.uiDC.cursory, 32, 32,
-                       uiInfo.uiDC.Assets.cursor);
+      uiInfo.uiDC.drawCursor(CURSOR_SIZE, CURSOR_SIZE,
+                             uiInfo.uiDC.Assets.cursor);
     }
   }
 }
@@ -7161,6 +7161,7 @@ void _UI_Init(int legacyClient, int clientVersion) {
   uiInfo.uiDC.setColor = &UI_SetColor;
   uiInfo.uiDC.drawHandlePic = &UI_DrawHandlePic;
   uiInfo.uiDC.drawStretchPic = &trap_R_DrawStretchPic;
+  uiInfo.uiDC.drawCursor = &ETJump::drawCursor;
   uiInfo.uiDC.drawText = &Text_Paint;
   uiInfo.uiDC.drawTextExt = &Text_Paint_Ext;
   uiInfo.uiDC.textWidth = &Text_Width;
@@ -7418,25 +7419,7 @@ UI_MouseEvent
 =================
 */
 void _UI_MouseEvent(int dx, int dy) {
-  float mdx, mdy;
-  ETJump::scaleMenuSensitivity(dx, dy, &mdx, &mdy);
-  dx = static_cast<int>(mdx);
-  dy = static_cast<int>(mdy);
-
-  // update mouse screen position
-  uiInfo.uiDC.cursorx += dx;
-  if (uiInfo.uiDC.cursorx < 0) {
-    uiInfo.uiDC.cursorx = 0;
-  } else if (uiInfo.uiDC.cursorx > SCREEN_WIDTH) {
-    uiInfo.uiDC.cursorx = SCREEN_WIDTH;
-  }
-
-  uiInfo.uiDC.cursory += dy;
-  if (uiInfo.uiDC.cursory < 0) {
-    uiInfo.uiDC.cursory = 0;
-  } else if (uiInfo.uiDC.cursory > SCREEN_HEIGHT) {
-    uiInfo.uiDC.cursory = SCREEN_HEIGHT;
-  }
+  ETJump::computeCursorPosition(dx, dy);
 
   if (Menu_Count() > 0) {
     Display_MouseMove(nullptr, uiInfo.uiDC.cursorx, uiInfo.uiDC.cursory);
@@ -7620,6 +7603,14 @@ void _UI_SetActiveMenu(const uiMenuCommand_t menu) {
 
   menutype = menu; //----(SA)	added
 
+  // FIXME: this is a dumb hack, we should just not draw the cursor at all,
+  // so that the next time UI is brought back, the cursor isn't at the bottom
+  // right of the screen, but rather remembers the last position it was in
+  const auto hideCursor = [] {
+    uiInfo.uiDC.realCursorX = uiInfo.uiDC.glconfig.vidWidth;
+    uiInfo.uiDC.realCursorY = uiInfo.uiDC.glconfig.vidHeight;
+  };
+
   switch (menu) {
     case UIMENU_NONE:
       trap_Key_SetCatcher(trap_Key_GetCatcher() & ~KEYCATCH_UI);
@@ -7738,48 +7729,42 @@ void _UI_SetActiveMenu(const uiMenuCommand_t menu) {
 
     // NERVE - SMF
     case UIMENU_WM_QUICKMESSAGE:
-      uiInfo.uiDC.cursorx = 640;
-      uiInfo.uiDC.cursory = 480;
+      hideCursor();
       trap_Key_SetCatcher(KEYCATCH_UI);
       Menus_CloseAll();
       Menus_OpenByName("wm_quickmessage");
       return;
 
     case UIMENU_WM_QUICKMESSAGEALT:
-      uiInfo.uiDC.cursorx = 640;
-      uiInfo.uiDC.cursory = 480;
+      hideCursor();
       trap_Key_SetCatcher(KEYCATCH_UI);
       Menus_CloseAll();
       Menus_OpenByName("wm_quickmessageAlt");
       return;
 
     case UIMENU_WM_FTQUICKMESSAGE:
-      uiInfo.uiDC.cursorx = 640;
-      uiInfo.uiDC.cursory = 480;
+      hideCursor();
       trap_Key_SetCatcher(KEYCATCH_UI);
       Menus_CloseAll();
       Menus_OpenByName("wm_ftquickmessage");
       return;
 
     case UIMENU_WM_FTQUICKMESSAGEALT:
-      uiInfo.uiDC.cursorx = 640;
-      uiInfo.uiDC.cursory = 480;
+      hideCursor();
       trap_Key_SetCatcher(KEYCATCH_UI);
       Menus_CloseAll();
       Menus_OpenByName("wm_ftquickmessageAlt");
       return;
 
     case UIMENU_WM_TAPOUT:
-      uiInfo.uiDC.cursorx = 640;
-      uiInfo.uiDC.cursory = 480;
+      hideCursor();
       trap_Key_SetCatcher(KEYCATCH_UI);
       Menus_CloseAll();
       Menus_OpenByName("tapoutmsg");
       return;
 
     case UIMENU_WM_TAPOUT_LMS:
-      uiInfo.uiDC.cursorx = 640;
-      uiInfo.uiDC.cursory = 480;
+      hideCursor();
       trap_Key_SetCatcher(KEYCATCH_UI);
       Menus_CloseAll();
       Menus_OpenByName("tapoutmsglms");

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -127,6 +127,8 @@ inline constexpr float SLIDER_HEIGHT = 10.0f;
 inline constexpr float SLIDER_THUMB_WIDTH = 12.0f;
 inline constexpr float SLIDER_THUMB_HEIGHT = 12.0f;
 
+inline constexpr float CURSOR_SIZE = 32.0f;
+
 inline constexpr int NUM_CROSSHAIRS = 17;
 
 // y offset applied to each line of autowrapped text, along with text height
@@ -466,6 +468,7 @@ typedef struct {
   void (*drawHandlePic)(float x, float y, float w, float h, qhandle_t asset);
   void (*drawStretchPic)(float x, float y, float w, float h, float s1, float t1,
                          float s2, float t2, qhandle_t hShader);
+  void (*drawCursor)(float w, float h, const qhandle_t shader);
   void (*drawText)(float x, float y, float scale, const vec4_t color,
                    const char *text, float adjust, int limit, int style);
   void (*drawTextExt)(float x, float y, float scalex, float scaley,
@@ -564,6 +567,8 @@ typedef struct {
   int frameTime;
   int cursorx;
   int cursory;
+  int32_t realCursorX; // real X coordinate as per resolution
+  int32_t realCursorY; // real Y coordinate as per resolution
   qboolean debug;
 
   cachedAssets_t Assets;
@@ -623,6 +628,8 @@ qboolean PC_Char_Parse(int handle, char *out); // NERVE - SMF
 namespace ETJump {
 bool PC_hasFloat(int handle);
 void scaleMenuSensitivity(int x, int y, float *mdx, float *mdy);
+void computeCursorPosition(int dx, int dy);
+void drawCursor(float w, float h, qhandle_t shader);
 qhandle_t shaderForCrosshair(int crosshairNum, bool isAltShader);
 } // namespace ETJump
 


### PR DESCRIPTION
This makes mouse movement work on real screen pixels rather than virtual grid pixels. Previously, the visual "steps" that the mouse would move in UI was restricted to the resolution of the virtual grid, which made the mouse feel choppy and inaccurate, especially on smaller movements. The visual position is now tracked on real screen pixels, which are then converted to virtual grid coordinates for actual UI interaction.

In the future, we could also consider tracking the real screen coordinates for UI interaction, since this would allow sliders to have more granularity on the drag operations.