### PR TITLE
Fix crash with tjl_displayByNumber + minor cleanup

### DIFF
--- a/src/cgame/etj_trickjump_lines.cpp
+++ b/src/cgame/etj_trickjump_lines.cpp
@@ -41,10 +41,7 @@ const char *getTextForEnum(int enumVal) { return EnumStrings[enumVal]; }
 TrickjumpLines::TrickjumpLines(
     const std::shared_ptr<ClientCommandsHandler> &serverCommandsHandler,
     const std::shared_ptr<ClientCommandsHandler> &consoleCommandsHandler)
-    : _recording(false), _enableLine(false), _enableMarker(false),
-      _jumpRelease(true), _debugVerbose(false), _nextRecording(1),
-      _nextAddTime(0), _currentRouteToRender(-1), _currentRotation({}),
-      serverCommandsHandler(serverCommandsHandler),
+    : serverCommandsHandler(serverCommandsHandler),
       consoleCommandsHandler(consoleCommandsHandler) {
   this->_currentRotation.init();
 
@@ -140,18 +137,15 @@ void TrickjumpLines::registerCommands() {
     setCurrentRouteToRender(num);
   };
 
-  serverCommandsHandler->subscribe(
-      "tjl_displaybynumber",
-      [&displayByNumber](const auto &args) { displayByNumber(args); }, false);
+  serverCommandsHandler->subscribe("tjl_displaybynumber", displayByNumber,
+                                   false);
 
   consoleCommandsHandler->subscribe(
       "tjl_displaybyname", [this](const auto &args) {
         displayByName(args.empty() ? nullptr : args[0].c_str());
       });
 
-  consoleCommandsHandler->subscribe(
-      "tjl_displaybynumber",
-      [&displayByNumber](const auto &args) { displayByNumber(args); });
+  consoleCommandsHandler->subscribe("tjl_displaybynumber", displayByNumber);
 
   consoleCommandsHandler->subscribe(
       "tjl_clearrender", [this](const auto &) { setCurrentRouteToRender(-1); });

--- a/src/cgame/etj_trickjump_lines.h
+++ b/src/cgame/etj_trickjump_lines.h
@@ -152,21 +152,21 @@ private:
   void registerCommands();
 
   // Private variable
-  bool _recording;
-  bool _enableLine;
-  bool _enableMarker;
-  bool _jumpRelease;
-  bool _debugVerbose;
+  bool _recording{};
+  bool _enableLine{};
+  bool _enableMarker{};
+  bool _jumpRelease{};
+  bool _debugVerbose{};
 
-  Route _currentRoute;
+  Route _currentRoute{};
   std::vector<Route> _routes;
   std::vector<Node> _currentTrail;
-  unsigned _nextRecording;
-  int _nextAddTime;
-  int _currentRouteToRender;
-  RotationMatrix _currentRotation;
+  unsigned _nextRecording{};
+  int _nextAddTime{};
+  int _currentRouteToRender{};
+  RotationMatrix _currentRotation{};
 
-  int32_t nextNearest;
+  int32_t nextNearest{};
 
   std::shared_ptr<ClientCommandsHandler> serverCommandsHandler;
   std::shared_ptr<ClientCommandsHandler> consoleCommandsHandler;


### PR DESCRIPTION
The `displayByNumber` was captured by both the console and server command by reference, but it was just a lambda in the local scope, so it became a dangling reference.

This whole TJL stuff is incredibly broken and this is just one of many crashes that this feature can cause from user input, I'll need to fix all of this some day. This command for example does no bounds checking for the input and just does a raw access by index to the route vector based off user input...

refs #1816 