### PR TITLE
Don't apply smoothangles during demo playback

### DIFF
--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -1363,8 +1363,8 @@ int CG_CalcViewValues() {
     if (!cgs.demoCam.renderingFreeCam) {
       VectorCopy(ps->origin, cg.refdef_current->vieworg);
 
-      if (etj_smoothAngles.integer && cg_pmove.pmove_fixed &&
-          !(ps->pm_flags & PMF_FOLLOW)) {
+      if (!cg.demoPlayback && etj_smoothAngles.integer &&
+          cg_pmove.pmove_fixed && !(ps->pm_flags & PMF_FOLLOW)) {
         ETJump::updateRefdefAngles(ps);
       } else {
         VectorCopy(ps->viewangles, cg.refdefViewAngles);


### PR DESCRIPTION
Explicitly check for `cg.demoPlayback` when determining whether to use `etj_smoothAngles` or not. This was "working" previously, because `cg_pmove.pmove_fixed` is 0 in demo playback.

Noticed this as a part of investigation on #1844, as the stale `cg_pmove` memory would sometimes have `pmove_fixed 1`, which caused the smooth angles to apply during demoplay back, and completely broke viewangles.

refs #1495 