### PR TITLE
Switch to Ninja as generator on Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
       matrix:
         arch: [x86, x86_64]
         config: [Release]
+        generator: [Ninja]
 
     steps:
       - name: Install dependencies
@@ -86,9 +87,9 @@ jobs:
       - name: Configure CMake
         run: |
           if [ ${{ matrix.arch }} == "x86" ]; then
-            cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_TOOLCHAIN_FILE=cmake/Toolchain-cross-x86-linux.cmake
+            cmake -B ${{ github.workspace }}/build -G ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_TOOLCHAIN_FILE=cmake/Toolchain-cross-x86-linux.cmake
           else
-            cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+            cmake -B ${{ github.workspace }}/build -G ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=${{ matrix.config }}
           fi
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
       matrix:
         arch: [x86, x86_64]
         config: [Release]
+        generator: [Ninja]
 
     steps:
       - name: Install dependencies
@@ -68,9 +69,9 @@ jobs:
       - name: Configure CMake
         run: |
           if [ ${{ matrix.arch }} == "x86" ]; then
-            cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_TOOLCHAIN_FILE=cmake/Toolchain-cross-x86-linux.cmake
+            cmake -B ${{ github.workspace }}/build -G ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_TOOLCHAIN_FILE=cmake/Toolchain-cross-x86-linux.cmake
           else
-            cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+            cmake -B ${{ github.workspace }}/build -G ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=${{ matrix.config }}
           fi
 
       - name: Build


### PR DESCRIPTION
Our CI has been pegged at almost max memory usage for a while now, Ninja builds use like 75% less memory, going down from average of ~13GB memory usage on Unix makefiles to ~3GB usage on Ninja. For build times, there isn't a meaningful change either way.