### PR TITLE
Fix initial jump speeds text size

### DIFF
--- a/src/cgame/etj_jump_speeds.cpp
+++ b/src/cgame/etj_jump_speeds.cpp
@@ -39,7 +39,7 @@ inline constexpr float DEFAULT_TEXT_SIZE = 0.2f;
 JumpSpeeds::JumpSpeeds(EntityEventsHandler *entityEventsHandler)
     : _entityEventsHandler{entityEventsHandler} {
   startListeners();
-  adjustSize(etj_upmoveMeterTextSize);
+  adjustSize(etj_jumpSpeedsTextSize);
 }
 
 JumpSpeeds::~JumpSpeeds() {


### PR DESCRIPTION
Initial size was set from a wrong cvar.

refs #1787 