### PR TITLE
Simplify clientside player collision resolving

### DIFF
--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -1915,26 +1915,6 @@ static float CG_ScanForCrosshairEntity(float *zChange, qboolean *hitClient) {
   return dist;
 }
 
-namespace ETJump {
-void cursorhintTrace(trace_t *trace, vec3_t start, vec3_t end) {
-  CG_Trace(trace, start, vec3_origin, vec3_origin, end, cg.snap->ps.clientNum,
-           MASK_PLAYERSOLID);
-
-  if (trace->entityNum >= MAX_CLIENTS) {
-    return;
-  }
-
-  while (trace->entityNum < MAX_CLIENTS &&
-         !playerIsSolid(cg.snap->ps.clientNum, trace->entityNum)) {
-    tempTraceIgnoreClient(trace->entityNum);
-    CG_Trace(trace, start, vec3_origin, vec3_origin, end, cg.snap->ps.clientNum,
-             MASK_PLAYERSOLID);
-  }
-
-  resetTempTraceIgnoredClients();
-}
-} // namespace ETJump
-
 /*
 ==============
 CG_CheckForCursorHints
@@ -1967,7 +1947,8 @@ void CG_CheckForCursorHints() {
   VectorCopy(cg.refdef_current->vieworg, start);
   VectorMA(start, CH_DIST, cg.refdef_current->viewaxis[0], end);
 
-  ETJump::cursorhintTrace(&trace, start, end);
+  CG_Trace(&trace, start, vec3_origin, vec3_origin, end, cg.snap->ps.clientNum,
+           MASK_PLAYERSOLID);
 
   if (trace.fraction == 1.0f) {
     return;

--- a/src/cgame/cg_flamethrower.cpp
+++ b/src/cgame/cg_flamethrower.cpp
@@ -139,29 +139,6 @@ inline constexpr int FLAME_BLUE_LIFE =
 int rotatingFlames = qtrue;
 
 namespace ETJump {
-static void flamechunkTrace(trace_t *trace, vec3_t start, vec3_t end,
-                            const int skipNumber, const int mask) {
-  CG_Trace(trace, start, flameChunkMins, flameChunkMaxs, end, skipNumber, mask);
-
-  // a flamechunk might be spawned by an entity in the map (props_flamethrower)
-  if (!isValidClientNum(skipNumber)) {
-    return;
-  }
-
-  if (trace->entityNum >= MAX_CLIENTS) {
-    return;
-  }
-
-  while (trace->entityNum < MAX_CLIENTS &&
-         !playerIsSolid(skipNumber, trace->entityNum)) {
-    tempTraceIgnoreClient(trace->entityNum);
-    CG_Trace(trace, start, flameChunkMins, flameChunkMaxs, end, skipNumber,
-             mask);
-  }
-
-  resetTempTraceIgnoredClients();
-}
-
 static bool drawFlamethrowerEffect(const flameChunk_t *f) {
   if (f->ownerCent == cg.snap->ps.clientNum) {
     if (etj_hideFlamethrowerEffects.integer &
@@ -268,8 +245,8 @@ void CG_FireFlameChunks(centity_t *cent, vec3_t origin, vec3_t angles,
     while (t <= cg.time) {
       // spawn a new chunk
       CG_FlameLerpVec(lastOrg, thisOrg, backLerp, org);
-      ETJump::flamechunkTrace(&trace, org, org, cent->currentState.number,
-                              MASK_SHOT | MASK_WATER);
+      CG_Trace(&trace, org, flameChunkMins, flameChunkMaxs, org,
+               cent->currentState.number, MASK_SHOT | MASK_WATER);
 
       // fix for engine bug where trace sometimes starts in solid even if
       // the entity that it starts in is nonsolid
@@ -663,8 +640,9 @@ void CG_MoveFlameChunk(flameChunk_t *f) {
   while (f->velSpeed > 1 && f->baseOrgTime != cg.time) {
     CG_FlameCalcOrg(f, cg.time, newOrigin);
 
-    ETJump::flamechunkTrace(&trace, sOrg, newOrigin, f->ownerCent,
-                            MASK_SHOT | MASK_WATER);
+    // trace a line from previous position to new position
+    CG_Trace(&trace, sOrg, flameChunkMins, flameChunkMaxs, newOrigin,
+             f->ownerCent, MASK_SHOT | MASK_WATER);
 
     // fix for engine bug where trace sometimes starts in solid even if
     // the entity that it starts in is nonsolid

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4226,7 +4226,6 @@ extern std::shared_ptr<EventLoop> eventLoop;
 extern std::shared_ptr<PlayerEventsHandler> playerEventsHandler;
 extern std::shared_ptr<ClientRtvHandler> rtvHandler;
 extern std::unique_ptr<DemoCompatibility> demoCompatibility;
-extern std::array<bool, MAX_CLIENTS> tempTraceIgnoredClients;
 extern std::shared_ptr<PlayerBBox> playerBBox;
 extern std::unique_ptr<SavePos> savePos;
 extern std::unique_ptr<SyscallExt> syscallExt;

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -93,7 +93,6 @@ std::shared_ptr<ClientRtvHandler> rtvHandler;
 std::shared_ptr<AreaIndicator> areaIndicator;
 std::unique_ptr<DemoCompatibility> demoCompatibility;
 std::shared_ptr<AccelColor> accelColor;
-std::array<bool, MAX_CLIENTS> tempTraceIgnoredClients;
 std::shared_ptr<PlayerBBox> playerBBox;
 std::unique_ptr<SavePos> savePos;
 std::unique_ptr<SyscallExt> syscallExt;
@@ -352,8 +351,6 @@ void init() {
 
   assert(timerun != nullptr);
   savePos = std::make_unique<SavePos>(timerun);
-
-  std::fill_n(tempTraceIgnoredClients.begin(), MAX_CLIENTS, false);
 
   ServerCommands::registerCommands();
   ConsoleCommands::registerCommands();

--- a/src/cgame/etj_overbounce_detector.cpp
+++ b/src/cgame/etj_overbounce_detector.cpp
@@ -57,7 +57,8 @@ bool OverbounceDetector::beforeRender() {
     VectorCopy(start, end);
     end[2] -= Overbounce::MAX_TRACE_DIST;
 
-    overbounceTrace(trace, start, end);
+    CG_Trace(&trace, start, nullptr, nullptr, end, ps->clientNum,
+             traceContents);
 
     if (trace.fraction != 1.0 && trace.plane.type == 2) {
       // something was hit and it's a floor
@@ -76,7 +77,7 @@ bool OverbounceDetector::beforeRender() {
   VectorCopy(cg.refdef.vieworg, start);
   VectorMA(start, Overbounce::MAX_TRACE_DIST, cg.refdef.viewaxis[0], end);
 
-  overbounceTrace(trace, start, end);
+  CG_Trace(&trace, start, nullptr, nullptr, end, ps->clientNum, traceContents);
 
   if (trace.fraction != 1.0 && trace.plane.type == 2) {
     // something was hit and it's a floor
@@ -143,25 +144,6 @@ void OverbounceDetector::render() const {
     CG_DrawStringExt(static_cast<int>(x - 20), etj_OBY.integer, "S", colorWhite,
                      qfalse, qtrue, TINYCHAR_WIDTH, TINYCHAR_HEIGHT, 0);
   }
-}
-
-void OverbounceDetector::overbounceTrace(trace_t &tr, const vec3_t tr_start,
-                                         const vec3_t tr_end) {
-  CG_Trace(&tr, tr_start, nullptr, nullptr, tr_end, ps->clientNum,
-           traceContents);
-
-  if (cg_ghostPlayers.integer != 1 || tr.entityNum >= MAX_CLIENTS) {
-    return;
-  }
-
-  while (tr.entityNum < MAX_CLIENTS &&
-         !ETJump::playerIsSolid(ps->clientNum, tr.entityNum)) {
-    tempTraceIgnoreClient(tr.entityNum);
-    CG_Trace(&tr, tr_start, nullptr, nullptr, tr_end, ps->clientNum,
-             traceContents);
-  }
-
-  resetTempTraceIgnoredClients();
 }
 
 bool OverbounceDetector::canSkipDraw() {

--- a/src/cgame/etj_overbounce_detector.h
+++ b/src/cgame/etj_overbounce_detector.h
@@ -32,7 +32,6 @@ class OverbounceDetector : public IRenderable {
   bool beforeRender() override;
   void render() const override;
   static bool canSkipDraw();
-  void overbounceTrace(trace_t &tr, const vec3_t tr_start, const vec3_t tr_end);
 
   playerState_t *ps;
   float x;

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -261,18 +261,6 @@ bool playerIsNoclipping(const int clientNum) {
          static_cast<int>(PlayerDensityFlags::Noclip);
 }
 
-void tempTraceIgnoreClient(int clientNum) {
-  if (clientNum < 0 || clientNum >= MAX_CLIENTS) {
-    return;
-  }
-
-  tempTraceIgnoredClients[clientNum] = true;
-}
-
-void resetTempTraceIgnoredClients() {
-  std::fill_n(tempTraceIgnoredClients.begin(), MAX_CLIENTS, false);
-}
-
 bool skipPortalDraw(const int selfNum, const int otherNum) {
   if (selfNum == otherNum) {
     return false;

--- a/src/cgame/etj_utilities.h
+++ b/src/cgame/etj_utilities.h
@@ -82,10 +82,6 @@ bool playerIsSolid(int self, int other);
 // checks if target client is noclipping
 bool playerIsNoclipping(int clientNum);
 
-void tempTraceIgnoreClient(int clientNum);
-
-void resetTempTraceIgnoredClients();
-
 bool skipPortalDraw(int selfNum, int otherNum);
 
 void registerGameShader(int32_t index, const char *shader);


### PR DESCRIPTION
Rather than filtering this out everywhere where it's relevant, just figure out which players are solid when building the solid entity list, so we don't need to take extra care everywhere when tracing against the world, as it just works automatically if the client doesn't think the entities are solid to begin with.

refs #1333 