### PR TITLE
Fix rankings computation performance

### DIFF
--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -25,6 +25,7 @@
 #include <cstddef>
 #include <utility>
 #include <chrono>
+#include <unordered_set>
 
 #include "etj_timerun_v2.h"
 
@@ -89,10 +90,14 @@ void ETJump::TimerunV2::computeRanks() {
         std::map<UserId, std::string> latestName{};
         const double maxPointsPerRun = 1000.0;
 
+        const auto maps = game.mapStatistics->getMaps();
+        const std::unordered_set<std::string> validMaps(maps.cbegin(),
+                                                        maps.cend());
+
         for (const auto &r : records) {
           // we don't want to compute score for maps not on the server,
           // e.g. when a new version of a map is released
-          if (!game.mapStatistics->mapExists(r.map)) {
+          if (validMaps.count(r.map) == 0) {
             continue;
           }
           if (scores.count(r.seasonId) == 0) {


### PR DESCRIPTION
Not a good idea to rebuild the valid maps set for every single record, who would have thought. The rankings computation on my system is now roughly 320x faster.

refs #1046 