### PR TITLE
Add CommandParser class to cgame

### DIFF
--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(cgame MODULE
 	"../game/bg_tracemap.cpp"
 	"../game/q_math.cpp"
 	"../game/q_shared.cpp"
+	"../game/etj_command_parser.cpp"
 	"../game/etj_entity_utilities_shared.cpp"
 	"../game/etj_file.cpp"
 	"../game/etj_filesystem.cpp"

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -19,7 +19,6 @@
 
 #include "../game/q_shared.h"
 #include "../game/bg_public.h"
-#include "../game/etj_syscalls.h"
 #include "../ui/ui_shared.h"
 
 #include "tr_types.h"
@@ -3499,6 +3498,7 @@ void CG_ShaderStateChanged(const std::string &state = "");
 void CG_ChargeTimesChanged(void);
 void CG_LoadVoiceChats();         // NERVE - SMF
 void CG_PlayBufferedVoiceChats(); // NERVE - SMF
+void CG_AddToTeamChat(const char *str, team_t team);
 void CG_AddToNotify(const char *str);
 void CG_wstatsParse_cmd(void);
 void CG_wtopshotsParse_cmd(qboolean doBest);
@@ -3659,8 +3659,8 @@ void trap_S_UpdateEntityPosition(int entityNum, const vec3_t origin);
 int trap_S_GetVoiceAmplitude(int entityNum);
 // done.
 
-// repatialize recalculates the volumes of sound as they should be heard by the
-// given entityNum and position
+// repatialize recalculates the volumes of sound as they should be heard by
+// the given entityNum and position
 void trap_S_Respatialize(int entityNum, const vec3_t origin, vec3_t axis[3],
                          int inwater);
 sfxHandle_t
@@ -3692,8 +3692,8 @@ qboolean trap_R_GetSkinModel(qhandle_t skinid, const char *type,
 qhandle_t trap_R_GetShaderFromModel(qhandle_t modelid, int surfnum,
                                     int withlightmap); //----(SA)	added
 
-// a scene is built up by calls to R_ClearScene and the various R_Add functions.
-// Nothing is drawn until R_RenderScene is called.
+// a scene is built up by calls to R_ClearScene and the various R_Add
+// functions. Nothing is drawn until R_RenderScene is called.
 void trap_R_ClearScene(void);
 void trap_R_AddRefEntityToScene(const refEntity_t *re);
 
@@ -4265,6 +4265,12 @@ enum class ExecFileType {
 enum class HideFlamethrowerFlags {
   HIDE_SELF = 1 << 0,
   HIDE_OTHERS = 1 << 1,
+};
+
+enum class ChatMessageType {
+  DEFAULT = 0,         // normal message from any team
+  REPLAY_MSG = 1 << 0, // chat replay message
+  SERVER_MSG = 1 << 1, // server console chat message
 };
 } // namespace ETJump
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -10,11 +10,12 @@
 
 #include "cg_local.h"
 #include "etj_init.h"
-#include "etj_cvar_shadow.h"
 #include "etj_cvar_update_handler.h"
 #include "etj_demo_compatibility.h"
 #include "etj_utilities.h"
 #include "etj_rtv_drawable.h"
+
+#include "../game/etj_syscalls.h"
 
 displayContextDef_t cgDC;
 

--- a/src/cgame/cg_syscalls.cpp
+++ b/src/cgame/cg_syscalls.cpp
@@ -1,6 +1,7 @@
 // cg_syscalls.c -- this file is only included when building a dll
 // cg_syscalls.asm is included instead when building a qvm
 #include "cg_local.h"
+#include "../game/etj_syscalls.h"
 #include "../game/etj_syscall_ext_shared.h"
 
 intptr_t(QDECL *vmSyscall)(intptr_t arg,

--- a/src/cgame/etj_consolecommands.cpp
+++ b/src/cgame/etj_consolecommands.cpp
@@ -119,6 +119,34 @@ bool forwardedConsoleCommand(const std::string_view cmd,
   return true;
 }
 
+std::optional<CommandParser::Command>
+getOptCommand(const std::string &commandPrefix,
+              const CommandParser::CommandDefinition &def,
+              const std::vector<std::string> &args) {
+  auto cmd = CommandParser(def, args).parse();
+
+  if (cmd.helpRequested) {
+    CG_AddToTeamChat(
+        stringFormat("^3%s: ^7check console for help.", commandPrefix).c_str(),
+        TEAM_SPECTATOR);
+    Com_Printf(def.help().c_str());
+    return std::nullopt;
+  }
+
+  if (!cmd.errors.empty()) {
+    CG_AddToTeamChat(
+        stringFormat(
+            "^3%s: ^7operation failed. Check console for more information.",
+            commandPrefix)
+            .c_str(),
+        TEAM_SPECTATOR);
+    CG_Printf("%s\n", cmd.getErrorMessage().c_str());
+    return std::nullopt;
+  }
+
+  return cmd;
+}
+
 void registerCommands() {
   consoleCommandsHandler->subscribe(
       "ftSaveLimitSet", [](const auto &) { ftSaveLimitSet(); }, false);

--- a/src/cgame/etj_consolecommands.h
+++ b/src/cgame/etj_consolecommands.h
@@ -27,9 +27,15 @@
 #include <string>
 #include <vector>
 
+#include "../game/etj_command_parser.h"
+
 namespace ETJump::ConsoleCommands {
 using Arguments = std::vector<std::string>;
 
 void registerCommands();
 bool forwardedConsoleCommand(std::string_view cmd, const Arguments &args);
+std::optional<CommandParser::Command>
+getOptCommand(const std::string &commandPrefix,
+              const CommandParser::CommandDefinition &def,
+              const std::vector<std::string> &args);
 } // namespace ETJump::ConsoleCommands

--- a/src/game/etj_shared.h
+++ b/src/game/etj_shared.h
@@ -67,6 +67,16 @@ public:
     return *this;
   }
 
+  constexpr EnumBitset &operator|=(EnumT flag) {
+    bits |= static_cast<UnderlyingT>(flag);
+    return *this;
+  }
+
+  constexpr EnumBitset &operator|=(EnumBitset other) {
+    bits |= other.bits;
+    return *this;
+  }
+
   constexpr EnumBitset &clear(EnumT flag) {
     bits &= ~static_cast<UnderlyingT>(flag);
     return *this;


### PR DESCRIPTION
`CommandParser` class can now be used in cgame to create console commands with good argument handling. The client side version of `getOptCommand` is in `etj_consolecommands.cpp`, and the signature is the same as in qagame, except `clientNum` is no longer required.