### PR TITLE
Add func_static_client entity

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4227,6 +4227,8 @@ extern std::shared_ptr<PlayerEventsHandler> playerEventsHandler;
 extern std::shared_ptr<ClientRtvHandler> rtvHandler;
 extern std::unique_ptr<DemoCompatibility> demoCompatibility;
 extern std::array<bool, MAX_CLIENTS> tempTraceIgnoredClients;
+// TODO: remove the client array and just use this for everything
+extern std::vector<int32_t> tempTraceIgnoredEntities;
 extern std::shared_ptr<PlayerBBox> playerBBox;
 extern std::unique_ptr<SavePos> savePos;
 extern std::unique_ptr<SyscallExt> syscallExt;

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -5,9 +5,11 @@
 // ahead the client's movement.
 // It also handles local physics interaction, like fragments bouncing off walls
 
+#include <algorithm>
 #include <array>
 #include "cg_local.h"
 #include "etj_utilities.h"
+
 #include "../game/etj_entity_utilities_shared.h"
 #include "../game/etj_portalgun_shared.h"
 
@@ -151,6 +153,14 @@ static void CG_ClipMoveToEntities(const vec3_t start, const vec3_t mins,
 
     if (ent->number < MAX_CLIENTS &&
         ETJump::tempTraceIgnoredClients[ent->number]) {
+      continue;
+    }
+
+    // ignore collision with 'func_static_client' if it's turned off for us
+    if (ent->eType == ET_STATIC_CLIENT &&
+        std::find(ETJump::tempTraceIgnoredEntities.cbegin(),
+                  ETJump::tempTraceIgnoredEntities.cend(),
+                  ent->number) != ETJump::tempTraceIgnoredEntities.cend()) {
       continue;
     }
 
@@ -1064,18 +1074,7 @@ void CG_PredictPlayerState() {
 
   cg_pmove.skill = cgs.clientinfo[cg.snap->ps.clientNum].skill;
 
-  for (int i = 0; i < MAX_CLIENTS; i++) {
-    const int other = cg_entities[i].currentState.number;
-
-    if (cg.snap->ps.clientNum == other) {
-      continue;
-    }
-
-    if (!ETJump::playerIsSolid(cg.snap->ps.clientNum, other) ||
-        ETJump::playerIsNoclipping(other)) {
-      ETJump::tempTraceIgnoreClient(other);
-    }
-  }
+  ETJump::tempTraceIgnoreEntities();
 
   cg_pmove.trace = CG_TraceCapsule;
   cg_pmove.pointcontents = CG_PointContents;
@@ -1459,6 +1458,7 @@ void CG_PredictPlayerState() {
   }
 
   ETJump::resetTempTraceIgnoredClients();
+  ETJump::tempTraceIgnoredEntities.clear();
 
   // unlagged - optimized prediction
   //  do a /condump after a few seconds of this

--- a/src/cgame/etj_init.cpp
+++ b/src/cgame/etj_init.cpp
@@ -94,6 +94,7 @@ std::shared_ptr<AreaIndicator> areaIndicator;
 std::unique_ptr<DemoCompatibility> demoCompatibility;
 std::shared_ptr<AccelColor> accelColor;
 std::array<bool, MAX_CLIENTS> tempTraceIgnoredClients;
+std::vector<int32_t> tempTraceIgnoredEntities;
 std::shared_ptr<PlayerBBox> playerBBox;
 std::unique_ptr<SavePos> savePos;
 std::unique_ptr<SyscallExt> syscallExt;

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -261,6 +261,33 @@ bool playerIsNoclipping(const int clientNum) {
          static_cast<int>(PlayerDensityFlags::Noclip);
 }
 
+void tempTraceIgnoreEntities() {
+  for (int i = 0; i < cg.snap->numEntities; i++) {
+    if (cg.snap->entities[i].eType == ET_PLAYER) {
+      const int other = cg.snap->entities[i].number;
+
+      if (!playerIsSolid(cg.snap->ps.clientNum, other) ||
+          playerIsNoclipping(other)) {
+        tempTraceIgnoreClient(other);
+      }
+    } else {
+      const entityState_t *es = &cg.snap->entities[i];
+
+      if (es->eType != ET_STATIC_CLIENT) {
+        continue;
+      }
+
+      const int32_t clientNum = cg.snap->ps.clientNum;
+
+      if (COM_BitCheck((clientNum < MAX_CLIENTS / 2) ? &es->effect1Time
+                                                     : &es->effect2Time,
+                       clientNum)) {
+        tempTraceIgnoredEntities.emplace_back(es->number);
+      }
+    }
+  }
+}
+
 void tempTraceIgnoreClient(int clientNum) {
   if (clientNum < 0 || clientNum >= MAX_CLIENTS) {
     return;

--- a/src/cgame/etj_utilities.h
+++ b/src/cgame/etj_utilities.h
@@ -82,6 +82,8 @@ bool playerIsSolid(int self, int other);
 // checks if target client is noclipping
 bool playerIsNoclipping(int clientNum);
 
+void tempTraceIgnoreEntities();
+
 void tempTraceIgnoreClient(int clientNum);
 
 void resetTempTraceIgnoredClients();

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(qagame MODULE
 	"etj_file.cpp"
 	"etj_filesystem.cpp"
 	"etj_fireteam_countdown.cpp"
+	"etj_func_static_client.cpp"
 	"etj_inactivity_timer.cpp"
 	"etj_json_utilities.cpp"
 	"etj_levels.cpp"

--- a/src/game/etj_func_static_client.cpp
+++ b/src/game/etj_func_static_client.cpp
@@ -1,0 +1,149 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_func_static_client.h"
+
+namespace ETJump {
+inline constexpr int32_t SF_START_INVIS = 1 << 0;
+inline constexpr int32_t SF_GIB_INSIDE = 1 << 1;
+
+/*
+ * 'ent->s.effect1Time' and 'ent->s.effect2Time' are treated as boolean
+ * bitsets by this entity. Clients 0-31 map to 'effect1Time',
+ * clients 32-63 map to 'effect2Time'. If the bit corresponding to the
+ * client's number is set in the entity, the entity is considered to be
+ * in "off" state, and the client ignores collision with the entity.
+ * Unless 'offShader' or 'offModel' are set, the entity will also be
+ * completely invisible to the client.
+ *
+ * If 'model2' is set, the entity's brushmodel will be used for collision.
+ */
+void FuncStaticClient::spawn(gentity_t *ent) {
+  trap_SetBrushModel(ent, ent->model);
+  InitMover(ent);
+
+  // re-link with correct origin
+  VectorCopy(ent->s.origin, ent->s.pos.trBase);
+  VectorCopy(ent->s.origin, ent->r.currentOrigin);
+  trap_LinkEntity(ent);
+
+  ent->use = use;
+  ent->s.eType = ET_STATIC_CLIENT;
+
+  // hide by default for all clients if spawnflag 1 is set
+  if (ent->spawnflags & SF_START_INVIS) {
+    ent->s.effect1Time = INT_MAX;
+    ent->s.effect2Time = INT_MAX;
+  }
+
+  char *s = nullptr;
+
+  // 'model2' support so we can also use models
+  // NOTE: using 'ent->s.density' for both 'offModel' and 'offShader',
+  // since they are mutually exclusive - client knows how to interpret this
+  // by checking if 'ent->s.modelindex2' is set or not
+  if (ent->s.modelindex2) {
+    // alternative model if 'model2' is set, when the brush is in "off" state
+    if (G_SpawnString("offModel", "", &s)) {
+      ent->s.density = G_ModelIndex(s);
+    }
+  } else {
+    // custom shader when the brush is in "off" state
+    if (G_SpawnString("offShader", "", &s)) {
+      ent->s.density = G_ShaderIndex(s);
+    }
+  }
+}
+
+void FuncStaticClient::use(gentity_t *self, [[maybe_unused]] gentity_t *other,
+                           gentity_t *activator) {
+  if (!activator || !activator->client) {
+    G_Error("'%s' cannot be used by a non-client entity", self->classname);
+  }
+
+  const int32_t clientNum = ClientNum(activator);
+
+  if (clientNum < MAX_CLIENTS / 2) {
+    COM_BitCheck(&self->s.effect1Time, clientNum) ? turnOn(self, clientNum)
+                                                  : turnOff(self, clientNum);
+  } else {
+    COM_BitCheck(&self->s.effect2Time, clientNum) ? turnOn(self, clientNum)
+                                                  : turnOff(self, clientNum);
+  }
+
+  self->activator = activator;
+
+  if (self->scriptName) {
+    G_Script_ScriptEvent(
+        self, "activate",
+        activator->client->sess.sessionTeam == TEAM_AXIS ? "axis" : "allies");
+  }
+
+  G_UseTargets(self, self->activator);
+}
+
+void FuncStaticClient::turnOn(gentity_t *self, const int32_t clientNum) {
+  if (clientNum < MAX_CLIENTS / 2) {
+    COM_BitClear(&self->s.effect1Time, clientNum);
+  } else {
+    COM_BitClear(&self->s.effect2Time, clientNum);
+  }
+
+  if (self->spawnflags & SF_GIB_INSIDE &&
+      activatorIsInsideEnt(self, clientNum)) {
+    G_Damage(g_entities + clientNum, self, self, nullptr, nullptr, 9999,
+             DAMAGE_NO_PROTECTION, MOD_CRUSH);
+  }
+}
+
+void FuncStaticClient::turnOff(gentity_t *self, const int32_t clientNum) {
+  if (clientNum < MAX_CLIENTS / 2) {
+    COM_BitSet(&self->s.effect1Time, clientNum);
+  } else {
+    COM_BitSet(&self->s.effect2Time, clientNum);
+  }
+}
+
+bool FuncStaticClient::activatorIsInsideEnt(const gentity_t *self,
+                                            const int32_t clientNum) {
+  std::array<int32_t, MAX_GENTITIES> touch{};
+  const gentity_t *activator = g_entities + clientNum;
+  vec3_t mins{};
+  vec3_t maxs{};
+
+  VectorAdd(activator->r.currentOrigin, activator->client->ps.mins, mins);
+  VectorAdd(activator->r.currentOrigin, activator->client->ps.maxs, maxs);
+
+  const int32_t count =
+      trap_EntitiesInBox(mins, maxs, touch.data(), MAX_GENTITIES);
+
+  for (int32_t i = 0; i < count; i++) {
+    if (touch[i] == self->s.number) {
+      return true;
+    }
+  }
+
+  return false;
+}
+} // namespace ETJump

--- a/src/game/etj_func_static_client.h
+++ b/src/game/etj_func_static_client.h
@@ -1,0 +1,38 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "g_local.h"
+
+namespace ETJump {
+class FuncStaticClient {
+public:
+  static void spawn(gentity_t *ent);
+  static void use(gentity_t *self, gentity_t *other, gentity_t *activator);
+  static void turnOn(gentity_t *self, int32_t clientNum);
+  static void turnOff(gentity_t *self, int32_t clientNum);
+  static bool activatorIsInsideEnt(const gentity_t *self, int32_t clientNum);
+};
+} // namespace ETJump

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1238,12 +1238,26 @@ void ClientThink_real(gentity_t *ent) {
     pm.cmd.weapon = client->ps.weapon;
   }
 
-  // setup nonsolid players
-  for (int i = 0; i < level.numConnectedClients; i++) {
-    const int otherNum = level.sortedClients[i];
+  // setup nonsolid entities
+  for (int i = 0; i < level.num_entities; i++) {
+    if (i < MAX_CLIENTS) {
+      const int otherNum = level.sortedClients[i];
 
-    if (!ETJump::EntityUtilities::playerIsSolid(clientNum, otherNum)) {
-      G_TempTraceIgnoreEntity(g_entities + otherNum);
+      if (!ETJump::EntityUtilities::playerIsSolid(clientNum, otherNum)) {
+        G_TempTraceIgnoreEntity(g_entities + otherNum);
+      }
+    } else {
+      gentity_t *tent = &g_entities[i];
+
+      if (tent->s.eType != ET_STATIC_CLIENT) {
+        continue;
+      }
+
+      if (COM_BitCheck((clientNum < MAX_CLIENTS / 2) ? &tent->s.effect1Time
+                                                     : &tent->s.effect2Time,
+                       clientNum)) {
+        G_TempTraceIgnoreEntity(tent);
+      }
     }
   }
 

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -23,6 +23,7 @@
 #include "etj_entity_utilities.h"
 #include "etj_progression_tracker.h"
 #include "etj_target_random.h"
+#include "etj_func_static_client.h"
 
 qboolean G_SpawnStringExt(const char *key, const char *defaultString,
                           char **out, const char *file, int line) {
@@ -729,6 +730,7 @@ spawn_t spawns[] = {
     {"target_ft_setrules", ETJump::TargetFtSetRules::spawn},
     {"target_spawn_relay", ETJump::TargetSpawnRelay::spawn},
     {"target_random", ETJump::TargetRandom::spawn},
+    {"func_static_client", ETJump::FuncStaticClient::spawn},
     {nullptr, nullptr},
 };
 

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -1621,6 +1621,8 @@ typedef enum {
 
   ET_FAKEBRUSH, // func_fakebrush
 
+  ET_STATIC_CLIENT, // func_static_client
+
   ET_EVENTS, // any of the EV_* events can be added freestanding
              // by setting eType to ET_EVENTS + eventNum
              // this avoids having to set eFlags and eventNum


### PR DESCRIPTION
A brush entity that is in a unique state for each client. When a client turns on/off the brush, it turns solid/nonsolid for the activating client only, without affecting the state for other players.

Supported keys:
* `model2` - optional model to draw
  * requires origin brush
  * uses the brushes of the entity for collision - use nonsolid shaders if you want the entity to be completely nonsolid
* `offShader/offModel` - optional shader/model to use when the brush is in "off" state
  * these keys are mutually exclusive, `offModel` is ignored unless `model2` is set, which in turn ignores `offShader`
  * if neither is set, the entity will simply turn invisible when in "off" state
* `scriptname` - optional, script block to call when activated. Calls the `activate` trigger, `activate allies/axis` supported
* `target` - optional, target(s) to fire when activated

Spawnflags:
* `1` - "off" by default for all clients
* `2` - gib the player if they are standing inside the entity when it's turned "on"

Entity for radiant:
```xml
<group name="func_static_client" color="0 0.5 0.8">
A brush model that just sits there, doing nothing.
Can be used for conditional walls and models.
The state of this brush is unique for each client.
-------- KEYS --------
<model key="model2" name="model2">Optional md3/mdc model to also draw.</model>
<model key="offModel" name="Off model">Optional md3/mdc model to when the brush is turned "off". Requires "model2" to also be set.</model>
<string key="offShader" name="Off shader">Optional alternative shader to draw when the brush is turned "off". Does nothing if "model2" is set.</string>
<targetname key="targetname" name="Targetname">When targeted, toggles existence for the activating client.</targetname>
<target key="target" name="Target">Target(s) to fire when used.</target>
<string key="scriptname" name="Scriptname">Optional, script block to call when activated. This calls the "activate" trigger.</string>
<texture key="targetShaderName" name="Target shader name">Shader to remap when targets are fired.</texture>
<texture key="targetShaderNewName" name="Target shader new name">Shader to remap "targetShaderName" to when targets are fired.</texture>
-------- Q3MAP2 KEYS --------
<integer key="_cs" name="Cast shadows">Per-entity control of shadow casting, used to disable (0) or enable shadow casting to entities with corresponding "_rs" value. Defaults to 1 on world, 0 on entities.</integer>
<integer key="_rs" name="Receive shadows">Per-entity control of shadow receiving, used to disable (0) or enable shadow receiving from entities with corresponding "_cs" value. Defaults to 1 on everything.</integer>
<real key="_lightmapscale" name="Lightmap Scale" value="1.0">Scaling factor for lightmap size.</real>
<integer key="_samplesize" name="Samplesize">Default surface lightmap sample size.</integer>
<real key="_shadeangle" name="Shadeangle">Largest allowed angle between faces to be treated as same nonplanar surface.</real>
<string key="_clone" name="Clone">Name of the brush entity to copy brushes from (can be used to use the same brush model multiple times).</string>
<string key="_clonename" name="Clonename">Name referenced by "_clone".</string>
<texture key="_celshader" name="CelShader">CelShader to use, omit "textures/" prefix.</texture>
<boolean key="_patchMeta" name="Patch Meta">Generate meta surfaces from patches.</boolean>
<integer key="_patchQuality" name="Patch Quality">Quality multiplier for patches when "_patchMeta" is set. Note: integer values only.</integer>
<integer key="_patchSubdivide" name="Patch Subdivide">Absolute quality setting for patches when "_patchMeta" is set. Note: integer values only.</integer>
-------- SPAWNFLAGS --------
<flag key="START_INVIS" name="Start invisible" bit="0">Start the entity as non-existent, if targeted, it will toggle existence when triggered.</flag>
<flag key="GIB_INSIDE" name="Gib inside" bit="1">Gib the activator if they would get stuck inside the brush when it's turned on.</flag>
-------- NOTES --------
This must be activated via an entity that passes on the activator data.
If neither "offModel" or "offShader" are set, the brush will simply become invisible when turned off.
If using "model2", you must have an origin brush as a part of this entity.
When "model2" is set, the brushes that are part of this entity will be used as the clipping brushes when the brush is visible. If you wish to not have clipping at all, make sure the brushes use a nonsolid shader.
</group>
```

The state of this brush is currently ignored in various traces, like bullets. Will fix this later, but I didn't want to do it here as I will refactor the entity ignoring while I'll fix that.

fixes #1723 (this effectively allows you to perform this, utilizing `offShader`)