### PR TITLE
Fix votes not drawing keybinds correctly

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -2162,6 +2162,7 @@ static void CG_DrawVote() {
 
   std::string line_a;
   std::string line_b;
+  std::string line_c; // used for rtv with spectator voting disabled
   float x_a = 8.0f;
   float x_b = 8.0f;
 
@@ -2247,7 +2248,8 @@ static void CG_DrawVote() {
         const int32_t totalYes =
             rtvYesVotes.playerCount + rtvYesVotes.spectatorCount;
 
-        if (ETJump::demoCompatibility->flags.noSpecCountInVoteCs) {
+        if (!etj_spectatorVote.integer ||
+            ETJump::demoCompatibility->flags.noSpecCountInVoteCs) {
           return ETJump::stringFormat(str, std::to_string(totalYes),
                                       std::to_string(cgs.voteNo));
         }
@@ -2259,7 +2261,8 @@ static void CG_DrawVote() {
             ETJump::stringFormat("%i(%i)", cgs.voteNo, cgs.voteNoSpectators));
       }
 
-      if (ETJump::demoCompatibility->flags.noSpecCountInVoteCs) {
+      if (!etj_spectatorVote.integer ||
+          ETJump::demoCompatibility->flags.noSpecCountInVoteCs) {
         return ETJump::stringFormat(str, std::to_string(cgs.voteYes),
                                     std::to_string(cgs.voteNo));
       }
@@ -2273,11 +2276,13 @@ static void CG_DrawVote() {
     if (isRtvVote) {
       if (!(cg.snap->ps.eFlags & EF_VOTED)) {
         line_a = ETJump::stringFormat("VOTE(%i): %s", sec, cgs.voteString);
-        line_b = formatVoteStr("Change map(" + str1 +
-                               "):%s, Keep current map(" + str2 + "):%s");
 
-        if (!canVote) {
-          line_b += " (Spectators can't vote)";
+        if (canVote) {
+          line_b = formatVoteStr("Change map(" + str1 +
+                                 "):%s, Keep current map(" + str2 + "):%s");
+        } else {
+          line_b = formatVoteStr("Change map:%s, Keep current map:%s");
+          line_c = "Spectators can't vote";
         }
       } else {
         line_a =
@@ -2319,10 +2324,12 @@ static void CG_DrawVote() {
     } else {
       if (!(cg.snap->ps.eFlags & EF_VOTED)) {
         line_a = ETJump::stringFormat("VOTE(%i): %s", sec, cgs.voteString);
-        line_b = formatVoteStr("YES:%s, NO:%s");
 
-        if (!canVote) {
-          line_b += " (Spectators can't vote)";
+        if (canVote) {
+          line_b = formatVoteStr("YES(" + str1 + "):%s, NO(" + str2 + "):%s");
+        } else {
+          line_b = formatVoteStr("YES:%s, NO:%s");
+          line_c = "Spectators can't vote";
         }
       } else {
         line_a =
@@ -2417,6 +2424,11 @@ static void CG_DrawVote() {
 
   if (!line_b.empty()) {
     ETJump::DrawString(x_b, 226, 0.23f, 0.25f, color, qtrue, line_b.c_str(), 80,
+                       ITEM_TEXTSTYLE_SHADOWED);
+  }
+
+  if (!line_c.empty()) {
+    ETJump::DrawString(x_b, 240, 0.23f, 0.25f, color, qtrue, line_c.c_str(), 80,
                        ITEM_TEXTSTYLE_SHADOWED);
   }
 }


### PR DESCRIPTION
This has been broken for a while, but the vote text now draws the keybinds for `vote yes/no` correctly, and properly hides the keybinds for spectators if spectator voting is disabled. The vote text also no longer displays spectator votes separately, if spectator voting is disabled.

This also introduces a new line to the vote UI, which shows the `Spectators can't vote` text, if spectator voting is disabled. The text was quite long on RTV votes, so it's better to have it on a separate line.

fixes #1796 
refs #1135, #1793