### PR TITLE
Add CMake option to disable timerun rankings calculations

### DIFF
--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -1,5 +1,7 @@
 file(GLOB GAME_HEADERS "*.h" "*.hpp")
 
+option(NO_TIMERUN_RANKINGS "Disable timerun rankings calculations" OFF)
+
 add_library(qagame MODULE
 	"bg_animation.cpp"
 	"bg_animgroup.cpp"
@@ -103,7 +105,14 @@ add_library(qagame MODULE
 	"etj_utilities.cpp"
 	${GAME_HEADERS}
 )
+
 target_compile_definitions(qagame PRIVATE GAMEDLL)
+
+if (NO_TIMERUN_RANKINGS)
+  add_compile_definitions(NO_TIMERUN_RANKINGS)
+  message(STATUS "Disabling timerun rankings calculations")
+endif()
+
 target_link_libraries(qagame PRIVATE cxx_compiler_opts libjson libsha1 libsqlite libsqlite_modern_cpp libuuid4 fmt::fmt)
 target_link_libraries(qagame PRIVATE $<IF:$<CXX_COMPILER_ID:MSVC>,,pthread>)
 set_target_properties(qagame PROPERTIES

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -141,7 +141,13 @@ bool listCustomVotes(gentity_t *ent, Arguments argv) {
   return true;
 }
 
-bool Rankings(gentity_t *ent, Arguments argv) {
+static bool Rankings(gentity_t *ent, Arguments argv) {
+#ifdef NO_TIMERUN_RANKINGS
+  Printer::console(ent ? ClientNum(ent) : Printer::CONSOLE_CLIENT_NUMBER,
+                   "Rankings are disabled on this build.\n");
+  return false;
+#endif
+
   // these are console commands but to make them more accessible
   // they were also made admin commands
   // server can't call these as they expect clientNum

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -253,7 +253,10 @@ void ETJump::TimerunV2::initialize() {
   }
 
   _sc->startWorkerThreads(1);
+
+#ifndef NO_TIMERUN_RANKINGS
   computeRanks();
+#endif
 }
 
 void ETJump::TimerunV2::shutdown() {


### PR DESCRIPTION
This is a significant time waste when developing anything related to databases via `SynchronizationContext` class, if the local timerun database has a lot of records. The whole worker stalls for 5-10 seconds at the beginning of every map load when the ranks are getting computed, during which any database access is held up from a command you execute. This is really only meant for development work, there's no reason we should ever actually enable this for release/test builds.