### PR TITLE
Workaround broken command tokenizer in ETe

### DIFF
--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -4995,6 +4995,12 @@ void ClientCommand(int clientNum) {
   }
   trap_Argv(0, cmd, sizeof(cmd));
 
+  // workaround for ETe's broken command tokenizer,
+  // which sometimes sends empty client commands on localhost
+  if (cmd[0] == '\0') {
+    return;
+  }
+
   if (OnClientCommand(ent)) {
     return;
   }


### PR DESCRIPTION
When using rcon in localhost on ETe, the engines command tokenizer performs illegal `strncpy` operations with overlapping `src` & `dest` memory regions, which sometimes results in the server getting an empty client command, potentially crashing the server.