### PR TITLE
Add mapscript/entity file hash lookup for clients

### DIFF
--- a/src/cgame/etj_demo_compatibility.cpp
+++ b/src/cgame/etj_demo_compatibility.cpp
@@ -179,6 +179,10 @@ void DemoCompatibility::setupCompatibilityFlags() {
     flags.stripLocalizationMarkers = true;
     compatibilityStrings.emplace_back(
         "Stripping localization markers from server commands manually");
+
+    flags.noMapCustomizationHashes = true;
+    compatibilityStrings.emplace_back(
+        "Custom mapscript and entity file hashes not available");
   }
 }
 

--- a/src/cgame/etj_demo_compatibility.h
+++ b/src/cgame/etj_demo_compatibility.h
@@ -71,6 +71,7 @@ public:
     bool predictedJumpSpeeds = false;
     bool noSpecCountInVoteCs = false;
     bool stripLocalizationMarkers = false;
+    bool noMapCustomizationHashes = false;
   };
 
   // everything in here will be set to false unless we're on demo playback

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -299,7 +299,11 @@ inline constexpr int CS_ENDGAME_STATS = 35;
 inline constexpr int CS_CHARGETIMES = 36;
 inline constexpr int CS_FILTERCAMS = 37;
 
-// 38-63 (or 40-63) = unused (see comment above)
+// any index up from 38/40 to 64 that isn't defined = unused (see comment above)
+
+// for now, this holds mapscript/entity file hashes, rename to something
+// more fitting if different data is added in the future
+inline constexpr int32_t CS_ETJUMP_MAPINFO = 40;
 
 inline constexpr int CS_MODELS = 64;
 inline constexpr int CS_SOUNDS = CS_MODELS + MAX_MODELS;


### PR DESCRIPTION
Server now stores SHA-1 hashes of a custom mapscript and/or custom entity file into a new configstring index (40), so that clients can see whether the server is running a custom mapscript or entity file. The hashes are computed after normalizing line endings to LF, so that a file created with CRLF or LF line endings will return the same hash, as we don't really care for the integrity of the exact file, but the contents of it.

Clients can view the hashes using `printMapCustomizationInfo` console command. Because the information is stored in configstrings, this will work in demo playback as well (except for old demos).