### PR TITLE
Reorganize ETJump UI stuff

### DIFF
--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -3,8 +3,10 @@ file(GLOB UI_HEADERS "*.h" "*.hpp")
 add_library(ui MODULE
 	"etj_colorpicker.cpp"
 	"etj_demo_queue.cpp"
+	"etj_main.cpp"
 	"etj_menu_integrity_checker.cpp"
 	"etj_quick_connect.cpp"
+	"etj_utilities.cpp"
 	"ui_atoms.cpp"
 	"ui_gameinfo.cpp"
 	"ui_loadpanel.cpp"

--- a/src/ui/etj_colorpicker.cpp
+++ b/src/ui/etj_colorpicker.cpp
@@ -22,13 +22,10 @@
  * SOFTWARE.
  */
 
-#include <unordered_map>
+#include "etj_colorpicker.h"
 
-#include "ui_shared.h"
 #include "../cgame/etj_utilities.h"
 #include "../game/etj_string_utilities.h"
-
-#include "etj_colorpicker.h"
 
 extern displayContextDef_t *DC;
 

--- a/src/ui/etj_colorpicker.h
+++ b/src/ui/etj_colorpicker.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include "ui_shared.h"
+
 namespace ETJump {
 class ColorPicker {
   enum ColorType {
@@ -44,8 +46,8 @@ class ColorPicker {
   vec4_t pickerColor{};
 
   // the cvar that the color picker is currently modifying
-  std::string currentCvar{};
-  std::string currentCvarOldValue{};
+  std::string currentCvar;
+  std::string currentCvarOldValue;
 
   bool normalizedRGBSliders;
 
@@ -89,6 +91,6 @@ public:
 
   // toggle RGB sliders between normalized and full RGB
   void toggleRGBSliderValues();
-  bool RGBSlidersAreNormalized() const;
+  [[nodiscard]] bool RGBSlidersAreNormalized() const;
 };
 } // namespace ETJump

--- a/src/ui/etj_local.h
+++ b/src/ui/etj_local.h
@@ -1,0 +1,48 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "etj_colorpicker.h"
+#include "etj_demo_queue.h"
+#include "etj_quick_connect.h"
+
+#include "../game/etj_syscall_ext_shared.h"
+
+namespace ETJump {
+// global UI objects
+struct UIContext {
+  std::unique_ptr<SyscallExt> syscallExt;
+  std::unique_ptr<ColorPicker> colorPicker;
+  std::unique_ptr<DemoQueue> demoQueue;
+  std::unique_ptr<QuickConnect> quickConnect;
+};
+
+inline UIContext ui;
+
+void init(int32_t legacyClient, int32_t clientVersion);
+void shutdown();
+// outside of 'init()', as this requires menus to be loaded already
+void initQuickConnect();
+} // namespace ETJump

--- a/src/ui/etj_main.cpp
+++ b/src/ui/etj_main.cpp
@@ -1,0 +1,202 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "ui_local.h"
+#include "etj_local.h"
+
+#include "../game/etj_file.h"
+
+#include "../../assets/ui/changelog/version_headers.h"
+
+namespace ETJump {
+static void initExtensionSystem() {
+  ui.syscallExt = std::make_unique<SyscallExt>();
+  ui.syscallExt->setupExtensions();
+}
+
+/*
+ * TL;DR - every client is shit and pretends to be something it's not.
+ *
+ * ET: Legacy sends 3 args to UI_INIT, but 2.60b only sends 1.
+ * The idea is that ET: Legacy wants to nag 2.60b users to download ET: Legacy
+ * client if legacy mod is loaded with the vanilla client.
+ * arg1 is a boolean (is this ET: Legacy client?) and arg2 is an integer
+ * representation of current version (for various compatibility checks).
+ *
+ * ETe also sends 3 args, and fakes being an ET: Legacy client (though for UI,
+ * I'm not sure what good this does as it doesn't get around the nagging).
+ * What this means for us is that we can't rely on checking the arg1/2
+ * to detect if a client is ET: Legacy or not, because ETe pretends
+ * that it's ET: Legacy too.
+ *
+ * Solution? Check the 'version' string that each client sends, right?
+ * Right...? Yeah lol, no.
+ *
+ * We CAN differentiate ETe from 2.60b using the version string, vanilla client
+ * is either 'ET 2.60b' or 'ET 2.60d', and ETe is 'ET 2.60e'.
+ * So this means we can just check for the version string first,
+ * try to match that to ETe, and then fallback to arg1/arg2 for ET: Legacy,
+ * and if neither match = vanilla client, right? Nope.
+ *
+ * The VM_Call argument parsing function in vanilla is not ideal.
+ * For every VM_Call, it reads memory as if you're sending the max amount of
+ * supported varags. This means that it will *very* likely read and send
+ * garbage memory as arg1 and arg2 to UI_Init, which means it can accidentally
+ * identify as an ET: Legacy client, because arg1 is treated as boolean.
+ *
+ * Okay, so just read the version string then and forget arg1/2 completely?
+ * Yeah nope, ET: Legacy needs to be special.
+ *
+ * For some reason it sends a faked 'version' string, pretending
+ * to be 2.60b client, presumably to maintain compatibility with some mods.
+ * Which is a bit odd as ETPro doesn't run anyway, and no other mod has a
+ * client version check that prevents you from playing them on custom clients.
+ *
+ * There is a saving grace though: ET: Legacy also sends a special 'etVersion'
+ * string, along with the regular 'version' string. So this means, we can
+ * identify the client by doing the following:
+ *
+ * 1. parse 'etVersion' string
+ * 2. if 'etVersion string is empty, we can parse the 'version' string safely
+ * to differentiate between vanilla client and ETe
+ * 3. if 'etVersion' string is not empty, we can parse arg1/2 to grab
+ * ET: Legacy client version.
+ */
+
+static void detectClientEngine(int legacyClient, int clientVersion) {
+  char etVersionStr[MAX_CVAR_VALUE_STRING]; // ET: Legacy exclusive
+  trap_Cvar_VariableStringBuffer("etVersion", etVersionStr,
+                                 sizeof(etVersionStr));
+
+  if (etVersionStr[0] == '\0') {
+    char versionStr[MAX_CVAR_VALUE_STRING];
+    trap_Cvar_VariableStringBuffer("version", versionStr, sizeof(versionStr));
+
+    // we can use this length for every detection
+    const auto len = static_cast<int>(strlen("ET 2.60b"));
+
+    if (!Q_stricmpn(versionStr, "ET 2.60b", len) ||
+        !Q_stricmpn(versionStr, "ET 2.60d", len)) {
+      uiInfo.vetClient = true;
+    } else if (!Q_stricmpn(versionStr, "ET 2.60e", len)) {
+      uiInfo.eteClient = true;
+    }
+  } else {
+    MOD_CHECK_ETLEGACY(legacyClient, clientVersion, uiInfo.etLegacyClient);
+  }
+}
+
+static void initColorPicker() {
+  ui.colorPicker = std::make_unique<ColorPicker>();
+
+  uiInfo.uiDC.updateSliderState = [p = ui.colorPicker.get()](itemDef_t *item) {
+    p->updateSliderState(item);
+  };
+
+  uiInfo.uiDC.cvarToColorPickerState =
+      [p = ui.colorPicker.get()](const std::string &cvar) {
+        p->cvarToColorPickerState(cvar);
+      };
+
+  uiInfo.uiDC.resetColorPickerState = [p = ui.colorPicker.get()] {
+    p->resetColorPickerState();
+  };
+
+  uiInfo.uiDC.colorPickerDragFunc =
+      [p = ui.colorPicker.get()](itemDef_t *item, const float cursorX,
+                                 const float cursorY, const int key) {
+        p->colorPickerDragFunc(item, cursorX, cursorY, key);
+      };
+
+  uiInfo.uiDC.toggleRGBSliderValues = [p = ui.colorPicker.get()] {
+    p->toggleRGBSliderValues();
+  };
+
+  uiInfo.uiDC.RGBSlidersAreNormalized = [p = ui.colorPicker.get()] {
+    return p->RGBSlidersAreNormalized();
+  };
+
+  uiInfo.uiDC.getColorSliderString = &ColorPicker::getColorSliderString;
+  uiInfo.uiDC.setColorSliderType = &ColorPicker::setColorSliderType;
+  uiInfo.uiDC.getColorSliderValue = &ColorPicker::getColorSliderValue;
+  uiInfo.uiDC.setColorSliderValue = &ColorPicker::setColorSliderValue;
+}
+
+static void initDemoQueueHandler() {
+  ui.demoQueue = std::make_unique<DemoQueue>();
+}
+
+static void parseChangelogs() {
+  // the "cvar" names are the filenames, excluding .txt extension
+  const std::vector<std::string> files =
+      StringUtil::split(CHANGELOG_CVARS, "|");
+  const std::string path = "ui/changelog/";
+
+  for (const auto &file : files) {
+    try {
+      File fIn(path + file + ".txt");
+      const auto contents = fIn.read();
+      uiInfo.changelogs[file] = std::string(contents.begin(), contents.end());
+    } catch (...) {
+      Com_Printf(S_COLOR_RED
+                 "%s: failed to open changelog '%s.txt' for reading.\n",
+                 __func__, file.c_str());
+    }
+  }
+}
+
+// NOTE: this must be called after 'UI_LoadMenus'!
+void initQuickConnect() {
+  assert(Menu_Count() > 0);
+
+  ui.quickConnect = std::make_unique<QuickConnect>();
+
+  uiInfo.uiDC.quickConnectListIsFull = [p = ui.quickConnect.get()] {
+    return p->isFull();
+  };
+}
+
+void init(const int32_t legacyClient, const int32_t clientVersion) {
+  initExtensionSystem();
+
+  detectClientEngine(legacyClient, clientVersion);
+
+  initColorPicker();
+  initDemoQueueHandler();
+
+  parseChangelogs();
+}
+
+void shutdown() {
+  if (etj_demoQueueCurrent.string[0] != '\0' && uiInfo.demoPlayback &&
+      !ui.demoQueue->manualSkip) {
+    trap_Cmd_ExecuteText(EXEC_APPEND, "demoQueue next\n");
+  }
+
+  ui.quickConnect = nullptr;
+  ui.demoQueue = nullptr;
+  ui.colorPicker = nullptr;
+  ui.syscallExt = nullptr;
+}
+} // namespace ETJump

--- a/src/ui/etj_quick_connect.h
+++ b/src/ui/etj_quick_connect.h
@@ -48,6 +48,8 @@ public:
   // if index is invalid, returns an empty string
   [[nodiscard]] std::string buildConnectCommand(int index) const;
 
+  static constexpr int32_t MAX_QUICKCONNECT_SERVERS = 5;
+
   // label texts are not fixed sized arrays, they are normally allocated
   // to the UI string pool with 'String_Alloc'. Because we're potentially
   // editing the label texts multiple times on one session, we hold the

--- a/src/ui/etj_utilities.cpp
+++ b/src/ui/etj_utilities.cpp
@@ -1,0 +1,301 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_utilities.h"
+#include "ui_local.h"
+
+namespace ETJump::Utilities {
+void parseMaplist() {
+  char arg[MAX_QPATH];
+
+  // start iterating from 1 to skip the command string
+  for (int i = 1, len = trap_Argc(); i < len; i++) {
+    trap_Argv(i, arg, sizeof(arg));
+    uiInfo.serverMaplist.emplace_back(arg);
+  }
+
+  ETJump::StringUtil::sortStrings(uiInfo.serverMaplist, true);
+}
+
+void parseNumCustomvotes() {
+  if (trap_Argc() < 2) {
+    Com_Printf(va(S_COLOR_YELLOW
+                  "%s: unable to parse customvote count: no arguments given.\n",
+                  __func__));
+    return;
+  }
+
+  char arg[MAX_TOKEN_CHARS];
+  trap_Argv(1, arg, sizeof(arg));
+  uiInfo.numCustomvotes = Q_atoi(arg);
+}
+
+void parseCustomvote() {
+  // if a mapsOnServer or otherMaps is empty, we only have 3 args
+  static constexpr int minArgs = 3;
+  const int numArgs = trap_Argc();
+
+  if (numArgs < minArgs) {
+    Com_Printf(va(S_COLOR_YELLOW "%s: unable to parse customvote: malformed "
+                                 "command - too few arguments (%i < %i).\n",
+                  __func__, numArgs, minArgs));
+    return;
+  }
+
+  char arg[MAX_TOKEN_CHARS];
+  CustomMapVotes::MapType *mapType = nullptr;
+
+  trap_Argv(1, arg, sizeof(arg));
+
+  // grab an existing list if we've already parsed this list before
+  for (auto &customVote : uiInfo.customVotes) {
+    if (customVote.type == arg) {
+      mapType = &customVote;
+      break;
+    }
+  }
+
+  // create a new entry if we didn't find an existing list
+  if (mapType == nullptr) {
+    uiInfo.customVotes.emplace_back();
+    mapType = &uiInfo.customVotes.back();
+    mapType->type = arg;
+  }
+
+  trap_Argv(2, arg, sizeof(arg));
+  const std::string field = arg;
+
+  if (field == CUSTOMVOTE_TYPE) {
+    trap_Argv(3, arg, sizeof(arg));
+    mapType->type = arg;
+  } else if (field == CUSTOMVOTE_CVTEXT) {
+    // this can potentially be multiple args
+    std::string cvtext;
+
+    for (int i = 3; i < numArgs; i++) {
+      trap_Argv(i, arg, sizeof(arg));
+      cvtext += std::string(arg) + " ";
+    }
+
+    cvtext.pop_back();
+    mapType->callvoteText = std::move(cvtext);
+  } else if (field == CUSTOMVOTE_SERVERMAPS) {
+    for (int i = 3; i < numArgs; i++) {
+      trap_Argv(i, arg, sizeof(arg));
+      mapType->mapsOnServer.emplace_back(arg);
+    }
+  } else if (field == CUSTOMVOTE_OTHERMAPS) {
+    for (int i = 3; i < numArgs; i++) {
+      trap_Argv(i, arg, sizeof(arg));
+      mapType->otherMaps.emplace_back(arg);
+    }
+  }
+}
+
+void resetCustomvotes() {
+  uiInfo.customVotes.clear();
+  uiInfo.numCustomvotes = -1;
+  uiInfo.customvoteIndex = 0;
+  uiInfo.customvoteMapsOnServerIndex = 0;
+  uiInfo.customvoteOtherMapsIndex = 0;
+
+  static constexpr char DETAILS_MENU[] = "ingame_customvote_details";
+  static constexpr char VOTE_MENU[] = "ingame_vote_customvote";
+
+  const menuDef_t *detailsMenu = Menus_FindByName(DETAILS_MENU);
+  const menuDef_t *voteMenu = Menus_FindByName(VOTE_MENU);
+
+  if (detailsMenu && detailsMenu->window.flags & WINDOW_VISIBLE) {
+    Menus_CloseByName(DETAILS_MENU);
+  }
+
+  if (voteMenu && voteMenu->window.flags & WINDOW_VISIBLE) {
+    Menus_CloseByName(VOTE_MENU);
+    Menus_OpenByName("ingame_vote");
+  }
+}
+
+void toggleSettingsMenu() {
+  const menuDef_t *activeMenu = Menu_GetFocused();
+
+  if (activeMenu &&
+      StringUtil::startsWith(activeMenu->window.name, "etjump_settings_")) {
+    Menus_CloseAll();
+  } else {
+    trap_Key_SetCatcher(KEYCATCH_UI);
+    Menus_CloseAll();
+    Menus_OpenByName("etjump_settings_general_gameplay");
+  }
+}
+
+static void markAllServersVisible() {
+  const int32_t count = trap_LAN_GetServerCount(ui_netSource.integer);
+
+  for (int i = 0; i < count; i++) {
+    trap_LAN_MarkServerVisible(ui_netSource.integer, i, qtrue);
+  }
+}
+
+static void keepServerListUpdating() {
+  uiInfo.serverStatus.refreshActive = qtrue;
+  uiInfo.serverStatus.refreshtime = uiInfo.uiDC.realTime + 1000;
+}
+
+static void openPlayOnlineMenu() {
+  Menus_CloseByName("main"); // opened by main_opener after ui reload
+  Menus_ActivateByName("playonline", qtrue);
+
+  const char *str = "clearError"; // clears com_errorMessage
+  uiInfo.uiDC.runScript(&str);
+}
+
+void handleIllegalRedirect() {
+  Com_Printf("^1ETJump: illegal redirect was detected, reacting...\n");
+
+  markAllServersVisible();
+  keepServerListUpdating();
+  openPlayOnlineMenu();
+}
+
+void drawLevelshotPreview(const rectDef_t &rect) {
+  // unregistered levelshot is -1, not 0
+  if (uiInfo.mapList[ui_mapIndex.integer].levelShot == -1) {
+    uiInfo.mapList[ui_mapIndex.integer].levelShot = trap_R_RegisterShaderNoMip(
+        va("levelshots/%s", uiInfo.mapList[ui_mapIndex.integer].mapLoadName));
+
+    if (!uiInfo.mapList[ui_mapIndex.integer].levelShot) {
+      uiInfo.mapList[ui_mapIndex.integer].levelShot =
+          trap_R_RegisterShaderNoMip("levelshots/unknownmap");
+    }
+  }
+
+  uiInfo.uiDC.drawHandlePic(rect.x, rect.y, rect.w, rect.h,
+                            uiInfo.mapList[ui_mapIndex.integer].levelShot);
+}
+
+void drawMapname(rectDef_t &rect, float scale, vec4_t color, float text_x,
+                 int textStyle, int align) {
+  rectDef_t textRect = {0, 0, rect.w, rect.h};
+
+  const int map = ui_currentNetMap.integer;
+  std::string mapname;
+
+  if (uiInfo.mapList[map].mapLoadName != nullptr) {
+    mapname = uiInfo.mapList[map].mapLoadName;
+  } else {
+    mapname = "unknownmap";
+  }
+
+  const auto width =
+      static_cast<float>(uiInfo.uiDC.textWidth(mapname.c_str(), scale, 0));
+
+  switch (align) {
+    case ITEM_ALIGN_LEFT:
+      textRect.x = text_x;
+      break;
+    case ITEM_ALIGN_RIGHT:
+      textRect.x = text_x - width;
+      break;
+    case ITEM_ALIGN_CENTER:
+      textRect.x = text_x - (width * 0.5f);
+      break;
+    default:
+      break;
+  }
+
+  textRect.x += rect.x;
+  textRect.y += rect.y;
+  uiInfo.uiDC.drawText(textRect.x, textRect.y, scale, color, mapname.c_str(), 0,
+                       0, textStyle);
+}
+
+std::vector<std::string>
+fitChangelogLinesToWidth(std::vector<std::string> &lines, const int maxW,
+                         const float scale, fontInfo_t *font) {
+  std::vector<std::string> fmtLines;
+
+  for (auto &line : lines) {
+    int width = 0;
+    size_t indent = 0;
+    size_t lastWhitespace = 0;
+
+    // do we have to split this line at all?
+    if (uiInfo.uiDC.textWidthExt(line.c_str(), scale, 0, font) <= maxW) {
+      fmtLines.emplace_back(line);
+      continue;
+    }
+
+    // find first non-dash, non-whitespace character to get indentation
+    auto textStart = std::find_if(line.begin(), line.end(), [](const char c) {
+      return c != '-' && !std::isspace(c);
+    });
+
+    if (textStart != line.end()) {
+      indent = std::distance(line.begin(), textStart);
+    }
+
+    std::string tmp;
+    tmp.reserve(line.length());
+
+    for (int i = 0; i < static_cast<int>(line.length()); i++) {
+      tmp += line[i];
+
+      if (std::isspace(line[i])) {
+        lastWhitespace = i;
+      }
+
+      width = uiInfo.uiDC.textWidthExt(tmp.c_str(), scale, 0, font);
+
+      if (width > maxW) {
+        if (lastWhitespace != 0) {
+          // we have a line with single word that is over max width,
+          // just split at the line end
+          if (lastWhitespace < indent) {
+            fmtLines.emplace_back(tmp.substr(0, i));
+            line.erase(0, i);
+          } else {
+            fmtLines.emplace_back(tmp.substr(0, lastWhitespace));
+            line.erase(0, lastWhitespace + 1); // consume the whitespace too
+          }
+
+          lastWhitespace = 0;
+        } else {
+          // this should never happen, but it protects against an infinite loop
+          fmtLines.emplace_back(tmp);
+          line.erase(0, i);
+        }
+
+        i = -1; // so we start from 0 again after i++
+
+        tmp.clear();
+        line.insert(0, indent, ' ');
+      }
+    }
+
+    fmtLines.emplace_back(line);
+  }
+
+  return fmtLines;
+}
+} // namespace ETJump::Utilities

--- a/src/ui/etj_utilities.h
+++ b/src/ui/etj_utilities.h
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "ui_shared.h"
+
+namespace ETJump::Utilities {
+// parses maplist for callvote menu
+void parseMaplist();
+
+// parses number of custom vote lists
+void parseNumCustomvotes();
+
+// parses information for custom vote lists
+void parseCustomvote();
+
+// invalidates custom vote data
+// called on module restarts, or when server updates custom votes
+void resetCustomvotes();
+
+// wacky hack to toggle ETJump settings menu with a keybind
+void toggleSettingsMenu();
+
+// handles illegal server redirect attacks to work around
+// exploits in 2.60b, when 'Play Online' menu is opened
+void handleIllegalRedirect();
+
+// draws levelshot in 'vote -> map -> details' menu
+// TODO: this should be somewhere else, after 'ui_shared.cpp' is cleaned up
+void drawLevelshotPreview(const rectDef_t &rect);
+
+// draws map name in 'vote -> map -> details' menu
+// TODO: this should be somewhere else, after 'ui_shared.cpp' is cleaned up
+void drawMapname(rectDef_t &rect, float scale, vec4_t color, float text_x,
+                 int textStyle, int align);
+
+// formats the current changelog to a given window width, preserving indentation
+// NOTE: this does not handle color codes, there's no reason we ever
+// should have color codes in the changelog
+std::vector<std::string>
+fitChangelogLinesToWidth(std::vector<std::string> &lines, int maxW, float scale,
+                         fontInfo_t *font);
+} // namespace ETJump::Utilities

--- a/src/ui/ui_atoms.cpp
+++ b/src/ui/ui_atoms.cpp
@@ -5,8 +5,9 @@
 
     User interface building blocks and support functions.
 **********************************************************************/
-#include "etj_demo_queue.h"
 #include "ui_local.h"
+#include "etj_local.h"
+#include "etj_utilities.h"
 
 uiStatic_t uis;
 qboolean m_entersound; // after a frame, so caching won't disrupt the sound
@@ -187,32 +188,32 @@ qboolean UI_ConsoleCommand(const int realTime) {
   }
 
   if (!Q_stricmp(cmd, "uiParseMaplist")) {
-    ETJump::parseMaplist();
+    ETJump::Utilities::parseMaplist();
     return qtrue;
   }
 
   if (!Q_stricmp(cmd, "uiNumCustomvotes")) {
-    ETJump::parseNumCustomvotes();
+    ETJump::Utilities::parseNumCustomvotes();
     return qtrue;
   }
 
   if (!Q_stricmp(cmd, "uiParseCustomvote")) {
-    ETJump::parseCustomvote();
+    ETJump::Utilities::parseCustomvote();
     return qtrue;
   }
 
   if (!Q_stricmp(cmd, "uiResetCustomvotes")) {
-    ETJump::resetCustomvotes();
+    ETJump::Utilities::resetCustomvotes();
     return qtrue;
   }
 
   if (!Q_stricmp(cmd, "demoQueue")) {
-    ETJump::demoQueue->commandHandler();
+    ETJump::ui.demoQueue->commandHandler();
     return qtrue;
   }
 
   if (!Q_stricmp(cmd, "uiDemoQueueManualSkip")) {
-    ETJump::demoQueue->setManualSkip();
+    ETJump::ui.demoQueue->setManualSkip();
     return qtrue;
   }
 
@@ -228,7 +229,7 @@ qboolean UI_ConsoleCommand(const int realTime) {
     // FIXME: this breaks if 'ui_restart' is performed while in demo playback,
     //  but there's no nice way to make this work for now, it is what it is
     if (cstate.connState == CA_ACTIVE && !uiInfo.demoPlayback) {
-      ETJump::toggleSettingsMenu();
+      ETJump::Utilities::toggleSettingsMenu();
     }
 
     return qtrue;

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -804,24 +804,4 @@ void trap_GetHunkData(int *hunkused, int *hunkexpected);
 void QDECL Com_DPrintf(const char *fmt, ...);
 
 const char *G_SHA1(const char *str);
-
-namespace ETJump {
-inline constexpr int MAX_QUICKCONNECT_SERVERS = 5;
-
-class SyscallExt;
-extern std::unique_ptr<SyscallExt> syscallExt;
-
-void parseMaplist();
-void parseNumCustomvotes();
-void parseCustomvote();
-void resetCustomvotes();
-
-void toggleSettingsMenu();
-
-class DemoQueue;
-class QuickConnect;
-
-extern std::unique_ptr<DemoQueue> demoQueue;
-extern std::unique_ptr<QuickConnect> quickConnect;
-} // namespace ETJump
 #endif

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -12,19 +12,15 @@ USER INTERFACE MAIN
 #include <memory>
 
 #include "ui_local.h"
-#include "etj_colorpicker.h"
-#include "etj_demo_queue.h"
-#include "etj_quick_connect.h"
+#include "etj_local.h"
+
 #include "etj_menu_integrity_checker.h"
+#include "etj_utilities.h"
 
 #include "../cgame/etj_cvar_parser.h"
 #include "../game/etj_string_utilities.h"
 #include "../cgame/etj_utilities.h"
 #include "../game/etj_filesystem.h"
-#include "../game/etj_file.h"
-#include "../game/etj_syscall_ext_shared.h"
-
-#include "../../assets/ui/changelog/version_headers.h"
 
 // NERVE - SMF
 inline constexpr int AXIS_TEAM = 0;
@@ -669,211 +665,6 @@ void UI_ShowPostGame(qboolean newHigh) {
   _UI_SetActiveMenu(UIMENU_POSTGAME);
 }
 
-namespace ETJump {
-std::unique_ptr<ColorPicker> colorPicker;
-std::unique_ptr<SyscallExt> syscallExt;
-std::unique_ptr<DemoQueue> demoQueue;
-std::unique_ptr<QuickConnect> quickConnect;
-
-static void initColorPicker() {
-  colorPicker = std::make_unique<ColorPicker>();
-
-  uiInfo.uiDC.updateSliderState = [p = colorPicker.get()](itemDef_t *item) {
-    p->updateSliderState(item);
-  };
-
-  uiInfo.uiDC.cvarToColorPickerState =
-      [p = colorPicker.get()](const std::string &cvar) {
-        p->cvarToColorPickerState(cvar);
-      };
-
-  uiInfo.uiDC.resetColorPickerState = [p = colorPicker.get()] {
-    p->resetColorPickerState();
-  };
-
-  uiInfo.uiDC.colorPickerDragFunc =
-      [p = colorPicker.get()](itemDef_t *item, const float cursorX,
-                              const float cursorY, const int key) {
-        p->colorPickerDragFunc(item, cursorX, cursorY, key);
-      };
-
-  uiInfo.uiDC.toggleRGBSliderValues = [p = colorPicker.get()] {
-    p->toggleRGBSliderValues();
-  };
-
-  uiInfo.uiDC.RGBSlidersAreNormalized = [p = colorPicker.get()] {
-    return p->RGBSlidersAreNormalized();
-  };
-
-  uiInfo.uiDC.getColorSliderString = &ColorPicker::getColorSliderString;
-  uiInfo.uiDC.setColorSliderType = &ColorPicker::setColorSliderType;
-  uiInfo.uiDC.getColorSliderValue = &ColorPicker::getColorSliderValue;
-  uiInfo.uiDC.setColorSliderValue = &ColorPicker::setColorSliderValue;
-}
-
-static void initExtensionSystem() {
-  syscallExt = std::make_unique<SyscallExt>();
-  syscallExt->setupExtensions();
-}
-
-static void drawLevelshotPreview(rectDef_t &rect) {
-  // unregistered levelshot is -1, not 0
-  if (uiInfo.mapList[ui_mapIndex.integer].levelShot == -1) {
-    uiInfo.mapList[ui_mapIndex.integer].levelShot = trap_R_RegisterShaderNoMip(
-        va("levelshots/%s", uiInfo.mapList[ui_mapIndex.integer].mapLoadName));
-
-    if (!uiInfo.mapList[ui_mapIndex.integer].levelShot) {
-      uiInfo.mapList[ui_mapIndex.integer].levelShot =
-          trap_R_RegisterShaderNoMip("levelshots/unknownmap");
-    }
-  }
-
-  uiInfo.uiDC.drawHandlePic(rect.x, rect.y, rect.w, rect.h,
-                            uiInfo.mapList[ui_mapIndex.integer].levelShot);
-}
-
-static void drawMapname(rectDef_t &rect, float scale, vec4_t color,
-                        float text_x, int textStyle, int align) {
-  rectDef_t textRect = {0, 0, rect.w, rect.h};
-
-  const int map = ui_currentNetMap.integer;
-  std::string mapname;
-
-  if (uiInfo.mapList[map].mapLoadName != nullptr) {
-    mapname = uiInfo.mapList[map].mapLoadName;
-  } else {
-    mapname = "unknownmap";
-  }
-
-  const auto width = static_cast<float>(Text_Width(mapname.c_str(), scale, 0));
-
-  switch (align) {
-    case ITEM_ALIGN_LEFT:
-      textRect.x = text_x;
-      break;
-    case ITEM_ALIGN_RIGHT:
-      textRect.x = text_x - width;
-      break;
-    case ITEM_ALIGN_CENTER:
-      textRect.x = text_x - (width * 0.5f);
-      break;
-    default:
-      break;
-  }
-
-  textRect.x += rect.x;
-  textRect.y += rect.y;
-  Text_Paint(textRect.x, textRect.y, scale, color, mapname.c_str(), 0, 0,
-             textStyle);
-}
-
-static void parseChangelogs() {
-  // the "cvar" names are the filenames, excluding .txt extension
-  const std::vector<std::string> files =
-      StringUtil::split(CHANGELOG_CVARS, "|");
-  const std::string path = "ui/changelog/";
-
-  for (const auto &file : files) {
-    try {
-      File fIn(path + file + ".txt");
-      const auto contents = fIn.read();
-      uiInfo.changelogs[file] = std::string(contents.begin(), contents.end());
-    } catch (...) {
-      Com_Printf(S_COLOR_RED
-                 "%s: failed to open changelog '%s.txt' for reading.\n",
-                 __func__, file.c_str());
-    }
-  }
-}
-
-// formats the current changelog to a give window width, preserving indentation
-// this does not handle color codes, there's no reason we ever
-// should have color codes in the changelog
-std::vector<std::string>
-fitChangelogLinesToWidth(std::vector<std::string> &lines, const int maxW,
-                         const float scale, fontInfo_t *font) {
-  std::vector<std::string> fmtLines;
-
-  for (auto &line : lines) {
-    int width = 0;
-    size_t indent = 0;
-    size_t lastWhitespace = 0;
-
-    // do we have to split this line at all?
-    if (Text_Width_Ext(line.c_str(), scale, 0, font) <= maxW) {
-      fmtLines.emplace_back(line);
-      continue;
-    }
-
-    // find first non-dash, non-whitespace character to get indentation
-    auto textStart = std::find_if(line.begin(), line.end(), [](const char c) {
-      return c != '-' && !std::isspace(c);
-    });
-
-    if (textStart != line.end()) {
-      indent = std::distance(line.begin(), textStart);
-    }
-
-    std::string tmp;
-    tmp.reserve(line.length());
-
-    for (int i = 0; i < static_cast<int>(line.length()); i++) {
-      tmp += line[i];
-
-      if (std::isspace(line[i])) {
-        lastWhitespace = i;
-      }
-
-      width = Text_Width_Ext(tmp.c_str(), scale, 0, font);
-
-      if (width > maxW) {
-        if (lastWhitespace != 0) {
-          // we have a line with single word that is over max width,
-          // just split at the line end
-          if (lastWhitespace < indent) {
-            fmtLines.emplace_back(tmp.substr(0, i));
-            line.erase(0, i);
-          } else {
-            fmtLines.emplace_back(tmp.substr(0, lastWhitespace));
-            line.erase(0, lastWhitespace + 1); // consume the whitespace too
-          }
-
-          lastWhitespace = 0;
-        } else {
-          // this should never happen, but it protects against an infinite loop
-          fmtLines.emplace_back(tmp);
-          line.erase(0, i);
-        }
-
-        i = -1; // so we start from 0 again after i++
-
-        tmp.clear();
-        line.insert(0, indent, ' ');
-      }
-    }
-
-    fmtLines.emplace_back(line);
-  }
-
-  return fmtLines;
-}
-
-static void initDemoQueueHandler() {
-  demoQueue = std::make_unique<DemoQueue>();
-}
-
-// NOTE: this must be called after 'UI_LoadMenus'!
-static void initQuickConnect() {
-  assert(Menu_Count() > 0);
-
-  quickConnect = std::make_unique<QuickConnect>();
-
-  uiInfo.uiDC.quickConnectListIsFull = [p = quickConnect.get()] {
-    return p->isFull();
-  };
-}
-} // namespace ETJump
-
 /*
 =================
 _UI_Refresh
@@ -947,11 +738,11 @@ void _UI_Refresh(int realtime) {
     UI_BuildFindPlayerList(qfalse);
 
     if (etj_drawQuickConnectMenu.integer) {
-      if (!ETJump::quickConnect->initialRefreshDone) {
-        ETJump::quickConnect->initialRefreshDone = true;
-        ETJump::quickConnect->refreshServers(true);
+      if (!ETJump::ui.quickConnect->initialRefreshDone) {
+        ETJump::ui.quickConnect->initialRefreshDone = true;
+        ETJump::ui.quickConnect->refreshServers(true);
       } else {
-        ETJump::quickConnect->refreshServers(false);
+        ETJump::ui.quickConnect->refreshServers(false);
       }
     }
 
@@ -979,15 +770,7 @@ _UI_Shutdown
 void _UI_Shutdown(void) {
   trap_LAN_SaveCachedServers();
 
-  if (etj_demoQueueCurrent.string[0] != '\0' && uiInfo.demoPlayback &&
-      !ETJump::demoQueue->manualSkip) {
-    trap_Cmd_ExecuteText(EXEC_APPEND, "demoQueue next\n");
-  }
-
-  ETJump::colorPicker = nullptr;
-  ETJump::syscallExt = nullptr;
-  ETJump::demoQueue = nullptr;
-  ETJump::quickConnect = nullptr;
+  ETJump::shutdown();
 
   Shutdown_Display();
 }
@@ -2473,21 +2256,22 @@ static void UI_OwnerDraw(float x, float y, float w, float h, float text_x,
       break;
     case UI_COLOR_PICKER:
       ETJump::ColorPicker::shrinkRectForColorPicker(rect);
-      ETJump::colorPicker->drawColorPicker(&rect);
+      ETJump::ui.colorPicker->drawColorPicker(&rect);
       break;
     case UI_COLOR_PICKER_PREVIEW_OLD:
       ETJump::ColorPicker::shrinkRectForColorPicker(rect);
-      ETJump::colorPicker->drawPreviewOld(&rect);
+      ETJump::ui.colorPicker->drawPreviewOld(&rect);
       break;
     case UI_COLOR_PICKER_PREVIEW_NEW:
       ETJump::ColorPicker::shrinkRectForColorPicker(rect);
-      ETJump::colorPicker->drawPreviewNew(&rect);
+      ETJump::ui.colorPicker->drawPreviewNew(&rect);
       break;
     case UI_MAPNAME:
-      ETJump::drawMapname(rect, scale, color, text_x, textStyle, align);
+      ETJump::Utilities::drawMapname(rect, scale, color, text_x, textStyle,
+                                     align);
       break;
     case UI_LEVELSHOT_PREVIEW:
-      ETJump::drawLevelshotPreview(rect);
+      ETJump::Utilities::drawLevelshotPreview(rect);
       break;
     default:
       break;
@@ -4998,7 +4782,7 @@ void UI_RunMenuScript(const char **args) {
       std::string contents = uiInfo.changelogs[ui_currentChangelog.string];
 
       uiInfo.formattedChangelog = ETJump::StringUtil::split(contents, "\n");
-      uiInfo.formattedChangelog = ETJump::fitChangelogLinesToWidth(
+      uiInfo.formattedChangelog = ETJump::Utilities::fitChangelogLinesToWidth(
           uiInfo.formattedChangelog,
           static_cast<int>(item->window.rect.w - SCROLLBAR_SIZE - 10),
           item->textscale, font);
@@ -5009,7 +4793,7 @@ void UI_RunMenuScript(const char **args) {
     }
 
     if (!Q_stricmp(name, "quickConnectRefresh")) {
-      ETJump::quickConnect->refreshServers(true);
+      ETJump::ui.quickConnect->refreshServers(true);
       return;
     }
 
@@ -5027,7 +4811,7 @@ void UI_RunMenuScript(const char **args) {
                                      sizeof(buf));
       const std::string customName = buf;
 
-      ETJump::quickConnect->addServer(address, password, customName);
+      ETJump::ui.quickConnect->addServer(address, password, customName);
       return;
     }
 
@@ -5035,7 +4819,7 @@ void UI_RunMenuScript(const char **args) {
       if (String_Parse(args, &name2)) {
         // menu variables are 1-indexed
         std::string command =
-            ETJump::quickConnect->buildConnectCommand(Q_atoi(name2) - 1);
+            ETJump::ui.quickConnect->buildConnectCommand(Q_atoi(name2) - 1);
 
         if (!command.empty()) {
           trap_Cmd_ExecuteText(EXEC_APPEND, command.c_str());
@@ -5052,7 +4836,7 @@ void UI_RunMenuScript(const char **args) {
       if (String_Parse(args, &name2)) {
         // menu variables are 1-indexed
         const int index = Q_atoi(name2) - 1;
-        ETJump::quickConnect->setEditData(index);
+        ETJump::ui.quickConnect->setEditData(index);
       } else {
         Com_Printf(S_COLOR_YELLOW "%s: '%s' called with no arguments!\n",
                    __func__, name);
@@ -5062,12 +4846,12 @@ void UI_RunMenuScript(const char **args) {
     }
 
     if (!Q_stricmp(name, "quickConnectEditServer")) {
-      ETJump::quickConnect->editServer();
+      ETJump::ui.quickConnect->editServer();
       return;
     }
 
     if (!Q_stricmp(name, "quickConnectDeleteServer")) {
-      ETJump::quickConnect->deleteServer();
+      ETJump::ui.quickConnect->deleteServer();
       return;
     }
 
@@ -5096,11 +4880,11 @@ void UI_RunMenuScript(const char **args) {
       };
 
       // hide everything by default
-      for (int i = 0; i < ETJump::MAX_QUICKCONNECT_SERVERS; i++) {
+      for (int i = 0; i < ETJump::QuickConnect::MAX_QUICKCONNECT_SERVERS; i++) {
         toggleButtonState(i, qfalse);
       }
 
-      const int count = ETJump::quickConnect->getServerCount();
+      const int count = ETJump::ui.quickConnect->getServerCount();
 
       if (count == 0) {
         // make sure the label is visible, e.g. if we deleted the last server
@@ -6979,80 +6763,6 @@ static void UI_DrawCinematic(int handle, float x, float y, float w, float h) {
 
 static void UI_RunCinematicFrame(int handle) { trap_CIN_RunCinematic(handle); }
 
-namespace ETJump {
-/*
- * TL;DR - every client is shit and pretends to be something it's not.
- *
- * ET: Legacy sends 3 args to UI_INIT, but 2.60b only sends 1.
- * The idea is that ET: Legacy wants to nag 2.60b users to download ET: Legacy
- * client if legacy mod is loaded with the vanilla client.
- * arg1 is a boolean (is this ET: Legacy client?) and arg2 is an integer
- * representation of current version (for various compatibility checks).
- *
- * ETe also sends 3 args, and fakes being an ET: Legacy client (though for UI,
- * I'm not sure what good this does as it doesn't get around the nagging).
- * What this means for us is that we can't rely on checking the arg1/2
- * to detect if a client is ET: Legacy or not, because ETe pretends
- * that it's ET: Legacy too.
- *
- * Solution? Check the 'version' string that each client sends, right?
- * Right...? Yeah lol, no.
- *
- * We CAN differentiate ETe from 2.60b using the version string, vanilla client
- * is either 'ET 2.60b' or 'ET 2.60d', and ETe is 'ET 2.60e'.
- * So this means we can just check for the version string first,
- * try to match that to ETe, and then fallback to arg1/arg2 for ET: Legacy,
- * and if neither match = vanilla client, right? Nope.
- *
- * The VM_Call argument parsing function in vanilla is not ideal.
- * For every VM_Call, it reads memory as if you're sending the max amount of
- * supported varags. This means that it will *very* likely read and send
- * garbage memory as arg1 and arg2 to UI_Init, which means it can accidentally
- * identify as an ET: Legacy client, because arg1 is treated as boolean.
- *
- * Okay, so just read the version string then and forget arg1/2 completely?
- * Yeah nope, ET: Legacy needs to be special.
- *
- * For some reason it sends a faked 'version' string, pretending
- * to be 2.60b client, presumably to maintain compatibility with some mods.
- * Which is a bit odd as ETPro doesn't run anyway, and no other mod has a
- * client version check that prevents you from playing them on custom clients.
- *
- * There is a saving grace though: ET: Legacy also sends a special 'etVersion'
- * string, along with the regular 'version' string. So this means, we can
- * identify the client by doing the following:
- *
- * 1. parse 'etVersion' string
- * 2. if 'etVersion string is empty, we can parse the 'version' string safely
- * to differentiate between vanilla client and ETe
- * 3. if 'etVersion' string is not empty, we can parse arg1/2 to grab
- * ET: Legacy client version.
- */
-
-static void detectClientEngine(int legacyClient, int clientVersion) {
-  char etVersionStr[MAX_CVAR_VALUE_STRING]; // ET: Legacy exclusive
-  trap_Cvar_VariableStringBuffer("etVersion", etVersionStr,
-                                 sizeof(etVersionStr));
-
-  if (etVersionStr[0] == '\0') {
-    char versionStr[MAX_CVAR_VALUE_STRING];
-    trap_Cvar_VariableStringBuffer("version", versionStr, sizeof(versionStr));
-
-    // we can use this length for every detection
-    const auto len = static_cast<int>(strlen("ET 2.60b"));
-
-    if (!Q_stricmpn(versionStr, "ET 2.60b", len) ||
-        !Q_stricmpn(versionStr, "ET 2.60d", len)) {
-      uiInfo.vetClient = true;
-    } else if (!Q_stricmpn(versionStr, "ET 2.60e", len)) {
-      uiInfo.eteClient = true;
-    }
-  } else {
-    MOD_CHECK_ETLEGACY(legacyClient, clientVersion, uiInfo.etLegacyClient);
-  }
-}
-} // namespace ETJump
-
 static void UI_RegisterConsoleCommands() {
   trap_AddCommand("ui_report");
   trap_AddCommand("demoQueue");
@@ -7104,8 +6814,6 @@ void _UI_Init(int legacyClient, int clientVersion) {
     // no wide screen
     uiInfo.uiDC.bias = 0;
   }
-
-  ETJump::detectClientEngine(legacyClient, clientVersion);
 
   char buf[MAX_CVAR_VALUE_STRING]{};
   trap_Cvar_VariableStringBuffer("fs_game", buf, sizeof(buf));
@@ -7185,14 +6893,11 @@ void _UI_Init(int legacyClient, int clientVersion) {
   uiInfo.uiDC.getConfigString = &trap_GetConfigString;
   uiInfo.uiDC.getActiveFont = &GetActiveFont;
 
-  ETJump::initColorPicker();
-  ETJump::initExtensionSystem();
-  ETJump::parseChangelogs();
-  ETJump::initDemoQueueHandler();
-
   Init_Display(&uiInfo.uiDC);
 
   String_Init();
+
+  ETJump::init(legacyClient, clientVersion);
 
   uiInfo.uiDC.cursor.registerShaders = &ETJump::registerCursors;
   uiInfo.uiDC.cursor.draw = &ETJump::drawCursor;
@@ -7236,6 +6941,7 @@ void _UI_Init(int legacyClient, int clientVersion) {
   UI_ParseGameInfo("gameinfo.txt");
 
   UI_LoadMenus(DEFAULT_MENU_FILE, qfalse);
+  ETJump::initQuickConnect();
 
   Com_DPrintf("Performing menu integrity check\n");
 
@@ -7244,8 +6950,6 @@ void _UI_Init(int legacyClient, int clientVersion) {
   if (!uiInfo.integrityCheckOk) {
     ETJump::MenuIntegrityChecker::printIntegrityViolation();
   }
-
-  ETJump::initQuickConnect();
 
   Menus_CloseAll();
 
@@ -7388,162 +7092,6 @@ uiMenuCommand_t _UI_GetActiveMenu(void) { return menutype; }
 
 inline constexpr char MISSING_FILES_MSG[] = "The following packs are missing:";
 
-/*
- *	We handle here illegal redirects, that happen upon serverlist loading
- *	due to incorrect response recieve for a getstatus request.
- */
-namespace ETJump {
-void markAllServersVisible() {
-  int count = trap_LAN_GetServerCount(ui_netSource.integer);
-  for (int i = 0; i < count; i++) {
-    trap_LAN_MarkServerVisible(ui_netSource.integer, i, qtrue);
-  }
-}
-
-void keepServerListUpdating() {
-  uiInfo.serverStatus.refreshActive = qtrue;
-  uiInfo.serverStatus.refreshtime = uiInfo.uiDC.realTime + 1000;
-}
-
-void openPlayOnlineMenu() {
-  Menus_CloseByName("main"); // opened by main_opener after ui reload
-  Menus_ActivateByName("playonline", qtrue);
-  const char *str = "clearError"; // clears com_errorMessage
-  UI_RunMenuScript(&str);
-}
-
-void handleIllegalRedirect() {
-  Com_Printf("^1ETJump: illegal redirect was detected, reacting...\n");
-  markAllServersVisible();
-  keepServerListUpdating();
-  openPlayOnlineMenu();
-}
-
-void parseMaplist() {
-  char arg[MAX_QPATH];
-
-  // start iterating from 1 to skip the command string
-  for (int i = 1, len = trap_Argc(); i < len; i++) {
-    trap_Argv(i, arg, sizeof(arg));
-    uiInfo.serverMaplist.emplace_back(arg);
-  }
-
-  ETJump::StringUtil::sortStrings(uiInfo.serverMaplist, true);
-}
-
-void parseNumCustomvotes() {
-  if (trap_Argc() < 2) {
-    Com_Printf(va(S_COLOR_YELLOW
-                  "%s: unable to parse customvote count: no arguments given.\n",
-                  __func__));
-    return;
-  }
-
-  char arg[MAX_TOKEN_CHARS];
-  trap_Argv(1, arg, sizeof(arg));
-  uiInfo.numCustomvotes = Q_atoi(arg);
-}
-
-void parseCustomvote() {
-  // if a mapsOnServer or otherMaps is empty, we only have 3 args
-  static constexpr int minArgs = 3;
-  const int numArgs = trap_Argc();
-
-  if (numArgs < minArgs) {
-    Com_Printf(va(S_COLOR_YELLOW "%s: unable to parse customvote: malformed "
-                                 "command - too few arguments (%i < %i).\n",
-                  __func__, numArgs, minArgs));
-    return;
-  }
-
-  char arg[MAX_TOKEN_CHARS];
-  CustomMapVotes::MapType *mapType = nullptr;
-
-  trap_Argv(1, arg, sizeof(arg));
-
-  // grab an existing list if we've already parsed this list before
-  for (auto &customVote : uiInfo.customVotes) {
-    if (customVote.type == arg) {
-      mapType = &customVote;
-      break;
-    }
-  }
-
-  // create a new entry if we didn't find an existing list
-  if (mapType == nullptr) {
-    uiInfo.customVotes.emplace_back();
-    mapType = &uiInfo.customVotes.back();
-    mapType->type = arg;
-  }
-
-  trap_Argv(2, arg, sizeof(arg));
-  const std::string field = arg;
-
-  if (field == CUSTOMVOTE_TYPE) {
-    trap_Argv(3, arg, sizeof(arg));
-    mapType->type = arg;
-  } else if (field == CUSTOMVOTE_CVTEXT) {
-    // this can potentially be multiple args
-    std::string cvtext;
-
-    for (int i = 3; i < numArgs; i++) {
-      trap_Argv(i, arg, sizeof(arg));
-      cvtext += std::string(arg) + " ";
-    }
-
-    cvtext.pop_back();
-    mapType->callvoteText = std::move(cvtext);
-  } else if (field == CUSTOMVOTE_SERVERMAPS) {
-    for (int i = 3; i < numArgs; i++) {
-      trap_Argv(i, arg, sizeof(arg));
-      mapType->mapsOnServer.emplace_back(arg);
-    }
-  } else if (field == CUSTOMVOTE_OTHERMAPS) {
-    for (int i = 3; i < numArgs; i++) {
-      trap_Argv(i, arg, sizeof(arg));
-      mapType->otherMaps.emplace_back(arg);
-    }
-  }
-}
-
-void resetCustomvotes() {
-  uiInfo.customVotes.clear();
-  uiInfo.numCustomvotes = -1;
-  uiInfo.customvoteIndex = 0;
-  uiInfo.customvoteMapsOnServerIndex = 0;
-  uiInfo.customvoteOtherMapsIndex = 0;
-
-  static constexpr char DETAILS_MENU[] = "ingame_customvote_details";
-  static constexpr char VOTE_MENU[] = "ingame_vote_customvote";
-
-  const menuDef_t *detailsMenu = Menus_FindByName(DETAILS_MENU);
-  const menuDef_t *voteMenu = Menus_FindByName(VOTE_MENU);
-
-  if (detailsMenu && detailsMenu->window.flags & WINDOW_VISIBLE) {
-    Menus_CloseByName(DETAILS_MENU);
-  }
-
-  if (voteMenu && voteMenu->window.flags & WINDOW_VISIBLE) {
-    Menus_CloseByName(VOTE_MENU);
-    Menus_OpenByName("ingame_vote");
-  }
-}
-
-void toggleSettingsMenu() {
-  const menuDef_t *activeMenu = Menu_GetFocused();
-
-  if (activeMenu &&
-      StringUtil::startsWith(activeMenu->window.name, "etjump_settings_")) {
-    Menus_CloseAll();
-  } else {
-    trap_Key_SetCatcher(KEYCATCH_UI);
-    Menus_CloseAll();
-    Menus_OpenByName("etjump_settings_general_gameplay");
-  }
-}
-
-} // namespace ETJump
-
 void _UI_SetActiveMenu(const uiMenuCommand_t menu) {
   // this should be the ONLY way the menu system is brought up
   // ensure minimum menu data is cached
@@ -7595,7 +7143,7 @@ void _UI_SetActiveMenu(const uiMenuCommand_t menu) {
         } else if (strlen(buf) > 5 && !Q_stricmpn(buf, "ET://", 5)) { // fretn
           // legal redirects contain source ip in this variable
           if (!UI_Cvar_VariableString("com_errorDiagnoseIP")[0]) {
-            ETJump::handleIllegalRedirect();
+            ETJump::Utilities::handleIllegalRedirect();
             return;
           }
 

--- a/src/ui/ui_syscalls.cpp
+++ b/src/ui/ui_syscalls.cpp
@@ -1,4 +1,5 @@
 #include "ui_local.h"
+#include "etj_local.h"
 #include "../game/etj_syscall_ext_shared.h"
 
 // this file is only included when building a dll
@@ -479,6 +480,6 @@ void trap_GetHunkData(int *hunkused, int *hunkexpected) {
 namespace ETJump {
 // entry point for additional system calls for other engines (ETe, ET: Legacy)
 bool SyscallExt::trap_GetValue(char *value, const int size, const char *key) {
-  return SystemCall(syscallExt->dll_com_trapGetValue, value, size, key);
+  return SystemCall(ui.syscallExt->dll_com_trapGetValue, value, size, key);
 }
 } // namespace ETJump


### PR DESCRIPTION
Not a fully exhaustive reorganization, but it's a start.

* Moved ETJump UI initalization/shutdown to `etj_main.cpp`
* Added `etj_local.h` for global ETJump UI objects/methods
* Added `etj_utilities.cpp/h` for UI and moved bunch of random utility functions there