### PR TITLE
Add EnumBitset template class

### DIFF
--- a/src/game/etj_shared.h
+++ b/src/game/etj_shared.h
@@ -33,4 +33,73 @@ const std::string GUID_REQUEST = "guid_request";
 const std::string AUTHENTICATE = "authenticate";
 } // namespace Authentication
 } // namespace Constants
+
+// template class for a bitset that uses 'enum class' as values for the bits
+template <typename EnumT>
+class EnumBitset {
+  using UnderlyingT = std::underlying_type_t<EnumT>;
+  UnderlyingT bits = 0;
+
+public:
+  // default constructor, empty bitset
+  constexpr EnumBitset() = default;
+
+  // construct from enum value
+  // EnumBitset<MyEnum> bitset(MyEnum::VALUE_1)
+  constexpr explicit EnumBitset(EnumT flag)
+      : bits(static_cast<UnderlyingT>(flag)) {}
+
+  // construct from initializer list
+  // EnumBitset<MyEnum> bitset({MyEnum::VALUE_1, MyEnum::VALUE_2 ...})
+  constexpr EnumBitset(std::initializer_list<EnumT> flags) {
+    for (auto flag : flags) {
+      bits |= static_cast<UnderlyingT>(flag);
+    }
+  }
+
+  // we don't want floating point implicit conversions for constructors
+  EnumBitset(float) = delete;
+  EnumBitset(double) = delete;
+  EnumBitset(long double) = delete;
+
+  constexpr EnumBitset &set(EnumT flag) {
+    bits |= static_cast<UnderlyingT>(flag);
+    return *this;
+  }
+
+  constexpr EnumBitset &clear(EnumT flag) {
+    bits &= ~static_cast<UnderlyingT>(flag);
+    return *this;
+  }
+
+  constexpr bool has(EnumT flag) const {
+    return (bits & static_cast<UnderlyingT>(flag)) != 0;
+  }
+
+  constexpr bool operator&(EnumT flag) const { return has(flag); }
+
+  constexpr EnumBitset operator&(EnumBitset other) const {
+    EnumBitset result;
+    result.bits = bits & other.bits;
+    return result;
+  }
+
+  constexpr EnumBitset operator|(EnumT flag) const {
+    EnumBitset result = *this;
+    result.set(flag);
+    return result;
+  }
+
+  constexpr EnumBitset operator|(EnumBitset other) const {
+    EnumBitset result;
+    result.bits = bits | other.bits;
+    return result;
+  }
+
+  constexpr bool operator==(EnumBitset other) const {
+    return bits == other.bits;
+  }
+
+  constexpr explicit operator bool() const { return bits != 0; }
+};
 } // namespace ETJump

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(GoogleTest)
 
-add_executable(tests 
+add_executable(tests
 	"../src/cgame/etj_client_commands_handler.cpp"
 	"../src/cgame/etj_entity_events_handler.cpp"
 	"../src/cgame/etj_utilities.cpp"
@@ -17,6 +17,7 @@ add_executable(tests
 	"command_parser_tests.cpp"
 	"deathrun_system_tests.cpp"
 	"entity_events_handler_tests.cpp"
+	"enum_bitset_tests.cpp"
 	"inline_command_parser_tests.cpp"
 	"string_utilities_tests.cpp"
 	"time_utilities_tests.cpp"

--- a/tests/enum_bitset_tests.cpp
+++ b/tests/enum_bitset_tests.cpp
@@ -1,0 +1,162 @@
+#include <gtest/gtest.h>
+#include "../src/game/etj_shared.h"
+
+namespace ETJump {
+class EnumBitsetTests : public testing::Test {
+  void SetUp() override {}
+  void TearDown() override {}
+
+public:
+  enum class TestEnum : uint8_t {
+    VALUE_NONE = 0,
+    VALUE_1 = 1 << 0,
+    VALUE_2 = 1 << 1,
+    VALUE_3 = 1 << 2,
+    VALUE_4 = 1 << 3,
+  };
+};
+
+TEST_F(EnumBitsetTests, ConstructsFromEnumValue) {
+  EnumBitset<TestEnum> bitset(TestEnum::VALUE_2);
+
+  EXPECT_TRUE(bitset.has(TestEnum::VALUE_2));
+  EXPECT_FALSE(bitset.has(TestEnum::VALUE_1));
+}
+
+TEST_F(EnumBitsetTests, ConstructsFromInitializerList) {
+  EnumBitset<TestEnum> bitset{TestEnum::VALUE_1, TestEnum::VALUE_3};
+
+  EXPECT_TRUE(bitset.has(TestEnum::VALUE_1));
+  EXPECT_FALSE(bitset.has(TestEnum::VALUE_2));
+  EXPECT_TRUE(bitset.has(TestEnum::VALUE_3));
+}
+
+TEST_F(EnumBitsetTests, DefaultConstructorIsEmpty) {
+  EnumBitset<TestEnum> bitset;
+
+  EXPECT_FALSE(bitset.has(TestEnum::VALUE_1));
+  EXPECT_FALSE(bitset.has(TestEnum::VALUE_2));
+  EXPECT_FALSE(static_cast<bool>(bitset));
+}
+
+TEST_F(EnumBitsetTests, SetAddsFlag) {
+  EnumBitset<TestEnum> bitset;
+  bitset.set(TestEnum::VALUE_1);
+
+  EXPECT_TRUE(bitset.has(TestEnum::VALUE_1));
+  EXPECT_FALSE(bitset.has(TestEnum::VALUE_2));
+}
+
+TEST_F(EnumBitsetTests, SetMultipleFlags) {
+  EnumBitset<TestEnum> bitset;
+  bitset.set(TestEnum::VALUE_1).set(TestEnum::VALUE_3);
+
+  EXPECT_TRUE(bitset.has(TestEnum::VALUE_1));
+  EXPECT_FALSE(bitset.has(TestEnum::VALUE_2));
+  EXPECT_TRUE(bitset.has(TestEnum::VALUE_3));
+}
+
+TEST_F(EnumBitsetTests, ClearRemovesFlag) {
+  EnumBitset<TestEnum> bitset(TestEnum::VALUE_2);
+  bitset.clear(TestEnum::VALUE_2);
+
+  EXPECT_FALSE(bitset.has(TestEnum::VALUE_2));
+}
+
+TEST_F(EnumBitsetTests, ClearDoesNotAffectOtherFlags) {
+  EnumBitset<TestEnum> bitset;
+  bitset.set(TestEnum::VALUE_1).set(TestEnum::VALUE_2);
+  bitset.clear(TestEnum::VALUE_1);
+
+  EXPECT_FALSE(bitset.has(TestEnum::VALUE_1));
+  EXPECT_TRUE(bitset.has(TestEnum::VALUE_2));
+}
+
+TEST_F(EnumBitsetTests, OrOperatorWithFlag) {
+  EnumBitset<TestEnum> bitset(TestEnum::VALUE_1);
+  auto result = bitset | TestEnum::VALUE_2;
+  EXPECT_TRUE(result.has(TestEnum::VALUE_1));
+  EXPECT_TRUE(result.has(TestEnum::VALUE_2));
+  // original remains unchanged
+  EXPECT_FALSE(bitset.has(TestEnum::VALUE_2));
+}
+
+TEST_F(EnumBitsetTests, OrOperatorWithBitset) {
+  EnumBitset<TestEnum> bitset1(TestEnum::VALUE_1);
+  EnumBitset<TestEnum> bitset2(TestEnum::VALUE_2);
+
+  const auto result = bitset1 | bitset2;
+
+  EXPECT_TRUE(result.has(TestEnum::VALUE_1));
+  EXPECT_TRUE(result.has(TestEnum::VALUE_2));
+}
+
+TEST_F(EnumBitsetTests, AndOperatorWithFlag) {
+  EnumBitset<TestEnum> bitset;
+  bitset.set(TestEnum::VALUE_1).set(TestEnum::VALUE_2);
+
+  EXPECT_TRUE(bitset & TestEnum::VALUE_1);
+  EXPECT_TRUE(bitset & TestEnum::VALUE_2);
+  EXPECT_FALSE(bitset & TestEnum::VALUE_3);
+}
+
+TEST_F(EnumBitsetTests, AndOperatorWithBitset) {
+  EnumBitset<TestEnum> bitset1;
+  bitset1.set(TestEnum::VALUE_1).set(TestEnum::VALUE_2);
+
+  EnumBitset<TestEnum> bitset2;
+  bitset2.set(TestEnum::VALUE_2).set(TestEnum::VALUE_3);
+
+  const auto result = bitset1 & bitset2;
+
+  EXPECT_FALSE(result.has(TestEnum::VALUE_1));
+  EXPECT_TRUE(result.has(TestEnum::VALUE_2));
+  EXPECT_FALSE(result.has(TestEnum::VALUE_3));
+}
+
+TEST_F(EnumBitsetTests, EqualityOperator) {
+  EnumBitset<TestEnum> bitset1(TestEnum::VALUE_1);
+  EnumBitset<TestEnum> bitset2(TestEnum::VALUE_1);
+  EnumBitset<TestEnum> bitset3(TestEnum::VALUE_2);
+
+  EXPECT_TRUE(bitset1 == bitset2);
+  EXPECT_FALSE(bitset1 == bitset3);
+}
+
+TEST_F(EnumBitsetTests, BoolConversion) {
+  EnumBitset<TestEnum> empty;
+  EnumBitset<TestEnum> nonEmpty(TestEnum::VALUE_1);
+
+  EXPECT_FALSE(static_cast<bool>(empty));
+  EXPECT_TRUE(static_cast<bool>(nonEmpty));
+}
+
+TEST_F(EnumBitsetTests, ChainedOperations) {
+  EnumBitset<TestEnum> bitset;
+
+  auto result = bitset | TestEnum::VALUE_1 | TestEnum::VALUE_2;
+  result.set(TestEnum::VALUE_3).clear(TestEnum::VALUE_1);
+
+  EXPECT_FALSE(result.has(TestEnum::VALUE_1));
+  EXPECT_TRUE(result.has(TestEnum::VALUE_2));
+  EXPECT_TRUE(result.has(TestEnum::VALUE_3));
+}
+
+TEST_F(EnumBitsetTests, UseInIfStatement) {
+  EnumBitset<TestEnum> bitset;
+  bitset.set(TestEnum::VALUE_1).set(TestEnum::VALUE_2);
+
+  if (bitset & TestEnum::VALUE_1) {
+    SUCCEED();
+  } else {
+    FAIL() << "Should have VALUE_1";
+  }
+
+  if (bitset.has(TestEnum::VALUE_3)) {
+    FAIL() << "Should not have VALUE_3";
+  }
+
+  SUCCEED();
+}
+
+} // namespace ETJump


### PR DESCRIPTION
This allows simple construction of `std::bitset`-like data structures by using `enum class` values as the "bits" in the set. The class abstracts away all the casting required to make this work, and provides some of the more common bitwise operators, and `std::bitset` method implementations. Will likely add more things to this in the future, it's just the basic building blocks for the most common operations for now.

Constructor examples:

* `EnumBitset<MyEnum> bitset()` - constructs empty bitset
* `EnumBitset<MyEnum> bitset(MyEnum::VALUE_1)` - construct from a single value
* `EnumBitset<MyEnum> bitset({MyEnum::VALUE_1, MyEnum::VALUE_2})` - construct from multiple values (like `(value1 | value2)`)

By design, this does not implement `constexpr bitset( unsigned long long val ) noexcept` constructor from `std::bitset`, as I find that extremely error prone and directly opposing to the idea of type-safe enum bitsets.