### PR TITLE
Hide mouse cursor properly, warp to center when UI is visible

### DIFF
--- a/src/cgame/cg_limbopanel.cpp
+++ b/src/cgame/cg_limbopanel.cpp
@@ -2382,19 +2382,12 @@ void CG_LimboPanel_RenderCounter(panel_button_t *button) {
 void CG_LimboPanel_Setup(void) {
   panel_button_t *button;
   clientInfo_t *ci = &cgs.clientinfo[cg.clientNum];
-  // bg_playerclass_t *classinfo;
   int i;
   char buffer[256];
 
   cgs.limboLoadoutModified = qfalse;
 
-  //	if( !cgs.playedLimboMusic ) {
-  //		trap_S_StartBackgroundTrack(
-  //"sound/music/menu_briefing.wav",
-  //"",
-  // 0
-  //); 		cgs.playedLimboMusic = qtrue;
-  //	}
+  ETJump::centerCursor();
 
   trap_Cvar_VariableStringBuffer("name", buffer, 256);
   trap_Cvar_Set("limboname", buffer);

--- a/src/cgame/cg_newDraw.cpp
+++ b/src/cgame/cg_newDraw.cpp
@@ -645,6 +645,9 @@ void CG_EventHandling(int type, qboolean fForced) {
     trap_Cvar_Set("cl_bypassMouseInput", 0);
   }
 
+  // assume we want cursor visible
+  cgDC.cursorVisible = true;
+
   switch (type) {
     // OSP - Demo support
     case CGAME_EVENT_DEMO:
@@ -712,10 +715,12 @@ void CG_EventHandling(int type, qboolean fForced) {
     cgs.ftMenuPos = static_cast<int>(FTMenuPos::FT_MENUPOS_NONE);
     cgs.ftMenuMode = static_cast<int>(FTMenuMode::FT_VSAY);
     cg.showFireteamMenu = qtrue;
+    cgDC.cursorVisible = false;
     trap_Cvar_Set("cl_bypassmouseinput", "1");
     trap_Key_SetCatcher(KEYCATCH_CGAME);
   } else if (type == CGAME_EVENT_RTV) {
     cg.showRtvMenu = true;
+    cgDC.cursorVisible = false;
     trap_Cvar_Set("cl_bypassmouseinput", "1");
     trap_Key_SetCatcher(KEYCATCH_CGAME);
   } else {

--- a/src/cgame/cg_sound.cpp
+++ b/src/cgame/cg_sound.cpp
@@ -3,6 +3,7 @@
 
 #include "cg_local.h"
 #include "etj_crosshair.h"
+#include "etj_utilities.h"
 
 #include "../game/etj_string_utilities.h"
 
@@ -1990,6 +1991,7 @@ void CG_ModifyEditSpeaker(void) {
   }
 
   CG_EventHandling(CGAME_EVENT_SPEAKEREDITOR, qfalse);
+  ETJump::centerCursor();
 
   editSpeakerActive = qtrue;
   memcpy(&undoSpeaker, editSpeaker, sizeof(undoSpeaker));

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -300,4 +300,16 @@ void ETJump::registerGameShader(const int32_t index, const char *shader) {
   Q_strncpyz(cgs.gameShaderNames[index], shader[0] == '*' ? shader + 1 : shader,
              MAX_QPATH);
 }
+
+void ETJump::centerCursor() {
+  cgDC.cursorx = SCREEN_CENTER_X;
+  cgDC.cursory = SCREEN_CENTER_Y;
+  cgDC.realCursorX = cgDC.glconfig.vidWidth / 2;
+  cgDC.realCursorY = cgDC.glconfig.vidHeight / 2;
+
+  cgs.cursorX = cgDC.cursorx;
+  cgs.cursorY = cgDC.cursory;
+  cgs.realCursorX = cgDC.realCursorX;
+  cgs.realCursorY = cgDC.realCursorY;
+}
 #endif

--- a/src/cgame/etj_utilities.h
+++ b/src/cgame/etj_utilities.h
@@ -89,5 +89,7 @@ void resetTempTraceIgnoredClients();
 bool skipPortalDraw(int selfNum, int otherNum);
 
 void registerGameShader(int32_t index, const char *shader);
+
+void centerCursor();
 #endif
 } // namespace ETJump

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -7552,13 +7552,8 @@ void _UI_SetActiveMenu(const uiMenuCommand_t menu) {
 
   menutype = menu; //----(SA)	added
 
-  // FIXME: this is a dumb hack, we should just not draw the cursor at all,
-  // so that the next time UI is brought back, the cursor isn't at the bottom
-  // right of the screen, but rather remembers the last position it was in
-  const auto hideCursor = [] {
-    uiInfo.uiDC.realCursorX = uiInfo.uiDC.glconfig.vidWidth;
-    uiInfo.uiDC.realCursorY = uiInfo.uiDC.glconfig.vidHeight;
-  };
+  // assume cursor is visible by default
+  uiInfo.uiDC.cursorVisible = true;
 
   switch (menu) {
     case UIMENU_NONE:
@@ -7678,42 +7673,42 @@ void _UI_SetActiveMenu(const uiMenuCommand_t menu) {
 
     // NERVE - SMF
     case UIMENU_WM_QUICKMESSAGE:
-      hideCursor();
+      uiInfo.uiDC.cursorVisible = false;
       trap_Key_SetCatcher(KEYCATCH_UI);
       Menus_CloseAll();
       Menus_OpenByName("wm_quickmessage");
       return;
 
     case UIMENU_WM_QUICKMESSAGEALT:
-      hideCursor();
+      uiInfo.uiDC.cursorVisible = false;
       trap_Key_SetCatcher(KEYCATCH_UI);
       Menus_CloseAll();
       Menus_OpenByName("wm_quickmessageAlt");
       return;
 
     case UIMENU_WM_FTQUICKMESSAGE:
-      hideCursor();
+      uiInfo.uiDC.cursorVisible = false;
       trap_Key_SetCatcher(KEYCATCH_UI);
       Menus_CloseAll();
       Menus_OpenByName("wm_ftquickmessage");
       return;
 
     case UIMENU_WM_FTQUICKMESSAGEALT:
-      hideCursor();
+      uiInfo.uiDC.cursorVisible = false;
       trap_Key_SetCatcher(KEYCATCH_UI);
       Menus_CloseAll();
       Menus_OpenByName("wm_ftquickmessageAlt");
       return;
 
     case UIMENU_WM_TAPOUT:
-      hideCursor();
+      uiInfo.uiDC.cursorVisible = false;
       trap_Key_SetCatcher(KEYCATCH_UI);
       Menus_CloseAll();
       Menus_OpenByName("tapoutmsg");
       return;
 
     case UIMENU_WM_TAPOUT_LMS:
-      hideCursor();
+      uiInfo.uiDC.cursorVisible = false;
       trap_Key_SetCatcher(KEYCATCH_UI);
       Menus_CloseAll();
       Menus_OpenByName("tapoutmsglms");
@@ -7731,6 +7726,13 @@ void _UI_SetActiveMenu(const uiMenuCommand_t menu) {
       // trap_Cvar_Set( "cl_paused", "1" );
       trap_Key_SetCatcher(KEYCATCH_UI);
       Menus_OpenByName("ingame_messagemode");
+
+      // special case for chat, we don't really want the cursor to be
+      // in the middle of the screen, it would be annoying to have the cursor
+      // constantly pop-up in the middle of the screen e.g. when spectating
+      // someone and chatting - set to top-left instead
+      uiInfo.uiDC.realCursorX = 0;
+      uiInfo.uiDC.realCursorY = 0;
       return;
 
     case UIMENU_INGAME_FT_SAVELIMIT:

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -1193,6 +1193,9 @@ void Menus_CloseAll() {
     Menus[i].window.flags &=
         ~(WINDOW_HASFOCUS | WINDOW_VISIBLE | WINDOW_MOUSEOVER);
   }
+
+  DC->realCursorX = DC->glconfig.vidWidth / 2;
+  DC->realCursorY = DC->glconfig.vidHeight / 2;
 }
 
 void Script_Show(itemDef_t *item, qboolean *bAbort, const char **args) {
@@ -8632,6 +8635,10 @@ void computeCursorPosition(int dx, int dy) {
 }
 
 void drawCursor(float w, float h, const qhandle_t shader) {
+  if (!DC->cursorVisible) {
+    return;
+  }
+
   float s0{};
   float s1{};
   float t0{};

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -568,6 +568,7 @@ typedef struct {
   int cursory;
   int32_t realCursorX; // real X coordinate as per resolution
   int32_t realCursorY; // real Y coordinate as per resolution
+  bool cursorVisible;
   qboolean debug;
 
   cachedAssets_t Assets;


### PR DESCRIPTION
Rather than setting the mouse position to the bottom right of the screen to effectively hide it, just don't draw the cursor at all if it's not supposed to draw.

The cursor is now also warped to the middle of the screen whenever UI is brought up. Previously, the cursor position was remembered when UI was toggled, which was a bit disorientating. An exception is chat UI, where we position the cursor to the top left, as it would be annoying to constantly have it pop up in the middle of the screen, if a player is e.g. spectating and actively chatting.