### PR TITLE
Remove redundant pointer validity check in CG_SetNextSnap

### DIFF
--- a/src/cgame/cg_snapshot.cpp
+++ b/src/cgame/cg_snapshot.cpp
@@ -361,9 +361,9 @@ static void CG_SetNextSnap(snapshot_t *snap) {
     }
   }
 
-  // if the next frame is a teleport for the playerstate, we
-  // can't interpolate during demos
-  if (cg.snap && ((snap->ps.eFlags ^ cg.snap->ps.eFlags) & EF_TELEPORT_BIT)) {
+  // if the next frame is a teleport for the playerstate,
+  // we can't interpolate during demos
+  if ((snap->ps.eFlags ^ cg.snap->ps.eFlags) & EF_TELEPORT_BIT) {
     cg.nextFrameTeleport = qtrue;
   } else {
     cg.nextFrameTeleport = qfalse;


### PR DESCRIPTION
`cg.snap` cannot be null here, no need to check for the validity. The pointer was already dereferenced once at the start of the function anyway, making this guard useless even if `cg.snap` could be null.