### PR TITLE
Clean up string utilities

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -1121,7 +1121,7 @@ void CG_ExtraTrace_f() {
   std::string listPrint{"Bitmask values for ^3etj_extraTrace^7:\n"};
 
   for (auto &traceList : extraTraceList) {
-    std::string listValues = ETJump::stringFormat(
+    std::string listValues = StringUtils::format(
         "  ^3%d ^7= %s\n", traceList.bitmaskValue, traceList.description);
     listPrint += (listValues);
   }
@@ -1196,10 +1196,10 @@ static void loadSavepos() {
 
   // this is obviously trivial to bypass by just editing the mapname field
   // in the savepos file, but it's a good idea to check this anyway
-  if (!StringUtil::iEqual(data.mapname, cgs.rawmapname, true)) {
+  if (!StringUtils::iEqual(data.mapname, cgs.rawmapname, true)) {
     CG_Printf("Savepos ^3'%s' ^7was not saved in the current map, change map "
               "to ^3'%s' ^7to load this position.\n",
-              filename.c_str(), ETJump::sanitize(data.mapname).c_str());
+              filename.c_str(), StringUtils::sanitize(data.mapname).c_str());
     return;
   }
 

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -855,7 +855,7 @@ static void CG_DrawLagometer() {
   const size_t pad = std::strlen(std::to_string(static_cast<int>(fps)).c_str());
 
   // server snapshot rate (sv_fps)
-  std::string svStr = ETJump::stringFormat(
+  std::string svStr = StringUtils::format(
       "sv: %*s", pad, std::to_string(static_cast<int>(fps)));
   CG_Text_Paint_Ext(x + 2, y + 13, 0.16f, 0.16f, textColor, svStr.c_str(), 0, 0,
                     ITEM_TEXTSTYLE_NORMAL, &cgs.media.limboFont2);
@@ -869,7 +869,7 @@ static void CG_DrawLagometer() {
     Vector4Copy(colorYellow, textColor);
   }
 
-  std::string clStr = ETJump::stringFormat(
+  std::string clStr = StringUtils::format(
       "cl: %*s", pad, std::to_string(static_cast<int>(avg)));
   CG_Text_Paint_Ext(x + 2, y + 7, 0.16f, 0.16f, textColor, clStr.c_str(), 0, 0,
                     ITEM_TEXTSTYLE_NORMAL, &cgs.media.limboFont2);
@@ -1055,7 +1055,7 @@ void logCenterPrint() {
   // this is called before center print gets automatically word wrapped
   // to fit on screen properly, so it's fairly safe to assume that
   // explicit newlines should be replaced with whitespace
-  StringUtil::replaceAll(msg, "\n", " ");
+  StringUtils::replaceAll(msg, "\n", " ");
 
   // it's possible to send an empty center print/only whitespace to "clear"
   // whatever is being displayed, but we don't want to log that obviously
@@ -2154,31 +2154,30 @@ static void CG_DrawVote() {
 
   if (cgs.applicationEndTime > cg.time && cgs.applicationClient >= 0) {
     line_a =
-        ETJump::stringFormat("Accept %s's application to join your fireteam?",
-                             cgs.clientinfo[cgs.applicationClient].name);
+        StringUtils::format("Accept %s's application to join your fireteam?",
+                            cgs.clientinfo[cgs.applicationClient].name);
     line_b =
-        ETJump::stringFormat("Press '%s' for YES, or '%s' for No", str1, str2);
+        StringUtils::format("Press '%s' for YES, or '%s' for No", str1, str2);
   } else if (cgs.propositionEndTime > cg.time && cgs.propositionClient >= 0) {
-    line_a = ETJump::stringFormat(
-        "Accept %s's proposition to invite %s to join your "
-        "fireteam?",
+    line_a = StringUtils::format(
+        "Accept %s's proposition to invite %s to join your fireteam?",
         cgs.clientinfo[cgs.propositionClient2].name,
         cgs.clientinfo[cgs.propositionClient].name);
     line_b =
-        ETJump::stringFormat("Press '%s' for YES, or '%s' for No", str1, str2);
+        StringUtils::format("Press '%s' for YES, or '%s' for No", str1, str2);
   } else if (cgs.invitationEndTime > cg.time && cgs.invitationClient >= 0) {
     line_a =
-        ETJump::stringFormat("Accept %s's invitation to join their fireteam?",
-                             cgs.clientinfo[cgs.invitationClient].name);
+        StringUtils::format("Accept %s's invitation to join their fireteam?",
+                            cgs.clientinfo[cgs.invitationClient].name);
     line_b =
-        ETJump::stringFormat("Press '%s' for YES, or '%s' for No", str1, str2);
+        StringUtils::format("Press '%s' for YES, or '%s' for No", str1, str2);
   } else if (cgs.autoFireteamEndTime > cg.time && cgs.autoFireteamNum == -1) {
     // make sure we're still on the fireteam before displaying
     // this prompt
     if (CG_IsOnFireteam(cg.clientNum)) {
       line_a = "Make Fireteam private?";
-      line_b = ETJump::stringFormat("Press '%s' for YES, or '%s' for No", str1,
-                                    str2);
+      line_b =
+          StringUtils::format("Press '%s' for YES, or '%s' for No", str1, str2);
     }
     // we have left, so reset the timer
     else {
@@ -2232,32 +2231,31 @@ static void CG_DrawVote() {
 
         if (!etj_spectatorVote.integer ||
             ETJump::cgame.demo.compatibility->flags.noSpecCountInVoteCs) {
-          return ETJump::stringFormat(str, std::to_string(totalYes),
-                                      std::to_string(cgs.voteNo));
+          return StringUtils::format(str, std::to_string(totalYes),
+                                     std::to_string(cgs.voteNo));
         }
 
-        return ETJump::stringFormat(
+        return StringUtils::format(
             str,
-            ETJump::stringFormat("%i(%i)", totalYes,
-                                 rtvYesVotes.spectatorCount),
-            ETJump::stringFormat("%i(%i)", cgs.voteNo, cgs.voteNoSpectators));
+            StringUtils::format("%i(%i)", totalYes, rtvYesVotes.spectatorCount),
+            StringUtils::format("%i(%i)", cgs.voteNo, cgs.voteNoSpectators));
       }
 
       if (!etj_spectatorVote.integer ||
           ETJump::cgame.demo.compatibility->flags.noSpecCountInVoteCs) {
-        return ETJump::stringFormat(str, std::to_string(cgs.voteYes),
-                                    std::to_string(cgs.voteNo));
+        return StringUtils::format(str, std::to_string(cgs.voteYes),
+                                   std::to_string(cgs.voteNo));
       }
 
-      return ETJump::stringFormat(
+      return StringUtils::format(
           str,
-          ETJump::stringFormat("%i(%i)", cgs.voteYes, cgs.voteYesSpectators),
-          ETJump::stringFormat("%i(%i)", cgs.voteNo, cgs.voteNoSpectators));
+          StringUtils::format("%i(%i)", cgs.voteYes, cgs.voteYesSpectators),
+          StringUtils::format("%i(%i)", cgs.voteNo, cgs.voteNoSpectators));
     };
 
     if (isRtvVote) {
       if (!(cg.snap->ps.eFlags & EF_VOTED)) {
-        line_a = ETJump::stringFormat("VOTE(%i): %s", sec, cgs.voteString);
+        line_a = StringUtils::format("VOTE(%i): %s", sec, cgs.voteString);
 
         if (canVote) {
           line_b = formatVoteStr("Change map(" + str1 +
@@ -2268,7 +2266,7 @@ static void CG_DrawVote() {
         }
       } else {
         line_a =
-            ETJump::stringFormat("(%i) YOU VOTED ON: %s", sec, cgs.voteString);
+            StringUtils::format("(%i) YOU VOTED ON: %s", sec, cgs.voteString);
         line_b = formatVoteStr("Change map:%s, Keep current map:%s");
 
         x_b = 13;
@@ -2285,14 +2283,14 @@ static void CG_DrawVote() {
           if (ETJump::cgame.demo.compatibility->flags.noSpecCountInVoteCs) {
             yesVotes += std::to_string(rtvYesVotes.playerCount);
           } else {
-            yesVotes += ETJump::stringFormat(
+            yesVotes += StringUtils::format(
                 "%i(%i)", rtvYesVotes.playerCount + rtvYesVotes.spectatorCount,
                 rtvYesVotes.spectatorCount);
           }
 
           // FIXME: this should probably actually format something..?
           std::string noVotes =
-              ETJump::stringFormat("Keep current map", cgs.voteNo);
+              StringUtils::format("Keep current map", cgs.voteNo);
 
           auto yesStrWidth = static_cast<float>(
               ETJump::DrawStringWidth(yesVotes.c_str(), 0.23f));
@@ -2305,7 +2303,7 @@ static void CG_DrawVote() {
       }
     } else {
       if (!(cg.snap->ps.eFlags & EF_VOTED)) {
-        line_a = ETJump::stringFormat("VOTE(%i): %s", sec, cgs.voteString);
+        line_a = StringUtils::format("VOTE(%i): %s", sec, cgs.voteString);
 
         if (canVote) {
           line_b = formatVoteStr("YES(" + str1 + "):%s, NO(" + str2 + "):%s");
@@ -2315,7 +2313,7 @@ static void CG_DrawVote() {
         }
       } else {
         line_a =
-            ETJump::stringFormat("(%i) YOU VOTED ON: %s", sec, cgs.voteString);
+            StringUtils::format("(%i) YOU VOTED ON: %s", sec, cgs.voteString);
         line_b = formatVoteStr("Y:%s, N:%s");
 
         x_b = 13;
@@ -2328,8 +2326,8 @@ static void CG_DrawVote() {
           if (ETJump::cgame.demo.compatibility->flags.noSpecCountInVoteCs) {
             yesVotes += std::to_string(cgs.voteYes);
           } else {
-            yesVotes += ETJump::stringFormat("%i(%i)", cgs.voteYes,
-                                             cgs.voteYesSpectators);
+            yesVotes += StringUtils::format("%i(%i)", cgs.voteYes,
+                                            cgs.voteYesSpectators);
           }
 
           auto strWidth = static_cast<float>(
@@ -2522,12 +2520,12 @@ static void CG_DrawSpectatorMessage(void) {
   if (!Q_stricmp(str2, "(openlimbomenu)")) {
     str2 = "ESCAPE";
   }
-  str = ETJump::stringFormat("Press %s to open Limbo Menu", str2);
+  str = StringUtils::format("Press %s to open Limbo Menu", str2);
   ETJump::DrawString(8, 154 + 12, 0.23f, 0.25f, colorWhite, qtrue, str.c_str(),
                      0, ITEM_TEXTSTYLE_SHADOWED);
 
   str2 = BindingFromName("+attack");
-  str = ETJump::stringFormat("Press %s to follow next player", str2);
+  str = StringUtils::format("Press %s to follow next player", str2);
   ETJump::DrawString(8, 172 + 12, 0.23f, 0.25f, colorWhite, qtrue, str.c_str(),
                      0, ITEM_TEXTSTYLE_SHADOWED);
 #ifdef MV_SUPPORT
@@ -2612,7 +2610,7 @@ static void CG_DrawLimboMessage(void) {
 
   // JPW NERVE
   str = "Reinforcements deploy in " +
-        ETJump::getSecondsString(CG_CalculateReinfTime(qfalse)) + ".";
+        StringUtils::getSecondsString(CG_CalculateReinfTime(qfalse)) + ".";
   ETJump::DrawString(INFOTEXT_STARTX, y, 0.23f, 0.25f, color, qfalse,
                      str.c_str(), 0, 0);
 }
@@ -2703,7 +2701,7 @@ static void CG_DrawFollow() {
     return;
   }
 
-  const std::string str = ETJump::stringFormat(
+  const std::string str = StringUtils::format(
       "^7Following %s^7", cgs.clientinfo[cg.snap->ps.clientNum].name);
   ETJump::DrawString(INFOTEXT_STARTX, 118 + 12, 0.23f, 0.25f, colorWhite,
                      qfalse, str.c_str(), 0, ITEM_TEXTSTYLE_SHADOWED);
@@ -4245,17 +4243,17 @@ void CG_DrawDemoRecording() {
   std::string waveStatus;
 
   if (cl_demorecording.integer) {
-    demoStatus = ETJump::stringFormat(" demo %s: %ik ", cl_demofilename.string,
-                                      cl_demooffset.integer / 1024);
+    demoStatus = StringUtils::format(" demo %s: %ik ", cl_demofilename.string,
+                                     cl_demooffset.integer / 1024);
   }
 
   if (cl_waverecording.integer) {
-    waveStatus = ETJump::stringFormat(" audio: %s %ik ", cl_wavefilename.string,
-                                      cl_waveoffset.integer / 1024);
+    waveStatus = StringUtils::format(" audio: %s %ik ", cl_wavefilename.string,
+                                     cl_waveoffset.integer / 1024);
   }
 
   const std::string status =
-      ETJump::stringFormat("RECORDING%s%s", demoStatus, waveStatus);
+      StringUtils::format("RECORDING%s%s", demoStatus, waveStatus);
 
   const float x = ETJump_AdjustPosition(etj_recordingStatusX.value);
   const float y = etj_recordingStatusY.value;

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -1512,10 +1512,10 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
   const auto debugPrint = [&] {
     const std::string entityType =
         es->eType < ET_EVENTS
-            ? ETJump::stringFormat("^z[%s]", entityTypeNames[es->eType])
+            ? StringUtils::format("^z[%s]", entityTypeNames[es->eType])
             : "^z[N/A]";
     const std::string eventName =
-        ETJump::stringFormat("^z[%s]", eventnames[event]);
+        StringUtils::format("^z[%s]", eventnames[event]);
     CG_Printf("time: %i ent: %3i %-22s ^7event: %3i %-28s ^7eventParm: %3i\n",
               cg.time, es->number, entityType.c_str(), event, eventName.c_str(),
               es->eventParm);

--- a/src/cgame/cg_fireteamoverlay.cpp
+++ b/src/cgame/cg_fireteamoverlay.cpp
@@ -317,9 +317,9 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect) {
 
   CG_FillRect(x, y, FT_WIDTH - 4, FT_HEADER_HEIGHT, clr1);
 
-  buffer = ETJump::StringUtil::toUpperCase(
-      ETJump::stringFormat("FT: %s%s", bg_fireteamNames[f->ident],
-                           f->teamJumpMode ? " (TJ MODE)" : ""));
+  buffer = StringUtils::toUpperCase(
+      StringUtils::format("FT: %s%s", bg_fireteamNames[f->ident],
+                          f->teamJumpMode ? " (TJ MODE)" : ""));
   CG_Text_Paint_Ext(x + 3, y + FT_BAR_HEIGHT, .19f, .19f, tclr, buffer, 0, 0, 0,
                     &cgs.media.limboFont1);
 
@@ -335,7 +335,7 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect) {
                       cgs.media.friendShader, friendShaderColor);
 
     } else {
-      buffer = ETJump::stringFormat("%i", f->saveLimit);
+      buffer = StringUtils::format("%i", f->saveLimit);
       saveTextW = static_cast<float>(
           CG_Text_Width_Ext(buffer, 0.19f, 0, &cgs.media.limboFont1));
       CG_Text_Paint_RightAligned_Ext(iconX, y + FT_BAR_HEIGHT, .19f, .19f, tclr,

--- a/src/cgame/cg_scoreboard.cpp
+++ b/src/cgame/cg_scoreboard.cpp
@@ -203,7 +203,7 @@ void CG_DrawHeader2(float x, float y, float fade) {
 
   // Draw the server hostname
   std::string ipAddress =
-      ETJump::stringFormat("^7%s", cg.ipAddr[0] ? cg.ipAddr : "localhost");
+      StringUtils::format("^7%s", cg.ipAddr[0] ? cg.ipAddr : "localhost");
   header = va("^7%s", Info_ValueForKey(configString, "sv_hostname"));
   CG_Text_Paint_Ext(tempX, tempY, 0.25f, 0.25f, textColor, header, 0, 0, 0,
                     font);
@@ -533,9 +533,9 @@ void CG_DrawHeader3(float x, float y, float fade, vec4_t textColor,
   float rightTextX = SCREEN_WIDTH - leftTextX;
 
   // Draw server name & map name (top row)
-  std::string hostName = ETJump::stringFormat(
+  std::string hostName = StringUtils::format(
       "^7%s", Info_ValueForKey(configString, "sv_hostname"));
-  std::string mapName = ETJump::stringFormat("^7%s", cgs.rawmapname);
+  std::string mapName = StringUtils::format("^7%s", cgs.rawmapname);
   if (cgs.cheats) {
     mapName += " ^9(cheats)";
   }
@@ -561,8 +561,8 @@ void CG_DrawHeader3(float x, float y, float fade, vec4_t textColor,
   // Server IP and mod version (bottom row)
 
   std::string ipAddress =
-      ETJump::stringFormat("^7%s", cg.ipAddr[0] ? cg.ipAddr : "localhost");
-  std::string modVersion = ETJump::stringFormat("^7%s", GAME_TAG);
+      StringUtils::format("^7%s", cg.ipAddr[0] ? cg.ipAddr : "localhost");
+  std::string modVersion = StringUtils::format("^7%s", GAME_TAG);
   float bottomTextY = headerTextY + ALT_SCOREBOARD_3_HEADER_HEIGHT -
                       ALT_SCOREBOARD_3_TEXT_XY_PADDING;
   auto modVersionOffsetX =
@@ -610,8 +610,7 @@ void CG_DrawScoreboardRows3(float x, float y, int j, score_t *score,
 
 void CG_DrawPlayerHeader3(float x, float y, int playerCount, float fade,
                           vec4_t textColor, fontInfo_t *font) {
-  std::string playerHeader =
-      ETJump::stringFormat("^7Players (%d)", playerCount);
+  std::string playerHeader = StringUtils::format("^7Players (%d)", playerCount);
   auto textHeight =
       static_cast<float>(CG_Text_Height_Ext(playerHeader, 0.2f, 0, font));
   float playerHeaderY = y + (ALT_SCOREBOARD_3_DIVIDER + textHeight) / 2;
@@ -636,7 +635,7 @@ void CG_AddPlayerToList3(float x, float y, float fpsCenterX, float infoX,
                     ITEM_TEXTSTYLE_SHADOWED, font);
 
   // Draw FPS
-  std::string maxFPS = ETJump::stringFormat("%i", ci->maxFPS);
+  std::string maxFPS = StringUtils::format("%i", ci->maxFPS);
   CG_Text_Paint_Centred_Ext(fpsCenterX, y, 0.15f, 0.15f, textColor, maxFPS, 0,
                             0, ITEM_TEXTSTYLE_SHADOWED, font);
 
@@ -672,7 +671,7 @@ void CG_AddPlayerToList3(float x, float y, float fpsCenterX, float infoX,
                             font);
 
   // Draw client ping
-  std::string ping = ETJump::stringFormat("%i", score->ping);
+  std::string ping = StringUtils::format("%i", score->ping);
   CG_Text_Paint_Centred_Ext(pingCenterX, y, 0.15f, 0.15f, textColor, ping, 0, 0,
                             ITEM_TEXTSTYLE_SHADOWED, font);
 }
@@ -735,7 +734,7 @@ void CG_DrawPlayerList3(float x, float y, float fade, vec4_t textColor,
 void CG_DrawSpectatorHeader3(float x, float y, int spectatorCount, float fade,
                              vec4_t textColor, fontInfo_t *font) {
   std::string playerHeader =
-      ETJump::stringFormat("^7Spectators (%d)", spectatorCount);
+      StringUtils::format("^7Spectators (%d)", spectatorCount);
   auto textHeight =
       static_cast<float>(CG_Text_Height_Ext(playerHeader, 0.2f, 0, font));
   float spectatorHeaderY = y + (ALT_SCOREBOARD_3_DIVIDER + textHeight) / 2;
@@ -751,7 +750,7 @@ void CG_AddSpectatorToList3(float x, float y, float pingCenterX, score_t *score,
   std::string spectator = "^3SPECTATOR";
   std::string followingArrow = "^3>";
   std::string followedClient = cgs.clientinfo[score->followedClient].name;
-  std::string ping = ETJump::stringFormat("%i", score->ping);
+  std::string ping = StringUtils::format("%i", score->ping);
   float playerX = ALT_SCOREBOARD_3_PLAYER_X;
   float rightTextX = ALT_SCOREBOARD_3_PING_X - ALT_SCOREBOARD_3_TEXT_XY_PADDING;
   auto followingArrowHalfW = static_cast<float>(CG_Text_Width_Ext(

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -2108,17 +2108,20 @@ static const char *addChatReplayModifications(const char *text) {
   }
 
   if (diffTime < 60) {
-    Q_strcat(msg, sizeof(msg), stringFormat("^z[%is ago] ", diffTime).c_str());
+    Q_strcat(msg, sizeof(msg),
+             StringUtils::format("^z[%is ago] ", diffTime).c_str());
   } else if (diffTime < 60 * 60) {
     const int min = diffTime / 60;
-    Q_strcat(msg, sizeof(msg), stringFormat("^z[%im ago] ", min).c_str());
+    Q_strcat(msg, sizeof(msg),
+             StringUtils::format("^z[%im ago] ", min).c_str());
   } else {
     // up to 12h
     if (diffTime >= 60 * 60 * 12) {
       Q_strcat(msg, sizeof(msg), "^z[12h+ ago] ");
     } else {
       const int hours = diffTime / 3600;
-      Q_strcat(msg, sizeof(msg), stringFormat("^z[%ih ago] ", hours).c_str());
+      Q_strcat(msg, sizeof(msg),
+               StringUtils::format("^z[%ih ago] ", hours).c_str());
     }
   }
 
@@ -2290,7 +2293,7 @@ static void CG_ServerCommand(void) {
     std::string s = CG_Argv(1);
 
     if (!ETJump::cgame.demo.compatibility->flags.stripLocalizationMarkers) {
-      ETJump::StringUtil::stripLocalizationMarkers(s);
+      StringUtils::stripLocalizationMarkers(s);
     }
 
     CG_AddPMItem(PM_MESSAGE, s.c_str(), cgs.media.voiceChatShader);
@@ -2302,7 +2305,7 @@ static void CG_ServerCommand(void) {
     std::string s = CG_Argv(1);
 
     if (!ETJump::cgame.demo.compatibility->flags.stripLocalizationMarkers) {
-      ETJump::StringUtil::stripLocalizationMarkers(s);
+      StringUtils::stripLocalizationMarkers(s);
     }
 
     CG_BannerPrint(s.c_str());
@@ -2315,12 +2318,12 @@ static void CG_ServerCommand(void) {
     std::string s = CG_Argv(1);
 
     if (ETJump::cgame.demo.compatibility->flags.stripLocalizationMarkers) {
-      ETJump::StringUtil::stripLocalizationMarkers(s);
+      StringUtils::stripLocalizationMarkers(s);
     }
 
     if (args >= 3) {
       if (args == 4) {
-        s = ETJump::stringFormat("%s%s", CG_Argv(3), s);
+        s = StringUtils::format("%s%s", CG_Argv(3), s);
       }
 
       // OSP - for client logging
@@ -2351,7 +2354,7 @@ static void CG_ServerCommand(void) {
     std::string s = CG_Argv(1);
 
     if (ETJump::cgame.demo.compatibility->flags.stripLocalizationMarkers) {
-      ETJump::StringUtil::stripLocalizationMarkers(s);
+      StringUtils::stripLocalizationMarkers(s);
     }
 
     CG_Printf("[cgnotify]%s", s.c_str());
@@ -2396,7 +2399,7 @@ static void CG_ServerCommand(void) {
     s = CG_Argv(1);
 
     if (ETJump::cgame.demo.compatibility->flags.stripLocalizationMarkers) {
-      ETJump::StringUtil::stripLocalizationMarkers(s);
+      StringUtils::stripLocalizationMarkers(s);
     }
 
     Q_strncpyz(text, s.c_str(), MAX_SAY_TEXT);
@@ -2427,7 +2430,7 @@ static void CG_ServerCommand(void) {
     std::string s = CG_Argv(1);
 
     if (ETJump::cgame.demo.compatibility->flags.stripLocalizationMarkers) {
-      ETJump::StringUtil::stripLocalizationMarkers(s);
+      StringUtils::stripLocalizationMarkers(s);
     }
 
     Q_strncpyz(text, s.c_str(), MAX_SAY_TEXT);

--- a/src/cgame/cg_sound.cpp
+++ b/src/cgame/cg_sound.cpp
@@ -642,10 +642,10 @@ qboolean CG_SaveSpeakersToScript(void) {
 
   trap_FS_FCloseFile(fh);
 
-  CG_Printf(
-      "Saved %s to 'sound/maps/%s.sps'\n",
-      ETJump::getPluralizedString(BG_NumScriptSpeakers(), "speaker").c_str(),
-      cgs.rawmapname);
+  CG_Printf("Saved %s to 'sound/maps/%s.sps'\n",
+            StringUtils::getPluralizedString(BG_NumScriptSpeakers(), "speaker")
+                .c_str(),
+            cgs.rawmapname);
 
   return qtrue;
 }
@@ -1053,7 +1053,7 @@ void CG_SpeakerEditor_RenderDropdown(panel_button_t *button) {
       button->rect.y + 9.f, button->font->scalex, button->font->scaley, colour,
       "V", 0, 0, 0, button->font->font);
 
-  const auto buttonStrings = ETJump::StringUtil::split(button->text, " ");
+  const auto buttonStrings = StringUtils::split(button->text, " ");
   s = buttonStrings[button->data[1]].c_str();
 
   CG_Text_Paint_Ext(

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -1750,7 +1750,7 @@ void CG_RegisterWeapon(int weaponNum, qboolean force) {
       COM_StripExtension(weaponInfo->pickupModelPath,
                          weaponInfo->pickupModelPath);
       std::string path =
-          ETJump::StringUtil::eraseLast(weaponInfo->pickupModelPath, "_pickup");
+          StringUtils::eraseLast(weaponInfo->pickupModelPath, "_pickup");
       path += "_stand.md3";
       weaponInfo->standModel = trap_R_RegisterModel(path.c_str());
     }

--- a/src/cgame/etj_accelmeter_drawable.cpp
+++ b/src/cgame/etj_accelmeter_drawable.cpp
@@ -151,8 +151,8 @@ bool AccelMeter::beforeRender() {
   y = etj_accelY.value;
 
   accelStr.clear();
-  accelStr.emplace_back(stringFormat("%.0f", accel[0]));
-  accelStr.emplace_back(stringFormat("%.0f", accel[1]));
+  accelStr.emplace_back(StringUtils::format("%.0f", accel[0]));
+  accelStr.emplace_back(StringUtils::format("%.0f", accel[1]));
 
   return true;
 }

--- a/src/cgame/etj_autodemo_recorder.cpp
+++ b/src/cgame/etj_autodemo_recorder.cpp
@@ -129,7 +129,7 @@ void AutoDemoRecorder::onTimerunEnd(const std::vector<std::string> &args,
     return;
   }
 
-  trySaveTimerunDemo(sanitize(args[1]), args[2]);
+  trySaveTimerunDemo(StringUtils::sanitize(args[1]), args[2]);
 }
 
 void AutoDemoRecorder::onManualSave(const std::vector<std::string> &args) {
@@ -165,8 +165,8 @@ std::string AutoDemoRecorder::TempNameGenerator::pop() {
 }
 
 std::string AutoDemoRecorder::TempNameGenerator::next() {
-  const std::string name =
-      stringFormat("%s/temp_%02d", TEMP_PATH, (nameCounter++ % MAX_TEMP) + 1);
+  const std::string name = StringUtils::format("%s/temp_%02d", TEMP_PATH,
+                                               (nameCounter++ % MAX_TEMP) + 1);
   names.push(name);
   return name;
 }
@@ -254,7 +254,7 @@ void AutoDemoRecorder::saveDemoWithRestart(const std::string &src,
 }
 
 std::string AutoDemoRecorder::createDemoPath(const std::string &name) {
-  return stringFormat(
+  return StringUtils::format(
       "demos/%s/%s_%s_%s[%s].dm_84",
       FileSystem::Path::sanitizeFolder(etj_ad_targetPath.string),
       FileSystem::Path::sanitize(cgs.clientinfo[cg.clientNum].cleanname),
@@ -264,7 +264,7 @@ std::string AutoDemoRecorder::createDemoPath(const std::string &name) {
 std::string
 AutoDemoRecorder::createTimerunDemoPath(const std::string &runName,
                                         const std::string &runTime) {
-  return stringFormat(
+  return StringUtils::format(
       "demos/%s/%s_%s_%s_%s[%s].dm_84",
       FileSystem::Path::sanitizeFolder(etj_ad_targetPath.string),
       FileSystem::Path::sanitize(cgs.clientinfo[cg.clientNum].cleanname),
@@ -273,19 +273,19 @@ AutoDemoRecorder::createTimerunDemoPath(const std::string &runName,
 }
 
 std::string AutoDemoRecorder::createDemoTempPath(const std::string &name) {
-  return stringFormat("demos/%s.dm_84", name);
+  return StringUtils::format("demos/%s.dm_84", name);
 }
 
 std::string AutoDemoRecorder::createTimeString() {
   Time time = getCurrentTime();
-  return stringFormat("%02d-%02d-%d-%02d%02d%02d", time.date.day, time.date.mon,
-                      time.date.year, time.clock.hours, time.clock.min,
-                      time.clock.sec);
+  return StringUtils::format("%02d-%02d-%d-%02d%02d%02d", time.date.day,
+                             time.date.mon, time.date.year, time.clock.hours,
+                             time.clock.min, time.clock.sec);
 }
 
 std::string AutoDemoRecorder::formatRunTime(int millis) {
   Clock clock = toClock(millis, false);
-  return stringFormat("%02d.%02d.%03d", clock.min, clock.sec, clock.ms);
+  return StringUtils::format("%02d.%02d.%03d", clock.min, clock.sec, clock.ms);
 }
 
 void AutoDemoRecorder::maybeCancelDelayedSave() {

--- a/src/cgame/etj_awaited_command_handler.cpp
+++ b/src/cgame/etj_awaited_command_handler.cpp
@@ -92,11 +92,11 @@ void AwaitedCommandHandler::runFrame() {
 }
 
 void AwaitedCommandHandler::message(const std::string &message) {
-  CG_Printf(stringFormat("%s\n", message).c_str());
+  CG_Printf(StringUtils::format("%s\n", message).c_str());
 }
 
 void AwaitedCommandHandler::executeConsoleCommand(const std::string &command) {
-  trap_SendConsoleCommand(stringFormat("%s\n", command).c_str());
+  trap_SendConsoleCommand(StringUtils::format("%s\n", command).c_str());
 }
 
 void AwaitedCommandHandler::awaitCommand(const std::vector<std::string> &args) {
@@ -112,9 +112,9 @@ void AwaitedCommandHandler::awaitCommand(const std::vector<std::string> &args) {
   const auto &waitedFramesStr = args[0];
   int waitedFrames;
   std::string outOfRangeError =
-      stringFormat("^3Error: ^7First parameter (number of frames) must be "
-                   "between ^31 ^7and ^3%i^7.",
-                   std::numeric_limits<int>::max());
+      StringUtils::format("^3Error: ^7First parameter (number of frames) must "
+                          "be between ^31 ^7and ^3%i^7.",
+                          std::numeric_limits<int>::max());
   try {
     waitedFrames = std::stoi(waitedFramesStr);
   } catch (const std::out_of_range &) {
@@ -141,9 +141,9 @@ void AwaitedCommandHandler::awaitCommand(const std::vector<std::string> &args) {
   auto numCommandsString =
       command->commands.size() == 1 ? "command" : "commands";
   auto numFramesString = command->requiredFrameCount == 1 ? "frame" : "frames";
-  message(stringFormat("Executing ^3%d ^7%s after ^3%d ^7%s.",
-                       command->commands.size(), numCommandsString,
-                       command->requiredFrameCount, numFramesString));
+  message(StringUtils::format("Executing ^3%d ^7%s after ^3%d ^7%s.",
+                              command->commands.size(), numCommandsString,
+                              command->requiredFrameCount, numFramesString));
   awaitedCommands.push_back(std::move(command));
 }
 } // namespace ETJump

--- a/src/cgame/etj_chs_data.cpp
+++ b/src/cgame/etj_chs_data.cpp
@@ -223,29 +223,30 @@ void CHSDataHandler::viewTrace(trace_t *tr, const int32_t mask) {
 std::string CHSDataHandler::speed(const SpeedType type) const {
   switch (type) {
     case SpeedType::X:
-      return stringFormat("%.0f", ps->velocity[0]);
+      return StringUtils::format("%.0f", ps->velocity[0]);
     case SpeedType::Y:
-      return stringFormat("%.0f", ps->velocity[1]);
+      return StringUtils::format("%.0f", ps->velocity[1]);
     case SpeedType::Z:
-      return stringFormat("%.0f", ps->velocity[2]);
+      return StringUtils::format("%.0f", ps->velocity[2]);
     case SpeedType::XY:
-      return stringFormat("%.0f", VectorLength2(ps->velocity));
+      return StringUtils::format("%.0f", VectorLength2(ps->velocity));
     case SpeedType::XYZ:
-      return stringFormat("%.0f", VectorLength(ps->velocity));
+      return StringUtils::format("%.0f", VectorLength(ps->velocity));
     case SpeedType::FORWARD:
-      return stringFormat("%.0f",
-                          DotProduct(ps->velocity, cg.refdef.viewaxis[0]));
+      return StringUtils::format(
+          "%.0f", DotProduct(ps->velocity, cg.refdef.viewaxis[0]));
     case SpeedType::SIDE:
-      return stringFormat("%.0f",
-                          DotProduct(ps->velocity, cg.refdef.viewaxis[1]));
+      return StringUtils::format(
+          "%.0f", DotProduct(ps->velocity, cg.refdef.viewaxis[1]));
     case SpeedType::FORWARD_SIDE:
-      return stringFormat("%.0f %.0f",
-                          DotProduct(ps->velocity, cg.refdef.viewaxis[0]),
-                          DotProduct(ps->velocity, cg.refdef.viewaxis[1]));
+      return StringUtils::format(
+          "%.0f %.0f", DotProduct(ps->velocity, cg.refdef.viewaxis[0]),
+          DotProduct(ps->velocity, cg.refdef.viewaxis[1]));
     case SpeedType::XY_FORWARD_SIDE:
-      return stringFormat("%.0f %.0f %.0f", VectorLength2(ps->velocity),
-                          DotProduct(ps->velocity, cg.refdef.viewaxis[0]),
-                          DotProduct(ps->velocity, cg.refdef.viewaxis[1]));
+      return StringUtils::format(
+          "%.0f %.0f %.0f", VectorLength2(ps->velocity),
+          DotProduct(ps->velocity, cg.refdef.viewaxis[0]),
+          DotProduct(ps->velocity, cg.refdef.viewaxis[1]));
     default:
       return "-";
   }
@@ -263,11 +264,11 @@ std::string CHSDataHandler::ammo() {
   CG_PlayerAmmoValue(&ammo, &clips, &akimboAmmo);
 
   if (akimboAmmo >= 0) {
-    return stringFormat("%i|%i/%i", akimboAmmo, ammo, clips);
+    return StringUtils::format("%i|%i/%i", akimboAmmo, ammo, clips);
   }
 
   if (clips >= 0) {
-    return stringFormat("%i/%i", ammo, clips);
+    return StringUtils::format("%i/%i", ammo, clips);
   }
 
   if (ammo >= 0) {
@@ -283,16 +284,17 @@ std::string CHSDataHandler::distance(const DistanceType type) {
       const trace_t tr = getTraceResults(CHS_10_11);
 
       return tr.fraction != 1.0f
-                 ? stringFormat("%.0f",
-                                std::sqrt(SQR(tr.endpos[0] - ps->origin[0]) +
-                                          SQR(tr.endpos[1] - ps->origin[1])))
+                 ? StringUtils::format(
+                       "%.0f", std::sqrt(SQR(tr.endpos[0] - ps->origin[0]) +
+                                         SQR(tr.endpos[1] - ps->origin[1])))
                  : "-";
     }
     case DistanceType::Z: {
       const trace_t tr = getTraceResults(CHS_10_11);
 
       return tr.fraction != 1.0f
-                 ? stringFormat("%.0f", tr.endpos[2] - ps->origin[2] - ZOffset)
+                 ? StringUtils::format("%.0f",
+                                       tr.endpos[2] - ps->origin[2] - ZOffset)
                  : "-";
     }
     case DistanceType::XYZ: {
@@ -303,14 +305,15 @@ std::string CHSDataHandler::distance(const DistanceType type) {
       origin[2] += ZOffset;
 
       return tr.fraction != 1.0f
-                 ? stringFormat("%.0f", Distance(tr.endpos, origin))
+                 ? StringUtils::format("%.0f", Distance(tr.endpos, origin))
                  : "-";
     }
     case DistanceType::VIEW_XYZ: {
       const trace_t tr = getTraceResults(CHS_13_15);
 
       return tr.fraction != 1.0f
-                 ? stringFormat("%.0f", Distance(tr.endpos, cg.refdef.vieworg))
+                 ? StringUtils::format("%.0f",
+                                       Distance(tr.endpos, cg.refdef.vieworg))
                  : "-";
     }
     case DistanceType::XY_Z_XYZ: {
@@ -321,11 +324,11 @@ std::string CHSDataHandler::distance(const DistanceType type) {
       origin[2] += ZOffset;
 
       return tr.fraction != 1.0f
-                 ? stringFormat("%.0f %.0f %.0f",
-                                std::sqrt(SQR(tr.endpos[0] - origin[0]) +
-                                          SQR(tr.endpos[1] - origin[1])),
-                                tr.endpos[2] - origin[2],
-                                Distance(tr.endpos, origin))
+                 ? StringUtils::format("%.0f %.0f %.0f",
+                                       std::sqrt(SQR(tr.endpos[0] - origin[0]) +
+                                                 SQR(tr.endpos[1] - origin[1])),
+                                       tr.endpos[2] - origin[2],
+                                       Distance(tr.endpos, origin))
                  : "- - -";
     }
     case DistanceType::XY_Z_VIEW_XYZ: {
@@ -336,11 +339,11 @@ std::string CHSDataHandler::distance(const DistanceType type) {
       origin[2] += ZOffset;
 
       return tr.fraction != 1.0f
-                 ? stringFormat("%.0f %.0f %.0f",
-                                std::sqrt(SQR(tr.endpos[0] - origin[0]) +
-                                          SQR(tr.endpos[1] - origin[1])),
-                                tr.endpos[2] - origin[2],
-                                Distance(tr.endpos, cg.refdef.vieworg))
+                 ? StringUtils::format("%.0f %.0f %.0f",
+                                       std::sqrt(SQR(tr.endpos[0] - origin[0]) +
+                                                 SQR(tr.endpos[1] - origin[1])),
+                                       tr.endpos[2] - origin[2],
+                                       Distance(tr.endpos, cg.refdef.vieworg))
                  : "- - -";
     }
     default:
@@ -352,9 +355,9 @@ std::string CHSDataHandler::lookXYZ() {
   const auto tr = getTraceResults(CHS_16);
 
   if (tr.fraction != 1.0f) {
-    return stringFormat("%.0f %.0f %.0f", tr.plane.dist * tr.plane.normal[0],
-                        tr.plane.dist * tr.plane.normal[1],
-                        tr.plane.dist * tr.plane.normal[2]);
+    return StringUtils::format(
+        "%.0f %.0f %.0f", tr.plane.dist * tr.plane.normal[0],
+        tr.plane.dist * tr.plane.normal[1], tr.plane.dist * tr.plane.normal[2]);
   }
 
   return "- - -";
@@ -363,11 +366,11 @@ std::string CHSDataHandler::lookXYZ() {
 std::string CHSDataHandler::angle(const int32_t angle) const {
   switch (angle) {
     case PITCH:
-      return stringFormat("%.2f", ps->viewangles[PITCH]);
+      return StringUtils::format("%.2f", ps->viewangles[PITCH]);
     case YAW:
-      return stringFormat("%.2f", ps->viewangles[YAW]);
+      return StringUtils::format("%.2f", ps->viewangles[YAW]);
     case ROLL:
-      return stringFormat("%.2f", ps->viewangles[ROLL]);
+      return StringUtils::format("%.2f", ps->viewangles[ROLL]);
     default:
       return "-";
   }
@@ -376,36 +379,37 @@ std::string CHSDataHandler::angle(const int32_t angle) const {
 std::string CHSDataHandler::position(const PositionType type) const {
   switch (type) {
     case PositionType::X:
-      return stringFormat("%.0f", ps->origin[0]);
+      return StringUtils::format("%.0f", ps->origin[0]);
     case PositionType::Y:
-      return stringFormat("%.0f", ps->origin[1]);
+      return StringUtils::format("%.0f", ps->origin[1]);
     case PositionType::Z:
-      return stringFormat("%.0f", ps->origin[2] + ZOffset);
+      return StringUtils::format("%.0f", ps->origin[2] + ZOffset);
     case PositionType::VIEW_X:
-      return stringFormat("%.0f", cg.refdef.vieworg[0]);
+      return StringUtils::format("%.0f", cg.refdef.vieworg[0]);
     case PositionType::VIEW_Y:
-      return stringFormat("%.0f", cg.refdef.vieworg[1]);
+      return StringUtils::format("%.0f", cg.refdef.vieworg[1]);
     case PositionType::VIEW_Z:
-      return stringFormat("%.0f", cg.refdef.vieworg[2]);
+      return StringUtils::format("%.0f", cg.refdef.vieworg[2]);
     default:
       return "-";
   }
 }
 
 std::string CHSDataHandler::lastJumpPos() const {
-  return stringFormat("%.0f %.0f %.0f", cg.etjLastJumpPos[0],
-                      cg.etjLastJumpPos[1], cg.etjLastJumpPos[2] + ZOffset);
+  return StringUtils::format("%.0f %.0f %.0f", cg.etjLastJumpPos[0],
+                             cg.etjLastJumpPos[1],
+                             cg.etjLastJumpPos[2] + ZOffset);
 }
 
 std::string CHSDataHandler::planeAngleZ() {
   const trace_t tr = getTraceResults(CHS_53);
 
   if (tr.fraction != 1.0f) {
-    return stringFormat("%.2f",
-                        std::atan2(std::sqrt(pow(tr.plane.normal[0], 2) +
-                                             pow(tr.plane.normal[1], 2)),
-                                   tr.plane.normal[2]) *
-                            180 / M_PI);
+    return StringUtils::format("%.2f",
+                               std::atan2(std::sqrt(pow(tr.plane.normal[0], 2) +
+                                                    pow(tr.plane.normal[1], 2)),
+                                          tr.plane.normal[2]) *
+                                   180 / M_PI);
   }
 
   return "-";

--- a/src/cgame/etj_client_authentication.cpp
+++ b/src/cgame/etj_client_authentication.cpp
@@ -52,8 +52,8 @@ void ETJump::ClientAuthentication::login() {
   }
   auto hwid = getHwid();
   auto authenticate =
-      ETJump::stringFormat("%s %s %s", Constants::Authentication::AUTHENTICATE,
-                           ETJump::hash(guid), hwid);
+      StringUtils::format("%s %s %s", Constants::Authentication::AUTHENTICATE,
+                          StringUtils::hash(guid), hwid);
   _sendClientCommand(authenticate);
 }
 
@@ -73,7 +73,7 @@ std::string ETJump::ClientAuthentication::createGuid() const {
   char buf[UUID4_LEN];
   uuid4_init();
   uuid4_generate(buf);
-  auto guid = ETJump::StringUtil::toUpperCase(buf);
+  auto guid = StringUtils::toUpperCase(buf);
   return guid;
 }
 

--- a/src/cgame/etj_client_commands_handler.cpp
+++ b/src/cgame/etj_client_commands_handler.cpp
@@ -35,7 +35,7 @@ ETJump::ClientCommandsHandler::~ClientCommandsHandler() {}
 
 bool ETJump::ClientCommandsHandler::check(
     const std::string &command, const std::vector<std::string> &arguments) {
-  auto lowercasedCommand = ETJump::StringUtil::toLowerCase(command);
+  auto lowercasedCommand = StringUtils::toLowerCase(command);
   auto match = _callbacks.find(lowercasedCommand);
   if (match != end(_callbacks)) {
     match->second(arguments);
@@ -48,7 +48,7 @@ bool ETJump::ClientCommandsHandler::subscribe(
     const std::string &command,
     std::function<void(const std::vector<std::string> &)> callback,
     bool autocomplete) {
-  auto lowercasedCommand = ETJump::StringUtil::toLowerCase(command);
+  auto lowercasedCommand = StringUtils::toLowerCase(command);
   if (_callbacks.find(lowercasedCommand) != end(_callbacks)) {
     return false;
   }
@@ -61,7 +61,7 @@ bool ETJump::ClientCommandsHandler::subscribe(
 }
 
 bool ETJump::ClientCommandsHandler::unsubscribe(const std::string &command) {
-  auto lowercasedCommand = ETJump::StringUtil::toLowerCase(command);
+  auto lowercasedCommand = StringUtils::toLowerCase(command);
   auto callback = _callbacks.find(lowercasedCommand);
   if (callback != end(_callbacks)) {
     return false;

--- a/src/cgame/etj_color_parser.cpp
+++ b/src/cgame/etj_color_parser.cpp
@@ -31,7 +31,7 @@ void ColorParser::parseColorString(const std::string &colorString,
                                    vec4_t &color) {
   Vector4Set(color, 0.0f, 0.0f, 0.0f, 1.0); // set defaults
 
-  std::string token{StringUtil::toLowerCase(trim(colorString))};
+  std::string token{StringUtils::toLowerCase(StringUtils::trim(colorString))};
 
   if (std::regex_match(token, alphaRegex)) {
     parseNamedColorString(token, color);

--- a/src/cgame/etj_console_shader.cpp
+++ b/src/cgame/etj_console_shader.cpp
@@ -47,7 +47,8 @@ std::string ConsoleShader::createBackground() {
 }
 
 std::string ConsoleShader::createTexturedBackground() const {
-  auto alphaGen = stringFormat("alphaGen const %f", etj_consoleAlpha.value);
+  auto alphaGen =
+      StringUtils::format("alphaGen const %f", etj_consoleAlpha.value);
 
   return composeShader(shaderName, {"nopicmip"},
                        {{"map textures/skies_sd/wurzburg_clouds.tga",
@@ -75,9 +76,10 @@ std::string ConsoleShader::createTexturedBackground() const {
 std::string ConsoleShader::createSolidBackground() const {
   vec4_t bg;
   cgame.utils.colorParser->parseColorString(etj_consoleColor.string, bg);
-  auto alphaGen = stringFormat("alphaGen const %f", etj_consoleAlpha.value);
+  auto alphaGen =
+      StringUtils::format("alphaGen const %f", etj_consoleAlpha.value);
   auto colorGen =
-      stringFormat("rgbGen const ( %f %f %f )", bg[0], bg[1], bg[2]);
+      StringUtils::format("rgbGen const ( %f %f %f )", bg[0], bg[1], bg[2]);
 
   return composeShader(shaderName, {"nopicmip"},
                        {{

--- a/src/cgame/etj_consolecommands.cpp
+++ b/src/cgame/etj_consolecommands.cpp
@@ -96,10 +96,10 @@ static void demoQueue(const Arguments &args) {
     return;
   }
 
-  if (StringUtil::iEqual(args[0], "next") ||
-      StringUtil::iEqual(args[0], "previous") ||
-      StringUtil::iEqual(args[0], "restart") ||
-      StringUtil::iEqual(args[0], "goto")) {
+  if (StringUtils::iEqual(args[0], "next") ||
+      StringUtils::iEqual(args[0], "previous") ||
+      StringUtils::iEqual(args[0], "restart") ||
+      StringUtils::iEqual(args[0], "goto")) {
     trap_SendConsoleCommand("uiDemoQueueManualSkip 1\n");
   }
 }
@@ -112,7 +112,7 @@ static bool fireteam(const Arguments &args) {
   // 'fireteam' commands are normally handled by the server,
   // but if we're using 'fireteam countdown', catch it here and make sure
   // the duration is sent with the command if it's not manually specified
-  if (!StringUtil::iEqual(args[0], "countdown")) {
+  if (!StringUtils::iEqual(args[0], "countdown")) {
     return true;
   }
 
@@ -139,14 +139,14 @@ static bool fireteam(const Arguments &args) {
  */
 bool forwardedConsoleCommand(const std::string_view cmd,
                              const Arguments &args) {
-  if (StringUtil::iEqual(cmd, "demoQueue")) {
+  if (StringUtils::iEqual(cmd, "demoQueue")) {
     // this should always return true, regardless if we actually modify
     // anything, as we always want UI to also handle this command
     demoQueue(args);
     return true;
   }
 
-  if (StringUtil::iEqual(cmd, "fireteam")) {
+  if (StringUtils::iEqual(cmd, "fireteam")) {
     return fireteam(args);
   }
 
@@ -161,9 +161,11 @@ getOptCommand(const std::string &commandPrefix,
 
   if (cmd.helpRequested) {
     CG_AddToTeamChat(
-        stringFormat("^3%s: ^7check console for help.", commandPrefix).c_str(),
+        StringUtils::format("^3%s: ^7check console for help.", commandPrefix)
+            .c_str(),
         TEAM_SPECTATOR);
-    const auto splits = wrapWords(def.help(), '\n', MAX_STRING_CHARS - 1);
+    const auto splits =
+        StringUtils::wrapWords(def.help(), '\n', MAX_STRING_CHARS - 1);
 
     for (const auto &s : splits) {
       CG_Printf("%s", s.c_str());
@@ -174,7 +176,7 @@ getOptCommand(const std::string &commandPrefix,
 
   if (!cmd.errors.empty()) {
     CG_AddToTeamChat(
-        stringFormat(
+        StringUtils::format(
             "^3%s: ^7operation failed. Check console for more information.",
             commandPrefix)
             .c_str(),

--- a/src/cgame/etj_custom_command_menu.cpp
+++ b/src/cgame/etj_custom_command_menu.cpp
@@ -944,8 +944,8 @@ CustomCommandMenu::getCustomCommands() const {
 
 void CustomCommandMenu::generateExampleFile(
     const std::vector<std::string> &args) {
-  if (args.empty() || (!StringUtil::iEqual(args[0], "-f") &&
-                       !StringUtil::iEqual(args[0], "--force"))) {
+  if (args.empty() || (!StringUtils::iEqual(args[0], "-f") &&
+                       !StringUtils::iEqual(args[0], "--force"))) {
     // we don't really care for a potential custom file here, just make sure
     // we don't overwrite the default one, that most players likely use.
     if (FileSystem::exists(DEFAULT_CUSTOM_COMMAND_FILE)) {

--- a/src/cgame/etj_custom_command_menu_drawable.cpp
+++ b/src/cgame/etj_custom_command_menu_drawable.cpp
@@ -180,8 +180,8 @@ void CustomCommandMenuDrawable::commandMenuTitleDraw(panel_button_t *button) {
   std::string title = "CUSTOM COMMANDS";
 
   if (!commands.empty()) {
-    title += stringFormat(" (PAGE %i OF %i)", currentPage,
-                          CUSTOM_COMMAND_MENU_MAX_PAGES);
+    title += StringUtils::format(" (PAGE %i OF %i)", currentPage,
+                                 CUSTOM_COMMAND_MENU_MAX_PAGES);
   }
 
   CG_Text_Paint_Ext(button->rect.x, button->rect.y, button->font->scalex,
@@ -238,7 +238,7 @@ void CustomCommandMenuDrawable::commandMenuTextDraw(panel_button_t *button) {
       continue;
     }
 
-    std::string s = stringFormat("%i. ", (i + 1) % NUM_MENU_ITEMS);
+    std::string s = StringUtils::format("%i. ", (i + 1) % NUM_MENU_ITEMS);
 
     switch (i) {
       case MENU_PREV:
@@ -248,8 +248,8 @@ void CustomCommandMenuDrawable::commandMenuTextDraw(panel_button_t *button) {
         s += "Next page";
         break;
       default:
-        s += StringUtil::truncate(commands.at(currentPage)[i].name,
-                                  MAX_COMNMAND_NAME_LEN);
+        s += StringUtils::truncate(commands.at(currentPage)[i].name,
+                                   MAX_COMNMAND_NAME_LEN);
         break;
     }
 

--- a/src/cgame/etj_cvar_parser.h
+++ b/src/cgame/etj_cvar_parser.h
@@ -69,7 +69,7 @@ public:
       return T{1.0f, 1.0f};
     }
 
-    auto scaleComponents = StringUtil::split(cvar.string, " ");
+    auto scaleComponents = StringUtils::split(cvar.string, " ");
 
     // remove any whitespace, if user inputs a string like "  2   3  "
     scaleComponents.erase(

--- a/src/cgame/etj_demo_compatibility.cpp
+++ b/src/cgame/etj_demo_compatibility.cpp
@@ -99,7 +99,7 @@ void DemoCompatibility::parseDemoVersion() {
 void DemoCompatibility::fillVersionInfo(Version &version,
                                         const std::string &versionStr,
                                         const std::string &delimiter) {
-  const auto splits = StringUtil::split(versionStr, delimiter);
+  const auto splits = StringUtils::split(versionStr, delimiter);
 
   // bail if we have some weird version without at least 3 digits
   if (splits.size() < 3) {

--- a/src/cgame/etj_demo_recorder.cpp
+++ b/src/cgame/etj_demo_recorder.cpp
@@ -23,8 +23,9 @@
  */
 
 #include "etj_demo_recorder.h"
-#include "../game/etj_string_utilities.h"
 #include "cg_local.h"
+
+#include "../game/etj_string_utilities.h"
 
 ETJump::DemoRecorder::DemoRecorder() {}
 
@@ -38,7 +39,7 @@ void ETJump::DemoRecorder::start(const std::string &name) {
   _startTime = cg.time;
 
   trap_SendConsoleCommand("set cl_noprint 1\n");
-  trap_SendConsoleCommand(stringFormat("record %s\n", name).c_str());
+  trap_SendConsoleCommand(StringUtils::format("record %s\n", name).c_str());
   trap_SendConsoleCommand("set cl_noprint 0\n");
 }
 
@@ -66,7 +67,7 @@ void ETJump::DemoRecorder::restart(const std::string &name) {
 }
 
 bool ETJump::DemoRecorder::recordingAutoDemo() {
-  return StringUtil::startsWith(cl_demofilename.string, "demos/temp/temp_");
+  return StringUtils::startsWith(cl_demofilename.string, "demos/temp/temp_");
 }
 
 int ETJump::DemoRecorder::elapsed() {

--- a/src/cgame/etj_entity_events_handler.cpp
+++ b/src/cgame/etj_entity_events_handler.cpp
@@ -29,7 +29,7 @@ ETJump::EntityEventsHandler::EntityEventsHandler() { _callbacks.clear(); }
 
 bool ETJump::EntityEventsHandler::check(const std::string &eventName,
                                         centity_t *cent) {
-  auto lowercasedCommand = ETJump::StringUtil::toLowerCase(eventName);
+  auto lowercasedCommand = StringUtils::toLowerCase(eventName);
   auto match = _callbacks.find(lowercasedCommand);
   if (match != end(_callbacks)) {
     for (const auto &callback : match->second) {
@@ -41,26 +41,26 @@ bool ETJump::EntityEventsHandler::check(const std::string &eventName,
 }
 
 bool ETJump::EntityEventsHandler::check(int event, centity_t *cent) {
-  auto eventName = ETJump::stringFormat("__event__%d", event);
+  auto eventName = StringUtils::format("__event__%d", event);
   return check(eventName, cent);
 }
 
 bool ETJump::EntityEventsHandler::subscribe(
     const std::string &eventName,
     const std::function<void(centity_t *cent)> &callback) {
-  auto lowercasedCommand = ETJump::StringUtil::toLowerCase(eventName);
+  auto lowercasedCommand = StringUtils::toLowerCase(eventName);
   _callbacks[lowercasedCommand].push_back(callback);
   return true;
 }
 
 bool ETJump::EntityEventsHandler::subscribe(
     int event, const std::function<void(centity_t *cent)> &callback) {
-  auto eventName = ETJump::stringFormat("__event__%d", event);
+  auto eventName = StringUtils::format("__event__%d", event);
   return subscribe(eventName, callback);
 }
 
 bool ETJump::EntityEventsHandler::unsubscribe(const std::string &eventName) {
-  auto lowercasedCommand = ETJump::StringUtil::toLowerCase(eventName);
+  auto lowercasedCommand = StringUtils::toLowerCase(eventName);
   auto callback = _callbacks.find(lowercasedCommand);
   if (callback != end(_callbacks)) {
     return false;
@@ -71,6 +71,6 @@ bool ETJump::EntityEventsHandler::unsubscribe(const std::string &eventName) {
 }
 
 bool ETJump::EntityEventsHandler::unsubscribe(int event) {
-  auto eventName = ETJump::stringFormat("__event__%d", event);
+  auto eventName = StringUtils::format("__event__%d", event);
   return unsubscribe(eventName);
 }

--- a/src/cgame/etj_inline_command_parser.cpp
+++ b/src/cgame/etj_inline_command_parser.cpp
@@ -53,5 +53,5 @@ ETJump::InlineCommandParser::parse(const std::vector<std::string> &args) {
 }
 
 bool ETJump::InlineCommandParser::isSeparator(const std::string &input) {
-  return trim(input) == "|";
+  return StringUtils::trim(input) == "|";
 }

--- a/src/cgame/etj_keyset_keybind_drawer.cpp
+++ b/src/cgame/etj_keyset_keybind_drawer.cpp
@@ -60,7 +60,7 @@ void KeySetKeyBindDrawer::drawPressShader(qhandle_t shader,
   if (keyCodeShader) {
     drawPic(x, y, sizeX, sizeY, keyCodeShader, color, shadowColor);
   } else {
-    auto binding = StringUtil::toUpperCase(getKeyCodeBinding(keyCode));
+    auto binding = StringUtils::toUpperCase(getKeyCodeBinding(keyCode));
     // factor = 16 / ... = 0.20
     // size / factor;
     auto bindWidth = DrawStringWidth(binding.c_str(), 0.2f);

--- a/src/cgame/etj_keyset_system.cpp
+++ b/src/cgame/etj_keyset_system.cpp
@@ -128,7 +128,7 @@ KeySetSystem::createKeyPressSetShaderPath(const std::string &keySetName,
     return "";
   }
 
-  return stringFormat("gfx/%s/key_%s_pressed", keySetName, keyName);
+  return StringUtils::format("gfx/%s/key_%s_pressed", keySetName, keyName);
 }
 
 qhandle_t KeySetSystem::registerShaderNoMip(const std::string &shaderName) {

--- a/src/cgame/etj_operating_system_linux.cpp
+++ b/src/cgame/etj_operating_system_linux.cpp
@@ -93,9 +93,9 @@ std::string ETJump::OperatingSystem::getHwid() {
 
   unsigned char mac_address[6];
   memcpy(mac_address, ifr.ifr_hwaddr.sa_data, sizeof(mac_address));
-  hwid += stringFormat("%02X:%02X:%02X:%02X:%02X:%02X", mac_address[0],
-                       mac_address[1], mac_address[2], mac_address[3],
-                       mac_address[4], mac_address[5]);
+  hwid += StringUtils::format("%02X:%02X:%02X:%02X:%02X:%02X", mac_address[0],
+                              mac_address[1], mac_address[2], mac_address[3],
+                              mac_address[4], mac_address[5]);
 
   // TODO: include this in HWID, when user database has been refactored
   //  to store HWIDs of individual components

--- a/src/cgame/etj_overbounce_watcher.cpp
+++ b/src/cgame/etj_overbounce_watcher.cpp
@@ -134,7 +134,8 @@ void OverbounceWatcher::render() const {
 
 void OverbounceWatcher::save(const std::vector<std::string> &args) {
   ps = getValidPlayerState();
-  const std::string name = !args.empty() ? sanitize(args[0], true) : "default";
+  const std::string name =
+      !args.empty() ? StringUtils::sanitize(args[0], true) : "default";
 
   VectorCopy(ps->origin, positions[name]);
   // shift z-coordinate to feet level
@@ -155,7 +156,8 @@ void OverbounceWatcher::reset() {
 }
 
 void OverbounceWatcher::load(const std::vector<std::string> &args) {
-  const std::string name = !args.empty() ? sanitize(args[0], true) : "default";
+  const std::string name =
+      !args.empty() ? StringUtils::sanitize(args[0], true) : "default";
 
   if (positions.find(name) == positions.cend()) {
     CG_AddPMItem(

--- a/src/cgame/etj_player_events_handler.cpp
+++ b/src/cgame/etj_player_events_handler.cpp
@@ -31,7 +31,7 @@ ETJump::PlayerEventsHandler::~PlayerEventsHandler() { _callbacks.clear(); }
 
 bool ETJump::PlayerEventsHandler::check(
     const std::string &event, const std::vector<std::string> &arguments) {
-  auto lowerEvent = ETJump::StringUtil::toLowerCase(event);
+  auto lowerEvent = StringUtils::toLowerCase(event);
   auto match = _callbacks.find(lowerEvent);
   if (match != end(_callbacks)) {
     for (const auto &listener : match->second) listener(arguments);
@@ -43,13 +43,13 @@ bool ETJump::PlayerEventsHandler::check(
 bool ETJump::PlayerEventsHandler::subscribe(
     const std::string &event,
     const std::function<void(const std::vector<std::string> &)> &callback) {
-  auto lowerEvent = ETJump::StringUtil::toLowerCase(event);
+  auto lowerEvent = StringUtils::toLowerCase(event);
   _callbacks[lowerEvent].push_back(callback);
   return true;
 }
 
 bool ETJump::PlayerEventsHandler::unsubscribe(const std::string &event) {
-  auto lowerEvent = ETJump::StringUtil::toLowerCase(event);
+  auto lowerEvent = StringUtils::toLowerCase(event);
   auto listeners = _callbacks.find(lowerEvent);
   if (listeners == end(_callbacks))
     return false;

--- a/src/cgame/etj_quick_follow_drawable.cpp
+++ b/src/cgame/etj_quick_follow_drawable.cpp
@@ -46,7 +46,7 @@ void ETJump::QuickFollowDrawer::render() const {
   }
 
   auto binding = BindingFromName("+activate");
-  auto hintText = stringFormat("^9[%s] to follow", binding);
+  auto hintText = StringUtils::format("^9[%s] to follow", binding);
   float w = DrawStringWidth(cgs.clientinfo[cg.crosshairClientNum].name, 0.23f);
   auto offx = SCREEN_CENTER_X - w / 2;
   DrawString(offx, 182 + 10, 0.16f, 0.16f, color, qfalse, hintText.c_str(), 0,

--- a/src/cgame/etj_rtv_drawable.cpp
+++ b/src/cgame/etj_rtv_drawable.cpp
@@ -126,7 +126,7 @@ void RtvDrawable::drawMenuTitleText(panel_button_t *button) {
     sec = 0;
   }
 
-  std::string str = stringFormat("VOTE FOR A MAP (%i)", sec);
+  std::string str = StringUtils::format("VOTE FOR A MAP (%i)", sec);
 
   CG_Text_Paint_Ext(
       button->rect.x, button->rect.y + static_cast<float>(button->data[0]),
@@ -146,15 +146,16 @@ void RtvDrawable::drawMenuText(panel_button_t *button) {
       continue;
     }
 
-    std::string str = stringFormat("%i. %s", (i + 1) % 10, rtvMenuStrings[i]);
+    std::string str =
+        StringUtils::format("%i. %s", (i + 1) % 10, rtvMenuStrings[i]);
 
     // last entry is current map, so we need 'No' vote count for that
     if (i == arrSize - 1) {
-      str += stringFormat(": %i(%i)", cgs.voteNo, cgs.voteNoSpectators);
+      str += StringUtils::format(": %i(%i)", cgs.voteNo, cgs.voteNoSpectators);
     } else {
-      str +=
-          stringFormat(": %i(%i)", cgame.handlers.rtv->getTotalVotesForMap(i),
-                       (*rtvMaps)[i].voteCountInfo.spectatorCount);
+      str += StringUtils::format(": %i(%i)",
+                                 cgame.handlers.rtv->getTotalVotesForMap(i),
+                                 (*rtvMaps)[i].voteCountInfo.spectatorCount);
     }
 
     CG_Text_Paint_Ext(button->rect.x, y, button->font->scalex,

--- a/src/cgame/etj_servercommands.cpp
+++ b/src/cgame/etj_servercommands.cpp
@@ -41,7 +41,7 @@ static void maplist(const Arguments &args) {
   // we need to forward this command to UI to parse the list there,
   // so we can populate the map vote list
   trap_SendConsoleCommand(
-      va("uiParseMaplist %s\n", StringUtil::join(args, " ").c_str()));
+      va("uiParseMaplist %s\n", StringUtils::join(args, " ").c_str()));
 }
 
 static void forceCustomvoteRefresh() { resetCustomvoteInfo(); }
@@ -59,7 +59,7 @@ static void numCustomvotes(const Arguments &args) {
 static void customvoteList(const Arguments &args) {
   // forward to UI
   trap_SendConsoleCommand(
-      va("uiParseCustomvote %s\n", StringUtil::join(args, " ").c_str()));
+      va("uiParseCustomvote %s\n", StringUtils::join(args, " ").c_str()));
 }
 
 static void pmFlashWindow() {
@@ -72,7 +72,7 @@ static void pmFlashWindow() {
 
 static void extShaderIndex(const Arguments &args) {
   for (const auto &arg : args) {
-    const auto shaderKvp = StringUtil::split(arg, "|");
+    const auto shaderKvp = StringUtils::split(arg, "|");
 
     // sanity check, shouldn't happen,
     // but just skip if the command is somehow malformed
@@ -91,7 +91,7 @@ static void extShaderState(const Arguments &args) {
   // this *should* be a single argument, but 'timeOffset' can have padding,
   // introducing whitespace to the command, which breaks it into multiple args
   // we don't need to preserve it, the parser will ignore it anyway
-  CG_ShaderStateChanged(StringUtil::join(args, ""));
+  CG_ShaderStateChanged(StringUtils::join(args, ""));
 }
 
 static void resetStrafeQuality() {
@@ -117,7 +117,7 @@ static void savePrint(const Arguments &args) {
   if (args.size() >= 2) {
     const int32_t remainingSaves = Q_atoi(args[1]);
     const std::string remainingSavesStr =
-        stringFormat("^7(^3%d ^7remaining)\n", remainingSaves);
+        StringUtils::format("^7(^3%d ^7remaining)\n", remainingSaves);
     saveMsg += '\n' + remainingSavesStr;
   }
 

--- a/src/cgame/etj_spectatorinfo_drawable.cpp
+++ b/src/cgame/etj_spectatorinfo_drawable.cpp
@@ -154,7 +154,8 @@ void SpectatorInfo::render() const {
 
     const auto remaining = static_cast<int>(totalClients - max);
     drawRow(
-        va("(%s hidden)", getPluralizedString(remaining, "spectator").c_str()),
+        va("(%s hidden)",
+           StringUtils::getPluralizedString(remaining, "spectator").c_str()),
         colorMdGrey);
   }
 }

--- a/src/cgame/etj_speed_drawable.cpp
+++ b/src/cgame/etj_speed_drawable.cpp
@@ -187,25 +187,25 @@ void DrawSpeed::setSize(const vmCvar_t *cvar) {
 std::string DrawSpeed::getSpeedString() const {
   switch (etj_drawSpeed2.integer) {
     case 2:
-      return stringFormat("%.0f %.0f", currentSpeed, maxSpeed);
+      return StringUtils::format("%.0f %.0f", currentSpeed, maxSpeed);
     case 3:
-      return stringFormat("%.0f ^z%.0f", currentSpeed, maxSpeed);
+      return StringUtils::format("%.0f ^z%.0f", currentSpeed, maxSpeed);
     case 4:
-      return stringFormat("%.0f (%.0f)", currentSpeed, maxSpeed);
+      return StringUtils::format("%.0f (%.0f)", currentSpeed, maxSpeed);
     case 5:
-      return stringFormat("%.0f ^z(%.0f)", currentSpeed, maxSpeed);
+      return StringUtils::format("%.0f ^z(%.0f)", currentSpeed, maxSpeed);
     case 6:
-      return stringFormat("%.0f ^z[%.0f]", currentSpeed, maxSpeed);
+      return StringUtils::format("%.0f ^z[%.0f]", currentSpeed, maxSpeed);
     case 7:
-      return stringFormat("%.0f | %.0f", currentSpeed, maxSpeed);
+      return StringUtils::format("%.0f | %.0f", currentSpeed, maxSpeed);
     case 8:
-      return stringFormat("Speed: %.0f", currentSpeed);
+      return StringUtils::format("Speed: %.0f", currentSpeed);
     // tens
     case 9:
-      return stringFormat("%02i",
-                          static_cast<int>(currentSpeed) / 10 % 10 * 10);
+      return StringUtils::format("%02i",
+                                 static_cast<int>(currentSpeed) / 10 % 10 * 10);
     default:
-      return stringFormat("%.0f", currentSpeed);
+      return StringUtils::format("%.0f", currentSpeed);
   }
 }
 

--- a/src/cgame/etj_timerun.cpp
+++ b/src/cgame/etj_timerun.cpp
@@ -268,8 +268,8 @@ std::string Timerun::createCompletionMessage(const clientInfo_t &player,
   }
 
   std::string message =
-      ETJump::stringFormat("^7%s ^7completed %s ^7in %s ^7%s^7", who, runName,
-                           timeFinished, timeDifference);
+      StringUtils::format("^7%s ^7completed %s ^7in %s ^7%s^7", who, runName,
+                          timeFinished, timeDifference);
 
   return message;
 }

--- a/src/cgame/etj_timerun_view.cpp
+++ b/src/cgame/etj_timerun_view.cpp
@@ -110,7 +110,7 @@ std::string TimerunView::getTimerString(int msec) {
   auto seconds = millis / 1000;
   millis -= seconds * 1000;
 
-  return stringFormat("%02d:%02d.%03d", minutes, seconds, millis);
+  return StringUtils::format("%02d:%02d.%03d", minutes, seconds, millis);
 }
 
 void TimerunView::draw() {

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -104,8 +104,9 @@ bool configFileExists(const std::string &filename) {
 
 void execFile(const std::string &filename, ExecFileType type) {
   const bool quiet = static_cast<int>(type) & etj_useExecQuiet.integer;
-  const std::string cmd = quiet ? stringFormat("execq \"%s.cfg\"\n", filename)
-                                : stringFormat("exec \"%s.cfg\"\n", filename);
+  const std::string cmd =
+      quiet ? StringUtils::format("execq \"%s.cfg\"\n", filename)
+            : StringUtils::format("exec \"%s.cfg\"\n", filename);
   trap_SendConsoleCommand(cmd.c_str());
 }
 

--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -31,7 +31,7 @@ static bool hasJustStoodUp() {
 
 template <typename... Targs>
 static void bgPrint(const std::string &msg, const Targs &...fargs) {
-  const std::string fmt = stringFormat(msg, fargs...);
+  const std::string fmt = format(msg, fargs...);
 
 #ifdef CGAMEDLL
   Com_Printf("^g[cl] ^7%s\n", fmt.c_str());

--- a/src/game/etj_banner_system.cpp
+++ b/src/game/etj_banner_system.cpp
@@ -35,13 +35,13 @@ static const char *LocationText[] = {"Center", "Top", "Chat", "Left"};
 ETJump::BannerSystem::BannerSystem(Options options) : _bannerIdx(0) {
   _options = std::move(options);
   subscribeToRunFrame([=](int levelTime) { check(levelTime); });
-  Printer::logLn(stringFormat("Initialized banner system\n"
-                              "- %d banners\n"
-                              "- %ds interval\n"
-                              "- %s location",
-                              _options.messages.size(),
-                              (_options.interval / 1000),
-                              LocationText[_options.location]));
+  Printer::logLn(StringUtils::format("Initialized banner system\n"
+                                     "- %d banners\n"
+                                     "- %ds interval\n"
+                                     "- %s location",
+                                     _options.messages.size(),
+                                     (_options.interval / 1000),
+                                     LocationText[_options.location]));
 }
 
 void ETJump::BannerSystem::check(int levelTime) {

--- a/src/game/etj_chat_replay.cpp
+++ b/src/game/etj_chat_replay.cpp
@@ -44,7 +44,7 @@ void ChatReplay::createChatMessage(const int clientNum, const std::string &name,
   msg.clientNum = clientNum;
   msg.name = name;
   msg.encoded = encoded;
-  msg.message = sanitize(message, false, false);
+  msg.message = StringUtils::sanitize(message, false, false);
   msg.expired = false;
 
   time_t t;
@@ -135,8 +135,9 @@ void ChatReplay::sendChatMessages(gentity_t *ent) {
 
 std::string ChatReplay::parseChatMessage(const ChatMessage &msg) {
   const char *cmd = msg.encoded ? "enc_chat" : "chat";
-  return stringFormat("%s \"^7%s%c%c%s\" %i 0 1", cmd, msg.name, Q_COLOR_ESCAPE,
-                      COLOR_LTGREY, msg.message, msg.clientNum);
+  return StringUtils::format("%s \"^7%s%c%c%s\" %i 0 1", cmd, msg.name,
+                             Q_COLOR_ESCAPE, COLOR_LTGREY, msg.message,
+                             msg.clientNum);
 }
 
 void ChatReplay::readChatsFromFile() {

--- a/src/game/etj_command_parser.cpp
+++ b/src/game/etj_command_parser.cpp
@@ -29,13 +29,13 @@
 
 const ETJump::CommandParser::OptionDefinition *
 ETJump::CommandParser::getOptionOrNull() {
-  if (StringUtil::startsWith(*_current, "--")) {
+  if (StringUtils::startsWith(*_current, "--")) {
     const auto optionName = (*_current).substr(2);
 
     if (_def.options.count(optionName) > 0) {
       return &_def.options[optionName];
     }
-  } else if (StringUtil::startsWith(*_current, "-")) {
+  } else if (StringUtils::startsWith(*_current, "-")) {
     const auto optionShortName = (*_current).substr(1);
 
     for (const auto &op : _def.options) {
@@ -62,8 +62,8 @@ void ETJump::CommandParser::expectToken(
   ++_current;
 
   if (_current == end(_args)) {
-    _cmd.errors.push_back(
-        stringFormat("Missing parameter for `%s`", optionDefinition->name));
+    _cmd.errors.push_back(StringUtils::format("Missing parameter for `%s`",
+                                              optionDefinition->name));
     return;
   }
 
@@ -84,8 +84,8 @@ void ETJump::CommandParser::expectMultipleTokens(
   ++_current;
 
   if (_current == end(_args)) {
-    _cmd.errors.push_back(
-        stringFormat("Missing parameter for `%s`", optionDefinition->name));
+    _cmd.errors.push_back(StringUtils::format("Missing parameter for `%s`",
+                                              optionDefinition->name));
     return;
   }
 
@@ -104,12 +104,12 @@ void ETJump::CommandParser::expectMultipleTokens(
   }
 
   if (tokens.empty()) {
-    _cmd.errors.push_back(
-        stringFormat("Missing parameter for `%s`", optionDefinition->name));
+    _cmd.errors.push_back(StringUtils::format("Missing parameter for `%s`",
+                                              optionDefinition->name));
     return;
   }
 
-  option.text = StringUtil::join(tokens, " ");
+  option.text = StringUtils::join(tokens, " ");
 
   _cmd.options[optionDefinition->name] = std::move(option);
 }
@@ -119,8 +119,8 @@ void ETJump::CommandParser::expectInteger(
   ++_current;
 
   if (_current == end(_args)) {
-    _cmd.errors.push_back(
-        stringFormat("Missing parameter for `%s`", optionDefinition->name));
+    _cmd.errors.push_back(StringUtils::format("Missing parameter for `%s`",
+                                              optionDefinition->name));
     return;
   }
 
@@ -136,11 +136,11 @@ ETJump::CommandParser::Option ETJump::CommandParser::createIntegerOption(
   try {
     option.integer = std::stoi(text);
   } catch (const std::invalid_argument &) {
-    _cmd.errors.push_back(stringFormat(
+    _cmd.errors.push_back(StringUtils::format(
         "`%s` is not an integer. Expected an integer for parameter `%s`", text,
         option.name));
   } catch (const std::out_of_range &) {
-    _cmd.errors.push_back(stringFormat(
+    _cmd.errors.push_back(StringUtils::format(
         "`%s` is out of range. Expected an integer for parameter `%s`", text,
         option.name));
   }
@@ -153,8 +153,8 @@ void ETJump::CommandParser::expectDecimal(
   ++_current;
 
   if (_current == end(_args)) {
-    _cmd.errors.push_back(
-        stringFormat("Missing parameter for `%s`", optionDefinition->name));
+    _cmd.errors.push_back(StringUtils::format("Missing parameter for `%s`",
+                                              optionDefinition->name));
     return;
   }
 
@@ -170,11 +170,11 @@ ETJump::CommandParser::Option ETJump::CommandParser::createDecimalOption(
   try {
     option.decimal = std::stod(text);
   } catch (const std::invalid_argument &) {
-    _cmd.errors.push_back(stringFormat(
+    _cmd.errors.push_back(StringUtils::format(
         "`%s` is not a decimal. Expected a decimal for parameter `%s`", text,
         option.name));
   } catch (const std::out_of_range &) {
-    _cmd.errors.push_back(stringFormat(
+    _cmd.errors.push_back(StringUtils::format(
         "`%s` is out of range. Expected a decimal for parameter `%s`", text,
         option.name));
   }
@@ -187,8 +187,8 @@ void ETJump::CommandParser::expectDate(
   ++_current;
 
   if (_current == end(_args)) {
-    _cmd.errors.push_back(
-        stringFormat("Missing parameter for `%s`", optionDefinition->name));
+    _cmd.errors.push_back(StringUtils::format("Missing parameter for `%s`",
+                                              optionDefinition->name));
     return;
   }
 
@@ -204,7 +204,7 @@ ETJump::CommandParser::Option ETJump::CommandParser::createDateOption(
   try {
     option.date = Date::fromString(text);
   } catch (const std::invalid_argument &) {
-    _cmd.errors.push_back(stringFormat(
+    _cmd.errors.push_back(StringUtils::format(
         "`%s` does not match the expected format of `YYYY-MM-DD`", text));
   }
 
@@ -252,7 +252,7 @@ void ETJump::CommandParser::expectOptionOrExtraArgs() {
     return;
   }
 
-  if (StringUtil::startsWith(*_current, "-")) {
+  if (StringUtils::startsWith(*_current, "-")) {
     expectOption();
   } else {
     expectExtraArg();
@@ -298,7 +298,7 @@ void ETJump::CommandParser::processPositionalArguments() {
 void ETJump::CommandParser::validateCommand() {
   for (const auto &option : _def.options) {
     if (option.second.required && _cmd.options.count(option.first) == 0) {
-      _cmd.errors.push_back(stringFormat(
+      _cmd.errors.push_back(StringUtils::format(
           "Required option `%s` was not specified.", option.first));
     }
   }
@@ -331,7 +331,7 @@ ETJump::CommandParser::Command ETJump::CommandParser::parse() {
     return _cmd;
   } catch (const std::runtime_error &e) {
     _cmd.errors.push_back(
-        stringFormat("Unknown runtime error: `%s`", e.what()));
+        StringUtils::format("Unknown runtime error: `%s`", e.what()));
     return _cmd;
   }
 }
@@ -345,28 +345,30 @@ std::string ETJump::CommandParser::formatCommandHelpString(
   const size_t flagPad = 23 - shortname.length();
 
   const std::string &opTypeStr = OptionDefinition::typeToString(optionType);
-  const std::string &positionStr = stringFormat(
-      "%s", position.has_value() ? stringFormat(" (pos: %d) ", position.value())
-                                 : "");
+  const std::string &positionStr = StringUtils::format(
+      "%s", position.has_value()
+                ? StringUtils::format(" (pos: %d) ", position.value())
+                : "");
   const std::string &requiredStr =
-      stringFormat("%s", required ? " [required] " : "");
+      StringUtils::format("%s", required ? " [required] " : "");
 
   const std::string &flagStr =
-      stringFormat("    ^7-%s, --%-*s", shortname, flagPad, name);
-  const std::string &descStr = stringFormat(
+      StringUtils::format("    ^7-%s, --%-*s", shortname, flagPad, name);
+  const std::string &descStr = StringUtils::format(
       "^z(%s) ^7%s%s%s", opTypeStr, description, requiredStr, positionStr);
 
   std::string combinedStr = flagStr + descStr;
 
   // split from the previous whitespace and indent the new line,
   // if the description text is too long to fit to console max line width
-  if (sanitize(combinedStr, false).length() > maxLineLen) {
+  if (StringUtils::sanitize(combinedStr, false).length() > maxLineLen) {
     const size_t lastWhiteSpace = combinedStr.find_last_of(' ', maxLineLen);
 
     if (lastWhiteSpace != std::string::npos) {
       combinedStr.replace(
           lastWhiteSpace, 1,
-          '\n' + std::string(sanitize(flagStr, false).length(), ' '));
+          '\n' +
+              std::string(StringUtils::sanitize(flagStr, false).length(), ' '));
     }
   }
 

--- a/src/game/etj_command_parser.h
+++ b/src/game/etj_command_parser.h
@@ -27,12 +27,10 @@
 #include <optional>
 #include <string>
 #include <map>
-#include <ostream>
 #include <utility>
 #include <vector>
 
 #include "etj_container_utilities.h"
-#include "etj_synchronization_context.h"
 #include "etj_time_utilities.h"
 
 namespace ETJump {
@@ -102,9 +100,9 @@ public:
             pair.second.position);
       });
 
-      return stringFormat("Usage: %s\n\n    %s\n\nOptions:\n%s\n", name,
-                          description,
-                          StringUtil::join(optionsToStrings, "\n"));
+      return StringUtils::format("Usage: %s\n\n    %s\n\nOptions:\n%s\n", name,
+                                 description,
+                                 StringUtils::join(optionsToStrings, "\n"));
     }
 
     static CommandDefinition create(const std::string &name,
@@ -143,10 +141,10 @@ public:
       for (const auto &o : this->options) {
         if (o.second.position.has_value() &&
             o.second.position.value() == position) {
-          throw std::runtime_error(
-              stringFormat("`%s` already has argument `%s` configured to "
-                           "position `%d`. Use a different position for `%s`.",
-                           this->name, o.second.name, position, name));
+          throw std::runtime_error(StringUtils::format(
+              "`%s` already has argument `%s` configured to position `%d`. Use "
+              "a different position for `%s`.",
+              this->name, o.second.name, position, name));
         }
       }
 
@@ -200,7 +198,7 @@ public:
     };
 
     [[nodiscard]] std::string getErrorMessage() const {
-      return StringUtil::join(errors, "\n");
+      return StringUtils::join(errors, "\n");
     }
   };
 

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -66,7 +66,7 @@ getOptCommand(const std::string &commandPrefix, int clientNum,
   if (command.helpRequested) {
     Printer::chat(
         clientNum,
-        ETJump::stringFormat("^3%s: ^7check console for help.", commandPrefix));
+        StringUtils::format("^3%s: ^7check console for help.", commandPrefix));
     Printer::console(clientNum, def.help());
     return std::nullopt;
   }
@@ -74,7 +74,7 @@ getOptCommand(const std::string &commandPrefix, int clientNum,
   if (!command.errors.empty()) {
     Printer::chat(
         clientNum,
-        stringFormat(
+        StringUtils::format(
             "^3%s: ^7operation failed. Check console for more information.",
             commandPrefix));
     Printer::console(clientNum, command.getErrorMessage() + "\n");
@@ -124,7 +124,7 @@ bool listCustomVotes(gentity_t *ent, Arguments argv) {
     size_t count = 0;
 
     for (const auto &type : types) {
-      msg += ETJump::stringFormat("^7%-20s", type);
+      msg += StringUtils::format("^7%-20s", type);
       count++;
 
       if (count % 3 == 0 || count == types.size()) {
@@ -132,7 +132,7 @@ bool listCustomVotes(gentity_t *ent, Arguments argv) {
       }
     }
 
-    msg += ETJump::stringFormat(
+    msg += StringUtils::format(
         "\n^7Use ^3%s [listname] ^7to view maps in the specified list.\n", cmd);
     Printer::console(ent, msg);
     return true;
@@ -143,8 +143,8 @@ bool listCustomVotes(gentity_t *ent, Arguments argv) {
 
   if (maplist.empty()) {
     Printer::console(
-        clientNum, ETJump::stringFormat("^3%s: ^7could not find list ^3'%s'\n",
-                                        cmd, type));
+        clientNum,
+        StringUtils::format("^3%s: ^7could not find list ^3'%s'\n", cmd, type));
     return false;
   }
 
@@ -616,15 +616,14 @@ bool GetChatReplay(gentity_t *ent, Arguments argv) {
 }
 
 static bool sendMaplist(gentity_t *ent, Arguments argv) {
-  std::string mapList =
-      ETJump::StringUtil::join(game.mapStatistics->getMaps(), " ");
+  std::string mapList = StringUtils::join(game.mapStatistics->getMaps(), " ");
   const std::string prefix = "maplist ";
   const size_t msgLen = BYTES_PER_PACKET - prefix.length() - 1;
 
   // split to multiple commands to ensure client gets the full list
   // each command is prefixed with 'maplist' so client recognizes
   // this command is part of the map list, and parses it correctly
-  auto splits = ETJump::wrapWords(mapList, ' ', msgLen);
+  auto splits = StringUtils::wrapWords(mapList, ' ', msgLen);
   for (auto &split : splits) {
     split.insert(0, prefix);
     trap_SendServerCommand(ClientNum(ent), std::string(split + '\n').c_str());
@@ -643,8 +642,8 @@ static bool sendNumCustomvotes(gentity_t *ent, Arguments argv) {
 static bool sendCustomvoteInfo(gentity_t *ent, Arguments argv) {
   if (argv->size() < 2) {
     Printer::console(
-        ent, ETJump::stringFormat("^3%s: ^7no list given as an argument.\n",
-                                  __func__));
+        ent, StringUtils::format("^3%s: ^7no list given as an argument.\n",
+                                 __func__));
     return false;
   }
 
@@ -652,7 +651,7 @@ static bool sendCustomvoteInfo(gentity_t *ent, Arguments argv) {
   const auto list = game.customMapVotes->getVotelistByIndex(index);
 
   if (list == nullptr) {
-    Printer::console(ent, ETJump::stringFormat(
+    Printer::console(ent, StringUtils::format(
                               "^3%s: ^7no list with a given index ^3'%i'^7.\n",
                               __func__, index));
     return false;
@@ -673,30 +672,29 @@ static bool sendCustomvoteInfo(gentity_t *ent, Arguments argv) {
    * guarantee.
    */
 
-  const std::string cmd = ETJump::stringFormat("%s \"%s\"", prefix, list->type);
+  const std::string cmd = StringUtils::format("%s \"%s\"", prefix, list->type);
 
   // we could omit the type from the end here, but this simplifies parsing
-  const std::string typeCmd = ETJump::stringFormat(
+  const std::string typeCmd = StringUtils::format(
       "%s %s \"%s\"\n", cmd, ETJump::CUSTOMVOTE_TYPE, list->type);
-  const std::string cvTextCmd = ETJump::stringFormat(
+  const std::string cvTextCmd = StringUtils::format(
       "%s %s \"%s\"\n", cmd, ETJump::CUSTOMVOTE_CVTEXT, list->callvoteText);
 
   trap_SendServerCommand(clientNum, typeCmd.c_str());
   trap_SendServerCommand(clientNum, cvTextCmd.c_str());
 
   const std::string serverMapsCmd =
-      ETJump::stringFormat("%s %s ", cmd, ETJump::CUSTOMVOTE_SERVERMAPS);
+      StringUtils::format("%s %s ", cmd, ETJump::CUSTOMVOTE_SERVERMAPS);
   const std::string otherMapsCmd =
-      ETJump::stringFormat("%s %s ", cmd, ETJump::CUSTOMVOTE_OTHERMAPS);
+      StringUtils::format("%s %s ", cmd, ETJump::CUSTOMVOTE_OTHERMAPS);
 
-  const std::string serverMaps =
-      ETJump::StringUtil::join(list->mapsOnServer, " ");
-  const std::string otherMaps = ETJump::StringUtil::join(list->otherMaps, " ");
+  const std::string serverMaps = StringUtils::join(list->mapsOnServer, " ");
+  const std::string otherMaps = StringUtils::join(list->otherMaps, " ");
 
   // we have to check if the combined string would be over max message length,
   // because we need to always attach the command prefix in front
   if (serverMapsCmd.length() + serverMaps.length() > BYTES_PER_PACKET - 1) {
-    const auto splits = ETJump::wrapWords(
+    const auto splits = StringUtils::wrapWords(
         serverMaps, ' ', BYTES_PER_PACKET - serverMapsCmd.length() - 1);
 
     for (const auto &split : splits) {
@@ -708,7 +706,7 @@ static bool sendCustomvoteInfo(gentity_t *ent, Arguments argv) {
   }
 
   if (otherMapsCmd.length() + otherMaps.length() > BYTES_PER_PACKET) {
-    const auto splits = ETJump::wrapWords(
+    const auto splits = StringUtils::wrapWords(
         otherMaps, ' ', BYTES_PER_PACKET - otherMapsCmd.length() - 1);
 
     for (const auto &split : splits) {
@@ -828,9 +826,9 @@ bool AddLevel(gentity_t *ent, Arguments argv) {
   std::string title;
 
   if (!ToInt(argv->at(1), level)) {
-    Printer::chat(
-        ent, ETJump::stringFormat("^3addlevel: ^7'%s^7' is not an integer.",
-                                  argv->at(1)));
+    Printer::chat(ent,
+                  StringUtils::format("^3addlevel: ^7'%s^7' is not an integer.",
+                                      argv->at(1)));
     return false;
   }
 
@@ -867,8 +865,8 @@ bool AddLevel(gentity_t *ent, Arguments argv) {
       it++;
     }
 
-    greeting = ETJump::trimEnd(greeting);
-    title = ETJump::trimEnd(title);
+    greeting = StringUtils::trimEnd(greeting);
+    title = StringUtils::trimEnd(title);
   }
 
   if (!game.levels->Add(level, std::move(title), std::move(commands),
@@ -914,7 +912,7 @@ bool Ball8(gentity_t *ent, Arguments argv) {
     const int remainingSeconds = std::ceil(
         (ent->client->last8BallTime + DELAY_8BALL - level.time) / 1000.0);
     Printer::chat(ent, "^3!8ball: ^7you must wait " +
-                           ETJump::getSecondsString(remainingSeconds) +
+                           StringUtils::getSecondsString(remainingSeconds) +
                            " before using !8ball again.");
     return false;
   }
@@ -1031,9 +1029,10 @@ bool DeleteLevel(gentity_t *ent, Arguments argv) {
 
   int usersWithLevel = ETJump::session->LevelDeleted(level);
 
-  Printer::chat(ent, "^3deletelevel: ^7deleted level. Set " +
-                         ETJump::getPluralizedString(usersWithLevel, "user") +
-                         " to level 0.");
+  Printer::chat(ent,
+                "^3deletelevel: ^7deleted level. Set " +
+                    StringUtils::getPluralizedString(usersWithLevel, "user") +
+                    " to level 0.");
   return true;
 }
 
@@ -1150,8 +1149,8 @@ bool EditLevel(gentity_t *ent, Arguments argv) {
 
   if (!ToInt(argv->at(1), adminLevel)) {
     Printer::chat(
-        ent, ETJump::stringFormat("^3editlevel: ^7'%s^7' is not an integer.",
-                                  argv->at(1)));
+        ent, StringUtils::format("^3editlevel: ^7'%s^7' is not an integer.",
+                                 argv->at(1)));
     return false;
   }
 
@@ -1209,8 +1208,8 @@ bool EditLevel(gentity_t *ent, Arguments argv) {
       it++;
     }
 
-    greeting = ETJump::trimEnd(greeting);
-    title = ETJump::trimEnd(title);
+    greeting = StringUtils::trimEnd(greeting);
+    title = StringUtils::trimEnd(title);
   }
 
   game.levels->Edit(adminLevel, title, commands, greeting, updated);
@@ -1296,8 +1295,8 @@ bool EditUser(gentity_t *ent, Arguments argv) {
     it++;
   }
 
-  greeting = ETJump::trimEnd(greeting);
-  title = ETJump::trimEnd(title);
+  greeting = StringUtils::trimEnd(greeting);
+  title = StringUtils::trimEnd(title);
 
   Printer::chat(ent, va("^3edituser: ^7updating user %d", id));
   return ETJump::database->UpdateUser(ent, id, commands, greeting, title,
@@ -1349,9 +1348,10 @@ bool FindMap(gentity_t *ent, Arguments argv) {
   }
 
   auto mapsOnCurrentRow = 0;
-  std::string buffer = "^zFound ^3" +
-                       ETJump::getPluralizedString(matching.size(), "^zmap") +
-                       " matching ^3" + argv->at(1) + "^z:\n^7";
+  std::string buffer =
+      "^zFound ^3" +
+      StringUtils::getPluralizedString(matching.size(), "^zmap") +
+      " matching ^3" + argv->at(1) + "^z:\n^7";
   for (auto &map : matching) {
     // color every other column grey for readability
     buffer += mapsOnCurrentRow % 2 == 0 ? "^7" : "^z";
@@ -1359,9 +1359,9 @@ bool FindMap(gentity_t *ent, Arguments argv) {
     ++mapsOnCurrentRow;
     if (mapsOnCurrentRow > perRow) {
       mapsOnCurrentRow = 1;
-      buffer += ETJump::stringFormat("\n^7%-23s", map);
+      buffer += StringUtils::format("\n^7%-23s", map);
     } else {
-      buffer += ETJump::stringFormat("%-23s", map);
+      buffer += StringUtils::format("%-23s", map);
     }
   }
 
@@ -1476,13 +1476,13 @@ std::string playedTimeFmtString(int seconds) {
 
   std::string str;
   if (weeks) {
-    str = ETJump::getWeeksString(weeks);
+    str = StringUtils::getWeeksString(weeks);
   } else if (days) {
-    str = ETJump::getDaysString(days);
+    str = StringUtils::getDaysString(days);
   } else if (hours || minutes || seconds) {
-    str = ETJump::getHoursString(hours) + " " +
-          ETJump::getMinutesString(minutes) + " " +
-          ETJump::getSecondsString(seconds);
+    str = StringUtils::getHoursString(hours) + " " +
+          StringUtils::getMinutesString(minutes) + " " +
+          StringUtils::getSecondsString(seconds);
   }
 
   if (str.length() == 0) {
@@ -1497,7 +1497,7 @@ bool LeastPlayed(gentity_t *ent, Arguments argv) {
     try {
       mapsToList = std::stoi(argv->at(1), nullptr, 10);
     } catch (const std::invalid_argument &) {
-      Printer::chat(ent, ETJump::stringFormat(
+      Printer::chat(ent, StringUtils::format(
                              "^3Error: ^7'%s^7' is not a number", argv->at(1)));
       return false;
     } catch (const std::out_of_range &) {
@@ -1526,10 +1526,10 @@ bool LeastPlayed(gentity_t *ent, Arguments argv) {
     }
 
     buffer += green ? "^g" : "^7";
-    buffer += ETJump::stringFormat(
-        "%-22s %-30s %-17s     %d\n", map->name,
-        playedTimeFmtString(map->secondsPlayed),
-        Utilities::timestampToString(map->lastPlayed), map->timesPlayed);
+    buffer += StringUtils::format("%-22s %-30s %-17s     %d\n", map->name,
+                                  playedTimeFmtString(map->secondsPlayed),
+                                  Utilities::timestampToString(map->lastPlayed),
+                                  map->timesPlayed);
     green = !green;
 
     ++listedMaps;
@@ -1585,8 +1585,8 @@ bool ListMaps(gentity_t *ent, Arguments argv) {
       perRow = std::stoi(argv->at(1), nullptr, 10);
     } catch (const std::invalid_argument &) {
       Printer::chat(ent,
-                    ETJump::stringFormat("^3listmaps: ^7'%s^7' is not a number",
-                                         argv->at(1)));
+                    StringUtils::format("^3listmaps: ^7'%s^7' is not a number",
+                                        argv->at(1)));
       return false;
     } catch (const std::out_of_range &) {
       perRow = 5;
@@ -1613,15 +1613,16 @@ bool ListMaps(gentity_t *ent, Arguments argv) {
     ++mapsOnCurrentRow;
     if (mapsOnCurrentRow > perRow) {
       mapsOnCurrentRow = 1;
-      buffer += ETJump::stringFormat("\n^7%-23s", map);
+      buffer += StringUtils::format("\n^7%-23s", map);
     } else {
-      buffer += ETJump::stringFormat("%-23s", map);
+      buffer += StringUtils::format("%-23s", map);
     }
   }
 
   buffer += "\n";
 
-  buffer += "\n^zFound ^3" + ETJump::getPluralizedString(maps.size(), "^zmap") +
+  buffer += "\n^zFound ^3" +
+            StringUtils::getPluralizedString(maps.size(), "^zmap") +
             " on the server.\n";
 
   Printer::console(ent, buffer);
@@ -1655,7 +1656,7 @@ bool ListPlayers(gentity_t *ent, Arguments argv) {
   if (level.numConnectedClients == 1) {
     Printer::console(ent, "^7There is currently 1 connected player.\n");
   } else {
-    Printer::console(ent, ETJump::stringFormat(
+    Printer::console(ent, StringUtils::format(
                               "^7There are currently %d connected players.\n",
                               level.numConnectedClients));
   }
@@ -1667,10 +1668,10 @@ bool ListPlayers(gentity_t *ent, Arguments argv) {
     gentity_t *player = g_entities + clientNum;
     const int id = ETJump::session->GetId(player);
 
-    msg += ETJump::stringFormat("^7%-2d %-9s %-6d %-s\n", clientNum,
-                                id == -1 ? "-" : std::to_string(id),
-                                ETJump::session->GetLevel(player),
-                                player->client->pers.netname);
+    msg += StringUtils::format("^7%-2d %-9s %-6d %-s\n", clientNum,
+                               id == -1 ? "-" : std::to_string(id),
+                               ETJump::session->GetLevel(player),
+                               player->client->pers.netname);
   }
 
   Printer::console(ent, msg);
@@ -1683,7 +1684,7 @@ bool Map(gentity_t *ent, Arguments argv) {
     return false;
   }
 
-  std::string requestedMap = ETJump::StringUtil::toLowerCase(argv->at(1));
+  std::string requestedMap = StringUtils::toLowerCase(argv->at(1));
 
   if (!ETJump::FileSystem::exists("maps/" + requestedMap + ".bsp")) {
     Printer::chat(ent, "^3map: ^7'" + requestedMap + "' is not on the server.");
@@ -1723,22 +1724,22 @@ bool MapInfo(gentity_t *ent, Arguments argv) {
     message = "^3mapinfo: ^7" + mi->name +
               " is the current map on the server. It has been played for a "
               "total of " +
-              ETJump::getDaysString(days) + " " +
-              ETJump::getHoursString(hours) + " " +
-              ETJump::getMinutesString(minutes) + " " +
-              ETJump::getSecondsString(seconds);
+              StringUtils::getDaysString(days) + " " +
+              StringUtils::getHoursString(hours) + " " +
+              StringUtils::getMinutesString(minutes) + " " +
+              StringUtils::getSecondsString(seconds);
   } else {
     if (mi->lastPlayed == 0) {
-      message = ETJump::stringFormat("^3mapinfo: ^7%s has never been played.",
-                                     mi->name);
+      message = StringUtils::format("^3mapinfo: ^7%s has never been played.",
+                                    mi->name);
     } else {
       message = "^3mapinfo: ^7" + mi->name + " was last played on " +
                 Utilities::timestampToString(mi->lastPlayed) +
                 ". It has been played for a total of " +
-                ETJump::getDaysString(days) + " " +
-                ETJump::getHoursString(hours) + " " +
-                ETJump::getMinutesString(minutes) + " " +
-                ETJump::getSecondsString(seconds);
+                StringUtils::getDaysString(days) + " " +
+                StringUtils::getHoursString(hours) + " " +
+                StringUtils::getMinutesString(minutes) + " " +
+                StringUtils::getSecondsString(seconds);
     }
   }
 
@@ -1752,7 +1753,7 @@ bool MostPlayed(gentity_t *ent, Arguments argv) {
     try {
       mapsToList = std::stoi(argv->at(1), nullptr, 10);
     } catch (const std::invalid_argument &) {
-      Printer::chat(ent, ETJump::stringFormat(
+      Printer::chat(ent, StringUtils::format(
                              "^3Error: ^7'%s^7' is not a number", argv->at(1)));
       return false;
     } catch (const std::out_of_range &) {
@@ -1781,10 +1782,10 @@ bool MostPlayed(gentity_t *ent, Arguments argv) {
     }
 
     buffer += green ? "^g" : "^7";
-    buffer += ETJump::stringFormat(
-        "%-22s %-30s %-17s     %d\n", map->name,
-        playedTimeFmtString(map->secondsPlayed),
-        Utilities::timestampToString(map->lastPlayed), map->timesPlayed);
+    buffer += StringUtils::format("%-22s %-30s %-17s     %d\n", map->name,
+                                  playedTimeFmtString(map->secondsPlayed),
+                                  Utilities::timestampToString(map->lastPlayed),
+                                  map->timesPlayed);
     green = !green;
 
     ++listedMaps;
@@ -1910,8 +1911,8 @@ bool Passvote(gentity_t *ent, Arguments argv) {
   if (level.voteInfo.voteTime) {
     if (level.voteInfo.vote_fn == ETJump::G_RockTheVote_v) {
       Printer::chat(
-          ent, ETJump::stringFormat("^3passvote:^7 %s cannot be force passed.",
-                                    level.voteInfo.voteString));
+          ent, StringUtils::format("^3passvote:^7 %s cannot be force passed.",
+                                   level.voteInfo.voteString));
     } else {
       level.voteInfo.forcePass = qtrue;
       Printer::chatAll("^3passvote:^7 vote has been passed.");
@@ -1954,12 +1955,12 @@ bool Rename(gentity_t *ent, Arguments argv) {
   }
 
   const std::string newName =
-      ETJump::StringUtil::join(ETJump::Container::skipFirstN(*argv, 2), " ");
+      StringUtils::join(ETJump::Container::skipFirstN(*argv, 2), " ");
 
   if (newName.length() > MAX_NETNAME) {
     Printer::chat(
-        ent, ETJump::stringFormat("^3rename: ^7new name is too long (%i > %i)",
-                                  newName.length(), MAX_NETNAME));
+        ent, StringUtils::format("^3rename: ^7new name is too long (%i > %i)",
+                                 newName.length(), MAX_NETNAME));
     return false;
   }
 
@@ -2192,7 +2193,7 @@ bool createToken(gentity_t *ent, Arguments argv) {
     return false;
   }
 
-  Printer::chat(ent, ETJump::stringFormat(
+  Printer::chat(ent, StringUtils::format(
                          "Creating a token at (%f, %f, %f) for difficulty '%s'",
                          coordinates[0], coordinates[1], coordinates[2],
                          ETJump::Tokens::tokenDifficultyToString(difficulty)));
@@ -2443,8 +2444,8 @@ bool NewMaps(gentity_t *ent, Arguments argv) {
       numMaps = std::stoi(argv->at(1), nullptr, 10);
     } catch (const std::invalid_argument &) {
       Printer::chat(ClientNum(ent),
-                    ETJump::stringFormat("^3newmaps: ^7%s^7 is not a number",
-                                         argv->at(1)));
+                    StringUtils::format("^3newmaps: ^7%s^7 is not a number",
+                                        argv->at(1)));
       return false;
     } catch (const std::out_of_range &) {
       numMaps = 5;
@@ -2470,12 +2471,12 @@ bool NewMaps(gentity_t *ent, Arguments argv) {
   }
 
   std::string buffer = "^zLatest ^3" +
-                       ETJump::getPluralizedString(numMaps, "^zmap") +
+                       StringUtils::getPluralizedString(numMaps, "^zmap") +
                        " added to server:\n\n";
   int lines = 0;
   for (int i = numMaps; i > 0; i--) {
     buffer += lines % 2 == 0 ? "^7" : "^z";
-    buffer += ETJump::stringFormat("%s\n", maps.at(totalMaps - i));
+    buffer += StringUtils::format("%s\n", maps.at(totalMaps - i));
     lines++;
   }
 
@@ -2522,7 +2523,7 @@ bool TimerunAddSeason(gentity_t *ent, Arguments argv) {
   if (end.has_value()) {
     if ((*end).date < start) {
       Printer::chat(clientNum,
-                    ETJump::stringFormat(
+                    StringUtils::format(
                         "^3addseason: ^7Start time `%s` is after end time `%s`",
                         start.toDateString(), end.value().date.toDateString()));
       return true;
@@ -2604,8 +2605,7 @@ bool TimerunDeleteSeason(gentity_t *ent, Arguments argv) {
   auto command = std::move(optCommand.value());
   const auto &name = command.options["name"].text;
 
-  game.timerunV2->deleteSeason(clientNum,
-                               ETJump::StringUtil::toLowerCase(name));
+  game.timerunV2->deleteSeason(clientNum, StringUtils::toLowerCase(name));
 
   return true;
 }
@@ -2627,18 +2627,18 @@ bool validateCustomVoteCommand(const std::string &cmdName, const int &clientNum,
   bool commandOk = true;
 
   for (const auto &op : command.options) {
-    if (ETJump::sanitize(op.second.text).empty()) {
+    if (StringUtils::sanitize(op.second.text).empty()) {
       Printer::chat(clientNum,
-                    ETJump::stringFormat("^3%s: ^7'%s' cannot be empty.",
-                                         cmdName, op.first));
+                    StringUtils::format("^3%s: ^7'%s' cannot be empty.",
+                                        cmdName, op.first));
       commandOk = false;
     }
 
     if (op.first == "name" && !ETJump::isValidVoteString(op.second.text)) {
       Printer::chat(
           clientNum,
-          ETJump::stringFormat("^3%s: ^7%s '%s' contains invalid characters.",
-                               cmdName, op.first, op.second.text));
+          StringUtils::format("^3%s: ^7%s '%s' contains invalid characters.",
+                              cmdName, op.first, op.second.text));
       commandOk = false;
     }
   }
@@ -2984,7 +2984,7 @@ bool Commands::AdminCommand(gentity_t *ent) {
     return false;
   }
 
-  command = ETJump::StringUtil::toLowerCase(command);
+  command = StringUtils::toLowerCase(command);
 
   ConstAdminCommandIterator it = adminCommands_.lower_bound(command);
 
@@ -3017,12 +3017,12 @@ bool Commands::AdminCommand(gentity_t *ent) {
                   flag) != std::end(CommandFlags::loggedCommandFlags)) {
 
       const std::string name =
-          ent ? ETJump::sanitize(ent->client->pers.netname) : "Console";
+          ent ? StringUtils::sanitize(ent->client->pers.netname) : "Console";
 
       // skip the first arg because we might have partially matched the command
-      const std::string cmdArgs = ETJump::StringUtil::join(
-          ETJump::Container::skipFirstN(*argv, 1), " ");
-      Printer::logAdminLn(ETJump::stringFormat(
+      const std::string cmdArgs =
+          StringUtils::join(ETJump::Container::skipFirstN(*argv, 1), " ");
+      Printer::logAdminLn(StringUtils::format(
           "admincommand: %s%s used '%s%s'",
           ent ? std::to_string(ent->s.number) + " " : "", name,
           foundCommands[0]->first, cmdArgs.empty() ? "" : " " + cmdArgs));
@@ -3037,7 +3037,7 @@ bool Commands::AdminCommand(gentity_t *ent) {
     std::string msg;
 
     for (const auto &cmd : foundCommands) {
-      msg += ETJump::stringFormat("* %s\n", cmd->first);
+      msg += StringUtils::format("* %s\n", cmd->first);
     }
 
     Printer::console(ent, msg);
@@ -3056,7 +3056,7 @@ void Commands::ListCommandFlags(gentity_t *ent) {
   std::string msg;
 
   for (const auto &cmd : adminCommands_) {
-    msg += ETJump::stringFormat("%c %s\n", cmd.second.second, cmd.first);
+    msg += StringUtils::format("%c %s\n", cmd.second.second, cmd.first);
   }
 
   // manually add this since it's not an actual command

--- a/src/game/etj_container_utilities.h
+++ b/src/game/etj_container_utilities.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <algorithm>
+#include <vector>
 
 namespace ETJump {
 namespace Container {

--- a/src/game/etj_custom_map_votes.cpp
+++ b/src/game/etj_custom_map_votes.cpp
@@ -99,7 +99,8 @@ void CustomMapVotes::loadCustomvotes(const bool init) {
       continue;
     }
 
-    customMapVotes_[curr].type = sanitize(customMapVotes_[curr].type, true);
+    customMapVotes_[curr].type =
+        StringUtils::sanitize(customMapVotes_[curr].type, true);
 
     if (customMapVotes_[curr].type.empty()) {
       customMapVotes_.pop_back();
@@ -115,7 +116,7 @@ void CustomMapVotes::loadCustomvotes(const bool init) {
     }
 
     customMapVotes_[curr].callvoteText =
-        sanitize(customMapVotes_[curr].callvoteText);
+        StringUtils::sanitize(customMapVotes_[curr].callvoteText);
 
     if (customMapVotes_[curr].callvoteText.empty()) {
       customMapVotes_.pop_back();
@@ -136,7 +137,7 @@ void CustomMapVotes::loadCustomvotes(const bool init) {
         return;
       }
 
-      mapName = sanitize(mapName, true);
+      mapName = StringUtils::sanitize(mapName, true);
 
       if (std::binary_search(_currentMapsOnServer->begin(),
                              _currentMapsOnServer->end(), mapName)) {
@@ -231,7 +232,7 @@ void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
                                        const std::string &maps) {
   const std::string &customVotesFile = g_customMapVotesFile.string;
   Json::Value root;
-  const std::string sanitizedName = sanitize(name, true);
+  const std::string sanitizedName = StringUtils::sanitize(name, true);
 
   // read and append to existing file if present
   if (FileSystem::exists(customVotesFile)) {
@@ -241,10 +242,10 @@ void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
         if (sanitizedName == lists.type) {
           Printer::chat(clientNum, "^3add-customvote: ^7operation failed, "
                                    "check console for more information.");
-          Printer::console(clientNum,
-                           stringFormat("^3add-customvote: ^7a list with the "
-                                        "name ^3'%s' ^7already exists.\n",
-                                        sanitizedName));
+          Printer::console(clientNum, StringUtils::format(
+                                          "^3add-customvote: ^7a list with the "
+                                          "name ^3'%s' ^7already exists.\n",
+                                          sanitizedName));
           return;
         }
       }
@@ -252,9 +253,9 @@ void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
       Printer::chat(clientNum, "^3add-customvote: ^7operation failed, check "
                                "console for more information.");
       Printer::console(clientNum,
-                       stringFormat("^3add-customvote: ^7couldn't open the "
-                                    "file ^3'%s' ^7for reading:\n",
-                                    customVotesFile));
+                       StringUtils::format("^3add-customvote: ^7couldn't open "
+                                           "the file ^3'%s' ^7for reading:\n",
+                                           customVotesFile));
       Printer::console(clientNum, errors + '\n');
       return;
     }
@@ -262,13 +263,13 @@ void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
 
   Json::Value vote;
   vote["name"] = sanitizedName;
-  vote["callvote_text"] = sanitize(fullName);
+  vote["callvote_text"] = StringUtils::sanitize(fullName);
   vote["maps"] = Json::arrayValue;
 
-  const auto mapList = StringUtil::split(maps, " ");
+  const auto mapList = StringUtils::split(maps, " ");
 
   for (const auto &map : mapList) {
-    vote["maps"].append(sanitize(map, true));
+    vote["maps"].append(StringUtils::sanitize(map, true));
   }
 
   root.append(vote);
@@ -277,17 +278,18 @@ void CustomMapVotes::addCustomvoteList(int clientNum, const std::string &name,
     Printer::chat(clientNum, "^3add-customvote: ^7operation failed, check "
                              "console for more information.");
     Printer::console(clientNum,
-                     stringFormat("^3add-customvote: ^7couldn't open the file "
-                                  "^3'%s' ^7for writing:\n",
-                                  customVotesFile));
+                     StringUtils::format("^3add-customvote: ^7couldn't open "
+                                         "the file ^3'%s' ^7for writing:\n",
+                                         customVotesFile));
     Printer::console(clientNum, errors + '\n');
     return;
   }
 
   loadCustomvotes(false);
-  Printer::chat(clientNum, stringFormat("^3add-customvote: ^7successfully "
-                                        "added a new custom vote list ^3'%s'",
-                                        sanitizedName));
+  Printer::chat(clientNum,
+                StringUtils::format("^3add-customvote: ^7successfully added a "
+                                    "new custom vote list ^3'%s'",
+                                    sanitizedName));
 }
 
 void CustomMapVotes::deleteCustomvoteList(int clientNum,
@@ -299,9 +301,9 @@ void CustomMapVotes::deleteCustomvoteList(int clientNum,
     Printer::chat(clientNum, "^3delete-customvote: ^7operation failed, check "
                              "console for more information.");
     Printer::console(clientNum,
-                     stringFormat("^3delete-customvote: ^7couldn't open the "
-                                  "file ^3'%s' ^7for reading.\n",
-                                  customVotesFile));
+                     StringUtils::format("^3delete-customvote: ^7couldn't open "
+                                         "the file ^3'%s' ^7for reading.\n",
+                                         customVotesFile));
     Printer::console(clientNum, errors + '\n');
     return;
   }
@@ -318,9 +320,10 @@ void CustomMapVotes::deleteCustomvoteList(int clientNum,
   }
 
   if (!found) {
-    Printer::chat(clientNum, stringFormat("^3delete-customvote: ^7a list with "
-                                          "the name ^3'%s' ^7was not found.\n",
-                                          name));
+    Printer::chat(clientNum,
+                  StringUtils::format("^3delete-customvote: ^7a list with the "
+                                      "name ^3'%s' ^7was not found.\n",
+                                      name));
     return;
   }
 
@@ -328,9 +331,9 @@ void CustomMapVotes::deleteCustomvoteList(int clientNum,
     Printer::chat(clientNum, "^3delete-customvote: ^7operation failed, check "
                              "console for more information.");
     Printer::console(clientNum,
-                     stringFormat("^3delete-customvote: ^7couldn't open the "
-                                  "file ^3'%s' ^7for writing.\n",
-                                  customVotesFile));
+                     StringUtils::format("^3delete-customvote: ^7couldn't open "
+                                         "the file ^3'%s' ^7for writing.\n",
+                                         customVotesFile));
     Printer::console(clientNum, errors + '\n');
     return;
   }
@@ -338,7 +341,7 @@ void CustomMapVotes::deleteCustomvoteList(int clientNum,
   loadCustomvotes(false);
   Printer::chat(
       clientNum,
-      stringFormat(
+      StringUtils::format(
           "^3delete-customvote: ^7successfully deleted custom vote list ^3'%s'",
           name));
 }
@@ -355,16 +358,16 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
     Printer::chat(clientNum, "^3edit-customvote: ^7operation failed, check "
                              "console for more information.");
     Printer::console(clientNum,
-                     stringFormat("^3edit-customvote: ^7couldn't open the file "
-                                  "^3'%s' ^7for reading.\n",
-                                  customVotesFile));
+                     StringUtils::format("^3edit-customvote: ^7couldn't open "
+                                         "the file ^3'%s' ^7for reading.\n",
+                                         customVotesFile));
     Printer::console(clientNum, errors + '\n');
     return;
   }
 
-  const std::string sanitizedList = sanitize(list, true);
-  const std::string sanitizedName = sanitize(name, true);
-  const std::string sanitizedFName = sanitize(fullName);
+  const std::string sanitizedList = StringUtils::sanitize(list, true);
+  const std::string sanitizedName = StringUtils::sanitize(name, true);
+  const std::string sanitizedFName = StringUtils::sanitize(fullName);
 
   bool found = false;
 
@@ -382,7 +385,7 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
       return;
     }
 
-    if (sanitize(temp, true) == sanitizedList) {
+    if (StringUtils::sanitize(temp, true) == sanitizedList) {
       if (!sanitizedName.empty()) {
         for (const auto &key : object) {
           if (!JsonUtils::parseValue(temp, object["name"], &errors, "name")) {
@@ -411,15 +414,15 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
       }
 
       if (!addMaps.empty()) {
-        const auto mapList = StringUtil::split(addMaps, " ");
+        const auto mapList = StringUtils::split(addMaps, " ");
 
         for (const auto &map : mapList) {
-          object["maps"].append(sanitize(map, true));
+          object["maps"].append(StringUtils::sanitize(map, true));
         }
       }
 
       if (!removeMaps.empty()) {
-        const auto mapList = StringUtil::split(removeMaps, " ");
+        const auto mapList = StringUtils::split(removeMaps, " ");
 
         for (const auto &map : mapList) {
           for (Json::ArrayIndex i = 0; i < object["maps"].size(); i++) {
@@ -429,7 +432,7 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
               return;
             }
 
-            if (StringUtil::iEqual(temp, map)) {
+            if (StringUtils::iEqual(temp, map)) {
               Json::Value removed;
               object["maps"].removeIndex(i, &removed);
               break;
@@ -444,9 +447,10 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
   }
 
   if (!found) {
-    Printer::chat(clientNum, stringFormat("^3edit-customvote: ^7a list with "
-                                          "the name ^3'%s' ^7was not found.\n",
-                                          sanitizedList));
+    Printer::chat(clientNum,
+                  StringUtils::format("^3edit-customvote: ^7a list with the "
+                                      "name ^3'%s' ^7was not found.\n",
+                                      sanitizedList));
     return;
   }
 
@@ -454,9 +458,9 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
     Printer::chat(clientNum, "^3edit-customvote: ^7operation failed, check "
                              "console for more information.");
     Printer::console(clientNum,
-                     stringFormat("^3edit-customvote: ^7couldn't open the file "
-                                  "^3'%s' ^7for writing.\n",
-                                  customVotesFile));
+                     StringUtils::format("^3edit-customvote: ^7couldn't open "
+                                         "the file ^3'%s' ^7for writing.\n",
+                                         customVotesFile));
     Printer::console(clientNum, errors + '\n');
     return;
   }
@@ -464,7 +468,7 @@ void CustomMapVotes::editCustomvoteList(int clientNum, const std::string &list,
   loadCustomvotes(false);
   Printer::chat(
       clientNum,
-      stringFormat(
+      StringUtils::format(
           "^3edit-customvote: ^7successfully edited custom vote list ^3'%s'",
           sanitizedList));
 }
@@ -474,12 +478,12 @@ std::string CustomMapVotes::listInfo(const std::string &type) {
 
   for (const auto &customMapVote : customMapVotes_) {
     if (customMapVote.type == type) {
-      buffer += stringFormat("^7Maps on the list ^3%s:\n\n", type);
+      buffer += StringUtils::format("^7Maps on the list ^3%s:\n\n", type);
       auto numMapsOnServer = customMapVote.mapsOnServer.size();
 
       int count = 0;
       for (const auto &mapOnServer : customMapVote.mapsOnServer) {
-        buffer += stringFormat("^7%-30s", mapOnServer);
+        buffer += StringUtils::format("^7%-30s", mapOnServer);
 
         ++count;
         if (count % 3 == 0 || count == numMapsOnServer) {
@@ -492,7 +496,7 @@ std::string CustomMapVotes::listInfo(const std::string &type) {
         count = 0;
         auto numMapsNotOnServer = customMapVote.otherMaps.size();
         for (const auto &mapNotOnServer : customMapVote.otherMaps) {
-          buffer += stringFormat("^9%-30s", mapNotOnServer);
+          buffer += StringUtils::format("^9%-30s", mapNotOnServer);
 
           ++count;
           if (count % 3 == 0 || count == numMapsNotOnServer) {

--- a/src/game/etj_database.cpp
+++ b/src/game/etj_database.cpp
@@ -227,7 +227,7 @@ bool Database::UserInfo(gentity_t *ent, int id) {
     ip = ipport.substr(0, pos);
   }
 
-  std::string msg = ETJump::stringFormat(
+  std::string msg = StringUtils::format(
       "^5ID: ^7%d\n"
       "^5GUID: ^7%s\n"
       "^5IP: ^7%s\n"
@@ -262,13 +262,13 @@ bool Database::ListUsers(gentity_t *ent, int page) {
   time_t t;
   time(&t);
 
-  std::string msg = ETJump::stringFormat("Listing page %d/%d\n", page, pages);
-  msg += ETJump::stringFormat("^7%-5s %-10s %-15s %-36s\n", "ID", "Level",
-                              "Last seen", "Name");
+  std::string msg = StringUtils::format("Listing page %d/%d\n", page, pages);
+  msg += StringUtils::format("^7%-5s %-10s %-15s %-36s\n", "ID", "Level",
+                             "Last seen", "Name");
 
   for (const auto &user : users_) {
     if (curr >= i && curr < i + USERS_PER_PAGE) {
-      msg += ETJump::stringFormat(
+      msg += StringUtils::format(
           "^7%-5d %-10d %-15s %-36s\n", user.second->id, user.second->level,
           TimeStampDifferenceToString(static_cast<int>(t) -
                                       user.second->lastSeen) +
@@ -345,14 +345,14 @@ bool Database::ListBans(gentity_t *ent, int page) {
   }
 
   Printer::chat(ent, "^3listbans: ^7check console for more information.");
-  std::string msg = ETJump::stringFormat("^7Showing page %d/%d\n", page, pages);
+  std::string msg = StringUtils::format("^7Showing page %d/%d\n", page, pages);
 
   for (; i < size; i++, printed++) {
     if (printed == BANS_PER_PAGE) {
       break;
     }
 
-    msg += ETJump::stringFormat(
+    msg += StringUtils::format(
         "%d %s ^7%s %s ^7%s %s\n", bans_[i]->id, bans_[i]->name,
         bans_[i]->banDate, bans_[i]->bannedBy,
         bans_[i]->expires != 0 ? TimeStampToString(bans_[i]->expires)
@@ -668,7 +668,7 @@ bool Database::AddNewHWIDToDatabase(User user) {
     return false;
   }
 
-  std::string hwids = ETJump::StringUtil::join(user->hwids, ",");
+  std::string hwids = StringUtils::join(user->hwids, ",");
 
   if (!BindString(stmt, 1, hwids) || !BindInt(stmt, 2, user->id)) {
     sqlite3_finalize(stmt);
@@ -851,7 +851,7 @@ bool Database::LoadUsers() {
         newUser.name = val ? val : "";
         val = (const char *)(sqlite3_column_text(stmt, 5));
         if (val) {
-          newUser.hwids = ETJump::StringUtil::split(val, ",");
+          newUser.hwids = StringUtils::split(val, ",");
         }
         val = (const char *)(sqlite3_column_text(stmt, 6));
         newUser.title = val ? val : "";
@@ -987,7 +987,7 @@ void Database::InsertUserOperation::Execute() {
     return;
   }
 
-  std::string hardwareIds = ETJump::StringUtil::join(user_->hwids, ",");
+  std::string hardwareIds = StringUtils::join(user_->hwids, ",");
 
   if (!BindInt(1, user_->id) || !BindString(2, user_->guid) ||
       !BindInt(3, user_->level) || !BindInt(4, user_->lastSeen) ||
@@ -1026,7 +1026,7 @@ void Database::InsertNewHardwareIdOperation::Execute() {
     return;
   }
 
-  std::string hwids = ETJump::StringUtil::join(user_->hwids, ",");
+  std::string hwids = StringUtils::join(user_->hwids, ",");
 
   if (!BindString(1, hwids) || !BindInt(2, user_->id)) {
     G_LogPrintf("ERROR: failed to bind value to update user "
@@ -1079,8 +1079,7 @@ void Database::AsyncSaveUserOperation::Execute() {
   }
 
   std::string query = "UPDATE users SET " +
-                      ETJump::StringUtil::join(queryOptions, ", ") +
-                      " WHERE id=:id;";
+                      StringUtils::join(queryOptions, ", ") + " WHERE id=:id;";
 
   if (!OpenDatabase(g_userConfig.string)) {
     G_LogPrintf("ERROR: failed to open database on save user "
@@ -1303,7 +1302,7 @@ void Database::FindUserOperation::Execute() {
   std::string msg = "ID       Name\n";
 
   for (const auto &user : users) {
-    msg += ETJump::stringFormat("%-8d %-36s^7\n", user.first, user.second);
+    msg += StringUtils::format("%-8d %-36s^7\n", user.first, user.second);
   }
 
   Printer::console(ent_, msg);
@@ -1327,7 +1326,7 @@ void Database::SaveNameOperation::Execute() {
     return;
   }
 
-  std::string sanitizedName = ETJump::sanitize(name_, true);
+  std::string sanitizedName = StringUtils::sanitize(name_, true);
 
   if (!BindString(1, sanitizedName) || !BindString(2, name_) ||
       !BindInt(3, id_)) {
@@ -1378,7 +1377,7 @@ void Database::ListUserNamesOperation::Execute() {
     Printer::chat(ent_,
                   "^3listusernames: ^7check console for more information.");
     std::string msg =
-        ETJump::stringFormat("Found %d names with id: %d\n", names.size(), id_);
+        StringUtils::format("Found %d names with id: %d\n", names.size(), id_);
 
     for (const auto &name : names) {
       msg += name + '\n';

--- a/src/game/etj_database_v2.cpp
+++ b/src/game/etj_database_v2.cpp
@@ -33,13 +33,13 @@ ETJump::Log logger("databasev2");
 namespace ETJump {
 DatabaseV2::DatabaseV2(const std::string &name, const std::string &fileName)
     : sql(sqlite::database(fileName)), _name(name) {
-  logger.info(stringFormat("Initializing `%s` at `%s`", name, fileName));
+  logger.info(StringUtils::format("Initializing `%s` at `%s`", name, fileName));
   sql << "PRAGMA journal_mode=WAL;";
 
   sql.define("lsanitize",
-             [](std::string s) { return ETJump::sanitize(s, true); });
+             [](std::string s) { return StringUtils::sanitize(s, true); });
   sql.define("sanitize",
-             [](std::string s) { return ETJump::sanitize(s, false); });
+             [](std::string s) { return StringUtils::sanitize(s, false); });
 }
 
 DatabaseV2::~DatabaseV2() = default;
@@ -54,7 +54,7 @@ void DatabaseV2::addMigration(const std::string &name,
 }
 
 void DatabaseV2::applyMigrations() {
-  logger.info(stringFormat("Applying migrations to `%s`", _name));
+  logger.info(StringUtils::format("Applying migrations to `%s`", _name));
 
   sql << R"(
       create table if not exists migrations (
@@ -104,7 +104,7 @@ void DatabaseV2::applyMigrations() {
     if (!_migrations.empty()) {
       latestMigration = _migrations[_migrations.size() - 1].name;
     }
-    logger.info(stringFormat(
+    logger.info(StringUtils::format(
         "`%s` is up to date. Latest migration `%s`. No migrations applied.",
         _name, latestMigration));
   }

--- a/src/game/etj_database_v2.h
+++ b/src/game/etj_database_v2.h
@@ -48,7 +48,7 @@ public:
 
   template <typename T>
   static std::string createPlaceholderString(const std::vector<T> &input) {
-    return StringUtil::join(
+    return StringUtils::join(
         Container::map(input, [](const auto &e) { return "?"; }), ",");
   }
 

--- a/src/game/etj_entity_utilities.cpp
+++ b/src/game/etj_entity_utilities.cpp
@@ -131,7 +131,7 @@ bool EntityUtilities::entitiesFree(const int threshold) {
 void EntityUtilities::setCursorhintFromString(int &value,
                                               const std::string &hint) {
   for (int i = 0; i < HINT_NUM_HINTS; i++) {
-    if (StringUtil::iEqual(hint, hintStrings[i])) {
+    if (StringUtils::iEqual(hint, hintStrings[i])) {
       value = i;
     }
   }
@@ -177,8 +177,8 @@ void EntityUtilities::storeParsedEntity() {
   std::string entity;
 
   for (int i = 0; i < level.numSpawnVars; i++) {
-    entity += ETJump::stringFormat("\"%s\" \"%s\"\n", level.spawnVars[i][0],
-                                   level.spawnVars[i][1]);
+    entity += StringUtils::format("\"%s\" \"%s\"\n", level.spawnVars[i][0],
+                                  level.spawnVars[i][1]);
   }
 
   parsedEntities.push_back("{\n" + entity + "}\n");

--- a/src/game/etj_file.cpp
+++ b/src/game/etj_file.cpp
@@ -112,9 +112,9 @@ void File::write(const char *data, int len) const {
   const auto bytesWritten = trap_FS_Write(data, len, handle);
 
   if (bytesWritten != len) {
-    throw FileIOException(
-        stringFormat("Write to file '%s' failed. Wrote %d out of %d bytes.",
-                     FileSystem::Path::getPath(file), bytesWritten, len));
+    throw FileIOException(StringUtils::format(
+        "Write to file '%s' failed. Wrote %d out of %d bytes.",
+        FileSystem::Path::getPath(file), bytesWritten, len));
   }
 #endif
 }

--- a/src/game/etj_filesystem.cpp
+++ b/src/game/etj_filesystem.cpp
@@ -107,7 +107,7 @@ std::vector<std::string> FileSystem::getFileList(const std::string &path,
   }
 
   if (sort) {
-    StringUtil::sortStrings(files, true);
+    StringUtils::sortStrings(files, true);
   }
 
   return files;
@@ -146,7 +146,7 @@ std::string FileSystem::Path::buildOSPath(const std::string &file) {
   }
 
   path += file;
-  StringUtil::replaceAll(path, "\\", "/");
+  StringUtils::replaceAll(path, "\\", "/");
   return path;
 }
 

--- a/src/game/etj_json_utilities.cpp
+++ b/src/game/etj_json_utilities.cpp
@@ -47,7 +47,7 @@ bool JsonUtils::writeFile(const std::string &file, const Json::Value &root,
     return true;
   } catch (const File::FileIOException &e) {
     if (errors) {
-      *errors = stringFormat("Failed to write JSON file: %s", e.what());
+      *errors = StringUtils::format("Failed to write JSON file: %s", e.what());
     }
 
     return false;
@@ -62,7 +62,7 @@ bool JsonUtils::readFile(const std::string &file, Json::Value &root,
     fIn.close();
 
     if (errors) {
-      *errors = stringFormat(
+      *errors = StringUtils::format(
           "Failed to read JSON file: unable to open file '%s' for reading",
           file);
     }
@@ -76,7 +76,8 @@ bool JsonUtils::readFile(const std::string &file, Json::Value &root,
 
   if (!parseFromStream(readerBuilder, fIn, &root, &err)) {
     if (errors) {
-      *errors = stringFormat("Failed to parse JSON file '%s':\n%s", file, err);
+      *errors =
+          StringUtils::format("Failed to parse JSON file '%s':\n%s", file, err);
     }
 
     return false;

--- a/src/game/etj_json_utilities.h
+++ b/src/game/etj_json_utilities.h
@@ -51,9 +51,9 @@ public:
       return true;
     } catch (const Json::LogicError &e) {
       if (errors) {
-        *errors = stringFormat(
+        *errors = StringUtils::format(
             "Failed to parse JSON value%s: %s",
-            field.empty() ? "" : stringFormat(" for field '%s'", field),
+            field.empty() ? "" : StringUtils::format(" for field '%s'", field),
             e.what());
       }
 

--- a/src/game/etj_levels.cpp
+++ b/src/game/etj_levels.cpp
@@ -184,7 +184,7 @@ void Levels::PrintLevelInfo(gentity_t *ent) {
   std::string msg = "Levels:";
 
   for (const auto &lvl : levels_) {
-    msg += ETJump::stringFormat(" %i,", lvl->level);
+    msg += StringUtils::format(" %i,", lvl->level);
   }
 
   if (!msg.empty() && msg.back() == ',') {
@@ -198,12 +198,12 @@ void Levels::PrintLevelInfo(gentity_t *ent, int level) {
   for (const auto &lvl : levels_) {
     if (lvl->level == level) {
       Printer::chat(ent, "^3levelinfo: ^7check console for more information.");
-      Printer::console(ent, ETJump::stringFormat("^5Level: ^7%d\n"
-                                                 "^5Name: ^7%s\n"
-                                                 "^5Commands: ^7%s\n"
-                                                 "^5Greeting: ^7%s",
-                                                 level, lvl->name,
-                                                 lvl->commands, lvl->greeting));
+      Printer::console(ent, StringUtils::format("^5Level: ^7%d\n"
+                                                "^5Name: ^7%s\n"
+                                                "^5Commands: ^7%s\n"
+                                                "^5Greeting: ^7%s",
+                                                level, lvl->name, lvl->commands,
+                                                lvl->greeting));
       return;
     }
   }
@@ -290,7 +290,7 @@ std::string ReadString(const char **configFile) {
     token = COM_ParseExt(configFile, qfalse);
   }
 
-  return ETJump::trimEnd(std::move(output));
+  return StringUtils::trimEnd(output);
 }
 
 bool Levels::ReadFromConfig() {

--- a/src/game/etj_log.cpp
+++ b/src/game/etj_log.cpp
@@ -33,7 +33,8 @@ std::vector<std::string> Log::_messages;
 
 void Log::println(const std::string &level, const std::string &message) const {
   std::lock_guard<std::mutex> lock(Log::_messagesLock);
-  _messages.push_back(stringFormat("%s [%s]: %s", _name, level, message));
+  _messages.push_back(
+      StringUtils::format("%s [%s]: %s", _name, level, message));
 }
 
 void Log::processMessages() {

--- a/src/game/etj_log.h
+++ b/src/game/etj_log.h
@@ -40,12 +40,12 @@ public:
 
   template <typename... Targs>
   void info(const std::string &format, const Targs &...fargs) const {
-    println("info", stringFormat(format, fargs...));
+    println("info", StringUtils::format(format, fargs...));
   }
 
   template <typename... Targs>
   void error(const std::string &format, const Targs &...fargs) const {
-    println("error", stringFormat(format, fargs...));
+    println("error", StringUtils::format(format, fargs...));
   }
 
   static void processMessages();

--- a/src/game/etj_main_ext.cpp
+++ b/src/game/etj_main_ext.cpp
@@ -58,24 +58,23 @@ static void computeCustomMapDataHashes() {
   const char *mapscriptHash = "-";
   const char *entityFileHash = "-";
 
+  // we do not care about different line endings here, as we care about the
+  // contents of the files, not the actual file integrity, therefore
+  // all line endings are normalized to LF while computing the hashes
   const auto computeHash = [](const std::string &filename) {
     File fIn(filename);
     const auto contents = fIn.read();
 
     std::string normalizedContents =
         std::string(contents.cbegin(), contents.cend());
-    StringUtil::replaceAll(normalizedContents, "\r\n", "\n");
+    StringUtils::replaceAll(normalizedContents, "\r\n", "\n");
 
     return G_SHA1(normalizedContents.c_str());
   };
 
-  // we do not care about different line endings here, as we care about the
-  // contents of the files, not the actual file integrity, therefore
-  // all line endings are normalized to LF while computing the hashes
-
   if (g_mapScriptDir.string[0] != '\0') {
     try {
-      mapscriptHash = computeHash(stringFormat(
+      mapscriptHash = computeHash(StringUtils::format(
           "%s/%s.script", g_mapScriptDir.string, level.rawmapname));
     } catch (const File::FileIOException &) {
       G_Printf("No custom map script loaded, skipping hash calculation\n");
@@ -89,7 +88,8 @@ static void computeCustomMapDataHashes() {
   // to be 2.60b, and 'etVersion' is client only, we can't rely on
   // either here and thus can't detect the mod running on etlded.
   try {
-    entityFileHash = computeHash(stringFormat("maps/%s.ent", level.rawmapname));
+    entityFileHash =
+        computeHash(StringUtils::format("maps/%s.ent", level.rawmapname));
   } catch (const File::FileIOException &) {
     G_Printf("No custom entity file found, skipping hash calculation\n");
   }
@@ -322,7 +322,7 @@ qboolean OnConnectedClientCommand(gentity_t *ent) {
             ConcatArgs(0), ent->client->pers.netname);
 
   auto argv = GetArgs();
-  auto command = ETJump::StringUtil::toLowerCase((*argv)[0]);
+  auto command = StringUtils::toLowerCase((*argv)[0]);
 
   if (ent->client->pers.connected != CON_CONNECTED) {
     return qfalse;
@@ -345,7 +345,7 @@ qboolean OnClientCommand(gentity_t *ent) {
             ConcatArgs(0), ent->client->pers.netname);
 
   auto argv = GetArgs();
-  auto command = ETJump::StringUtil::toLowerCase((*argv)[0]);
+  auto command = StringUtils::toLowerCase((*argv)[0]);
 
   if (command == ETJump::Constants::Authentication::AUTHENTICATE) {
     ETJump::session->GuidReceived(ent);
@@ -366,7 +366,7 @@ qboolean OnConsoleCommand() {
   G_DPrintf("OnConsoleCommand called: %s.\n", ConcatArgs(0));
 
   auto argv = GetArgs();
-  auto command = ETJump::StringUtil::toLowerCase((*argv)[0]);
+  auto command = StringUtils::toLowerCase((*argv)[0]);
 
   if (command == "generatemotd") {
     game.motd->generateMotdFile();
@@ -406,7 +406,7 @@ std::vector<std::string> getMapsOnList(const std::string &name) {
 const char *G_MatchOneMap(const char *arg) {
   auto currentMaps = game.mapStatistics->getCurrentMaps();
   std::vector<std::string> matchingMaps;
-  std::string mapName = arg ? ETJump::StringUtil::toLowerCase(arg) : "";
+  std::string mapName = arg ? StringUtils::toLowerCase(arg) : "";
 
   for (auto &map : *(currentMaps)) {
     if (map.find(mapName) != std::string::npos) {
@@ -434,7 +434,7 @@ const char *G_MatchOneMap(const char *arg) {
 std::vector<std::string> G_MatchAllMaps(const char *arg) {
   auto currentMaps = game.mapStatistics->getCurrentMaps();
   std::vector<std::string> matchingMaps;
-  std::string mapName = arg ? ETJump::StringUtil::toLowerCase(arg) : "";
+  std::string mapName = arg ? StringUtils::toLowerCase(arg) : "";
 
   for (auto &map : *(currentMaps)) {
     if (map.find(mapName) != std::string::npos) {
@@ -499,8 +499,8 @@ void LogServerState() {
     int clientNum = level.sortedClients[i];
 
     state +=
-        ETJump::stringFormat("%i %s %s\n", clientNum, GetTeamString(clientNum),
-                             (g_entities + clientNum)->client->pers.netname);
+        StringUtils::format("%i %s %s\n", clientNum, GetTeamString(clientNum),
+                            (g_entities + clientNum)->client->pers.netname);
   }
 
   if (level.numConnectedClients == 0) {

--- a/src/game/etj_map_statistics.cpp
+++ b/src/game/etj_map_statistics.cpp
@@ -150,38 +150,38 @@ void MapStatistics::saveChanges() {
   auto rc = sqlite3_open(
       ETJump::FileSystem::Path::getPath(_databaseName).c_str(), &db);
   if (rc != SQLITE_OK) {
-    Utilities::Error(ETJump::stringFormat("MapStatistics::saveChanges: Error: "
-                                          "Failed to open database. (%d) %s.\n",
-                                          rc, sqlite3_errmsg(db)));
+    Utilities::Error(StringUtils::format("MapStatistics::saveChanges: Error: "
+                                         "Failed to open database. (%d) %s.\n",
+                                         rc, sqlite3_errmsg(db)));
     return;
   }
 
   rc = sqlite3_exec(db, "BEGIN TRANSACTION;", nullptr, nullptr, nullptr);
   if (rc != SQLITE_OK) {
     Utilities::Error(
-        ETJump::stringFormat("MapStatistics::saveChanges: Error: Failed to "
-                             "start transaction. (%d) %s.\n",
-                             rc, sqlite3_errmsg(db)));
+        StringUtils::format("MapStatistics::saveChanges: Error: Failed to "
+                            "start transaction. (%d) %s.\n",
+                            rc, sqlite3_errmsg(db)));
     return;
   }
 
   for (auto &map : _maps) {
     if (map.changed) {
       rc = sqlite3_exec(db,
-                        ETJump::stringFormat(
-                            "UPDATE map_statistics SET "
-                            "seconds_played=%d, callvoted=%d, "
-                            "votes_passed=%d, times_played=%d, "
-                            "last_played=%d WHERE id=%d;",
-                            map.secondsPlayed, map.callvoted, map.votesPassed,
-                            map.timesPlayed, map.lastPlayed, map.id)
+                        StringUtils::format("UPDATE map_statistics SET "
+                                            "seconds_played=%d, callvoted=%d, "
+                                            "votes_passed=%d, times_played=%d, "
+                                            "last_played=%d WHERE id=%d;",
+                                            map.secondsPlayed, map.callvoted,
+                                            map.votesPassed, map.timesPlayed,
+                                            map.lastPlayed, map.id)
                             .c_str(),
                         nullptr, nullptr, nullptr);
       if (rc != SQLITE_OK) {
-        Utilities::Error(ETJump::stringFormat("MapStatistics::saveChanges: "
-                                              "Error: Failed to "
-                                              "update map. (%d) %s.\n",
-                                              rc, sqlite3_errmsg(db)));
+        Utilities::Error(
+            StringUtils::format("MapStatistics::saveChanges: Error: Failed to "
+                                "update map. (%d) %s.\n",
+                                rc, sqlite3_errmsg(db)));
         return;
       }
     }
@@ -190,17 +190,16 @@ void MapStatistics::saveChanges() {
   rc = sqlite3_exec(db, "END TRANSACTION;", nullptr, nullptr, nullptr);
   if (rc != SQLITE_OK) {
     Utilities::Error(
-        ETJump::stringFormat("MapStatistics::saveChanges: Error: Failed to end "
-                             "transaction. (%d) %s.\n",
-                             rc, sqlite3_errmsg(db)));
+        StringUtils::format("MapStatistics::saveChanges: Error: Failed to end "
+                            "transaction. (%d) %s.\n",
+                            rc, sqlite3_errmsg(db)));
     return;
   }
 
   rc = sqlite3_close(db);
   if (rc != SQLITE_OK) {
-    Utilities::Error(ETJump::stringFormat(
-        "MapStatistics::saveChanges: Error: Failed to close "
-        "sqlite db. (%d) %s",
+    Utilities::Error(StringUtils::format(
+        "MapStatistics::saveChanges: Error: Failed to close sqlite db. (%d) %s",
         rc, sqlite3_errmsg(db)));
   }
 }
@@ -261,9 +260,8 @@ void MapStatistics::setCurrentMap(const std::string currentMap) {
                          });
 
   if (it == _maps.end()) {
-    Utilities::Error(ETJump::stringFormat(
-        "Error: Failed to set the current map to %s. Map could "
-        "not be found in "
+    Utilities::Error(StringUtils::format(
+        "Error: Failed to set the current map to %s. Map could not be found in "
         "the maps vector. Map count: %d\n",
         currentMap, _maps.size()));
     return;
@@ -292,7 +290,7 @@ void MapStatistics::addNewMaps() {
     }
 
     Utilities::Console(
-        ETJump::stringFormat("Notification: New map %s found.\n", map));
+        StringUtils::format("Notification: New map %s found.\n", map));
 
     MapInformation mapInformation;
     mapInformation.name = map;
@@ -305,7 +303,7 @@ void MapStatistics::addNewMaps() {
   auto count = newMaps.size();
   saveNewMaps(std::move(newMaps));
 
-  Utilities::Console(ETJump::stringFormat(
+  Utilities::Console(StringUtils::format(
       "%d maps on the server. Added %d new maps.\n", mapCount, count));
 }
 
@@ -314,32 +312,30 @@ void MapStatistics::saveNewMaps(std::vector<std::string> newMaps) {
   auto rc = sqlite3_open(
       ETJump::FileSystem::Path::getPath(_databaseName).c_str(), &db);
   if (rc != SQLITE_OK) {
-    Utilities::Error(ETJump::stringFormat(
-        "MapStatistics::saveNewMaps: Error: Could not open map "
-        "database %s\n",
+    Utilities::Error(StringUtils::format(
+        "MapStatistics::saveNewMaps: Error: Could not open map database %s\n",
         _databaseName));
     return;
   }
 
   for (auto &newMap : newMaps) {
     std::string sqlEscapedMapName = newMap;
-    ETJump::StringUtil::replaceAll(sqlEscapedMapName, "'", "''");
+    StringUtils::replaceAll(sqlEscapedMapName, "'", "''");
     // Map names won't be doing any SQL injection
-    rc = sqlite3_exec(db,
-                      ETJump::stringFormat(
-                          "INSERT INTO map_statistics (name, seconds_played, "
-                          "callvoted, votes_passed, times_played, "
-                          "last_played) "
-                          "VALUES ('%s', 0, 0, 0, 0, 0);",
-                          sqlEscapedMapName)
-                          .c_str(),
-                      nullptr, nullptr, nullptr);
+    rc = sqlite3_exec(
+        db,
+        StringUtils::format("INSERT INTO map_statistics (name, seconds_played, "
+                            "callvoted, votes_passed, times_played, "
+                            "last_played) "
+                            "VALUES ('%s', 0, 0, 0, 0, 0);",
+                            sqlEscapedMapName)
+            .c_str(),
+        nullptr, nullptr, nullptr);
     if (rc != SQLITE_OK) {
       Utilities::Error(
-          ETJump::stringFormat("MapStatistics::saveNewMaps: Error: Failed "
-                               "to "
-                               "execute statement: (%d) %s",
-                               rc, sqlite3_errmsg(db)));
+          StringUtils::format("MapStatistics::saveNewMaps: Error: Failed to "
+                              "execute statement: (%d) %s",
+                              rc, sqlite3_errmsg(db)));
       sqlite3_close(db);
       return;
     }
@@ -377,9 +373,9 @@ bool MapStatistics::loadMaps() {
   auto rc = sqlite3_open(
       ETJump::FileSystem::Path::getPath(_databaseName).c_str(), &db);
   if (rc != SQLITE_OK) {
-    Utilities::Error(ETJump::stringFormat("MapStatistics::loadMaps: Error: "
-                                          "Failed to open database %s\n",
-                                          _databaseName));
+    Utilities::Error(StringUtils::format(
+        "MapStatistics::loadMaps: Error: Failed to open database %s\n",
+        _databaseName));
     return false;
   }
 
@@ -394,9 +390,9 @@ bool MapStatistics::loadMaps() {
                        -1, &stmt, nullptr);
   if (rc != SQLITE_OK) {
     Utilities::Error(
-        ETJump::stringFormat("MapStatistics::loadMaps: Error: Failed to "
-                             "prepare statement: (%d) %s\n",
-                             rc, sqlite3_errmsg(db)));
+        StringUtils::format("MapStatistics::loadMaps: Error: Failed to prepare "
+                            "statement: (%d) %s\n",
+                            rc, sqlite3_errmsg(db)));
     sqlite3_close(db);
     return false;
   }
@@ -421,9 +417,9 @@ bool MapStatistics::loadMaps() {
 
   if (rc != SQLITE_DONE) {
     Utilities::Error(
-        ETJump::stringFormat("MapStatistics::loadMaps: Error: Reading map "
-                             "statistics failed. (%d) %s\n",
-                             rc, sqlite3_errmsg(db)));
+        StringUtils::format("MapStatistics::loadMaps: Error: Reading map "
+                            "statistics failed. (%d) %s\n",
+                            rc, sqlite3_errmsg(db)));
     sqlite3_finalize(stmt);
     sqlite3_close(db);
     return false;
@@ -440,9 +436,8 @@ bool MapStatistics::createDatabase() {
   auto rc = sqlite3_open(
       ETJump::FileSystem::Path::getPath(_databaseName).c_str(), &db);
   if (rc != SQLITE_OK) {
-    Utilities::Error(ETJump::stringFormat(
-        "MapStatistics::createDatabase: Error: Failed to open "
-        "database %s\n",
+    Utilities::Error(StringUtils::format(
+        "MapStatistics::createDatabase: Error: Failed to open database %s\n",
         _databaseName));
     return false;
   }
@@ -461,9 +456,9 @@ bool MapStatistics::createDatabase() {
     sqlite3_free(errorMessage);
     sqlite3_close(db);
     Utilities::Error(
-        ETJump::stringFormat("MapStatistics::createDatabase: Error: Failed to "
-                             "create database %s. (%d) %s\n",
-                             _databaseName, rc, errorMessage));
+        StringUtils::format("MapStatistics::createDatabase: Error: Failed to "
+                            "create database %s. (%d) %s\n",
+                            _databaseName, rc, errorMessage));
     return false;
   }
   sqlite3_free(errorMessage);
@@ -508,15 +503,15 @@ const char *MapStatistics::randomMap() const {
 
 std::vector<std::string> MapStatistics::blockedMaps() {
   const std::string blockedMapsStr =
-      ETJump::StringUtil::toLowerCase(g_blockedMaps.string);
-  return ETJump::StringUtil::split(blockedMapsStr, " ");
+      StringUtils::toLowerCase(g_blockedMaps.string);
+  return StringUtils::split(blockedMapsStr, " ");
 }
 
 bool MapStatistics::isBlockedMap(const std::string &mapName) {
   const auto &blockedMaps = MapStatistics::blockedMaps();
   return std::any_of(blockedMaps.begin(), blockedMaps.end(),
                      [&mapName](const std::string &map) {
-                       return ETJump::StringUtil::iEqual(map, mapName);
+                       return StringUtils::iEqual(map, mapName);
                      });
 }
 

--- a/src/game/etj_printer.cpp
+++ b/src/game/etj_printer.cpp
@@ -27,7 +27,7 @@
 #include "g_local.h"
 
 void Printer::log(const std::string &message) {
-  const auto splits = ETJump::wrapWords(message, '\n', BYTES_PER_PACKET);
+  const auto splits = StringUtils::wrapWords(message, '\n', BYTES_PER_PACKET);
 
   for (const auto &split : splits) {
     G_LogPrintf(split.c_str());
@@ -54,7 +54,7 @@ void Printer::logAdminLn(const std::string &message) {
 }
 
 void Printer::console(int clientNum, const std::string &message) {
-  const auto splits = ETJump::wrapWords(message, '\n', BYTES_PER_PACKET);
+  const auto splits = StringUtils::wrapWords(message, '\n', BYTES_PER_PACKET);
 
   for (const auto &split : splits) {
     if (clientNum == CONSOLE_CLIENT_NUMBER) {
@@ -76,7 +76,7 @@ void Printer::console(const gclient_t *client, const std::string &message) {
 }
 
 void Printer::consoleAll(const std::string &message) {
-  const auto splits = ETJump::wrapWords(message, '\n', BYTES_PER_PACKET);
+  const auto splits = StringUtils::wrapWords(message, '\n', BYTES_PER_PACKET);
 
   for (const auto &split : splits) {
     trap_SendServerCommand(ALL_CLIENTS, va("print \"%s\"", split.c_str()));
@@ -142,7 +142,7 @@ void Printer::popupAll(const std::string &message) {
 void Printer::center(int clientNum, const std::string &message, bool log) {
   const std::string cmd = log ? "cp" : "cpnl";
   trap_SendServerCommand(
-      clientNum, ETJump::stringFormat("%s \"%s\n\"", cmd, message).c_str());
+      clientNum, StringUtils::format("%s \"%s\n\"", cmd, message).c_str());
 }
 
 void Printer::center(const gentity_t *ent, const std::string &message,
@@ -160,7 +160,7 @@ void Printer::center(const gclient_t *client, const std::string &message,
 void Printer::centerAll(const std::string &message, bool log) {
   const std::string cmd = log ? "cp" : "cpnl";
   trap_SendServerCommand(
-      ALL_CLIENTS, ETJump::stringFormat("%s \"%s\n\"", cmd, message).c_str());
+      ALL_CLIENTS, StringUtils::format("%s \"%s\n\"", cmd, message).c_str());
 
   if (g_dedicated.integer) {
     G_Printf("%s\n", message.c_str());
@@ -172,7 +172,7 @@ void Printer::centerPriority(int clientNum, const std::string &message,
   const std::string cmd = log ? "cp" : "cpnl";
   trap_SendServerCommand(
       clientNum,
-      ETJump::stringFormat("%s \"%s\" %i", cmd, message, priority).c_str());
+      StringUtils::format("%s \"%s\" %i", cmd, message, priority).c_str());
 }
 
 void Printer::centerPriority(const gentity_t *ent, const std::string &message,
@@ -193,7 +193,7 @@ void Printer::centerPriorityAll(const std::string &message, const int priority,
   const std::string cmd = log ? "cp" : "cpnl";
   trap_SendServerCommand(
       ALL_CLIENTS,
-      ETJump::stringFormat("%s \"%s\" %i", cmd, message, priority).c_str());
+      StringUtils::format("%s \"%s\" %i", cmd, message, priority).c_str());
 
   if (g_dedicated.integer) {
     G_Printf("%s\n", message.c_str());

--- a/src/game/etj_progression_tracker.cpp
+++ b/src/game/etj_progression_tracker.cpp
@@ -40,7 +40,7 @@ ProgressionTrackers::~ProgressionTrackers() {}
 void ProgressionTrackers::printParserErrors(
     const std::vector<std::string> &errors, const std::string &text) {
   auto buffer = "Tracker parse error on line: " + text + "\n";
-  buffer += StringUtil::join(errors, "\n");
+  buffer += StringUtils::join(errors, "\n");
   G_Error(buffer.c_str());
 }
 
@@ -217,7 +217,7 @@ void ProgressionTrackers::printTrackerChanges(
 
   for (int i = 0; i < oldValues.size(); i++) {
     if (oldValues[i] != activator->client->pers.progression[i]) {
-      const std::string &trackerChangeMsg = stringFormat(
+      const std::string &trackerChangeMsg = StringUtils::format(
           "^7Tracker change - index: ^3%i ^7value: ^2%i ^7from: ^9%i^7\n",
           i + 1, activator->client->pers.progression[i], oldValues[i]);
       Printer::popup(clientNum, trackerChangeMsg);

--- a/src/game/etj_progression_tracker_parser.cpp
+++ b/src/game/etj_progression_tracker_parser.cpp
@@ -42,13 +42,11 @@ void ProgressionTrackerParser::parse() {
       end(_trackerString));
 
   // get pairs
-  std::vector<std::string> pairs =
-      ETJump::StringUtil::split(_trackerString, "|");
+  std::vector<std::string> pairs = StringUtils::split(_trackerString, "|");
 
   _parsedPairs.clear();
   for (const auto &pair : pairs) {
-    std::vector<std::string> indexValuePair =
-        ETJump::StringUtil::split(pair, ",");
+    std::vector<std::string> indexValuePair = StringUtils::split(pair, ",");
 
     _parsedPairs.push_back(parseIndexValuePair(indexValuePair));
   }
@@ -63,36 +61,36 @@ ProgressionTrackerParser::parseIndexValuePair(
     try {
       result.value = stoi(indexValuePair[0]);
     } catch (const std::invalid_argument &) {
-      _errors.push_back(ETJump::stringFormat("value \"%s\" is not an integer",
-                                             indexValuePair[0]));
+      _errors.push_back(StringUtils::format("value \"%s\" is not an integer",
+                                            indexValuePair[0]));
     } catch (const std::out_of_range &) {
-      _errors.push_back(ETJump::stringFormat("value \"%s\" is out of range",
-                                             indexValuePair[0]));
+      _errors.push_back(StringUtils::format("value \"%s\" is out of range",
+                                            indexValuePair[0]));
     }
   } else {
     try {
       result.index = stoi(indexValuePair[0]) - 1;
     } catch (const std::invalid_argument &) {
-      _errors.push_back(ETJump::stringFormat("index \"%s\" is not an integer",
-                                             indexValuePair[0]));
+      _errors.push_back(StringUtils::format("index \"%s\" is not an integer",
+                                            indexValuePair[0]));
     } catch (const std::out_of_range &) {
-      _errors.push_back(ETJump::stringFormat("index \"%s\" is out of range",
-                                             indexValuePair[0]));
+      _errors.push_back(StringUtils::format("index \"%s\" is out of range",
+                                            indexValuePair[0]));
     }
 
     if (result.index < 0) {
-      _errors.push_back(ETJump::stringFormat("index \"%s\" is less than 0",
-                                             indexValuePair[0]));
+      _errors.push_back(StringUtils::format("index \"%s\" is less than 0",
+                                            indexValuePair[0]));
     }
 
     try {
       result.value = stoi(indexValuePair[1]);
     } catch (const std::invalid_argument &) {
-      _errors.push_back(ETJump::stringFormat("value \"%s\" is not an integer",
-                                             indexValuePair[1]));
+      _errors.push_back(StringUtils::format("value \"%s\" is not an integer",
+                                            indexValuePair[1]));
     } catch (const std::out_of_range &) {
-      _errors.push_back(ETJump::stringFormat("value \"%s\" is out of range",
-                                             indexValuePair[1]));
+      _errors.push_back(StringUtils::format("value \"%s\" is out of range",
+                                            indexValuePair[1]));
     }
   }
   return result;

--- a/src/game/etj_remapshader_handler.cpp
+++ b/src/game/etj_remapshader_handler.cpp
@@ -33,7 +33,7 @@ void RemapShaderHandler::addRemap(const std::string_view oldShader,
 
   for (int32_t i = 0; i < remapCount; i++) {
     // already registered, just update and exit
-    if (StringUtil::iEqual(oldShader, shaderRemaps[i].oldShader)) {
+    if (StringUtils::iEqual(oldShader, shaderRemaps[i].oldShader)) {
       shaderRemaps[i].newShader = newShader;
       shaderRemaps[i].timeOffset = timeOffset;
       return;
@@ -97,11 +97,12 @@ std::string RemapShaderHandler::buildShaderStateConfig(const int32_t index) {
   const int32_t i1 = G_ShaderIndex(shaderRemaps[index].oldShader.c_str());
   const int32_t i2 = G_ShaderIndex(shaderRemaps[index].newShader.c_str());
 
-  return stringFormat("%i=%i:%5.2f@", i1, i2, shaderRemaps[index].timeOffset);
+  return StringUtils::format("%i=%i:%5.2f@", i1, i2,
+                             shaderRemaps[index].timeOffset);
 }
 
 void RemapShaderHandler::sendExtShaderState(const int32_t index) {
   Printer::commandAll(
-      stringFormat("extShaderState %s", extShaderStates[index]));
+      StringUtils::format("extShaderState %s", extShaderStates[index]));
 }
 } // namespace ETJump

--- a/src/game/etj_result_set_formatter.cpp
+++ b/src/game/etj_result_set_formatter.cpp
@@ -93,7 +93,7 @@ std::string Utilities::ResultSetFormatter::toString(
     for (const auto &header : headers) {
       const auto iter = row.find(header);
       if (iter == end(row)) {
-        auto lwrCase = ETJump::StringUtil::toLowerCase(header);
+        auto lwrCase = StringUtils::toLowerCase(header);
         if (lwrCase == "index" || lwrCase == "idx" || lwrCase == "i") {
           maxColumnWidths[header] =
               std::max(maxColumnWidths[header],

--- a/src/game/etj_rtv.cpp
+++ b/src/game/etj_rtv.cpp
@@ -83,7 +83,7 @@ void RockTheVote::setRtvConfigstrings() {
   std::string newcs;
 
   for (size_t i = 0; i < maxMaps; ++i) {
-    newcs += stringFormat(
+    newcs += StringUtils::format(
         "%s\\%i,%i%s", rtvMaps[i].mapName, rtvMaps[i].voteCountInfo.playerCount,
         rtvMaps[i].voteCountInfo.spectatorCount, i == maxMaps - 1 ? "" : "\\");
   }
@@ -201,8 +201,8 @@ void RockTheVote::callAutoRtv() {
   anyonePlayedSinceLastVote = false;
   isRtvVote = true;
 
-  std::string voteMsg = stringFormat("Server called an automatic %s.\n",
-                                     level.voteInfo.voteString);
+  std::string voteMsg = StringUtils::format("Server called an automatic %s.\n",
+                                            level.voteInfo.voteString);
 
   Printer::consoleAll(voteMsg);
   Printer::centerAll("Server called an automatic vote.");

--- a/src/game/etj_savepos_shared.cpp
+++ b/src/game/etj_savepos_shared.cpp
@@ -27,24 +27,24 @@
 
 namespace ETJump {
 std::string SavePosData::serialize(const SavePosData &data) {
-  const std::string &origin = StringUtil::join(data.pos.origin, " ");
-  const std::string &angles = StringUtil::join(data.pos.angles, " ");
-  const std::string &velocity = StringUtil::join(data.pos.velocity, " ");
+  const std::string &origin = StringUtils::join(data.pos.origin, " ");
+  const std::string &angles = StringUtils::join(data.pos.angles, " ");
+  const std::string &velocity = StringUtils::join(data.pos.velocity, " ");
 
   // omit timerun data if this position wasn't saved during a timerun
   if (data.timerunInfo.runName.empty()) {
-    return stringFormat("loadpos %s %s %s %i", origin, angles, velocity,
-                        static_cast<int>(data.pos.stance));
+    return StringUtils::format("loadpos %s %s %s %i", origin, angles, velocity,
+                               static_cast<int>(data.pos.stance));
   }
 
   const std::string &checkpoints =
-      StringUtil::join(data.timerunInfo.checkpoints, ",");
+      StringUtils::join(data.timerunInfo.checkpoints, ",");
   const std::string &previousRecordCheckpoints =
-      StringUtil::join(data.timerunInfo.previousRecordCheckpoints, ",");
+      StringUtils::join(data.timerunInfo.previousRecordCheckpoints, ",");
   const std::string &checkpointIndicesHit =
-      StringUtil::join(data.timerunInfo.checkpointIndicesHit, ",");
+      StringUtils::join(data.timerunInfo.checkpointIndicesHit, ",");
 
-  return stringFormat(
+  return StringUtils::format(
       "loadpos %s %s %s %i \"%s\" %i %i %s %s %s", origin, angles, velocity,
       static_cast<int>(data.pos.stance), data.timerunInfo.runName,
       data.timerunInfo.currentRunTimer, data.timerunInfo.previousRecord,
@@ -59,8 +59,9 @@ SavePosData SavePosData::deserialize(const std::vector<std::string> &args) {
   static constexpr int MIN_SAVEPOS_TIMERUN_ARGS = 16;
 
   if (args.size() < MIN_SAVEPOS_ARGS) {
-    data.error = stringFormat("Too few arguments to parse position (%i < %i)\n",
-                              argc, MIN_SAVEPOS_ARGS);
+    data.error =
+        StringUtils::format("Too few arguments to parse position (%i < %i)\n",
+                            argc, MIN_SAVEPOS_ARGS);
     return data;
   }
 
@@ -78,7 +79,7 @@ SavePosData SavePosData::deserialize(const std::vector<std::string> &args) {
     }
 
     if (argc < MIN_SAVEPOS_TIMERUN_ARGS) {
-      data.error = stringFormat(
+      data.error = StringUtils::format(
           "Too few arguments to parse timerun information (%i < %i)", argc,
           MIN_SAVEPOS_TIMERUN_ARGS);
       return data;
@@ -88,9 +89,9 @@ SavePosData SavePosData::deserialize(const std::vector<std::string> &args) {
     data.timerunInfo.currentRunTimer = std::stoi(args[11]);
     data.timerunInfo.previousRecord = std::stoi(args[12]);
 
-    const auto checkpoints = StringUtil::split(args[13], ",");
-    const auto previousRecordCheckpoints = StringUtil::split(args[14], ",");
-    const auto checkpointIndicesHit = StringUtil::split(args[15], ",");
+    const auto checkpoints = StringUtils::split(args[13], ",");
+    const auto previousRecordCheckpoints = StringUtils::split(args[14], ",");
+    const auto checkpointIndicesHit = StringUtils::split(args[15], ",");
 
     // sanity check
     if (checkpoints.size() != MAX_TIMERUN_CHECKPOINTS ||
@@ -107,10 +108,11 @@ SavePosData SavePosData::deserialize(const std::vector<std::string> &args) {
           static_cast<bool>(std::stoi(checkpointIndicesHit[i]));
     }
   } catch (const std::invalid_argument &e) {
-    data.error = stringFormat("invalid argument for %s\n", e.what());
+    data.error = StringUtils::format("invalid argument for %s\n", e.what());
     return data;
   } catch (const std::out_of_range &e) {
-    data.error = stringFormat("argument out of range for %s\n", e.what());
+    data.error =
+        StringUtils::format("argument out of range for %s\n", e.what());
     return data;
   }
 

--- a/src/game/etj_session.cpp
+++ b/src/game/etj_session.cpp
@@ -153,12 +153,13 @@ bool Session::GuidReceived(gentity_t *ent) {
   int clientNum = ClientNum(ent);
   char guidBuf[MAX_CVAR_VALUE_STRING];
   char hwidBuf[MAX_CVAR_VALUE_STRING];
-  const std::string cleanName = ETJump::sanitize(ent->client->pers.netname);
+  const std::string cleanName =
+      StringUtils::sanitize(ent->client->pers.netname);
 
   // Client sends 'AUTHENTICATE guid hwid'
   constexpr int ARGC = 3;
   if (argc != ARGC) {
-    Printer::logAdminLn(ETJump::stringFormat(
+    Printer::logAdminLn(StringUtils::format(
         "authentication: Potential GUID/HWID spoof attempt by %i %s (%s)",
         clientNum, cleanName, ClientIPAddr(ent)));
     return false;
@@ -168,7 +169,7 @@ bool Session::GuidReceived(gentity_t *ent) {
   trap_Argv(2, hwidBuf, sizeof(hwidBuf));
 
   if (!ValidGuid(guidBuf) || !ValidGuid(hwidBuf)) {
-    Printer::logAdminLn(ETJump::stringFormat(
+    Printer::logAdminLn(StringUtils::format(
         "authentication: Potential GUID/HWID spoof attempt by %i %s (%s)",
         clientNum, cleanName, ClientIPAddr(ent)));
     return false;
@@ -181,7 +182,7 @@ bool Session::GuidReceived(gentity_t *ent) {
             clients_[clientNum].guid.c_str(), clients_[clientNum].hwid.c_str());
 
   if (database_->IsBanned(clients_[clientNum].guid, clients_[clientNum].hwid)) {
-    Printer::logAdminLn(ETJump::stringFormat(
+    Printer::logAdminLn(StringUtils::format(
         "authentication: Banned player %s tried to connect with GUID '%s' and "
         "HWID '%s'",
         cleanName, clients_[clientNum].guid, clients_[clientNum].hwid));
@@ -315,11 +316,9 @@ void Session::PrintGreeting(gentity_t *ent) {
   // If user has own greeting, print it
   if (cl->user->greeting.length() > 0) {
     std::string greeting = cl->user->greeting;
-    ETJump::StringUtil::replaceAll(greeting, "[n]", ent->client->pers.netname);
-    ETJump::StringUtil::replaceAll(greeting, "[t]",
-                                   cl->user->GetLastSeenString());
-    ETJump::StringUtil::replaceAll(greeting, "[d]",
-                                   cl->user->GetLastVisitString());
+    StringUtils::replaceAll(greeting, "[n]", ent->client->pers.netname);
+    StringUtils::replaceAll(greeting, "[t]", cl->user->GetLastSeenString());
+    StringUtils::replaceAll(greeting, "[d]", cl->user->GetLastVisitString());
     G_DPrintf("Printing greeting %s\n", greeting.c_str());
     Printer::chatAll(greeting);
   } else {
@@ -329,12 +328,9 @@ void Session::PrintGreeting(gentity_t *ent) {
     // if user has a level greeting, print it
     if (cl->level->greeting.length() > 0) {
       std::string greeting = cl->level->greeting;
-      ETJump::StringUtil::replaceAll(greeting, "[n]",
-                                     ent->client->pers.netname);
-      ETJump::StringUtil::replaceAll(greeting, "[t]",
-                                     cl->user->GetLastSeenString());
-      ETJump::StringUtil::replaceAll(greeting, "[d]",
-                                     cl->user->GetLastVisitString());
+      StringUtils::replaceAll(greeting, "[n]", ent->client->pers.netname);
+      StringUtils::replaceAll(greeting, "[t]", cl->user->GetLastSeenString());
+      StringUtils::replaceAll(greeting, "[d]", cl->user->GetLastVisitString());
       G_DPrintf("Printing greeting %s\n", greeting.c_str());
       Printer::chatAll(greeting);
     }
@@ -460,7 +456,7 @@ void Session::PrintFinger(gentity_t *ent, gentity_t *target) {
 
   const auto user = clients_[num].user;
   Printer::console(
-      ent, ETJump::stringFormat(
+      ent, StringUtils::format(
                "^7Name: %s\n"
                "^7Original name: %s\n"
                "^7ID: %d\n"

--- a/src/game/etj_string_utilities.cpp
+++ b/src/game/etj_string_utilities.cpp
@@ -32,7 +32,8 @@ extern "C" {
 #include "../sha-1/sha1.h"
 }
 
-std::string ETJump::hash(const std::string &input) {
+namespace StringUtils {
+std::string hash(const std::string &input) {
   SHA1Context sha;
 
   SHA1Reset(&sha);
@@ -68,8 +69,8 @@ unsigned int levenshteinDistance(const std::string &s1, const std::string &s2) {
   return d[len1][len2];
 }
 
-std::string ETJump::getBestMatch(const std::vector<std::string> &words,
-                                 const std::string &current) {
+std::string getBestMatch(const std::vector<std::string> &words,
+                         const std::string &current) {
   std::vector<std::pair<std::string, int>> distances;
 
   for (const auto &word : words) {
@@ -86,12 +87,12 @@ std::string ETJump::getBestMatch(const std::vector<std::string> &words,
   return smallest->first;
 }
 
-std::string ETJump::sanitize(const std::string_view text, const bool toLower,
-                             const bool removeControlChars) {
+std::string sanitize(const std::string_view text, const bool toLower,
+                     const bool removeControlChars) {
   std::string out;
 
   for (size_t i = 0; i < text.length(); ++i) {
-    if (StringUtil::isColorString(text, i)) {
+    if (isColorString(text, i)) {
       i++;
       continue;
     }
@@ -106,17 +107,16 @@ std::string ETJump::sanitize(const std::string_view text, const bool toLower,
   return out;
 }
 
-std::string ETJump::getValue(const char *value,
-                             const std::string &defaultValue) {
+std::string getValue(const char *value, const std::string &defaultValue) {
   return strlen(value) > 0 ? value : defaultValue;
 }
 
-std::string ETJump::getValue(const std::string &value,
-                             const std::string &defaultValue) {
+std::string getValue(const std::string &value,
+                     const std::string &defaultValue) {
   return value.length() > 0 ? value : defaultValue;
 }
 
-std::string ETJump::trimStart(const std::string &input) {
+std::string trimStart(const std::string &input) {
   std::string str = input;
   str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](int ch) {
               return !std::isspace(ch);
@@ -124,7 +124,7 @@ std::string ETJump::trimStart(const std::string &input) {
   return str;
 }
 
-std::string ETJump::trimEnd(const std::string &input) {
+std::string trimEnd(const std::string &input) {
   std::string str = input;
   str.erase(std::find_if(str.rbegin(), str.rend(),
                          [](int ch) { return !std::isspace(ch); })
@@ -133,13 +133,11 @@ std::string ETJump::trimEnd(const std::string &input) {
   return str;
 }
 
-std::string ETJump::trim(const std::string &input) {
-  return trimEnd(trimStart(input));
-}
+std::string trim(const std::string &input) { return trimEnd(trimStart(input)); }
 
 // word-wrapper
-std::vector<std::string> ETJump::wrapWords(const std::string &input,
-                                           char separator, size_t maxLength) {
+std::vector<std::string> wrapWords(const std::string &input, char separator,
+                                   size_t maxLength) {
   std::vector<std::string> output;
   size_t lastPos = 0;
 
@@ -183,50 +181,49 @@ std::vector<std::string> ETJump::wrapWords(const std::string &input,
   return output;
 }
 
-std::string ETJump::getSecondsString(const int &seconds) {
+std::string getSecondsString(const int &seconds) {
   return getPluralizedString(seconds, "second");
 }
 
-std::string ETJump::getMinutesString(const int &minutes) {
+std::string getMinutesString(const int &minutes) {
   return getPluralizedString(minutes, "minute");
 }
 
-std::string ETJump::getHoursString(const int &hours) {
+std::string getHoursString(const int &hours) {
   return getPluralizedString(hours, "hour");
 }
 
-std::string ETJump::getDaysString(const int &days) {
+std::string getDaysString(const int &days) {
   return getPluralizedString(days, "day");
 }
 
-std::string ETJump::getWeeksString(const int &weeks) {
+std::string getWeeksString(const int &weeks) {
   return getPluralizedString(weeks, "week");
 }
 
-std::string ETJump::getMonthsString(const int &months) {
+std::string getMonthsString(const int &months) {
   return getPluralizedString(months, "month");
 }
 
-std::string ETJump::getYearsString(const int &years) {
+std::string getYearsString(const int &years) {
   return getPluralizedString(years, "year");
 }
 
-std::string ETJump::StringUtil::toLowerCase(const std::string &input) {
+std::string toLowerCase(const std::string &input) {
   std::string str = input;
   std::transform(str.begin(), str.end(), str.begin(),
                  [](unsigned char c) { return std::tolower(c); });
   return str;
 }
 
-std::string ETJump::StringUtil::toUpperCase(const std::string &input) {
+std::string toUpperCase(const std::string &input) {
   std::string str = input;
   std::transform(str.begin(), str.end(), str.begin(),
                  [](unsigned char c) { return std::toupper(c); });
   return str;
 }
 
-std::string ETJump::StringUtil::eraseLast(const std::string &input,
-                                          const std::string &substring) {
+std::string eraseLast(const std::string &input, const std::string &substring) {
   std::string str = input;
   auto pos = str.rfind(substring);
   if (pos != std::string::npos) {
@@ -235,9 +232,8 @@ std::string ETJump::StringUtil::eraseLast(const std::string &input,
   return str;
 }
 
-std::vector<std::string>
-ETJump::StringUtil::split(const std::string &input,
-                          const std::string &delimiter) {
+std::vector<std::string> split(const std::string &input,
+                               const std::string &delimiter) {
   size_t posStart = 0, posEnd, delimLen = delimiter.length();
   std::string token;
   std::vector<std::string> splits;
@@ -253,8 +249,8 @@ ETJump::StringUtil::split(const std::string &input,
   return splits;
 }
 
-void ETJump::StringUtil::replaceAll(std::string &input, const std::string &from,
-                                    const std::string &to) {
+void replaceAll(std::string &input, const std::string &from,
+                const std::string &to) {
   size_t startPost = 0;
   while ((startPost = input.find(from, startPost)) != std::string::npos) {
     input.replace(startPost, from.length(), to);
@@ -262,9 +258,8 @@ void ETJump::StringUtil::replaceAll(std::string &input, const std::string &from,
   }
 }
 
-void ETJump::StringUtil::stringSubstitute(std::string &input, char character,
-                                          const std::string &replacement,
-                                          size_t numChars) {
+void stringSubstitute(std::string &input, char character,
+                      const std::string &replacement, size_t numChars) {
   size_t startPos = 0;
 
   while ((startPos = input.find(character, startPos)) != std::string::npos) {
@@ -274,16 +269,14 @@ void ETJump::StringUtil::stringSubstitute(std::string &input, char character,
   }
 }
 
-bool ETJump::StringUtil::startsWith(const std::string &str,
-                                    const std::string &prefix) {
+bool startsWith(const std::string &str, const std::string &prefix) {
   if (prefix.length() > str.length())
     return false;
 
   return str.compare(0, prefix.length(), prefix) == 0;
 }
 
-bool ETJump::StringUtil::endsWith(const std::string &str,
-                                  const std::string &suffix) {
+bool endsWith(const std::string &str, const std::string &suffix) {
   if (suffix.length() > str.length())
     return false;
 
@@ -291,8 +284,8 @@ bool ETJump::StringUtil::endsWith(const std::string &str,
          0;
 }
 
-bool ETJump::StringUtil::iEqual(const std::string_view str1,
-                                const std::string_view str2, bool sanitized) {
+bool iEqual(const std::string_view str1, const std::string_view str2,
+            bool sanitized) {
   if (sanitized) {
     return sanitize(str1, true) == sanitize(str2, true);
   }
@@ -303,14 +296,13 @@ bool ETJump::StringUtil::iEqual(const std::string_view str1,
                     });
 }
 
-int32_t ETJump::StringUtil::countExtraPadding(const std::string &input,
-                                              const int32_t targetPadding) {
+int32_t countExtraPadding(const std::string &input,
+                          const int32_t targetPadding) {
   return targetPadding +
          static_cast<int32_t>(input.length() - sanitize(input).length());
 }
 
-std::string
-ETJump::StringUtil::normalizeNumberString(const std::string &input) {
+std::string normalizeNumberString(const std::string &input) {
   if (input.empty()) {
     return "";
   }
@@ -339,8 +331,7 @@ ETJump::StringUtil::normalizeNumberString(const std::string &input) {
   return result;
 }
 
-void ETJump::StringUtil::removeTrailingChars(std::string &str,
-                                             const char charToRemove) {
+void removeTrailingChars(std::string &str, const char charToRemove) {
   if (str.empty()) {
     return;
   }
@@ -354,8 +345,7 @@ void ETJump::StringUtil::removeTrailingChars(std::string &str,
   }
 }
 
-void ETJump::StringUtil::removeLeadingChars(std::string &str,
-                                            const char charToRemove) {
+void removeLeadingChars(std::string &str, const char charToRemove) {
   if (str.empty()) {
     return;
   }
@@ -369,13 +359,11 @@ void ETJump::StringUtil::removeLeadingChars(std::string &str,
   }
 }
 
-bool ETJump::StringUtil::isColorString(const std::string_view str,
-                                       const size_t idx) {
+bool isColorString(const std::string_view str, const size_t idx) {
   return str[idx] == '^' && str.length() > idx + 1 && str[idx + 1] != '^';
 }
 
-std::string ETJump::StringUtil::truncate(const std::string &str,
-                                         const size_t len) {
+std::string truncate(const std::string &str, const size_t len) {
   if (str.empty() || str.length() <= len || sanitize(str).length() <= len) {
     return str;
   }
@@ -398,7 +386,7 @@ std::string ETJump::StringUtil::truncate(const std::string &str,
   return out;
 }
 
-void ETJump::StringUtil::stripExtension(std::string &str) {
+void stripExtension(std::string &str) {
   const auto pos = str.rfind('.');
 
   if (pos != std::string::npos) {
@@ -406,12 +394,12 @@ void ETJump::StringUtil::stripExtension(std::string &str) {
   }
 }
 
-void ETJump::StringUtil::stripLocalizationMarkers(std::string &str) {
-  ETJump::StringUtil::replaceAll(str, "[lon]", "");
-  ETJump::StringUtil::replaceAll(str, "[lof]", "");
+void stripLocalizationMarkers(std::string &str) {
+  replaceAll(str, "[lon]", "");
+  replaceAll(str, "[lof]", "");
 }
 
-void ETJump::StringUtil::escapeColorCodes(std::string &str, char escapeColor) {
+void escapeColorCodes(std::string &str, char escapeColor) {
   for (size_t i = 0; i < str.length(); i++) {
     if (isColorString(str, i) && str.length() > i + 2) {
       str.insert(i + 1, "^");
@@ -420,3 +408,4 @@ void ETJump::StringUtil::escapeColorCodes(std::string &str, char escapeColor) {
     }
   }
 }
+} // namespace StringUtils

--- a/src/game/etj_string_utilities.h
+++ b/src/game/etj_string_utilities.h
@@ -29,7 +29,7 @@
 #include <vector>
 #include <fmt/printf.h>
 
-namespace ETJump {
+namespace StringUtils {
 std::string hash(const std::string &input);
 std::string getBestMatch(const std::vector<std::string> &words,
                          const std::string &current);
@@ -41,7 +41,7 @@ std::string getValue(const std::string &value,
                      const std::string &defaultValue = "");
 
 template <typename... Targs>
-std::string stringFormat(const std::string &format, const Targs &...Fargs) {
+std::string format(const std::string &format, const Targs &...Fargs) {
   try {
     return fmt::sprintf(format, Fargs...);
   } catch (const fmt::v10::format_error &e) {
@@ -74,10 +74,10 @@ std::string getWeeksString(const int &weeks);
 std::string getMonthsString(const int &months);
 std::string getYearsString(const int &years);
 
-namespace StringUtil {
 std::string toLowerCase(const std::string &input);
 std::string toUpperCase(const std::string &input);
 std::string eraseLast(const std::string &input, const std::string &substring);
+
 template <typename T>
 std::string join(const T &v, const std::string &delim) {
   std::ostringstream s;
@@ -112,6 +112,7 @@ bool contains(const std::string &str, const T &text) {
 // case-insensitive string comparison, optionally with sanitized strings
 bool iEqual(std::string_view str1, std::string_view str2,
             bool sanitized = false);
+
 // Counts the padding needed to reach 'targetPadding' when using
 // format specifiers like '%-20s' with text that contains ET color codes
 int32_t countExtraPadding(const std::string &input, int32_t targetPadding);
@@ -150,7 +151,7 @@ void sortStrings(T &v, const bool noCase) {
   std::sort(
       v.begin(), v.end(), [&](const std::string &lhs, const std::string &rhs) {
         if (noCase) {
-          return StringUtil::toUpperCase(lhs) < StringUtil::toUpperCase(rhs);
+          return StringUtils::toUpperCase(lhs) < StringUtils::toUpperCase(rhs);
         } else {
           return lhs < rhs;
         }
@@ -162,5 +163,4 @@ void stripLocalizationMarkers(std::string &str);
 // escapes color codes in a string that contains carets,
 // which are not meant to be used as color codes
 void escapeColorCodes(std::string &str, char escapeColor);
-} // namespace StringUtil
-} // namespace ETJump
+} // namespace StringUtils

--- a/src/game/etj_target_ft_setrules.cpp
+++ b/src/game/etj_target_ft_setrules.cpp
@@ -74,8 +74,8 @@ void TargetFtSetRules::use(const gentity_t *self, gentity_t *activator) {
 
       // this will never be nullptr, otherwise we wouldn't have gotten this far
       const gentity_t *leader = getFireteamLeader(clientNum);
-      StringUtil::replaceAll(msg, "%s",
-                             std::string(leader->client->pers.netname) + "^7");
+      StringUtils::replaceAll(msg, "%s",
+                              std::string(leader->client->pers.netname) + "^7");
       Printer::center(activator, msg);
     }
 

--- a/src/game/etj_target_spawn_relay.cpp
+++ b/src/game/etj_target_spawn_relay.cpp
@@ -72,14 +72,14 @@ void TargetSpawnRelay::setTeams(gentity_t *self) {
     return;
   }
 
-  const auto teams = StringUtil::split(self->team, ",");
+  const auto teams = StringUtils::split(self->team, ",");
 
   for (const auto &team : teams) {
-    if (StringUtil::iEqual(team, "axis")) {
+    if (StringUtils::iEqual(team, "axis")) {
       registerEntity(TEAM_AXIS);
-    } else if (StringUtil::iEqual(team, "allies")) {
+    } else if (StringUtils::iEqual(team, "allies")) {
       registerEntity(TEAM_ALLIES);
-    } else if (StringUtil::iEqual(team, "spectator")) {
+    } else if (StringUtils::iEqual(team, "spectator")) {
       registerEntity(TEAM_SPECTATOR);
     }
   }
@@ -150,14 +150,14 @@ void TargetSpawnRelay::invalidateSpawnRelayPointers(const gentity_t *ent) {
     level.spawnRelayEntities.axisRelay = nullptr;
     level.spawnRelayEntities.spectatorRelay = nullptr;
   } else {
-    const auto teams = StringUtil::split(ent->team, ",");
+    const auto teams = StringUtils::split(ent->team, ",");
 
     for (const auto &team : teams) {
-      if (StringUtil::iEqual(team, "allies")) {
+      if (StringUtils::iEqual(team, "allies")) {
         level.spawnRelayEntities.alliesRelay = nullptr;
-      } else if (StringUtil::iEqual(team, "axis")) {
+      } else if (StringUtils::iEqual(team, "axis")) {
         level.spawnRelayEntities.axisRelay = nullptr;
-      } else if (StringUtil::iEqual(team, "spectator")) {
+      } else if (StringUtils::iEqual(team, "spectator")) {
         level.spawnRelayEntities.spectatorRelay = nullptr;
       }
     }

--- a/src/game/etj_time_utilities.cpp
+++ b/src/game/etj_time_utilities.cpp
@@ -77,7 +77,7 @@ std::string ETJump::millisToString(int millis) {
   seconds = millis / 1000;
   millis -= seconds * 1000;
 
-  return ETJump::stringFormat("%02d:%02d.%03d", minutes, seconds, millis);
+  return StringUtils::format("%02d:%02d.%03d", minutes, seconds, millis);
 }
 
 std::string ETJump::diffToString(int selfTime, int otherTime) {
@@ -94,6 +94,6 @@ std::string ETJump::diffToString(int selfTime, int otherTime) {
     diffSign = "^7+";
   }
 
-  return ETJump::stringFormat("%s%02i:%02i.%03i", diffSign, diffComponents.min,
-                              diffComponents.sec, diffComponents.ms);
+  return StringUtils::format("%s%02i:%02i.%03i", diffSign, diffComponents.min,
+                             diffComponents.sec, diffComponents.ms);
 }

--- a/src/game/etj_time_utilities.h
+++ b/src/game/etj_time_utilities.h
@@ -76,17 +76,17 @@ struct Date {
     ss >> std::get_time(&t, format.c_str());
 
     if (ss.fail()) {
-      throw std::invalid_argument(stringFormat(
+      throw std::invalid_argument(StringUtils::format(
           "`%s` does not match to format `%s`", dateString, format));
     }
 
     if (t.tm_year < 70) {
       throw std::invalid_argument(
-          stringFormat("`%s` has to be above year 1970"));
+          StringUtils::format("`%s` has to be above year 1970"));
     }
 
     if (t.tm_mday < 1) {
-      throw std::invalid_argument(stringFormat("Day should be defined"));
+      throw std::invalid_argument(StringUtils::format("Day should be defined"));
     }
 
     date.year = t.tm_year + 1900;
@@ -98,7 +98,8 @@ struct Date {
   }
 
   std::string toDateString() const {
-    return stringFormat("%04d-%02d-%02d", this->year, this->mon, this->day);
+    return StringUtils::format("%04d-%02d-%02d", this->year, this->mon,
+                               this->day);
   }
 
   int year{}; // year
@@ -153,15 +154,16 @@ struct Time {
   bool operator>=(const Time &other) const { return !(*this < other); }
 
   std::string toDateTimeString() const {
-    return stringFormat("%04d-%02d-%02d %02d:%02d:%02d", this->date.year,
-                        this->date.mon, this->date.day, this->clock.hours,
-                        this->clock.min, this->clock.sec);
+    return StringUtils::format(
+        "%04d-%02d-%02d %02d:%02d:%02d", this->date.year, this->date.mon,
+        this->date.day, this->clock.hours, this->clock.min, this->clock.sec);
   }
 
   // date with abbreviated month, e.g. 01 Jan 1970
   std::string toAbbrevMonthDateString() const {
-    return stringFormat("%02d %s %04d", this->date.day,
-                        date.abbrevMonths[this->date.mon - 1], this->date.year);
+    return StringUtils::format("%02d %s %04d", this->date.day,
+                               date.abbrevMonths[this->date.mon - 1],
+                               this->date.year);
   }
 
   static Time fromInt(int input) {
@@ -189,10 +191,10 @@ struct Time {
     ss >> std::get_time(&t, format.c_str());
 
     if (ss.fail()) {
-      Printer::logLn(
-          stringFormat("%s: Failed to parse timestamp string '%s' in given "
-                       "format '%s', using default timestamp.",
-                       __func__, input, format));
+      Printer::logLn(StringUtils::format(
+          "%s: Failed to parse timestamp string '%s' in given "
+          "format '%s', using default timestamp.",
+          __func__, input, format));
 
       t = {};
       std::istringstream defaultTime("1900-01-01 00:00:00");

--- a/src/game/etj_timerun_entities.cpp
+++ b/src/game/etj_timerun_entities.cpp
@@ -69,8 +69,8 @@ int TimerunEntity::getOrSetTimerunIndex(const std::string &runName) {
     runIndices[runName] = level.timerunNamesCount++;
   }
 
-  cleanNames.insert(sanitize(runName, true));
-  names.insert(sanitize(runName, true));
+  cleanNames.insert(StringUtils::sanitize(runName, true));
+  names.insert(StringUtils::sanitize(runName, true));
 
   if (cleanNames.size() != names.size()) {
     G_Error(
@@ -107,7 +107,7 @@ void TimerunEntity::validateTimerunEntities() {
 
     if (!std::any_of(timerunEntities.cbegin(), timerunEntities.cend(),
                      [&ent](const std::string &entity) {
-                       return StringUtil::iEqual(ent->classname, entity);
+                       return StringUtils::iEqual(ent->classname, entity);
                      })) {
       continue;
     }
@@ -116,14 +116,14 @@ void TimerunEntity::validateTimerunEntities() {
       validationResults[ent->runName] = TimerunEntityValidationResult{};
     }
 
-    if (StringUtil::iEqual(ent->classname, "target_startTimer") ||
-        StringUtil::iEqual(ent->classname, "trigger_startTimer")) {
+    if (StringUtils::iEqual(ent->classname, "target_startTimer") ||
+        StringUtils::iEqual(ent->classname, "trigger_startTimer")) {
       validationResults[ent->runName].hasStartTimer = true;
-    } else if (StringUtil::iEqual(ent->classname, "target_stopTimer") ||
-               StringUtil::iEqual(ent->classname, "trigger_stopTimer")) {
+    } else if (StringUtils::iEqual(ent->classname, "target_stopTimer") ||
+               StringUtils::iEqual(ent->classname, "trigger_stopTimer")) {
       validationResults[ent->runName].hasStopTimer = true;
-    } else if (StringUtil::iEqual(ent->classname, "target_checkpoint") ||
-               StringUtil::iEqual(ent->classname, "trigger_checkpoint")) {
+    } else if (StringUtils::iEqual(ent->classname, "target_checkpoint") ||
+               StringUtils::iEqual(ent->classname, "trigger_checkpoint")) {
       validationResults[ent->runName].hasCheckpoints = true;
     }
   }
@@ -197,18 +197,18 @@ bool TimerunEntity::canStartTimerun(const gentity_t *self,
   }
 
   if (speed > self->velocityUpperLimit) {
-    Printer::center(clientNum,
-                    stringFormat("^3WARNING: ^7Timerun was not started. Too "
-                                 "high starting speed (%.2f > %.2f)\n",
-                                 speed, self->velocityUpperLimit));
+    Printer::center(clientNum, StringUtils::format(
+                                   "^3WARNING: ^7Timerun was not started. Too "
+                                   "high starting speed (%.2f > %.2f)\n",
+                                   speed, self->velocityUpperLimit));
     return false;
   }
 
   if (client->ps.viewangles[ROLL] != 0) {
     Printer::center(clientNum,
-                    stringFormat("^3WARNING: ^7Timerun was not started. "
-                                 "Illegal roll angles (%.2f != 0)",
-                                 client->ps.viewangles[ROLL]));
+                    StringUtils::format("^3WARNING: ^7Timerun was not started. "
+                                        "Illegal roll angles (%.2f != 0)",
+                                        client->ps.viewangles[ROLL]));
     return false;
   }
 

--- a/src/game/etj_timerun_repository.cpp
+++ b/src/game/etj_timerun_repository.cpp
@@ -36,12 +36,13 @@ Timerun::Record getRecordFromStandardQueryResult(
     std::string checkpointsString, std::string recordDate,
     std::string playerName, std::string metadataString) {
   auto checkpoints = Container::map(
-      Container::filter(
-          StringUtil::split(checkpointsString, ","),
-          [](const std::string &input) { return trim(input).length() > 0; }),
+      Container::filter(StringUtils::split(checkpointsString, ","),
+                        [](const std::string &input) {
+                          return StringUtils::trim(input).length() > 0;
+                        }),
       [](const std::string &checkpoint) {
         try {
-          return std::stoi(trim(checkpoint));
+          return std::stoi(StringUtils::trim(checkpoint));
         } catch (const std::logic_error &) {
           return TIMERUN_CHECKPOINT_NOT_SET;
         }
@@ -49,9 +50,9 @@ Timerun::Record getRecordFromStandardQueryResult(
   Time recordDateTime = Time::fromString(recordDate);
 
   std::map<std::string, std::string> metadata;
-  for (const auto &kvp : Container::map(StringUtil::split(metadataString, ","),
+  for (const auto &kvp : Container::map(StringUtils::split(metadataString, ","),
                                         [](const std::string &kvp) {
-                                          return StringUtil::split(kvp, "=");
+                                          return StringUtils::split(kvp, "=");
                                         })) {
     if (kvp.size() != 2) {
       continue;
@@ -81,13 +82,13 @@ void TimerunRepository::shutdown() { _database = nullptr; }
 std::vector<Timerun::Record>
 TimerunRepository::getRecordsForPlayer(const std::vector<int> activeSeasons,
                                        const std::string &map, int userId) {
-  auto parameters = StringUtil::join(
+  auto parameters = StringUtils::join(
       Container::map(activeSeasons,
                      [](int season) { return std::to_string(season); }),
       ", ");
 
   auto binder = _database->sql
-                << stringFormat(R"(
+                << StringUtils::format(R"(
           select
             %s
           from record
@@ -95,7 +96,7 @@ TimerunRepository::getRecordsForPlayer(const std::vector<int> activeSeasons,
             map=? and
             user_id=?;
         )",
-                                _defaultRecordFieldsStr, parameters)
+                                       _defaultRecordFieldsStr, parameters)
                 << map << userId;
 
   auto records = getRecordsFromQuery(binder);
@@ -112,7 +113,7 @@ Timerun::Season TimerunRepository::addSeason(Timerun::AddSeasonParams params) {
       count;
 
   if (count > 0) {
-    throw std::runtime_error(stringFormat(
+    throw std::runtime_error(StringUtils::format(
         "Cannot add season `%s` as it already exists.", params.name));
   }
 
@@ -152,7 +153,7 @@ TimerunRepository::getRecordsForPlayer(const std::vector<int> &activeSeasons,
                                        const std::string &run, int userId) {
   auto records = std::vector<Timerun::Record>();
 
-  _database->sql << stringFormat(R"(
+  _database->sql << StringUtils::format(R"(
     select
       season_id,
       map,
@@ -169,7 +170,7 @@ TimerunRepository::getRecordsForPlayer(const std::vector<int> &activeSeasons,
       run=? and
       user_id=?;
     )",
-                                 StringUtil::join(activeSeasons, ", "))
+                                        StringUtils::join(activeSeasons, ", "))
                  << map << run << userId >>
       [&records](int seasonId, std::string map, std::string runName, int userId,
                  int time, std::string checkpointsString,
@@ -216,7 +217,7 @@ void TimerunRepository::insertRecord(const Timerun::Record &record) {
     );
   )" << record.seasonId
                  << record.map << record.run << record.userId << record.time
-                 << StringUtil::join(record.checkpoints, ",")
+                 << StringUtils::join(record.checkpoints, ",")
                  << record.recordDate.toDateTimeString() << record.playerName
                  << serializeMetadata(record.metadata);
 }
@@ -237,7 +238,7 @@ void TimerunRepository::updateRecord(const Timerun::Record &record) {
       run=? and
       user_id=?;
   )" << record.time
-                 << StringUtil::join(record.checkpoints, ",")
+                 << StringUtils::join(record.checkpoints, ",")
                  << record.recordDate.toDateTimeString() << record.playerName
                  << serializeMetadata(record.metadata) << record.seasonId
                  << record.map << record.run << record.userId;
@@ -285,7 +286,7 @@ TimerunRepository::getTopRecords(const std::vector<int> &seasonIds,
                                  const std::string &run) const {
   auto seasonIdsPlaceholder = DatabaseV2::createPlaceholderString(seasonIds);
 
-  std::string query = stringFormat(
+  std::string query = StringUtils::format(
       R"(
         select *
         from (select season_id,
@@ -351,7 +352,7 @@ void TimerunRepository::editSeason(const Timerun::EditSeasonParams &params) {
 
   if (seasonId < 0) {
     throw std::runtime_error(
-        stringFormat("No season matching name `%s`", params.name));
+        StringUtils::format("No season matching name `%s`", params.name));
   }
 
   std::vector<std::string> updatedFields;
@@ -382,10 +383,10 @@ void TimerunRepository::editSeason(const Timerun::EditSeasonParams &params) {
     return;
   }
 
-  std::string updatedFieldsString = StringUtil::join(
+  std::string updatedFieldsString = StringUtils::join(
       Container::map(updatedFields, [](auto a) { return a + "=?"; }), ",");
 
-  auto query = stringFormat(R"(
+  auto query = StringUtils::format(R"(
     update
       season
     set
@@ -393,7 +394,7 @@ void TimerunRepository::editSeason(const Timerun::EditSeasonParams &params) {
     where
       id=?
   )",
-                            updatedFieldsString);
+                                   updatedFieldsString);
 
   auto q = _database->sql << query;
 
@@ -410,14 +411,14 @@ TimerunRepository::getMapsForName(const std::string &map, bool exact) {
   std::string mapSearchString = exact ? map : "%" + map + "%";
 
   std::vector<std::string> maps;
-  _database->sql << stringFormat(R"(
+  _database->sql << StringUtils::format(R"(
     select
       distinct map
     from record
     where %s
     collate nocase
   )",
-                                 mapFilter)
+                                        mapFilter)
                  << mapSearchString >>
       [&maps](std::string map) { maps.push_back(map); };
   return maps;
@@ -432,7 +433,7 @@ TimerunRepository::getRunsForName(const std::string &map,
   std::string runSearchString = exact ? run : "%" + run + "%";
 
   std::vector<std::string> runs;
-  _database->sql << stringFormat(R"(
+  _database->sql << StringUtils::format(R"(
     select
       distinct run
     from record
@@ -440,10 +441,11 @@ TimerunRepository::getRunsForName(const std::string &map,
       and map = ?
     collate nocase
   )",
-                                 runFilter)
+                                        runFilter)
                  << runSearchString << map >>
       [&runs, sanitizeResults](const std::string &run) {
-        runs.push_back(sanitizeResults ? sanitize(run, true) : run);
+        runs.push_back(sanitizeResults ? StringUtils::sanitize(run, true)
+                                       : run);
       };
   return runs;
 }
@@ -478,7 +480,7 @@ TimerunRepository::getRecords(const Timerun::PrintRecordsParams &params) {
 
   if (seasons.empty()) {
     throw std::runtime_error(
-        stringFormat("No season matches name `%s`", season));
+        StringUtils::format("No season matches name `%s`", season));
   }
 
   const auto maps = getMapsForName(map, params.exactMap);
@@ -493,7 +495,7 @@ TimerunRepository::getRecords(const Timerun::PrintRecordsParams &params) {
     }
 
     if (!exactMapFound) {
-      std::string error = stringFormat(
+      std::string error = StringUtils::format(
           "^3records: ^7found %d maps matching ^3%s^7\n", maps.size(), map);
 
       const int perRow = 3;
@@ -503,7 +505,7 @@ TimerunRepository::getRecords(const Timerun::PrintRecordsParams &params) {
           error += "\n";
         }
 
-        error += stringFormat("%-22s", m);
+        error += StringUtils::format("%-22s", m);
         ++i;
       }
 
@@ -525,11 +527,12 @@ TimerunRepository::getRecords(const Timerun::PrintRecordsParams &params) {
     runBinder = runs.size() == 1 ? runs[0] : "%" + run + "%";
   }
 
-  const std::string seasonPlaceholders = StringUtil::join(
+  const std::string seasonPlaceholders = StringUtils::join(
       Container::map(seasons, [](const auto &s) { return "season_id=?"; }),
       " or ");
 
-  const std::string query = stringFormat(R"(
+  const std::string query =
+      StringUtils::format(R"(
     select
       season_id,
       map,
@@ -548,7 +551,7 @@ TimerunRepository::getRecords(const Timerun::PrintRecordsParams &params) {
     collate nocase
     order by season_id, map, run, time asc, record_date asc
   )",
-                                         seasonPlaceholders, runPlaceholder);
+                          seasonPlaceholders, runPlaceholder);
 
   auto binder = _database->sql << query;
 
@@ -556,7 +559,7 @@ TimerunRepository::getRecords(const Timerun::PrintRecordsParams &params) {
     binder << s.id;
   }
 
-  binder << StringUtil::toLowerCase(!maps.empty() ? maps[0] : map);
+  binder << StringUtils::toLowerCase(!maps.empty() ? maps[0] : map);
 
   if (runSpecified) {
     binder << runBinder;
@@ -696,7 +699,8 @@ void TimerunRepository::deleteSeason(const std::string &name) {
                  << name >>
       id;
   if (id < 0) {
-    throw std::runtime_error(stringFormat("Season `%s` does not exist.", name));
+    throw std::runtime_error(
+        StringUtils::format("Season `%s` does not exist.", name));
   }
 
   // for some reason someone named it something else
@@ -719,7 +723,7 @@ std::vector<Timerun::Checkpoints> TimerunRepository::getCheckpoints(
 
   if (seasons.empty()) {
     throw std::runtime_error(
-        stringFormat("No seasons found matching name '%s'", season));
+        StringUtils::format("No seasons found matching name '%s'", season));
   }
 
   const std::string map = params.map;
@@ -736,7 +740,7 @@ std::vector<Timerun::Checkpoints> TimerunRepository::getCheckpoints(
     }
 
     if (!exactMapFound) {
-      std::string error = stringFormat(
+      std::string error = StringUtils::format(
           "^3records: ^7found %d maps matching ^3%s^7\n", maps.size(), map);
 
       const int perRow = 3;
@@ -746,7 +750,7 @@ std::vector<Timerun::Checkpoints> TimerunRepository::getCheckpoints(
           error += "\n";
         }
 
-        error += stringFormat("%-22s", m);
+        error += StringUtils::format("%-22s", m);
         ++i;
       }
 
@@ -761,11 +765,11 @@ std::vector<Timerun::Checkpoints> TimerunRepository::getCheckpoints(
   const std::string runBinder =
       runs.size() == 1 ? runs[0] : "%" + params.run + "%";
 
-  const std::string seasonPlaceholders = StringUtil::join(
+  const std::string seasonPlaceholders = StringUtils::join(
       Container::map(seasons, [](const auto &) { return "season_id=?"; }),
       " or ");
 
-  std::string query = stringFormat(R"(
+  std::string query = StringUtils::format(R"(
     select *
       from (
         select
@@ -781,7 +785,7 @@ std::vector<Timerun::Checkpoints> TimerunRepository::getCheckpoints(
       ) as ranked_records
       where rank = ?;
   )",
-                                   seasonPlaceholders, runPlaceHolder);
+                                          seasonPlaceholders, runPlaceHolder);
 
   sqlite::database_binder binder = _database->sql << query;
 
@@ -789,7 +793,7 @@ std::vector<Timerun::Checkpoints> TimerunRepository::getCheckpoints(
     binder << s.id;
   }
 
-  binder << StringUtil::toLowerCase(maps.empty() ? map : maps[0]);
+  binder << StringUtils::toLowerCase(maps.empty() ? map : maps[0]);
   binder << runBinder;
   binder << params.rank;
 
@@ -804,7 +808,7 @@ std::vector<Timerun::Checkpoints> TimerunRepository::getCheckpoints(
     cp.run = run;
     cp.runTime = runTime;
 
-    for (const auto &time : StringUtil::split(checkpointsStr, ",")) {
+    for (const auto &time : StringUtils::split(checkpointsStr, ",")) {
       cp.checkpoints.emplace_back(Q_atoi(time));
     }
 

--- a/src/game/etj_timerun_repository.h
+++ b/src/game/etj_timerun_repository.h
@@ -84,26 +84,26 @@ private:
   const std::vector<std::string> _defaultSeasonFields{"id", "name",
                                                       "start_time", "end_time"};
   const std::string _defaultSeasonFieldsStr =
-      StringUtil::join(_defaultSeasonFields, ",");
+      StringUtils::join(_defaultSeasonFields, ",");
   const std::string _defaultSeasonQueryBase =
-      stringFormat(R"(
+      StringUtils::format(R"(
     select
       %s
     from season
   )",
-                   _defaultSeasonFieldsStr);
+                          _defaultSeasonFieldsStr);
   const std::vector<std::string> _defaultRecordFields{
       "season_id",   "map",         "run",         "user_id", "time",
       "checkpoints", "record_date", "player_name", "metadata"};
   const std::string _defaultRecordFieldsStr =
-      StringUtil::join(_defaultRecordFields, ",");
+      StringUtils::join(_defaultRecordFields, ",");
   const std::string _defaultRecordQueryBase =
-      stringFormat(R"(
+      StringUtils::format(R"(
         select
           %s
         from record
       )",
-                   _defaultRecordFieldsStr);
+                          _defaultRecordFieldsStr);
 
   static std::vector<Timerun::Record>
   getRecordsFromQuery(sqlite::database_binder &binder);

--- a/src/game/etj_timerun_shared.cpp
+++ b/src/game/etj_timerun_shared.cpp
@@ -75,11 +75,11 @@ TimerunCommands::Start::Start(
       checkpoints(checkpoints), currentRunCheckpoints(currentRunCheckpoints) {}
 
 std::string TimerunCommands::Start::serialize() const {
-  return stringFormat("timerun start %d %d \"%s\" %d %d \"%s\" \"%s\"",
-                      clientNum, startTime, runName,
-                      previousRecord.value_or(-1), runHasCheckpoints,
-                      StringUtil::join(checkpoints, ","),
-                      StringUtil::join(currentRunCheckpoints, ","));
+  return StringUtils::format("timerun start %d %d \"%s\" %d %d \"%s\" \"%s\"",
+                             clientNum, startTime, runName,
+                             previousRecord.value_or(-1), runHasCheckpoints,
+                             StringUtils::join(checkpoints, ","),
+                             StringUtils::join(currentRunCheckpoints, ","));
 }
 
 std::optional<TimerunCommands::Start>
@@ -129,7 +129,7 @@ TimerunCommands::Start::deserialize(const std::vector<std::string> &args) {
 
   unsigned idx = 0;
   for (const auto &v :
-       Container::map(StringUtil::split(args[7], ","),
+       Container::map(StringUtils::split(args[7], ","),
                       [](const auto &c) { return std::stoi(c); })) {
     if (idx >= start.checkpoints.size()) {
       break;
@@ -142,7 +142,7 @@ TimerunCommands::Start::deserialize(const std::vector<std::string> &args) {
 
   idx = 0;
   for (const auto &v :
-       Container::map(StringUtil::split(args[8], ","),
+       Container::map(StringUtils::split(args[8], ","),
                       [](const auto &c) { return std::stoi(c); })) {
     if (idx >= start.currentRunCheckpoints.size()) {
       break;
@@ -166,16 +166,17 @@ TimerunCommands::SavePosStart::SavePosStart(
       checkpoints(checkpoints), currentRunCheckpoints(currentRunCheckpoints) {}
 
 std::string TimerunCommands::SavePosStart::serialize() const {
-  return stringFormat("timerun saveposstart %d %d \"%s\" %d %d \"%s\" \"%s\"",
-                      clientNum, startTime, runName,
-                      previousRecord.value_or(-1), runHasCheckpoints,
-                      StringUtil::join(checkpoints, ","),
-                      StringUtil::join(currentRunCheckpoints, ","));
+  return StringUtils::format(
+      "timerun saveposstart %d %d \"%s\" %d %d \"%s\" \"%s\"", clientNum,
+      startTime, runName, previousRecord.value_or(-1), runHasCheckpoints,
+      StringUtils::join(checkpoints, ","),
+      StringUtils::join(currentRunCheckpoints, ","));
 }
 
 std::string TimerunCommands::Checkpoint::serialize() const {
-  return stringFormat("timerun checkpoint %d %d %d \"%s\" %d", clientNum,
-                      checkpointNum, checkpointTime, runName, checkpointIndex);
+  return StringUtils::format("timerun checkpoint %d %d %d \"%s\" %d", clientNum,
+                             checkpointNum, checkpointTime, runName,
+                             checkpointIndex);
 }
 
 std::optional<TimerunCommands::Checkpoint>
@@ -232,7 +233,7 @@ TimerunCommands::Checkpoint::deserialize(const std::vector<std::string> &args) {
 }
 
 std::string TimerunCommands::Interrupt::serialize() const {
-  return stringFormat("timerun interrupt %d", clientNum);
+  return StringUtils::format("timerun interrupt %d", clientNum);
 }
 
 std::optional<TimerunCommands::Interrupt>
@@ -251,9 +252,9 @@ TimerunCommands::Interrupt::deserialize(const std::vector<std::string> &args) {
 }
 
 std::string TimerunCommands::Completion::serialize() const {
-  return stringFormat("timerun completion %d %d %d \"%s\"", clientNum,
-                      completionTime,
-                      previousRecordTime.value_or(NO_PREVIOUS_RECORD), runName);
+  return StringUtils::format(
+      "timerun completion %d %d %d \"%s\"", clientNum, completionTime,
+      previousRecordTime.value_or(NO_PREVIOUS_RECORD), runName);
 }
 
 std::optional<TimerunCommands::Completion>
@@ -285,9 +286,9 @@ TimerunCommands::Completion::deserialize(const std::vector<std::string> &args) {
 }
 
 std::string TimerunCommands::Record::serialize() const {
-  return stringFormat("timerun record %d %d %d \"%s\"", clientNum,
-                      completionTime,
-                      previousRecordTime.value_or(NO_PREVIOUS_RECORD), runName);
+  return StringUtils::format(
+      "timerun record %d %d %d \"%s\"", clientNum, completionTime,
+      previousRecordTime.value_or(NO_PREVIOUS_RECORD), runName);
 }
 
 std::optional<TimerunCommands::Record>
@@ -317,8 +318,8 @@ TimerunCommands::Record::deserialize(const std::vector<std::string> &args) {
 }
 
 std::string TimerunCommands::Stop::serialize() const {
-  return stringFormat("timerun stop %d %d \"%s\"", clientNum, completionTime,
-                      runName);
+  return StringUtils::format("timerun stop %d %d \"%s\"", clientNum,
+                             completionTime, runName);
 }
 
 std::optional<TimerunCommands::Stop>

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -243,14 +243,14 @@ void TimerunV2::initialize() {
 
     _mostRelevantSeason = getMostRelevantSeason();
 
-    _logger->info("Active seasons: %s",
-                  StringUtil::join(Container::map(_activeSeasons,
-                                                  [](const Timerun::Season &s) {
-                                                    return stringFormat(
-                                                        "%s (%d)", s.name,
-                                                        s.id);
-                                                  }),
-                                   ", "));
+    _logger->info(
+        "Active seasons: %s",
+        StringUtils::join(Container::map(_activeSeasons,
+                                         [](const Timerun::Season &s) {
+                                           return StringUtils::format(
+                                               "%s (%d)", s.name, s.id);
+                                         }),
+                          ", "));
 
   } catch (const std::exception &e) {
     Printer::logLn(std::string("Unable to initialize timerun database") +
@@ -280,7 +280,7 @@ public:
 void TimerunV2::clientConnect(int clientNum, int userId) {
   _sc->postTask(
       [this, clientNum, userId] {
-        auto parameters = StringUtil::join(
+        auto parameters = StringUtils::join(
             Container::map(_activeSeasonsIds,
                            [](int season) { return std::to_string(season); }),
             ", ");
@@ -310,7 +310,8 @@ void TimerunV2::clientConnect(int clientNum, int userId) {
                       "Unable to load player information. Any timeruns will "
                       "not work. Try to reconnect or file a bug report at "
                       "github.com/etjump/etjump.");
-        Printer::console(clientNum, stringFormat("cause: %s\n", error.what()));
+        Printer::console(clientNum,
+                         StringUtils::format("cause: %s\n", error.what()));
       });
 }
 
@@ -462,8 +463,8 @@ void TimerunV2::addSeason(const Timerun::AddSeasonParams &season) {
         try {
           _repository->addSeason(season);
           updateSeasonStates();
-          return std::make_unique<AddSeasonResult>(
-              stringFormat("Successfully added season `%s`", season.name));
+          return std::make_unique<AddSeasonResult>(StringUtils::format(
+              "Successfully added season `%s`", season.name));
         } catch (const std::runtime_error &e) {
           return std::make_unique<AddSeasonResult>(e.what());
         }
@@ -476,8 +477,9 @@ void TimerunV2::addSeason(const Timerun::AddSeasonParams &season) {
       },
       [this, season](const std::runtime_error &e) {
         const char *what = e.what();
-        Printer::console(season.clientNum,
-                         stringFormat("Unable to add season: %s\n", e.what()));
+        Printer::console(
+            season.clientNum,
+            StringUtils::format("Unable to add season: %s\n", e.what()));
       });
 }
 
@@ -495,8 +497,8 @@ void TimerunV2::editSeason(const Timerun::EditSeasonParams &params) {
         try {
           _repository->editSeason(params);
           updateSeasonStates();
-          return std::make_unique<EditSeasonResult>(
-              stringFormat("Successfully edited season `%s`", params.name));
+          return std::make_unique<EditSeasonResult>(StringUtils::format(
+              "Successfully edited season `%s`", params.name));
         } catch (const std::runtime_error &e) {
           return std::make_unique<EditSeasonResult>(e.what());
         }
@@ -506,8 +508,9 @@ void TimerunV2::editSeason(const Timerun::EditSeasonParams &params) {
         Printer::console(params.clientNum, editSeasonResult->message + "\n");
       },
       [this, params](const std::runtime_error &e) {
-        Printer::console(params.clientNum,
-                         stringFormat("Unable to edit season: %s\n", e.what()));
+        Printer::console(
+            params.clientNum,
+            StringUtils::format("Unable to edit season: %s\n", e.what()));
       });
 }
 
@@ -656,10 +659,11 @@ void TimerunV2::printRecords(const Timerun::PrintRecordsParams &params) {
           const Timerun::Season *season = &seasonIt->second;
 
           if (seasonIt->first == defaultSeasonId) {
-            message += stringFormat("^2Overall records for map ^7%s\n",
-                                    result->records[0].map);
+            message += StringUtils::format("^2Overall records for map ^7%s\n",
+                                           result->records[0].map);
           } else {
-            message += stringFormat("^2Records for map ^7%s ^2on season ^7%s\n",
+            message +=
+                StringUtils::format("^2Records for map ^7%s ^2on season ^7%s\n",
                                     result->records[0].map, season->name);
           }
 
@@ -686,7 +690,7 @@ void TimerunV2::printRecords(const Timerun::PrintRecordsParams &params) {
               // clang-format off
               message += "^g-------------------------------------------------------------\n";
               // clang-format on
-              message += stringFormat(" ^2Run: ^7%s\n\n", rkvp.first);
+              message += StringUtils::format(" ^2Run: ^7%s\n\n", rkvp.first);
 
               constexpr int rankWidth = 4;
               constexpr int timeWidth = 10;
@@ -742,26 +746,26 @@ void TimerunV2::printRecords(const Timerun::PrintRecordsParams &params) {
                       ownRecord ? r->playerName + " ^g(You)" : r->playerName;
 
                   const int32_t rankPadding =
-                      StringUtil::countExtraPadding(rankString, rankWidth);
+                      StringUtils::countExtraPadding(rankString, rankWidth);
                   const int32_t millisPadding =
-                      StringUtil::countExtraPadding(millisString, timeWidth);
+                      StringUtils::countExtraPadding(millisString, timeWidth);
                   const int32_t diffPadding =
-                      StringUtil::countExtraPadding(diffString, diffWidth);
+                      StringUtils::countExtraPadding(diffString, diffWidth);
 
-                  auto formatString =
-                      stringFormat("^7 %%-%ds^7 %%-%ds^7 %%-%ds^7 %%s^7\n",
-                                   rankPadding, millisPadding, diffPadding);
+                  auto formatString = StringUtils::format(
+                      "^7 %%-%ds^7 %%-%ds^7 %%-%ds^7 %%s^7\n", rankPadding,
+                      millisPadding, diffPadding);
 
                   // we want to print our own record as the last one if it's not
                   // visible
                   if (isOnVisiblePage) {
-                    message +=
-                        stringFormat(formatString, rankString, millisString,
-                                     diffString, playerNameString);
+                    message += StringUtils::format(formatString, rankString,
+                                                   millisString, diffString,
+                                                   playerNameString);
                   } else {
-                    ownRecordString =
-                        stringFormat(formatString, rankString, millisString,
-                                     diffString, playerNameString);
+                    ownRecordString = StringUtils::format(
+                        formatString, rankString, millisString, diffString,
+                        playerNameString);
                   }
                 }
                 rank++;
@@ -781,7 +785,7 @@ void TimerunV2::printRecords(const Timerun::PrintRecordsParams &params) {
                 const int32_t end =
                     std::min(start + params.pageSize - 1, numRecords);
 
-                message += stringFormat(
+                message += StringUtils::format(
                     "\n ^7Showing ^2%i-%i ^7of ^2%i ^7total records\n", start,
                     end, numRecords);
 
@@ -820,7 +824,8 @@ void TimerunV2::loadCheckpoints(int clientNum, const std::string &mapName,
   _sc->postTask(
       [this, clientNum, mapName, runName, rank] {
         std::string matchedRun;
-        const std::string sanitizedRunName = sanitize(runName, true);
+        const std::string sanitizedRunName =
+            StringUtils::sanitize(runName, true);
         std::string errMsg;
         int matchedCount = 0;
         const auto matchedRuns =
@@ -842,16 +847,18 @@ void TimerunV2::loadCheckpoints(int clientNum, const std::string &mapName,
         if (matchedCount > 1) {
           const int runsPerRow = 3;
           int runsOnCurrentRow = 0;
-          errMsg = stringFormat("Multiple matches found for run ^3`%s`^7.\n",
-                                runName);
+          errMsg = StringUtils::format(
+              "Multiple matches found for run ^3`%s`^7.\n", runName);
 
           for (const auto &matches : matchedRuns) {
             ++runsOnCurrentRow;
             if (runsOnCurrentRow > runsPerRow) {
               runsOnCurrentRow = 1;
-              errMsg += stringFormat("\n%-16s", sanitize(matches, false));
+              errMsg += StringUtils::format(
+                  "\n%-16s", StringUtils::sanitize(matches, false));
             } else {
-              errMsg += stringFormat("%-16s", sanitize(matches, false));
+              errMsg += StringUtils::format(
+                  "%-16s", StringUtils::sanitize(matches, false));
             }
           }
           throw std::runtime_error(errMsg);
@@ -859,14 +866,14 @@ void TimerunV2::loadCheckpoints(int clientNum, const std::string &mapName,
         if (rank == -1) {
           _players[clientNum]->overriddenCheckpoints = {};
           // not really a runtime error but can't return here so bleh
-          throw std::runtime_error(stringFormat(
+          throw std::runtime_error(StringUtils::format(
               "^7Cleared loaded checkpoints for run ^3`%s`", matchedRun));
         }
 
         const auto record = _repository->getRecord(mapName, matchedRun, rank);
 
         if (!record.has_value()) {
-          throw std::runtime_error(stringFormat(
+          throw std::runtime_error(StringUtils::format(
               "^7Could not find a record on map ^3`%s` ^7for run ^3`%s` ^7for "
               "rank ^3`%d`",
               mapName, matchedRun.empty() ? runName : matchedRun, rank));
@@ -892,9 +899,9 @@ void TimerunV2::loadCheckpoints(int clientNum, const std::string &mapName,
         // bail out if no checkpoints are present
         if (result->checkpoints[0] == TIMERUN_CHECKPOINT_NOT_SET) {
           throw std::runtime_error(
-              stringFormat("^7No checkpoint times found for run ^3`%s`^7 "
-                           "from rank ^3`%d`^7 record.",
-                           runName, rank));
+              StringUtils::format("^7No checkpoint times found for run "
+                                  "^3`%s`^7 from rank ^3`%d`^7 record.",
+                                  runName, rank));
         }
 
         _players[clientNum]->overriddenCheckpoints[runName] = {};
@@ -906,10 +913,10 @@ void TimerunV2::loadCheckpoints(int clientNum, const std::string &mapName,
         std::copy_n(begin(result->checkpoints), checkpointsToCopy,
                     begin(_players[clientNum]->overriddenCheckpoints[runName]));
 
-        Printer::console(clientNum,
-                         stringFormat("^7Loaded checkpoints for run ^3`%s`^7 "
-                                      "from rank ^3`%d`^7 record.\n",
-                                      runName, rank));
+        Printer::console(clientNum, StringUtils::format(
+                                        "^7Loaded checkpoints for run ^3`%s`^7 "
+                                        "from rank ^3`%d`^7 record.\n",
+                                        runName, rank));
 
         if (_players[clientNum]->running) {
           Printer::console(clientNum, "^7You need to restart the run for the "
@@ -945,30 +952,30 @@ TimerunV2::getRankingsStringFor(const std::vector<Ranking> *rankings,
     if (isOnVisiblePage) {
       const std::string rankString = rankToString(static_cast<int32_t>(i) + 1);
       const int32_t rankStringWidth =
-          StringUtil::countExtraPadding(rankString, rankWidth);
+          StringUtils::countExtraPadding(rankString, rankWidth);
 
       const std::string name = isOwnRanking ? (r->name + " ^g(You)") : r->name;
       const int32_t nameStringWidth =
-          StringUtil::countExtraPadding(name, MAX_NAME_LENGTH + 1 + youWidth);
+          StringUtils::countExtraPadding(name, MAX_NAME_LENGTH + 1 + youWidth);
 
-      const std::string formatString = stringFormat(
+      const std::string formatString = StringUtils::format(
           "^7%%-%ds ^7%%-%ds  ^7%%.0f\n", rankStringWidth, nameStringWidth);
 
-      message += stringFormat(formatString, rankString, name, r->score);
+      message += StringUtils::format(formatString, rankString, name, r->score);
     }
 
     if (isOwnRanking && !isOnVisiblePage) {
       const std::string rankString = rankToString(static_cast<int32_t>(i) + 1);
       const int32_t rankStringWidth =
-          StringUtil::countExtraPadding(rankString, rankWidth);
+          StringUtils::countExtraPadding(rankString, rankWidth);
       const std::string name = r->name + " ^g(You)";
       const int32_t nameStringWidth =
-          StringUtil::countExtraPadding(name, MAX_NAME_LENGTH + 1 + youWidth);
+          StringUtils::countExtraPadding(name, MAX_NAME_LENGTH + 1 + youWidth);
 
-      const std::string formatString = stringFormat(
+      const std::string formatString = StringUtils::format(
           "\n^7%%-%ds ^7%%-%ds  ^7%%.0f\n", rankStringWidth, nameStringWidth);
 
-      message += stringFormat(formatString, rankString, name, r->score);
+      message += StringUtils::format(formatString, rankString, name, r->score);
     }
   }
   return message;
@@ -983,16 +990,17 @@ void TimerunV2::printRankings(const Timerun::PrintRankingsParams &params) {
               _repository->getSeasonsForName(params.season.value(), false);
 
           if (matchingSeasons.empty()) {
-            message = stringFormat("No matching season for name `%s`\n",
-                                   params.season.value());
+            message = StringUtils::format("No matching season for name `%s`\n",
+                                          params.season.value());
           } else {
             for (const auto &s : matchingSeasons) {
               if (_rankingsPerSeason.count(s.id) == 0) {
-                message = stringFormat("No records for season `%s`\n", s.name);
+                message =
+                    StringUtils::format("No records for season `%s`\n", s.name);
               } else {
                 // clang-format off
                 message =
-                    stringFormat(
+                    StringUtils::format(
                         "^g=============================================================\n"
                         " ^gRankings for season: ^2%s^7\n"
                         "^g=============================================================\n",
@@ -1038,7 +1046,7 @@ void TimerunV2::printRankings(const Timerun::PrintRankingsParams &params) {
       [params](auto e) {
         Printer::console(
             params.clientNum,
-            stringFormat("Unable to print rankings: %s\n", e.what()));
+            StringUtils::format("Unable to print rankings: %s\n", e.what()));
       });
 }
 
@@ -1052,7 +1060,7 @@ void TimerunV2::printSeasons(int clientNum) {
         }
 
         constexpr int32_t seasonWidth = 30;
-        std::string seasonHeader = stringFormat(
+        std::string seasonHeader = StringUtils::format(
             "\n^g %-30s %-15s%s\n", "Season", "Start Date", "End date");
 
         // clang-format off
@@ -1071,11 +1079,11 @@ void TimerunV2::printSeasons(int clientNum) {
               continue;
             }
 
-            const std::string formatString = stringFormat(
+            const std::string formatString = StringUtils::format(
                 " ^7%%-%ds ^7%%-15s%%s\n",
-                StringUtil::countExtraPadding(s.name, seasonWidth));
+                StringUtils::countExtraPadding(s.name, seasonWidth));
 
-            message += stringFormat(
+            message += StringUtils::format(
                 formatString, s.name, s.startTime.toAbbrevMonthDateString(),
                 s.endTime.has_value()
                     ? s.endTime.value().toAbbrevMonthDateString()
@@ -1090,11 +1098,11 @@ void TimerunV2::printSeasons(int clientNum) {
           message += " ^gUpcoming seasons\n" + seasonHeader;
 
           for (const auto &s : _upcomingSeasons) {
-            const std::string formatString = stringFormat(
+            const std::string formatString = StringUtils::format(
                 " ^7%%-%ds ^7%%-15s%%s\n",
-                StringUtil::countExtraPadding(s.name, seasonWidth));
+                StringUtils::countExtraPadding(s.name, seasonWidth));
 
-            message += stringFormat(
+            message += StringUtils::format(
                 formatString, s.name, s.startTime.toAbbrevMonthDateString(),
                 s.endTime.has_value()
                     ? s.endTime.value().toAbbrevMonthDateString()
@@ -1109,11 +1117,11 @@ void TimerunV2::printSeasons(int clientNum) {
           message += " ^gPast seasons\n" + seasonHeader;
 
           for (const auto &s : _pastSeasons) {
-            const std::string formatString = stringFormat(
+            const std::string formatString = StringUtils::format(
                 " ^9%%-%ds ^9%%-15s%%s\n",
-                StringUtil::countExtraPadding(s.name, seasonWidth));
+                StringUtils::countExtraPadding(s.name, seasonWidth));
 
-            message += stringFormat(
+            message += StringUtils::format(
                 formatString, s.name, s.startTime.toAbbrevMonthDateString(),
                 s.endTime.has_value()
                     ? s.endTime.value().toAbbrevMonthDateString()
@@ -1139,7 +1147,8 @@ void TimerunV2::printSeasons(int clientNum) {
       },
       [clientNum](auto e) {
         Printer::console(
-            clientNum, stringFormat("Unable to print seasons: %s\n", e.what()));
+            clientNum,
+            StringUtils::format("Unable to print seasons: %s\n", e.what()));
       });
 }
 
@@ -1158,7 +1167,7 @@ void TimerunV2::deleteSeason(int clientNum, const std::string &name) {
           _repository->deleteSeason(name);
           updateSeasonStates();
           return std::make_unique<DeleteSeasonResult>(
-              stringFormat("Successfully deleted season `%s`", name));
+              StringUtils::format("Successfully deleted season `%s`", name));
         } catch (const std::runtime_error &e) {
           return std::make_unique<DeleteSeasonResult>(e.what());
         }
@@ -1173,7 +1182,8 @@ void TimerunV2::deleteSeason(int clientNum, const std::string &name) {
       [this, clientNum](const std::runtime_error &e) {
         const char *what = e.what();
         Printer::console(
-            clientNum, stringFormat("Unable to delete season: %s\n", e.what()));
+            clientNum,
+            StringUtils::format("Unable to delete season: %s\n", e.what()));
       });
 }
 
@@ -1190,6 +1200,7 @@ public:
 void TimerunV2::listCheckpoints(const Timerun::ListCheckpointsParams &params) {
   const int32_t clientNum = params.clientNum;
   const int32_t rank = params.rank;
+  const std::string func = __func__;
 
   _sc->postTask(
       [this, params]() {
@@ -1198,7 +1209,7 @@ void TimerunV2::listCheckpoints(const Timerun::ListCheckpointsParams &params) {
             _repository->getSeasonsForName(params.season.value(), false);
         return std::make_unique<ListCheckpointsResult>(checkpoints, seasons);
       },
-      [this, clientNum, rank](const auto results) {
+      [this, clientNum, rank, func](const auto results) {
         const auto *const r =
             dynamic_cast<ListCheckpointsResult *>(results.get());
 
@@ -1207,8 +1218,9 @@ void TimerunV2::listCheckpoints(const Timerun::ListCheckpointsParams &params) {
                          "ListCheckpointsResult is NULL",
                          clientNum);
           throw std::runtime_error(
-              stringFormat("%s: unable to list checkpoints. This is a bug, "
-                           "please report this to the developers."));
+              StringUtils::format("%s: unable to list checkpoints. This is a "
+                                  "bug, please report this to the developers.",
+                                  func));
         }
 
         // ensure we have at least some valid checkpoint times
@@ -1253,7 +1265,7 @@ void TimerunV2::listCheckpoints(const Timerun::ListCheckpointsParams &params) {
                              "Malformed data received from the timerun "
                              "database. Please inform the server owner, more "
                              "information is available in the server logs.\n");
-            _logger->error(stringFormat(
+            _logger->error(StringUtils::format(
                 "Record on map %s, run %s by player %s with time %i "
                 "contains invalid season ID '%i'. The database might have been "
                 "manually modified, or is corrupted. If you have manually "
@@ -1271,16 +1283,17 @@ void TimerunV2::listCheckpoints(const Timerun::ListCheckpointsParams &params) {
           std::string s = "\n";
 
           if (data.seasonID == defaultSeasonId) {
-            s += stringFormat("^2Checkpoint times for map ^7%s\n", data.map);
+            s += StringUtils::format("^2Checkpoint times for map ^7%s\n",
+                                     data.map);
           } else {
-            s += stringFormat(
+            s += StringUtils::format(
                 "^2Checkpoint times on season ^7%s ^2for map ^7%s\n",
                 season.name, data.map);
           }
 
           s += "^g-------------------------------------------------------------"
                "\n";
-          s += stringFormat(
+          s += StringUtils::format(
               " ^2Run: ^7%s\n ^2Player: ^7%s\n ^2Time: ^7%s (%s^7)\n\n",
               data.run, data.playerName, millisToString(data.runTime),
               rankToString(rank));
@@ -1290,15 +1303,16 @@ void TimerunV2::listCheckpoints(const Timerun::ListCheckpointsParams &params) {
               break;
             }
 
-            s += stringFormat(" ^g%2i. ^7%s", static_cast<int32_t>(i + 1),
-                              millisToString(data.checkpoints[i]));
+            s +=
+                StringUtils::format(" ^g%2i. ^7%s", static_cast<int32_t>(i + 1),
+                                    millisToString(data.checkpoints[i]));
 
             // from 2nd checkpoint onwards, display the absolute time
             // difference between checkpoints
             if (i > 0) {
-              s += stringFormat(" ^z(%s)",
-                                millisToString(data.checkpoints[i] -
-                                               data.checkpoints[i - 1]));
+              s += StringUtils::format(" ^z(%s)",
+                                       millisToString(data.checkpoints[i] -
+                                                      data.checkpoints[i - 1]));
             }
 
             s += "\n";
@@ -1308,7 +1322,7 @@ void TimerunV2::listCheckpoints(const Timerun::ListCheckpointsParams &params) {
         }
       },
       [this, clientNum](const std::runtime_error &e) {
-        Printer::console(clientNum, stringFormat("%s\n", e.what()));
+        Printer::console(clientNum, StringUtils::format("%s\n", e.what()));
       });
 }
 
@@ -1331,6 +1345,7 @@ void TimerunV2::compareCheckpoints(
   const int32_t clientNum = params.clientNum;
   const int32_t baseRank = params.rankBase;
   const int32_t cmpRank = params.rankCmp;
+  const std::string func = __func__;
 
   _sc->postTask(
       [this, params]() {
@@ -1348,7 +1363,7 @@ void TimerunV2::compareCheckpoints(
         return std::make_unique<CompareCheckpointsResult>(
             baseCheckpoints, cmpCheckpoints, seasons);
       },
-      [this, clientNum, baseRank, cmpRank](const auto results) {
+      [this, clientNum, baseRank, cmpRank, func](const auto results) {
         const auto *const r =
             dynamic_cast<CompareCheckpointsResult *>(results.get());
 
@@ -1356,9 +1371,10 @@ void TimerunV2::compareCheckpoints(
           _logger->error("%s: unable to compare checkpoints for player %i: "
                          "CompareCheckpointsResult is NULL",
                          clientNum);
-          throw std::runtime_error(
-              stringFormat("%s: unable to compare checkpoints. This is a bug, "
-                           "please report this to the developers."));
+          throw std::runtime_error(StringUtils::format(
+              "%s: unable to compare checkpoints. This is a bug, please report "
+              "this to the developers.",
+              func));
         }
 
         if (r->baseCheckpoints.empty()) {
@@ -1401,7 +1417,7 @@ void TimerunV2::compareCheckpoints(
                              "Malformed data received from the timerun "
                              "database. Please inform the server owner, more "
                              "information is available in the server logs.\n");
-            _logger->error(stringFormat(
+            _logger->error(StringUtils::format(
                 "Record on map %s, run %s by player %s with time %i "
                 "contains invalid season ID '%i'. The database might have been "
                 "manually modified, or is corrupted. If you have manually "
@@ -1419,17 +1435,17 @@ void TimerunV2::compareCheckpoints(
           std::string s = "\n";
 
           if (base.seasonID == defaultSeasonId) {
-            s += stringFormat("^2Comparing checkpoints for map ^7%s\n",
-                              base.map);
+            s += StringUtils::format("^2Comparing checkpoints for map ^7%s\n",
+                                     base.map);
           } else {
-            s += stringFormat(
+            s += StringUtils::format(
                 "^2Comparing checkpoints on season ^7%s ^2for map ^7%s\n",
                 season.name, base.map);
           }
 
           s += "^g-------------------------------------------------------------"
                "\n";
-          s += stringFormat(" ^2Run: ^7%s\n\n", base.run);
+          s += StringUtils::format(" ^2Run: ^7%s\n\n", base.run);
 
           // minimum column width
           constexpr int32_t BASE_MIN_PADDING = 24;
@@ -1437,23 +1453,23 @@ void TimerunV2::compareCheckpoints(
           std::string tmpName;
           tmpName.insert(0, MAX_NETNAME, 'A');
 
-          const std::string baseHeader = stringFormat(
+          const std::string baseHeader = StringUtils::format(
               "^7%s ^7(%s^7)", base.playerName, rankToString(baseRank));
-          const std::string cmpHeader = stringFormat(
+          const std::string cmpHeader = StringUtils::format(
               "^7%s ^7(%s^7)", cmp.playerName, rankToString(cmpRank));
 
-          const int32_t baseWidth =
-              std::max(static_cast<int32_t>(sanitize(baseHeader).length()),
-                       BASE_MIN_PADDING);
-          const int32_t cmpWidth =
-              std::max(static_cast<int32_t>(sanitize(cmpHeader).length()),
-                       BASE_MIN_PADDING);
+          const int32_t baseWidth = std::max(
+              static_cast<int32_t>(StringUtils::sanitize(baseHeader).length()),
+              BASE_MIN_PADDING);
+          const int32_t cmpWidth = std::max(
+              static_cast<int32_t>(StringUtils::sanitize(cmpHeader).length()),
+              BASE_MIN_PADDING);
 
           const int32_t basePadding =
-              StringUtil::countExtraPadding(baseHeader, baseWidth);
+              StringUtils::countExtraPadding(baseHeader, baseWidth);
 
-          s += stringFormat("     %-*s ^g| ^7%s\n", basePadding, baseHeader,
-                            cmpHeader);
+          s += StringUtils::format("     %-*s ^g| ^7%s\n", basePadding,
+                                   baseHeader, cmpHeader);
 
           s += "     ^g";
           s.insert(s.length(), baseWidth + 1, '-');
@@ -1468,7 +1484,7 @@ void TimerunV2::compareCheckpoints(
               break;
             }
 
-            s += stringFormat(" ^g%2i. ", i + 1);
+            s += StringUtils::format(" ^g%2i. ", i + 1);
 
             // because checkpoints aren't mandatory, runs might have different
             // number of checkpoints, so ensure we only display valid times
@@ -1485,16 +1501,17 @@ void TimerunV2::compareCheckpoints(
             // the checkpoint times are never going to be wider than that,
             // so we don't need to compare against the current column width
             const size_t baseTimePadding =
-                StringUtil::countExtraPadding(baseTime, baseWidth);
+                StringUtils::countExtraPadding(baseTime, baseWidth);
 
-            s += stringFormat("^7%-*s ^g| ^7%s", baseTimePadding, baseTime,
-                              cmpTime);
+            s += StringUtils::format("^7%-*s ^g| ^7%s", baseTimePadding,
+                                     baseTime, cmpTime);
 
             // only display diff if both times are valid
             if (base.checkpoints[i] != TIMERUN_CHECKPOINT_NOT_SET &&
                 cmp.checkpoints[i] != TIMERUN_CHECKPOINT_NOT_SET) {
-              s += stringFormat(" (%s^7)", diffToString(cmp.checkpoints[i],
-                                                        base.checkpoints[i]));
+              s += StringUtils::format(
+                  " (%s^7)",
+                  diffToString(cmp.checkpoints[i], base.checkpoints[i]));
             }
 
             s += "\n";
@@ -1508,19 +1525,21 @@ void TimerunV2::compareCheckpoints(
 
           const std::string baseRunTime = millisToString(base.runTime);
           const int32_t baseRunTimeWidth = std::max(
-              static_cast<int32_t>(sanitize(baseRunTime).length()), baseWidth);
+              static_cast<int32_t>(StringUtils::sanitize(baseRunTime).length()),
+              baseWidth);
           const int32_t baseRunTimePadding =
-              StringUtil::countExtraPadding(baseRunTime, baseRunTimeWidth);
+              StringUtils::countExtraPadding(baseRunTime, baseRunTimeWidth);
 
-          s += stringFormat("     ^7%-*s ^g| ^7%s (%s^7)\n", baseRunTimePadding,
-                            baseRunTime, millisToString(cmp.runTime),
-                            diffToString(cmp.runTime, base.runTime));
+          s += StringUtils::format("     ^7%-*s ^g| ^7%s (%s^7)\n",
+                                   baseRunTimePadding, baseRunTime,
+                                   millisToString(cmp.runTime),
+                                   diffToString(cmp.runTime, base.runTime));
 
           Printer::console(clientNum, s);
         }
       },
       [this, clientNum](const std::runtime_error &e) {
-        Printer::console(clientNum, stringFormat("%s\n", e.what()));
+        Printer::console(clientNum, StringUtils::format("%s\n", e.what()));
       });
 }
 
@@ -1600,7 +1619,8 @@ bool TimerunV2::isDebugging(const int clientNum) {
   Printer::popup(clientNum, "Record not saved:\n");
 
   for (auto &debugger : debuggers) {
-    std::string fmt = stringFormat("- ^3%s ^7debugging enabled.\n", debugger);
+    std::string fmt =
+        StringUtils::format("- ^3%s ^7debugging enabled.\n", debugger);
     Printer::popup(clientNum, fmt);
   }
 
@@ -1610,10 +1630,10 @@ bool TimerunV2::isDebugging(const int clientNum) {
 int TimerunV2::indexForRunname(const std::string &runName) {
   int index;
   std::string currentRun;
-  std::string activeRun = sanitize(runName, true);
+  std::string activeRun = StringUtils::sanitize(runName, true);
 
   for (index = 0; index < level.timerunNamesCount; index++) {
-    currentRun = sanitize(level.timerunNames[index], true);
+    currentRun = StringUtils::sanitize(level.timerunNames[index], true);
     if (currentRun == activeRun) {
       break;
     }
@@ -1834,11 +1854,11 @@ void TimerunV2::checkRecord(Player *player) {
                          diffToString(completionTime, previousTopRecordTime) +
                          "^7)";
 
-            Printer::bannerAll(
-                stringFormat("^7%s ^7broke the overall server record for "
-                             "^3%s\n^7with ^3%s %s ^7!!!\n",
-                             playerName, sanitize(record.record.run),
-                             millisToString(record.record.time), diffString));
+            Printer::bannerAll(StringUtils::format(
+                "^7%s ^7broke the overall server record for ^3%s\n^7with ^3%s "
+                "%s ^7!!!\n",
+                playerName, StringUtils::sanitize(record.record.run),
+                millisToString(record.record.time), diffString));
           }
           Printer::commandAll(
               TimerunCommands::Record(clientNum, record.record.time,
@@ -1866,10 +1886,11 @@ void TimerunV2::checkRecord(Player *player) {
                          diffToString(completionTime, previousTopRecordTime) +
                          "^7)";
 
-            Printer::bannerAll(stringFormat(
+            Printer::bannerAll(StringUtils::format(
                 "^7%s ^7broke the server record on ^3%s^7 season for "
                 "^3%s\n^7with ^3%s %s ^7!!!\n",
-                playerName, record.seasonName, sanitize(record.record.run),
+                playerName, record.seasonName,
+                StringUtils::sanitize(record.record.run),
                 millisToString(record.record.time), diffString));
           }
 
@@ -1901,11 +1922,11 @@ void TimerunV2::checkRecord(Player *player) {
           }
           Printer::console(
               checkRecordResult->clientNum,
-              stringFormat("^7New personal record on season ^3%s^7 for ^7^3%s "
-                           "^7with ^3%s %s^7!\n",
-                           record.second.seasonName, record.second.record.run,
-                           millisToString(record.second.record.time),
-                           diffString));
+              StringUtils::format(
+                  "^7New personal record on season ^3%s^7 for ^7^3%s ^7with "
+                  "^3%s %s^7!\n",
+                  record.second.seasonName, record.second.record.run,
+                  millisToString(record.second.record.time), diffString));
         }
 
         for (const auto &newRecord :

--- a/src/game/etj_tokens.cpp
+++ b/src/game/etj_tokens.cpp
@@ -115,11 +115,13 @@ std::pair<bool, std::string> Tokens::deleteToken(const Difficulty difficulty,
     token->entity = nullptr;
     saveTokens(_filepath);
     return std::make_pair(
-        true, stringFormat("Successfully deleted %s token #%d",
-                           tokenDifficultyToString(difficulty), index + 1));
+        true,
+        StringUtils::format("Successfully deleted %s token #%d",
+                            tokenDifficultyToString(difficulty), index + 1));
   }
   return std::make_pair(
-      false, stringFormat("%s token with number #%d does not exist.",
+      false,
+      StringUtils::format("%s token with number #%d does not exist.",
                           tokenDifficultyToString(difficulty), index + 1));
 }
 
@@ -135,10 +137,10 @@ Tokens::deleteNearestToken(const std::array<float, 3> coordinates) {
   saveTokens(_filepath);
   G_FreeEntity(nearestToken.token->entity);
   nearestToken.token->entity = nullptr;
-  return std::make_pair(
-      true, stringFormat("Deleted %s token #%d.",
-                         tokenDifficultyToString(nearestToken.difficulty),
-                         nearestToken.number));
+  return std::make_pair(true, StringUtils::format("Deleted %s token #%d.",
+                                                  tokenDifficultyToString(
+                                                      nearestToken.difficulty),
+                                                  nearestToken.number));
 }
 
 std::pair<bool, std::string>
@@ -155,9 +157,10 @@ Tokens::moveNearestToken(std::array<float, 3> coordinates) {
   saveTokens(_filepath);
 
   return std::make_pair(
-      true, stringFormat("Moved %s #%d to new location.",
-                         tokenDifficultyToString(nearestToken.difficulty),
-                         nearestToken.number));
+      true,
+      StringUtils::format("Moved %s #%d to new location.",
+                          tokenDifficultyToString(nearestToken.difficulty),
+                          nearestToken.number));
 }
 
 std::pair<bool, std::string>
@@ -192,8 +195,8 @@ Tokens::createToken(const Difficulty difficulty,
 
   if (nextFreeToken == nullptr) {
     return std::make_pair(
-        false, stringFormat("No free tokens left for '%s' difficulty.",
-                            tokenDifficultyToString(difficulty)));
+        false, StringUtils::format("No free tokens left for '%s' difficulty.",
+                                   tokenDifficultyToString(difficulty)));
   }
 
   nextFreeToken->isActive = true;

--- a/src/game/etj_toml_utilities.h
+++ b/src/game/etj_toml_utilities.h
@@ -48,16 +48,16 @@ public:
       }
     } catch (const toml::syntax_error &e) {
       if (err) {
-        *err =
-            stringFormat("Failed to parse TOML file '%s': %s", file, e.what());
-        StringUtil::escapeColorCodes(*err, '7');
+        *err = StringUtils::format("Failed to parse TOML file '%s': %s", file,
+                                   e.what());
+        StringUtils::escapeColorCodes(*err, '7');
       }
 
       return false;
     } catch (toml::file_io_error &e) {
       if (err) {
-        *err = stringFormat("Failed to open file '%s' for reading: %s", file,
-                            e.what());
+        *err = StringUtils::format("Failed to open file '%s' for reading: %s",
+                                   file, e.what());
       }
 
       return false;
@@ -82,7 +82,7 @@ public:
       fOut.write(toml::format(table));
     } catch (const File::FileIOException &e) {
       if (err) {
-        *err = stringFormat("Failed to write TOML file: %s", e.what());
+        *err = StringUtils::format("Failed to write TOML file: %s", e.what());
       }
 
       return false;
@@ -96,7 +96,7 @@ public:
   // back an escaped version of the error string.
   static std::string getError(const char *exception) {
     std::string err = exception;
-    StringUtil::escapeColorCodes(err, '7');
+    StringUtils::escapeColorCodes(err, '7');
     return err;
   }
 };

--- a/src/game/etj_user.cpp
+++ b/src/game/etj_user.cpp
@@ -45,7 +45,7 @@ std::string User_s::GetGuid() { return guid; }
 
 char const *User_s::ToChar() const {
   return va("%d %s %d %d %s %s %s %s %s", id, guid.c_str(), level, lastSeen,
-            name.c_str(), (ETJump::StringUtil::join(hwids, ", ")).c_str(),
+            name.c_str(), (StringUtils::join(hwids, ", ")).c_str(),
             title.c_str(), commands.c_str(), greeting.c_str());
 }
 

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -587,10 +587,10 @@ qboolean ClientInactivityTimer(gclient_t *client) {
                   client->sess.sessionTeam, vtosf(client->ps.origin),
                   vtosf(client->ps.viewangles));
 
-      Printer::popupAll(ETJump::stringFormat(
+      Printer::popupAll(StringUtils::format(
           "%s ^7was removed from teams due to inactivity! (%s)",
           client->pers.netname,
-          ETJump::getSecondsString(g_inactivity.integer)));
+          StringUtils::getSecondsString(g_inactivity.integer)));
 
       SetTeam(g_entities + (client - level.clients), "s", qtrue,
               static_cast<weapon_t>(-1), static_cast<weapon_t>(-1), qfalse);

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -1675,9 +1675,9 @@ void G_NameChanged(gentity_t *ent) {
 
   if (g_nameChangeLimit.integer - client->sess.nameChangeCount == 0) {
     Printer::popup(
-        ent,
-        va("^3WARNING: ^7You must wait at least %s before renaming.",
-           ETJump::getSecondsString(g_nameChangeInterval.integer).c_str()));
+        ent, va("^3WARNING: ^7You must wait at least %s before renaming.",
+                StringUtils::getSecondsString(g_nameChangeInterval.integer)
+                    .c_str()));
   } else if (client->sess.nameChangeCount > g_nameChangeLimit.integer) {
     trap_DropClient(ClientNum(ent), "You were kicked for spamming rename.", 0);
   } else {
@@ -1879,8 +1879,8 @@ void ClientUserinfoChanged(int clientNum) {
 
       ClientNameChanged(ent);
 
-      Printer::consoleAll(ETJump::stringFormat("%s ^7renamed to %s\n", oldname,
-                                               client->pers.netname));
+      Printer::consoleAll(StringUtils::format("%s ^7renamed to %s\n", oldname,
+                                              client->pers.netname));
 
       G_NameChanged(ent);
     }
@@ -1994,7 +1994,7 @@ const char *ClientConnect(int clientNum, qboolean firstTime, qboolean isBot) {
         "Possible DoS attack. Rejecting client from %s "
         "(%s already)\n",
         ip,
-        ETJump::getPluralizedString(g_maxConnsPerIP.integer, "connection")
+        StringUtils::getPluralizedString(g_maxConnsPerIP.integer, "connection")
             .c_str());
     return "Too many connections from your ip.";
   }
@@ -2182,7 +2182,7 @@ void ClientBegin(int clientNum) {
 
   if (client->sess.sessionTeam != TEAM_SPECTATOR) {
     Printer::consoleAll(
-        ETJump::stringFormat("%s ^7entered the game\n", client->pers.netname));
+        StringUtils::format("%s ^7entered the game\n", client->pers.netname));
   }
 
   client->pers.nofatigue =

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -299,15 +299,14 @@ int ClientNumberFromString(gentity_t *to, char *s) {
   if (fIsNumber) {
     idnum = Q_atoi(s);
     if (idnum < 0 || idnum >= level.maxclients) {
-      Printer::console(to,
-                       ETJump::stringFormat("Bad client slot: %i\n", idnum));
+      Printer::console(to, StringUtils::format("Bad client slot: %i\n", idnum));
       return -1;
     }
 
     cl = &level.clients[idnum];
     if (cl->pers.connected != CON_CONNECTED) {
-      Printer::console(
-          to, ETJump::stringFormat("Client %i is not active\n", idnum));
+      Printer::console(to,
+                       StringUtils::format("Client %i is not active\n", idnum));
       return -1;
     }
     return (idnum);
@@ -322,7 +321,7 @@ int ClientNumberFromString(gentity_t *to, char *s) {
   }
 
   Printer::console(to,
-                   ETJump::stringFormat("User %s is not on the server\n", s));
+                   StringUtils::format("User %s is not on the server\n", s));
   return (-1);
 }
 
@@ -570,13 +569,15 @@ void updateVotingInfo(gentity_t *ent, int mapNum, VotingTypes vote) {
   if (isRtvVote) {
     game.rtv->setRtvConfigstrings();
   } else {
-    std::string newcs = stringFormat("tot\\%i\\spe\\%i", level.voteInfo.voteYes,
-                                     level.voteInfo.voteYesSpectators);
+    std::string newcs =
+        StringUtils::format("tot\\%i\\spe\\%i", level.voteInfo.voteYes,
+                            level.voteInfo.voteYesSpectators);
     trap_SetConfigstring(CS_VOTE_YES, newcs.c_str());
   }
 
-  std::string newcs = stringFormat("tot\\%i\\spe\\%i", level.voteInfo.voteNo,
-                                   level.voteInfo.voteNoSpectators);
+  std::string newcs =
+      StringUtils::format("tot\\%i\\spe\\%i", level.voteInfo.voteNo,
+                          level.voteInfo.voteNoSpectators);
   trap_SetConfigstring(CS_VOTE_NO, newcs.c_str());
 }
 } // namespace ETJump
@@ -926,8 +927,8 @@ void decreaseNoclipCount(gentity_t *ent, const std::string &action) {
     --ent->client->pers.noclipCount;
     Printer::center(
         ClientNum(ent),
-        ETJump::stringFormat("^7You may use ^3%s ^2%d^7 more times.\n", action,
-                             ent->client->pers.noclipCount));
+        StringUtils::format("^7You may use ^3%s ^2%d^7 more times.\n", action,
+                            ent->client->pers.noclipCount));
   }
 }
 
@@ -948,7 +949,7 @@ void setPlayerOffset(gentity_t *ent) {
   auto result = canNoclip(ent);
 
   if (!result.success) {
-    std::string str = ETJump::stringFormat(result.message, "setoffset");
+    std::string str = StringUtils::format(result.message, "setoffset");
     capitalizeWithColor(str);
     Printer::console(clientNum, str);
     return;
@@ -1029,8 +1030,8 @@ void printTracker(gentity_t *ent) {
   }
 
   if (trap_Argc() < 2) {
-    printTrackerMsg = stringFormat("Index: ^3%i ^7value: ^2%i\n", 1,
-                                   ent->client->pers.progression[0]);
+    printTrackerMsg = StringUtils::format("Index: ^3%i ^7value: ^2%i\n", 1,
+                                          ent->client->pers.progression[0]);
     Printer::console(clientNum, printTrackerMsg);
     return;
   }
@@ -1039,8 +1040,9 @@ void printTracker(gentity_t *ent) {
 
   if (!Q_stricmp("all", buffer)) {
     for (i = 0; i < MAX_PROGRESSION_TRACKERS; i++) {
-      printTrackerMsg = stringFormat("Index: ^3%i ^7value: ^2%i\n", i + 1,
-                                     ent->client->pers.progression[i]);
+      printTrackerMsg =
+          StringUtils::format("Index: ^3%i ^7value: ^2%i\n", i + 1,
+                              ent->client->pers.progression[i]);
       Printer::console(clientNum, printTrackerMsg);
     }
   } else {
@@ -1051,8 +1053,9 @@ void printTracker(gentity_t *ent) {
       int idx = Q_atoi(buffer);
 
       if (checkTrackerIndex(clientNum, idx, buffer, false)) {
-        printTrackerMsg = stringFormat("Index: ^3%i ^7value: ^2%i\n", idx,
-                                       ent->client->pers.progression[idx - 1]);
+        printTrackerMsg =
+            StringUtils::format("Index: ^3%i ^7value: ^2%i\n", idx,
+                                ent->client->pers.progression[idx - 1]);
         Printer::console(clientNum, printTrackerMsg);
       }
     }
@@ -1100,9 +1103,8 @@ void setTracker(gentity_t *ent) {
         ent->client->pers.progression[i] = value;
       }
 
-      setTrackerMsg = stringFormat("^7Set tracker value on all "
-                                   "indices to ^2%i^7.\n",
-                                   value);
+      setTrackerMsg = StringUtils::format(
+          "^7Set tracker value on all indices to ^2%i^7.\n", value);
       Printer::console(clientNum, setTrackerMsg);
     }
   }
@@ -1113,9 +1115,8 @@ void setTracker(gentity_t *ent) {
       if (checkTrackerIndex(clientNum, idx, bufferIndex, noIndex)) {
         ent->client->pers.progression[0] = idx; // No index specified, use it
                                                 // for value on index 1
-        setTrackerMsg = stringFormat("^7Tracker set - index: ^31 "
-                                     "^7value: ^2%i\n",
-                                     idx);
+        setTrackerMsg = StringUtils::format(
+            "^7Tracker set - index: ^31 ^7value: ^2%i\n", idx);
         Printer::console(clientNum, setTrackerMsg);
         return;
       }
@@ -1137,9 +1138,8 @@ void setTracker(gentity_t *ent) {
       if (checkTrackerValue(clientNum, bufferValue)) {
         value = Q_atoi(bufferValue);
         ent->client->pers.progression[idx - 1] = value;
-        setTrackerMsg = stringFormat("^7Tracker set - index: ^3%i "
-                                     "^7value: ^2%i\n",
-                                     idx, value);
+        setTrackerMsg = StringUtils::format(
+            "^7Tracker set - index: ^3%i ^7value: ^2%i\n", idx, value);
         Printer::console(clientNum, setTrackerMsg);
       }
     }
@@ -1168,7 +1168,7 @@ static void dumpEntities(gentity_t *ent) {
 
   std::string arg = ConcatArgs(1);
   const std::string filename =
-      stringFormat("maps/%s.ent", arg.empty() ? level.rawmapname : arg);
+      StringUtils::format("maps/%s.ent", arg.empty() ? level.rawmapname : arg);
 
   try {
     File out(filename, File::Mode::Write);
@@ -1179,11 +1179,11 @@ static void dumpEntities(gentity_t *ent) {
     }
 
     out.write(contents);
-    Printer::console(ent,
-                     stringFormat("Dumped entities to ^3'%s'\n", filename));
+    Printer::console(
+        ent, StringUtils::format("Dumped entities to ^3'%s'\n", filename));
   } catch (const File::FileIOException &e) {
-    Printer::console(ent,
-                     stringFormat("Failed to write file ^3'%s'\n", e.what()));
+    Printer::console(
+        ent, StringUtils::format("Failed to write file ^3'%s'\n", e.what()));
   }
 }
 } // namespace ETJump
@@ -1201,7 +1201,7 @@ void Cmd_Noclip_f(gentity_t *ent) {
   auto result = ETJump::canNoclip(ent);
 
   if (!result.success) {
-    std::string str = ETJump::stringFormat(result.message, "noclip");
+    std::string str = StringUtils::format(result.message, "noclip");
     capitalizeWithColor(str);
     Printer::center(clientNum, str);
     return;
@@ -2121,9 +2121,9 @@ void G_Say(gentity_t *ent, gentity_t *target, int mode, qboolean encoded,
       color = COLOR_YELLOW;
       break;
     case SAY_ADMIN:
-      Printer::logAdminLn(ETJump::stringFormat(
+      Printer::logAdminLn(StringUtils::format(
           "adminchat: %i %s: %s", ent->s.number,
-          ETJump::sanitize(ent->client->pers.netname), chatText));
+          StringUtils::sanitize(ent->client->pers.netname), chatText));
       Com_sprintf(name, sizeof(name),
                   "^A> ^7%s^7: ", ent->client->pers.netname);
       color = COLOR_LTORANGE;
@@ -2625,7 +2625,7 @@ bool checkVoteConditions(gentity_t *ent, int clientNum) {
 
   if (vote_limit.integer > 0 &&
       ent->client->pers.voteCount >= vote_limit.integer) {
-    voteError = ETJump::stringFormat(
+    voteError = StringUtils::format(
         "You have already called the maximum number of votes (%d).",
         vote_limit.integer);
     Printer::popup(clientNum, voteError);
@@ -2636,7 +2636,8 @@ bool checkVoteConditions(gentity_t *ent, int clientNum) {
     const int remainingTime = std::ceil(
         (g_disableVoteAfterMapChange.integer - (level.time - level.startTime)) /
         1000.0);
-    voteError = "You must wait " + ETJump::getSecondsString(remainingTime) +
+    voteError = "You must wait " +
+                StringUtils::getSecondsString(remainingTime) +
                 " before voting after a map change.";
     Printer::popup(clientNum, voteError);
     return false;
@@ -2648,7 +2649,7 @@ bool checkVoteConditions(gentity_t *ent, int clientNum) {
                    (level.time - ent->client->lastVoteTime)) /
                   1000.0);
     voteError = "^3callvote:^7 you must wait " +
-                ETJump::getSecondsString(voteCooldown) +
+                StringUtils::getSecondsString(voteCooldown) +
                 " before voting again.";
     Printer::chat(clientNum, voteError);
     return false;
@@ -2664,11 +2665,11 @@ void setCvString(char *voteMsg, char *voteArg) {
   const auto func = level.voteInfo.vote_fn;
 
   if (func == G_DevMap_v_Wrapper) {
-    voteString = stringFormat("%s (cheats enabled)", voteArg);
+    voteString = StringUtils::format("%s (cheats enabled)", voteArg);
     Q_strncpyz(voteArg, voteString.c_str(), MAX_STRING_TOKENS);
   } else if (func == G_RandomMap_v || func == G_RockTheVote_v) {
     if (voteArg[0]) {
-      voteString = stringFormat("from %s", voteArg);
+      voteString = StringUtils::format("from %s", voteArg);
       Q_strncpyz(voteArg, voteString.c_str(), MAX_STRING_TOKENS);
     }
   } else if (func == G_AutoRtv_v) {
@@ -2677,11 +2678,13 @@ void setCvString(char *voteMsg, char *voteArg) {
     if (voteArgInt == 0) {
       Q_strncpyz(voteArg, "Off", MAX_STRING_TOKENS);
     } else {
-      voteString = stringFormat("%s", getMinutesString(voteArgInt));
+      voteString =
+          StringUtils::format("%s", StringUtils::getMinutesString(voteArgInt));
       Q_strncpyz(voteArg, voteString.c_str(), MAX_STRING_TOKENS);
     }
   } else if (func == G_PortalPredict_v) {
-    voteString = stringFormat("%s", Q_atoi(voteArg) ? "ON" : "OFF", voteMsg);
+    voteString =
+        StringUtils::format("%s", Q_atoi(voteArg) ? "ON" : "OFF", voteMsg);
     Q_strncpyz(voteArg, voteString.c_str(), MAX_STRING_TOKENS);
   }
 
@@ -2692,7 +2695,7 @@ void setCvString(char *voteMsg, char *voteArg) {
 bool isValidVoteString(const std::string &str) {
   return std::none_of(
       tokenDelimiters.cbegin(), tokenDelimiters.cend(),
-      [&](const char token) { return StringUtil::contains(str, token); });
+      [&](const char token) { return StringUtils::contains(str, token); });
 }
 
 } // namespace ETJump
@@ -2724,7 +2727,7 @@ void Cmd_CallVote_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
   if ((i = G_voteCmdCheck(ent, arg1, arg2)) != G_OK) {
     if (i == G_NOTFOUND) {
       if (arg1[0]) {
-        std::string errorMessage = ETJump::stringFormat(
+        std::string errorMessage = StringUtils::format(
             "\n^3Unknown vote command: ^7%s %s\n", arg1, arg2);
         Printer::console(clientNum, errorMessage);
       }
@@ -2754,13 +2757,13 @@ void Cmd_CallVote_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
     trap_SendServerCommand(clientNum, "voted yes");
   }
 
-  std::string calledVoteString = ETJump::stringFormat(
-      "%s^7 called a vote. Voting for: %s\n", ent->client->pers.netname,
-      level.voteInfo.voteString);
+  std::string calledVoteString =
+      StringUtils::format("%s^7 called a vote. Voting for: %s\n",
+                          ent->client->pers.netname, level.voteInfo.voteString);
   Printer::consoleAll(calledVoteString);
 
   calledVoteString =
-      ETJump::stringFormat("%s^7 called a vote.", ent->client->pers.netname);
+      StringUtils::format("%s^7 called a vote.", ent->client->pers.netname);
   Printer::centerAll(calledVoteString);
 
   G_LogPrintf("%s called a vote. Voting for: %s\n", ent->client->pers.netname,
@@ -2792,13 +2795,13 @@ void Cmd_CallVote_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
     game.rtv->setRtvConfigstrings();
   } else {
     std::string newcs =
-        ETJump::stringFormat("tot\\%i\\spe\\%i", level.voteInfo.voteYes,
-                             level.voteInfo.voteYesSpectators);
+        StringUtils::format("tot\\%i\\spe\\%i", level.voteInfo.voteYes,
+                            level.voteInfo.voteYesSpectators);
     trap_SetConfigstring(CS_VOTE_YES, newcs.c_str());
   }
   std::string newcs =
-      ETJump::stringFormat("tot\\%i\\spe\\%i", level.voteInfo.voteNo,
-                           level.voteInfo.voteNoSpectators);
+      StringUtils::format("tot\\%i\\spe\\%i", level.voteInfo.voteNo,
+                          level.voteInfo.voteNoSpectators);
   trap_SetConfigstring(CS_VOTE_NO, newcs.c_str());
 }
 
@@ -2830,22 +2833,22 @@ void Cmd_Vote_f(gentity_t *ent) {
   const auto printVoteMsgs = [&] {
     std::string voteMsgs = "^7Invalid vote argument.\n";
     voteMsgs += "  ^7Valid arguments for '^2Yes^7' are: ^3<" +
-                ETJump::StringUtil::join(yesMsgs, "|") + "^3>\n";
+                StringUtils::join(yesMsgs, "|") + "^3>\n";
     voteMsgs += "  ^7Valid arguments for '^1No^7' are: ^3<" +
-                ETJump::StringUtil::join(noMsgs, "|") + "^3>\n";
+                StringUtils::join(noMsgs, "|") + "^3>\n";
     Printer::console(clientNum, voteMsgs);
   };
 
   const auto printRtvVoteMsgs = [&] {
     const auto *rtvMaps = game.rtv->getRtvMaps();
     std::string voteMsgs = "^7Invalid vote argument.\n";
-    voteMsgs += ETJump::stringFormat(
+    voteMsgs += StringUtils::format(
         "^7Valid arguments for this vote are:\n  ^3rtvVote 1-%i\n",
         rtvMaps->size());
     voteMsgs += "  ^7Open map selection with: ^3vote <" +
-                ETJump::StringUtil::join(yesMsgs, "|") + ">\n";
+                StringUtils::join(yesMsgs, "|") + ">\n";
     voteMsgs += "  ^7Vote '^1No^7' to keep current map with: ^3vote <" +
-                ETJump::StringUtil::join(noMsgs, "|") + ">\n";
+                StringUtils::join(noMsgs, "|") + ">\n";
     Printer::console(clientNum, voteMsgs);
   };
 
@@ -2860,11 +2863,13 @@ void Cmd_Vote_f(gentity_t *ent) {
   };
 
   trap_Argv(0, voteCmd, sizeof(voteCmd));
-  const std::string voteCmdStr = ETJump::sanitize(std::string(voteCmd), true);
+  const std::string voteCmdStr =
+      StringUtils::sanitize(std::string(voteCmd), true);
   const bool isRtvVoteCmd = voteCmdStr == "rtvvote";
 
   trap_Argv(1, voteArg, sizeof(voteArg));
-  const std::string voteArgStr = ETJump::sanitize(std::string(voteArg), true);
+  const std::string voteArgStr =
+      StringUtils::sanitize(std::string(voteArg), true);
 
   if (ent->client->pers.applicationEndTime > level.time) {
 
@@ -3120,9 +3125,9 @@ void Cmd_Vote_f(gentity_t *ent) {
         // this will need to be adjusted!
         Printer::popup(
             clientNum,
-            ETJump::stringFormat(
+            StringUtils::format(
                 "^7You must wait for ^3%s ^7before re-voting.",
-                ETJump::getSecondsString(ETJump::VOTING_TIMEOUT / 1000)));
+                StringUtils::getSecondsString(ETJump::VOTING_TIMEOUT / 1000)));
       }
       return;
     }
@@ -3161,9 +3166,9 @@ void Cmd_Vote_f(gentity_t *ent) {
       }
     }
 
-    Printer::popup(clientNum, ETJump::stringFormat(
+    Printer::popup(clientNum, StringUtils::format(
                                   "Vote cast, you can change your vote %s.",
-                                  ETJump::getPluralizedString(
+                                  StringUtils::getPluralizedString(
                                       ETJump::VOTING_ATTEMPTS + 1 -
                                           client->pers.votingInfo.attempts,
                                       "time")));
@@ -3826,7 +3831,7 @@ bool allowQuickFollow(gentity_t *ent, gentity_t *traceEnt) {
   }
   if (!G_AllowFollow(ent, traceEnt)) {
     auto clientNum = ClientNum(ent);
-    std::string specLockMsg = ETJump::stringFormat(
+    std::string specLockMsg = StringUtils::format(
         "%s is speclocked.", traceEnt->client->pers.netname);
     Printer::popup(clientNum, specLockMsg);
     return false;
@@ -4472,11 +4477,11 @@ void Cmd_Goto_f(gentity_t *ent) {
   VectorClear(ent->client->ps.velocity);
 
   Printer::popup(ClientNum(ent),
-                 ETJump::stringFormat("%s ^7-> %s", ent->client->pers.netname,
-                                      other->client->pers.netname));
+                 StringUtils::format("%s ^7-> %s", ent->client->pers.netname,
+                                     other->client->pers.netname));
   Printer::popup(ClientNum(other),
-                 ETJump::stringFormat("%s ^7-> %s", ent->client->pers.netname,
-                                      other->client->pers.netname));
+                 StringUtils::format("%s ^7-> %s", ent->client->pers.netname,
+                                     other->client->pers.netname));
 }
 
 void Cmd_Call_f(gentity_t *ent) {
@@ -4557,11 +4562,11 @@ void Cmd_Call_f(gentity_t *ent) {
   VectorCopy(ent->client->ps.origin, other->client->ps.origin);
 
   Printer::popup(ClientNum(ent),
-                 ETJump::stringFormat("%s ^7-> %s", other->client->pers.netname,
-                                      ent->client->pers.netname));
+                 StringUtils::format("%s ^7-> %s", other->client->pers.netname,
+                                     ent->client->pers.netname));
   Printer::popup(ClientNum(other),
-                 ETJump::stringFormat("%s ^7-> %s", other->client->pers.netname,
-                                      ent->client->pers.netname));
+                 StringUtils::format("%s ^7-> %s", other->client->pers.netname,
+                                     ent->client->pers.netname));
 }
 
 void Cmd_PrivateMessage_f(gentity_t *ent) {
@@ -4751,7 +4756,7 @@ void Cmd_Class_f(gentity_t *ent) {
     std::string usageText{"^3Usage:\n"};
 
     for (auto &loadout : ETJump::availableLoadouts) {
-      usageText += ETJump::stringFormat(
+      usageText += StringUtils::format(
           "  ^7%-30s ^9/class %c %i\n", loadout.description,
           ETJump::getPlayerClassSymbol(loadout.classId), loadout.weaponSlot);
     }
@@ -4792,10 +4797,10 @@ void Cmd_Class_f(gentity_t *ent) {
   for (auto &loadout : ETJump::availableLoadouts) {
     if (loadout.classId == classId && loadout.weaponSlot == weaponSlot) {
       Printer::center(clientNum,
-                      ETJump::stringFormat("You will spawn as an %s %s",
-                                           ETJump::getPlayerTeamName(
-                                               ent->client->sess.sessionTeam),
-                                           loadout.description),
+                      StringUtils::format("You will spawn as an %s %s",
+                                          ETJump::getPlayerTeamName(
+                                              ent->client->sess.sessionTeam),
+                                          loadout.description),
                       false);
       break;
     }
@@ -5115,7 +5120,7 @@ void ClientCommand(int clientNum) {
           "You don't have permission to use adminchat on this server.");
     } else if (ClientIsFlooding(ent)) {
       Printer::console(clientNum,
-                       ETJump::stringFormat(
+                       StringUtils::format(
                            "^1Spam Protection: ^7command %s ^7ignored\n", cmd));
     } else if (!ent->client->sess.muted) {
       Cmd_Say_f(ent, SAY_ADMIN, qfalse, enc);

--- a/src/game/g_cmds_ext.cpp
+++ b/src/game/g_cmds_ext.cpp
@@ -302,15 +302,14 @@ void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
         break;
     }
 
-    const std::string name =
-        ETJump::StringUtil::truncate(client->pers.netname, 23);
+    const std::string name = StringUtils::truncate(client->pers.netname, 23);
 
     if (ent) {
       const int colorChars =
           strlen(client->pers.netname) - Q_PrintStrlen(client->pers.netname);
       Printer::console(clientNum,
-                       ETJump::stringFormat("%s%2d  %-*s^7%s\n", team, idNum,
-                                            25 + colorChars, name, info));
+                       StringUtils::format("%s%2d  %-*s^7%s\n", team, idNum,
+                                           25 + colorChars, name, info));
     } else {
       char cleanName[MAX_NETNAME];
       Q_strncpyz(cleanName, name.c_str(), sizeof(cleanName));
@@ -326,7 +325,7 @@ void G_players_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
                                    level.numConnectedClients == 1 ? "" : "s"));
   } else {
     G_Printf("\n%s\n\n",
-             ETJump::getPluralizedString(count, "total player").c_str());
+             StringUtils::getPluralizedString(count, "total player").c_str());
   }
 }
 
@@ -744,32 +743,32 @@ static void Cmd_SpecInvite_f(gentity_t *ent, unsigned int dwCommand,
 
   // can't invite self
   if (other == ent) {
-    selfMsg = ETJump::stringFormat("You can not spec%sinvite yourself!\n",
-                                   invite ? "" : "un");
+    selfMsg = StringUtils::format("You can not spec%sinvite yourself!\n",
+                                  invite ? "" : "un");
     Printer::console(selfClient, selfMsg);
     return;
   }
 
   if (invite) {
     if (COM_BitCheck(ent->client->sess.specInvitedClients, targetClient)) {
-      selfMsg = ETJump::stringFormat("%s^7 is already specinvited.\n",
-                                     other->client->pers.netname);
+      selfMsg = StringUtils::format("%s^7 is already specinvited.\n",
+                                    other->client->pers.netname);
       Printer::console(selfClient, selfMsg);
       return;
     }
     COM_BitSet(ent->client->sess.specInvitedClients, targetClient);
 
     selfMsg =
-        ETJump::stringFormat("%s^7 has been sent a spectator invitation.\n",
-                             other->client->pers.netname);
+        StringUtils::format("%s^7 has been sent a spectator invitation.\n",
+                            other->client->pers.netname);
     Printer::console(selfClient, selfMsg);
-    otherMsg = ETJump::stringFormat("You have been invited to spectate %s^7.",
-                                    ent->client->pers.netname);
+    otherMsg = StringUtils::format("You have been invited to spectate %s^7.",
+                                   ent->client->pers.netname);
     Printer::popup(targetClient, otherMsg);
   } else {
     if (!COM_BitCheck(ent->client->sess.specInvitedClients, targetClient)) {
-      selfMsg = ETJump::stringFormat("%s^7 is not specinvited.\n",
-                                     other->client->pers.netname);
+      selfMsg = StringUtils::format("%s^7 is not specinvited.\n",
+                                    other->client->pers.netname);
       Printer::console(selfClient, selfMsg);
       return;
     }
@@ -781,13 +780,12 @@ static void Cmd_SpecInvite_f(gentity_t *ent, unsigned int dwCommand,
       StopFollowing(other);
     }
 
-    selfMsg =
-        ETJump::stringFormat("%s^7 was removed from invited spectators.\n",
-                             other->client->pers.netname);
+    selfMsg = StringUtils::format("%s^7 was removed from invited spectators.\n",
+                                  other->client->pers.netname);
     Printer::console(selfClient, selfMsg);
     otherMsg =
-        ETJump::stringFormat("^7You are no longer invited to spectate %s^7.",
-                             ent->client->pers.netname);
+        StringUtils::format("^7You are no longer invited to spectate %s^7.",
+                            ent->client->pers.netname);
     Printer::popup(targetClient, otherMsg);
   }
 }
@@ -811,7 +809,7 @@ static void Cmd_SpecLock_f(gentity_t *ent, unsigned int dwCommand,
   }
 
   if (ent->client->sess.sessionTeam == TEAM_SPECTATOR) {
-    msg = ETJump::stringFormat(
+    msg = StringUtils::format(
         "^7You cannot use ^3spec%slock ^7while spectating!\n",
         lock ? "" : "un");
     Printer::console(client, msg);
@@ -819,8 +817,8 @@ static void Cmd_SpecLock_f(gentity_t *ent, unsigned int dwCommand,
   }
 
   if (ent->client->sess.specLocked == lock) {
-    msg = ETJump::stringFormat("You are already %slocked from spectators!\n",
-                               lock ? "" : "un");
+    msg = StringUtils::format("You are already %slocked from spectators!\n",
+                              lock ? "" : "un");
     Printer::console(client, msg);
     return;
   }
@@ -871,7 +869,7 @@ static void Cmd_SpecList_f(gentity_t *ent, unsigned int dwCommand,
   for (i = 0; i < level.numConnectedClients; i++)
     if (COM_BitCheck(ent->client->sess.specInvitedClients,
                      level.sortedClients[i])) {
-      msg = ETJump::stringFormat(
+      msg = StringUtils::format(
           "%s ^7is specinvited.\n",
           level.clients[level.sortedClients[i]].pers.netname);
       Printer::console(client, msg);

--- a/src/game/g_combat.cpp
+++ b/src/game/g_combat.cpp
@@ -585,8 +585,8 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker,
     const auto fmt = ETJump::DeathrunSystem::getMessageFormat(
         ETJump::deathrunSystem->getPrintLocation());
     auto message = ETJump::deathrunSystem->getEndMessage();
-    ETJump::StringUtil::replaceAll(message, "[n]", self->client->pers.netname);
-    ETJump::StringUtil::replaceAll(message, "[s]", std::to_string(score));
+    StringUtils::replaceAll(message, "[n]", self->client->pers.netname);
+    StringUtils::replaceAll(message, "[s]", std::to_string(score));
     auto affectedPlayers = Utilities::getSpectators(clientNum);
     affectedPlayers.push_back(clientNum);
     for (const auto &c : affectedPlayers) {

--- a/src/game/g_fireteams.cpp
+++ b/src/game/g_fireteams.cpp
@@ -734,14 +734,14 @@ void setSaveLimitForFTMembers(fireteamData_t *ft, const int limit) {
 
     gentity_t *ent = g_entities + ft->joinOrder[i];
     ent->client->sess.saveLimitFt = limit;
-    Printer::popup(
-        ent, stringFormat("fireteam: ^3savelimit ^7was set to ^3%i", limit));
+    Printer::popup(ent, StringUtils::format(
+                            "fireteam: ^3savelimit ^7was set to ^3%i", limit));
   }
 }
 
 void setFireTeamGhosting(fireteamData_t *ft, const bool noGhost) {
-  const std::string &msg = stringFormat("fireteam: ^3noghost ^7has been ^3%s",
-                                        noGhost ? "enabled" : "disabled");
+  const std::string &msg = StringUtils::format(
+      "fireteam: ^3noghost ^7has been ^3%s", noGhost ? "enabled" : "disabled");
 
   ft->noGhost = noGhost;
 
@@ -768,8 +768,8 @@ void setFireTeamGhosting(fireteamData_t *ft, const bool noGhost) {
 
 void setFireteamTeamjumpMode(fireteamData_t *ft, const bool teamjumpMode) {
   const std::string &msg =
-      stringFormat("fireteam: ^3teamjump mode ^7has been ^3%s",
-                   teamjumpMode ? "enabled" : "disabled");
+      StringUtils::format("fireteam: ^3teamjump mode ^7has been ^3%s",
+                          teamjumpMode ? "enabled" : "disabled");
 
   ft->teamJumpMode = teamjumpMode;
 
@@ -923,9 +923,10 @@ static void setFireTeamRules(const int &clientNum) {
 
   if (!Q_stricmp(arg1, "noghost")) {
     if (g_ghostPlayers.integer != 1) {
-      Printer::popup(clientNum,
-                     stringFormat("fireteam: ^3noghost ^7is disabled by the %s",
-                                  level.noGhost ? "map" : "server"));
+      Printer::popup(
+          clientNum,
+          StringUtils::format("fireteam: ^3noghost ^7is disabled by the %s",
+                              level.noGhost ? "map" : "server"));
       return;
     }
 

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -1471,8 +1471,8 @@ void G_UpdateCvars(void) {
 
         if (cv->trackChange && !(cv->cvarFlags & CVAR_LATCH)) {
           Printer::popupAll(
-              ETJump::stringFormat("Server: ^3%s ^7changed to ^3%s",
-                                   cv->cvarName, cv->vmCvar->string));
+              StringUtils::format("Server: ^3%s ^7changed to ^3%s",
+                                  cv->cvarName, cv->vmCvar->string));
         }
 
         if (cv->teamShader) {
@@ -1816,7 +1816,7 @@ void G_InitGame(int levelTime, int randomSeed, int restart) {
   // callvote already turns the name to all lower case, which means
   // custom mapscripts are required to be lower case on Linux
   const std::string &mapName =
-      ETJump::StringUtil::toLowerCase(Info_ValueForKey(cs, "mapname"));
+      StringUtils::toLowerCase(Info_ValueForKey(cs, "mapname"));
   Info_SetValueForKey(cs, "mapname", mapName.c_str());
   trap_Cvar_Set("mapname", mapName.c_str());
   Q_strncpyz(level.rawmapname, mapName.c_str(), sizeof(level.rawmapname));
@@ -2919,8 +2919,8 @@ void CheckVote() {
   } else if (level.voteInfo.voteNo >=
                  level.numConnectedClients - requiredClients ||
              level.time - level.voteInfo.voteTime >= VOTE_TIME) {
-    std::string voteFailedMsg = ETJump::stringFormat("^3Vote FAILED! ^3(%s)",
-                                                     level.voteInfo.voteString);
+    std::string voteFailedMsg =
+        StringUtils::format("^3Vote FAILED! ^3(%s)", level.voteInfo.voteString);
     Printer::popupAll(voteFailedMsg);
     G_LogPrintf("Vote Failed: %s\n", level.voteInfo.voteString);
 

--- a/src/game/g_script_actions.cpp
+++ b/src/game/g_script_actions.cpp
@@ -3395,8 +3395,8 @@ qboolean G_ScriptAction_Announce(gentity_t *ent, char *params) {
   auto activator = ent->activator;
   if (activator && activator->client) {
     const std::string name =
-        ETJump::stringFormat("%s^7", activator->client->pers.netname);
-    ETJump::StringUtil::replaceAll(str, "%s", name);
+        StringUtils::format("%s^7", activator->client->pers.netname);
+    StringUtils::replaceAll(str, "%s", name);
   }
 
   Printer::popupAll(str);
@@ -4486,7 +4486,7 @@ inline constexpr char wmAnnouncePrivateUsage[] =
 inline constexpr char trackerUsage[] = "tracker [index] <command> <value>";
 inline constexpr char changeSkinUsage[] = "changeskin <skinfile>";
 
-#define FMT_FUNC(x) stringFormat("ScriptActions::%s", x).c_str()
+#define FMT_FUNC(x) StringUtils::format("ScriptActions::%s", x).c_str()
 
 enum class ScriptSpawnType {
   PLAYER_SPAWN = 1,
@@ -4719,7 +4719,7 @@ qboolean deleteAction(gentity_t *ent, char *params) {
     int valueInt{};
     float valueFloat{};
     vec3_t valueVec{};
-    std::vector<std::string> args = ETJump::StringUtil::split(value, " ");
+    std::vector<std::string> args = StringUtils::split(value, " ");
 
     const auto invalidArgCount = [&](const int expectedArgs,
                                      const size_t numArgs) {
@@ -4755,7 +4755,7 @@ qboolean deleteAction(gentity_t *ent, char *params) {
         while ((found = G_FindInt(found, fields[i].ofs, valueInt)) != nullptr) {
           pass[found->s.number].first++;
           pass[found->s.number].second.emplace_back(
-              ETJump::stringFormat(R"(%s "%s")", key, value));
+              StringUtils::format(R"(%s "%s")", key, value));
         }
 
         break;
@@ -4776,7 +4776,7 @@ qboolean deleteAction(gentity_t *ent, char *params) {
                nullptr) {
           pass[found->s.number].first++;
           pass[found->s.number].second.emplace_back(
-              ETJump::stringFormat(R"(%s "%s")", key, value));
+              StringUtils::format(R"(%s "%s")", key, value));
         }
 
         break;
@@ -4785,7 +4785,7 @@ qboolean deleteAction(gentity_t *ent, char *params) {
         while ((found = G_Find(found, fields[i].ofs, value)) != nullptr) {
           pass[found->s.number].first++;
           pass[found->s.number].second.emplace_back(
-              ETJump::stringFormat(R"(%s "%s")", key, value));
+              StringUtils::format(R"(%s "%s")", key, value));
         }
         break;
 
@@ -4809,7 +4809,7 @@ qboolean deleteAction(gentity_t *ent, char *params) {
         while ((found = G_FindVec(found, fields[i].ofs, valueVec)) != nullptr) {
           pass[found->s.number].first++;
           pass[found->s.number].second.emplace_back(
-              ETJump::stringFormat(R"(%s "%s")", key, value));
+              StringUtils::format(R"(%s "%s")", key, value));
         }
 
         break;
@@ -4831,7 +4831,7 @@ qboolean deleteAction(gentity_t *ent, char *params) {
         while ((found = G_FindVec(found, fields[i].ofs, valueVec)) != nullptr) {
           pass[found->s.number].first++;
           pass[found->s.number].second.emplace_back(
-              ETJump::stringFormat(R"(%s "%s")", key, value));
+              StringUtils::format(R"(%s "%s")", key, value));
         }
 
         break;
@@ -4849,7 +4849,7 @@ qboolean deleteAction(gentity_t *ent, char *params) {
         while ((found = G_FindInt(found, fields[i].ofs, valueInt)) != nullptr) {
           pass[found->s.number].first++;
           pass[found->s.number].second.emplace_back(
-              ETJump::stringFormat(R"(%s "%s")", key, value));
+              StringUtils::format(R"(%s "%s")", key, value));
         }
 
         break;
@@ -4872,13 +4872,11 @@ qboolean deleteAction(gentity_t *ent, char *params) {
   for (int i = MAX_CLIENTS + BODY_QUEUE_SIZE; i < ENTITYNUM_MAX_NORMAL; i++) {
     if (pass[i].first == count) {
       numDeleted++;
-      const std::string paramsMatched =
-          ETJump::StringUtil::join(pass[i].second, ", ");
+      const std::string paramsMatched = StringUtils::join(pass[i].second, ", ");
       G_Printf("%s: deleted entity %i [^z%s^7], matched params: ^3'%s'\n",
                __func__, i, g_entities[i].classname, paramsMatched.c_str());
 
-      if (ETJump::StringUtil::iEqual(g_entities[i].classname,
-                                     "target_spawn_relay")) {
+      if (StringUtils::iEqual(g_entities[i].classname, "target_spawn_relay")) {
         ETJump::TargetSpawnRelay::invalidateSpawnRelayPointers(&g_entities[i]);
       }
 
@@ -4965,8 +4963,8 @@ qboolean wmAnnouncePrivate(gentity_t *ent, char *params) {
 
   std::string str = token;
   const std::string name =
-      ETJump::stringFormat("%s^7", activator->client->pers.netname);
-  ETJump::StringUtil::replaceAll(str, "%s", name);
+      StringUtils::format("%s^7", activator->client->pers.netname);
+  StringUtils::replaceAll(str, "%s", name);
 
   Printer::popup(activator, str);
 

--- a/src/game/g_spawn.cpp
+++ b/src/game/g_spawn.cpp
@@ -1072,7 +1072,7 @@ static void initStrictSaveLoad() {
   } else {
     std::string token;
     while (str >> token) {
-      token = ETJump::StringUtil::toLowerCase(token);
+      token = StringUtils::toLowerCase(token);
       value |= static_cast<int>(allowedStrictValues[token]); // else 0
     }
   }
@@ -1328,7 +1328,7 @@ void SP_worldspawn(void) {
     int limit = Q_atoi(s);
     level.limitedSaves = limit;
     G_Printf("Save is limited to %s.\n",
-             ETJump::getPluralizedString(limit, "save").c_str());
+             StringUtils::getPluralizedString(limit, "save").c_str());
   } else {
     level.limitedSaves = 0;
     G_Printf("Save is not limited.\n");

--- a/src/game/g_stats.cpp
+++ b/src/game/g_stats.cpp
@@ -201,12 +201,12 @@ void G_LoseSkillPoints(gentity_t *ent, skillType_t skill, float points) {
     ent->client->sess.skillpoints[skill] = skillLevels[oldskill];
   }
 
-  G_Printf("%s just lost %s for skill %s\n", ent->client->pers.netname,
-           ETJump::getPluralizedString(oldskillpoints -
-                                           ent->client->sess.skillpoints[skill],
-                                       "skill point")
-               .c_str(),
-           skillNames[skill]);
+  G_Printf(
+      "%s just lost %s for skill %s\n", ent->client->pers.netname,
+      StringUtils::getPluralizedString(
+          oldskillpoints - ent->client->sess.skillpoints[skill], "skill point")
+          .c_str(),
+      skillNames[skill]);
 
   trap_PbStat(ent - g_entities, "loseskill",
               va("%d %d %d %f", ent->client->sess.sessionTeam,

--- a/src/game/g_target.cpp
+++ b/src/game/g_target.cpp
@@ -227,9 +227,9 @@ void Use_Target_Print(gentity_t *ent, gentity_t *other, gentity_t *activator) {
       static_cast<int>(TargetPrintSpawnFlags::ReplaceETJumpShortcuts)) {
     if (activator && activator->client) {
       const std::string nameStr =
-          ETJump::stringFormat("%s^7", activator->client->pers.netname);
-      ETJump::StringUtil::stringSubstitute(message, '%', nameStr, 1);
-      ETJump::StringUtil::replaceAll(message, "[n]", nameStr);
+          StringUtils::format("%s^7", activator->client->pers.netname);
+      StringUtils::stringSubstitute(message, '%', nameStr, 1);
+      StringUtils::replaceAll(message, "[n]", nameStr);
     } else {
       // better not call G_Error here since this error handling
       // wasn't here earlier, just print a warning and exit
@@ -2024,8 +2024,7 @@ void target_deathrun_start_use(gentity_t *self, gentity_t *other,
   auto message = ETJump::deathrunSystem->getStartMessage();
   auto location = ETJump::deathrunSystem->getPrintLocation();
   if (message.length() > 0) {
-    ETJump::StringUtil::replaceAll(message, "[n]",
-                                   activator->client->pers.netname);
+    StringUtils::replaceAll(message, "[n]", activator->client->pers.netname);
     auto fmtString = ETJump::DeathrunSystem::getMessageFormat(location);
     auto output = va(fmtString.c_str(), message.c_str());
     for (const auto &c : affectedClients) {
@@ -2081,9 +2080,8 @@ void target_deathrun_checkpoint_use(gentity_t *self, gentity_t *other,
     auto checkpointMessage =
         ETJump::deathrunSystem->getCheckpointMessage(self->id);
     auto score = ETJump::deathrunSystem->getScore(clientNum);
-    ETJump::StringUtil::replaceAll(message, "[n]",
-                                   activator->client->pers.netname);
-    ETJump::StringUtil::replaceAll(message, "[s]", std::to_string(score));
+    StringUtils::replaceAll(message, "[n]", activator->client->pers.netname);
+    StringUtils::replaceAll(message, "[s]", std::to_string(score));
     auto output = va(fmtString.c_str(), message.c_str());
     for (const auto &cnum : affectedPlayers) {
       trap_SendServerCommand(cnum, output);

--- a/src/game/g_team.cpp
+++ b/src/game/g_team.cpp
@@ -1204,7 +1204,7 @@ void checkpoint_use(gentity_t *ent, gentity_t *other, gentity_t *activator) {
     time++;
     trap_SendServerCommand(activator - g_entities,
                            va("cp \"Flag will be held in %s!\n\"",
-                              ETJump::getSecondsString(time).c_str()));
+                              StringUtils::getSecondsString(time).c_str()));
     return;
   }
 
@@ -1228,7 +1228,7 @@ void checkpoint_use(gentity_t *ent, gentity_t *other, gentity_t *activator) {
   time++;
   trap_SendServerCommand(activator - g_entities,
                          va("cp \"Flag will be held in %s!\n\"",
-                            ETJump::getSecondsString(time).c_str()));
+                            StringUtils::getSecondsString(time).c_str()));
 
   ent->count2 = level.time;
   ent->think = checkpoint_use_think;

--- a/src/game/g_utilities.cpp
+++ b/src/game/g_utilities.cpp
@@ -179,17 +179,17 @@ std::string TimeStampDifferenceToString(int diff) {
   constexpr int YEAR = 365 * DAY;
 
   if (diff < HOUR) {
-    return ETJump::getMinutesString(diff / MINUTE);
+    return StringUtils::getMinutesString(diff / MINUTE);
   } else if (diff < DAY) {
-    return ETJump::getHoursString(diff / HOUR);
+    return StringUtils::getHoursString(diff / HOUR);
   } else if (diff < WEEK) {
-    return ETJump::getDaysString(diff / DAY);
+    return StringUtils::getDaysString(diff / DAY);
   } else if (diff < MONTH) {
-    return ETJump::getWeeksString(diff / WEEK);
+    return StringUtils::getWeeksString(diff / WEEK);
   } else if (diff < YEAR) {
-    return ETJump::getMonthsString(diff / MONTH);
+    return StringUtils::getMonthsString(diff / MONTH);
   } else {
-    return ETJump::getYearsString(diff / YEAR);
+    return StringUtils::getYearsString(diff / YEAR);
   }
 }
 
@@ -209,7 +209,7 @@ bool ValidGuid(std::string guid) {
 
 const char *EscapeString(const char *in) {
   string str = in;
-  ETJump::StringUtil::replaceAll(str, "=", "\x19=");
+  StringUtils::replaceAll(str, "=", "\x19=");
   static char out[MAX_TOKEN_CHARS] = "\0";
   Q_strncpyz(out, str.c_str(), sizeof(out));
   return out;
@@ -222,7 +222,7 @@ std::vector<std::string> getNames(const std::vector<int> &ids) {
     std::string name = (g_entities + id)->client->pers.netname;
 
     // escape '=' for QP-encoding
-    ETJump::StringUtil::replaceAll(name, "=", "\x19=");
+    StringUtils::replaceAll(name, "=", "\x19=");
     names.push_back(name);
   }
 
@@ -243,7 +243,7 @@ std::vector<int> getMatchingIds(const std::string &name) {
 
 std::string interpolateNametags(std::string input, const int color) {
   std::string interpolated;
-  const std::vector<std::string> split = ETJump::StringUtil::split(input, "@");
+  const std::vector<std::string> split = StringUtils::split(input, "@");
 
   if (split.size() == 1 || split.size() == 2) {
     return input;
@@ -263,8 +263,7 @@ std::string interpolateNametags(std::string input, const int color) {
       auto names = getNames(getMatchingIds(split[i]));
       if (!names.empty()) {
         const std::string &splitStr = colorCode + ", ^7";
-        interpolated +=
-            "^7" + ETJump::StringUtil::join(names, splitStr) + colorCode;
+        interpolated += "^7" + StringUtils::join(names, splitStr) + colorCode;
       } else {
         interpolated += "@" + split[i] + "@";
       }
@@ -291,7 +290,7 @@ const char *findAndReplaceNametags(const char *text, const char *name) {
   static char buf[MAX_SAY_TEXT] = "\0";
 
   auto str = std::string(text);
-  ETJump::StringUtil::replaceAll(str, "[n]", name);
+  StringUtils::replaceAll(str, "[n]", name);
 
   Q_strncpyz(buf, str.c_str(), sizeof(buf));
   return buf;

--- a/src/game/g_utils.cpp
+++ b/src/game/g_utils.cpp
@@ -75,10 +75,10 @@ int G_FindConfigstringIndex(const char *name, int start, int max,
 
     if (it != csStrings.end()) {
       err =
-          ETJump::stringFormat("%s: overflow on index %s (%s = %i)\n", __func__,
-                               it->second.first, it->second.second, max);
+          StringUtils::format("%s: overflow on index %s (%s = %i)\n", __func__,
+                              it->second.first, it->second.second, max);
     } else {
-      err = ETJump::stringFormat("%s: overflow on index %i\n", __func__, start);
+      err = StringUtils::format("%s: overflow on index %i\n", __func__, start);
     }
 
     G_Error("%s", err.c_str());

--- a/src/game/g_vote.cpp
+++ b/src/game/g_vote.cpp
@@ -271,8 +271,8 @@ static bool matchMap(const char *voteArg, std::string &resultedMap,
   auto matchedMaps = G_MatchAllMaps(voteArg);
 
   if (matchedMaps.size() == 0) {
-    resultedMap =
-        stringFormat("^3callvote: ^7no maps found matching ^3%s^7.\n", voteArg);
+    resultedMap = StringUtils::format(
+        "^3callvote: ^7no maps found matching ^3%s^7.\n", voteArg);
     return false;
   }
 
@@ -285,18 +285,18 @@ static bool matchMap(const char *voteArg, std::string &resultedMap,
   }
 
   if (matchedMaps.size() > 1 && resultedMap.empty()) {
-    resultedMap =
-        stringFormat("^3callvote: ^7found ^3%i ^7maps matching ^3%s^7.\n",
-                     static_cast<int>(matchedMaps.size()), voteArg);
+    resultedMap = StringUtils::format(
+        "^3callvote: ^7found ^3%i ^7maps matching ^3%s^7.\n",
+        static_cast<int>(matchedMaps.size()), voteArg);
     auto perRow = 3;
     auto mapsOnCurrentRow = 0;
     for (auto &map : matchedMaps) {
       ++mapsOnCurrentRow;
       if (mapsOnCurrentRow > perRow) {
         mapsOnCurrentRow = 1;
-        resultedMap += ETJump::stringFormat("\n%-22s", map);
+        resultedMap += StringUtils::format("\n%-22s", map);
       } else {
-        resultedMap += ETJump::stringFormat("%-22s", map);
+        resultedMap += StringUtils::format("%-22s", map);
       }
     }
     resultedMap += "\n";
@@ -307,15 +307,15 @@ static bool matchMap(const char *voteArg, std::string &resultedMap,
 
   if (resultedMap == level.rawmapname &&
       cheats == static_cast<bool>(g_cheats.integer)) {
-    resultedMap =
-        stringFormat("^3callvote: ^7%s is the current map (cheats %s).\n",
-                     level.rawmapname, cheats ? "enabled" : "disabled");
+    resultedMap = StringUtils::format(
+        "^3callvote: ^7%s is the current map (cheats %s).\n", level.rawmapname,
+        cheats ? "enabled" : "disabled");
     return false;
   }
 
   if (ETJump::MapStatistics::isBlockedMap(resultedMap)) {
-    resultedMap = stringFormat("^3callvote: ^7Voting for %s is not allowed.\n",
-                               resultedMap);
+    resultedMap = StringUtils::format(
+        "^3callvote: ^7Voting for %s is not allowed.\n", resultedMap);
     return false;
   }
 
@@ -328,9 +328,8 @@ bool matchRandomMap(const char *arg, std::string &map) {
   if (isCustomMapType) {
     auto customMapType = CustomMapTypeExists(arg);
     if (!customMapType) {
-      map = stringFormat("^3randommap: ^7Map type %s "
-                         "does not exist\n.",
-                         arg);
+      map = StringUtils::format("^3randommap: ^7Map type %s does not exist\n.",
+                                arg);
       return false;
     }
 
@@ -488,8 +487,8 @@ int G_RockTheVote_v(gentity_t *ent, unsigned dwVoteIndex, char *arg,
       if (!CustomMapTypeExists(arg2)) {
         Printer::popup(
             clientNum,
-            stringFormat("Specified custom vote type ^3'%s' ^7does not exist.",
-                         arg2));
+            StringUtils::format(
+                "Specified custom vote type ^3'%s' ^7does not exist.", arg2));
         return G_INVALID;
       }
 
@@ -498,10 +497,11 @@ int G_RockTheVote_v(gentity_t *ent, unsigned dwVoteIndex, char *arg,
 
       // in case someone made an empty map list, or none are available
       if (numMaps == 0) {
-        Printer::popup(clientNum,
-                       stringFormat("Specified custom vote type ^3'%s' ^7is "
-                                    "empty or none of the maps are available.",
-                                    arg2));
+        Printer::popup(
+            clientNum,
+            StringUtils::format("Specified custom vote type ^3'%s' ^7is empty "
+                                "or none of the maps are available.",
+                                arg2));
         return G_INVALID;
       }
 
@@ -526,10 +526,10 @@ int G_RockTheVote_v(gentity_t *ent, unsigned dwVoteIndex, char *arg,
                     "use this feature.\n",
                     arg);
       } else {
-        Printer::popup(clientNum,
-                       stringFormat("Sorry, calling ^3%s^7 with less than 3 "
-                                    "valid maps on %s is not possible.",
-                                    arg, arg2[0] ? "a list" : "the server"));
+        Printer::popup(clientNum, StringUtils::format(
+                                      "Sorry, calling ^3%s^7 with less than 3 "
+                                      "valid maps on %s is not possible.",
+                                      arg, arg2[0] ? "a list" : "the server"));
       }
       return G_INVALID;
     }
@@ -560,8 +560,8 @@ int G_RockTheVote_v(gentity_t *ent, unsigned dwVoteIndex, char *arg,
 
     for (size_t i = 0; i < maxMaps; ++i, ++it) {
       (*rtvMaps)[i].mapName = *it;
-      cs += stringFormat("%s\\0%s", (*rtvMaps)[i].mapName,
-                         i == maxMaps - 1 ? "" : "\\");
+      cs += StringUtils::format("%s\\0%s", (*rtvMaps)[i].mapName,
+                                i == maxMaps - 1 ? "" : "\\");
     }
 
     if (arg2[0] != '\0') {
@@ -634,8 +634,8 @@ int G_AutoRtv_v(gentity_t *ent, unsigned dwVoteIndex, char *arg, char *arg2) {
       Printer::popupAll(voteMsg);
       if (nextVoteTime > 0) {
         Printer::popupAll(
-            stringFormat("^7Next vote will be called in ^3%i ^7%s.",
-                         nextVoteTime, minutesStr));
+            StringUtils::format("^7Next vote will be called in ^3%i ^7%s.",
+                                nextVoteTime, minutesStr));
       }
     }
   }

--- a/src/game/g_weapon.cpp
+++ b/src/game/g_weapon.cpp
@@ -547,7 +547,7 @@ qboolean ReviveEntity(gentity_t *ent, gentity_t *traceEnt) {
   trap_LinkEntity(ent);
 
   // DHM - Nerve :: Let the person being revived know about it
-  Printer::center(traceEnt, ETJump::stringFormat(
+  Printer::center(traceEnt, StringUtils::format(
                                 "You have been revived by %s %s!",
                                 ent->client->sess.sessionTeam == TEAM_ALLIES
                                     ? rankNames_Allies[ent->client->sess.rank]

--- a/src/ui/etj_colorpicker.cpp
+++ b/src/ui/etj_colorpicker.cpp
@@ -115,8 +115,8 @@ void ColorPicker::colorPickerStateToCvar(const bool reset) const {
     DC->setCVar(currentCvar.c_str(), currentCvarOldValue.c_str());
   } else {
     const std::string &value =
-        stringFormat("%f %f %f %f", normalizedRGB[0], normalizedRGB[1],
-                     normalizedRGB[2], normalizedRGB[3]);
+        StringUtils::format("%f %f %f %f", normalizedRGB[0], normalizedRGB[1],
+                            normalizedRGB[2], normalizedRGB[3]);
     DC->setCVar(currentCvar.c_str(), value.c_str());
   }
 }

--- a/src/ui/etj_demo_queue.cpp
+++ b/src/ui/etj_demo_queue.cpp
@@ -277,13 +277,13 @@ void DemoQueue::printStatus() {
   std::string msg;
 
   for (int i = 0; i < static_cast<int>(queue.size()); i++) {
-    msg +=
-        stringFormat("%-4i%s %s\n", i + 1, current == queue[i] ? "^z>^7" : " ",
-                     sanitize(queue[i]));
+    msg += StringUtils::format("%-4i%s %s\n", i + 1,
+                               current == queue[i] ? "^z>^7" : " ",
+                               StringUtils::sanitize(queue[i]));
   }
 
   // this can be quite lengthy with lots of demos in queue, so do splits
-  const auto splits = wrapWords(msg, '\n', 998);
+  const auto splits = StringUtils::wrapWords(msg, '\n', 998);
   for (const auto &split : splits) {
     uiInfo.uiDC.Print("%s", split.c_str());
   }

--- a/src/ui/etj_main.cpp
+++ b/src/ui/etj_main.cpp
@@ -150,7 +150,7 @@ static void initDemoQueueHandler() {
 static void parseChangelogs() {
   // the "cvar" names are the filenames, excluding .txt extension
   const std::vector<std::string> files =
-      StringUtil::split(CHANGELOG_CVARS, "|");
+      StringUtils::split(CHANGELOG_CVARS, "|");
   const std::string path = "ui/changelog/";
 
   for (const auto &file : files) {

--- a/src/ui/etj_menu_integrity_checker.cpp
+++ b/src/ui/etj_menu_integrity_checker.cpp
@@ -61,7 +61,7 @@ bool MenuIntegrityChecker::checkIntegrity() {
       const auto *const currentHash =
           G_SHA1(std::string(contents.cbegin(), contents.cend()).c_str());
 
-      if (!StringUtil::iEqual(currentHash, hash)) {
+      if (!StringUtils::iEqual(currentHash, hash)) {
         Com_DPrintf("Integrity check failed on file '%s' - invalid hash!\n",
                     file.c_str());
         return false;
@@ -80,7 +80,7 @@ std::vector<std::pair<std::string, std::string>>
 MenuIntegrityChecker::generateFileHashList() {
   std::vector<std::pair<std::string, std::string>> list;
 
-  const auto fileHashKvp = StringUtil::split(MENU_HASH_LIST, ",");
+  const auto fileHashKvp = StringUtils::split(MENU_HASH_LIST, ",");
 
   for (const auto &kvp : fileHashKvp) {
     const size_t pos = kvp.find(':');

--- a/src/ui/etj_quick_connect.cpp
+++ b/src/ui/etj_quick_connect.cpp
@@ -227,7 +227,7 @@ void QuickConnect::updateLabels() {
 
     // NOTE: only handles a single digit, if we were want to support
     // more than 9 quick connect servers, this needs to be updated!
-    if (StringUtil::startsWith(name, "lblQuickConnectServer")) {
+    if (StringUtils::startsWith(name, "lblQuickConnectServer")) {
       // menu entries are 1-indexed
       char buf[2] = {name.back(), '\0'};
       int index = Q_atoi(buf) - 1;
@@ -253,21 +253,21 @@ void QuickConnect::buildLabelString(const int index) {
   bool infoValid = servers[index].valid;
   bool hasCustomName = !servers[index].customName.empty();
 
-  const std::string line1 = StringUtil::truncate(
+  const std::string line1 = StringUtils::truncate(
       hasCustomName ? servers[index].customName : servers[index].serverName,
       MAX_LABEL_LINE_CHARS);
 
-  const std::string playerCountStr = stringFormat(
+  const std::string playerCountStr = StringUtils::format(
       " (%s/%s)", infoValid ? std::to_string(servers[index].players) : "-",
       infoValid ? std::to_string(servers[index].maxClients) : "-");
   const std::string mapStr =
-      StringUtil::truncate(infoValid ? servers[index].map : "-",
-                           MAX_LABEL_LINE_CHARS - playerCountStr.length());
+      StringUtils::truncate(infoValid ? servers[index].map : "-",
+                            MAX_LABEL_LINE_CHARS - playerCountStr.length());
 
-  const std::string line2 = stringFormat("%s%s", mapStr, playerCountStr);
+  const std::string line2 = StringUtils::format("%s%s", mapStr, playerCountStr);
 
   Com_sprintf(serverLabels[index], sizeof(serverLabels[index]),
-              stringFormat("%s\n%s", line1, line2).c_str());
+              StringUtils::format("%s\n%s", line1, line2).c_str());
 }
 
 void QuickConnect::addServer(const std::string &address,

--- a/src/ui/etj_utilities.cpp
+++ b/src/ui/etj_utilities.cpp
@@ -35,7 +35,7 @@ void parseMaplist() {
     uiInfo.serverMaplist.emplace_back(arg);
   }
 
-  ETJump::StringUtil::sortStrings(uiInfo.serverMaplist, true);
+  StringUtils::sortStrings(uiInfo.serverMaplist, true);
 }
 
 void parseNumCustomvotes() {
@@ -140,7 +140,7 @@ void toggleSettingsMenu() {
   const menuDef_t *activeMenu = Menu_GetFocused();
 
   if (activeMenu &&
-      StringUtil::startsWith(activeMenu->window.name, "etjump_settings_")) {
+      StringUtils::startsWith(activeMenu->window.name, "etjump_settings_")) {
     Menus_CloseAll();
   } else {
     trap_Key_SetCatcher(KEYCATCH_UI);

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -316,7 +316,7 @@ fontInfo_t *GetActiveFont() {
 }
 
 int Multiline_Text_Width(const char *text, float scale, int limit) {
-  const auto lines = ETJump::StringUtil::split(text, "\n");
+  const auto lines = StringUtils::split(text, "\n");
 
   // if no linebreaks, just return the text width
   if (lines.size() == 1) {
@@ -382,7 +382,7 @@ int Text_Height(const char *text, float scale, int limit) {
 
 // despite the name, this is also used for single line tooltips
 int Multiline_Text_Height(const char *text, float scale, int limit) {
-  const auto lines = ETJump::StringUtil::split(text, "\n");
+  const auto lines = StringUtils::split(text, "\n");
 
   // single line, just return the text height
   if (lines.size() == 1) {
@@ -1422,17 +1422,17 @@ void UI_DrawMapDescription(rectDef_t *rect, float scale, const vec4_t color,
 
     if (!briefing.empty()) {
       // replace any carriage returns with whitespace
-      ETJump::StringUtil::replaceAll(briefing, "\r", " ");
+      StringUtils::replaceAll(briefing, "\r", " ");
 
       // replace special '*' char with a regular linebreak char
-      ETJump::StringUtil::replaceAll(briefing, "*", "\n");
+      StringUtils::replaceAll(briefing, "*", "\n");
     }
   } else {
     briefing = "^1No text supplied";
   }
 
   BG_FitTextToWidth_Ext(briefing, scale, textRect.w, font);
-  std::vector<std::string> lines = ETJump::StringUtil::split(briefing, "\n");
+  std::vector<std::string> lines = StringUtils::split(briefing, "\n");
 
   // remove any potential empty strings from the back of the vector
   while (!lines.empty() && lines.back().empty()) {
@@ -2988,7 +2988,7 @@ static void UI_LoadDemos() {
   }
 
   const std::string path =
-      ETJump::StringUtil::join(uiInfo.currentDemoPath, PATH_SEP_STRING);
+      StringUtils::join(uiInfo.currentDemoPath, PATH_SEP_STRING);
   const std::string ext =
       "dm_" +
       std::to_string(static_cast<int>(trap_Cvar_VariableValue("protocol")));
@@ -3004,7 +3004,8 @@ static void UI_LoadDemos() {
     FileSystemObjectInfo objectInfo;
     objectInfo.type = FileSystemObjectType::Folder;
     objectInfo.name = dir;
-    objectInfo.displayName = "^7" + ETJump::sanitize(objectInfo.name, false);
+    objectInfo.displayName =
+        "^7" + StringUtils::sanitize(objectInfo.name, false);
 
     if (dir == "." || dir == "..") {
       continue;
@@ -3022,9 +3023,9 @@ static void UI_LoadDemos() {
     objectInfo.type = FileSystemObjectType::Item;
     objectInfo.name = demo;
     objectInfo.displayName = demo;
-    ETJump::StringUtil::stripExtension(objectInfo.displayName);
+    StringUtils::stripExtension(objectInfo.displayName);
     objectInfo.displayName =
-        ETJump::sanitize(objectInfo.displayName) + "^*." + ext;
+        StringUtils::sanitize(objectInfo.displayName) + "^*." + ext;
     files.emplace_back(objectInfo);
   }
 
@@ -3043,7 +3044,7 @@ static void UI_LoadDemos() {
 
     // remove trailing slash
     currentPath.pop_back();
-    back.displayName = "^7" + ETJump::sanitize(currentPath, false);
+    back.displayName = "^7" + StringUtils::sanitize(currentPath, false);
     FileSystemObjectInfo beginning;
     beginning.type = FileSystemObjectType::Folder;
     beginning.name = "..";
@@ -3425,8 +3426,8 @@ void UI_RunMenuScript(const char **args) {
           if (uiInfo.currentDemoPath.empty()) {
             demoPath = uiInfo.demoObjects[uiInfo.demoIndex].name;
           } else {
-            demoPath = ETJump::StringUtil::join(uiInfo.currentDemoPath, "/") +
-                       "/" + uiInfo.demoObjects[uiInfo.demoIndex].name;
+            demoPath = StringUtils::join(uiInfo.currentDemoPath, "/") + "/" +
+                       uiInfo.demoObjects[uiInfo.demoIndex].name;
           }
 
           uiInfo.currentDemoPath.push_front(front);
@@ -3439,8 +3440,8 @@ void UI_RunMenuScript(const char **args) {
     if (Q_stricmp(name, "deleteDemo") == 0) {
       if (uiInfo.demoIndex >= 0 &&
           uiInfo.demoIndex < static_cast<int>(uiInfo.demoObjects.size())) {
-        auto demoPath = ETJump::StringUtil::join(uiInfo.currentDemoPath, "/") +
-                        "/" + uiInfo.demoObjects[uiInfo.demoIndex].name;
+        auto demoPath = StringUtils::join(uiInfo.currentDemoPath, "/") + "/" +
+                        uiInfo.demoObjects[uiInfo.demoIndex].name;
         trap_FS_Delete(demoPath.c_str());
       }
       return;
@@ -4783,7 +4784,7 @@ void UI_RunMenuScript(const char **args) {
       fontInfo_t *font = &uiInfo.uiDC.Assets.fonts[item->font];
       std::string contents = uiInfo.changelogs[ui_currentChangelog.string];
 
-      uiInfo.formattedChangelog = ETJump::StringUtil::split(contents, "\n");
+      uiInfo.formattedChangelog = StringUtils::split(contents, "\n");
       uiInfo.formattedChangelog = ETJump::Utilities::fitChangelogLinesToWidth(
           uiInfo.formattedChangelog,
           static_cast<int>(item->window.rect.w - SCROLLBAR_SIZE - 10),
@@ -7025,8 +7026,7 @@ void _UI_KeyEvent(int key, qboolean down) {
 
       if (bindBuf[0] != '\0' && down && !g_editingField && !g_waitingForKey &&
           !Q_stricmp(bindBuf, "toggleETJumpSettings") &&
-          ETJump::StringUtil::startsWith(menu->window.name,
-                                         "etjump_settings_")) {
+          StringUtils::startsWith(menu->window.name, "etjump_settings_")) {
         // color picker and writeconfig menus run an exit script that restores
         // the previously opened menu, so if we have either of them open,
         // we end up with a menu open after Menus_CloseAll call

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -2941,12 +2941,12 @@ const char *Item_Multi_Setting(itemDef_t *item) {
 
     if (multiPtr->strDef) {
       // if a string is empty or a hex color, return as-is
-      if (buff[0] == '\0' || ETJump::StringUtil::startsWith(buff, "#") ||
-          ETJump::StringUtil::startsWith(buff, "0x")) {
+      if (buff[0] == '\0' || StringUtils::startsWith(buff, "#") ||
+          StringUtils::startsWith(buff, "0x")) {
         return va("Custom (%s)", buff);
       }
 
-      std::vector<std::string> splits = ETJump::StringUtil::split(buff, " ");
+      std::vector<std::string> splits = StringUtils::split(buff, " ");
 
       // at this point, we might still have nonsense strings such as
       // 'aaa.00.0000aaa.555' or some other stupid stuff, so ensure the
@@ -2958,14 +2958,14 @@ const char *Item_Multi_Setting(itemDef_t *item) {
       }
 
       for (auto &split : splits) {
-        split = ETJump::StringUtil::normalizeNumberString(split);
+        split = StringUtils::normalizeNumberString(split);
       }
 
-      const std::string &val = ETJump::StringUtil::join(splits, " ");
+      const std::string &val = StringUtils::join(splits, " ");
       return va("Custom (%s)", val.c_str());
     } else {
       std::string val = std::to_string(DC->getCVarValue(item->cvar));
-      val = ETJump::StringUtil::normalizeNumberString(val);
+      val = StringUtils::normalizeNumberString(val);
 
       return va("Custom (%s)", val.c_str());
     }

--- a/tests/command_parser_tests.cpp
+++ b/tests/command_parser_tests.cpp
@@ -6,15 +6,13 @@ using namespace ETJump;
 
 class CommandParserTests : public testing::Test {
 public:
-  void SetUp() override {
-  }
+  void SetUp() override {}
 
-  void TearDown() override {
-  }
+  void TearDown() override {}
 
-  static CommandParser CreateCommandParser(
-      CommandParser::CommandDefinition definition,
-      const std::vector<std::string> &args) {
+  static CommandParser
+  CreateCommandParser(CommandParser::CommandDefinition definition,
+                      const std::vector<std::string> &args) {
     return {definition, args};
   }
 
@@ -23,12 +21,11 @@ public:
   }
 
   static std::vector<std::string> CreateDefaultArgs() {
-    return {"action", "target", "--token", "singleToken", "parabel",
-            "--multitoken", "non", "linear", "action", "type"};
+    return {"action",       "target", "--token", "singleToken", "parabel",
+            "--multitoken", "non",    "linear",  "action",      "type"};
   }
 
-  static CommandParser::CommandDefinition CreateCommandDefinition(
-      ) {
+  static CommandParser::CommandDefinition CreateCommandDefinition() {
     auto def = CommandParser::CommandDefinition();
     def.name = "name";
     def.description = "desc";
@@ -41,28 +38,25 @@ TEST_F(CommandParserTests, CommandParser_Returns_CommandWithSingleTokenOption) {
   auto args = Args({"random", "parameter", "--token", "aSingleToken", "with",
                     "some", "additional", "stuff"});
 
-  auto cmd =
-      CreateCommandParser(
-          CreateCommandDefinition().addOption("token", "t",  "desc",
-                                              CommandParser::OptionDefinition::Type::Token,
-                                              true)
-          ,
-          args)
-      .parse();
+  auto cmd = CreateCommandParser(
+                 CreateCommandDefinition().addOption(
+                     "token", "t", "desc",
+                     CommandParser::OptionDefinition::Type::Token, true),
+                 args)
+                 .parse();
   ASSERT_EQ(cmd.options["token"].text, "aSingleToken");
 }
 
 TEST_F(CommandParserTests,
        CommandParser_Returns_CorrectAdditionalArgsWithSingleToken) {
-  auto args = Args({"--token", "aSingleToken", "with", "some", "additional",
-                    "stuff"});
-  auto cmd =
-      CreateCommandParser(
-          CreateCommandDefinition().addOption("token", "t", "desc",
-                                              CommandParser::OptionDefinition::Type::Token,
-                                              true),
-          args)
-      .parse();
+  auto args =
+      Args({"--token", "aSingleToken", "with", "some", "additional", "stuff"});
+  auto cmd = CreateCommandParser(
+                 CreateCommandDefinition().addOption(
+                     "token", "t", "desc",
+                     CommandParser::OptionDefinition::Type::Token, true),
+                 args)
+                 .parse();
   ASSERT_TRUE(vectorsAreEqual(args, 2, cmd.extraArgs));
 }
 
@@ -70,32 +64,29 @@ TEST_F(CommandParserTests,
        CommandParser_Returns_CorrectAdditionalArgsWithSingleTokenInTheMiddle) {
   auto args = Args({"random", "parameter", "--token", "aSingleToken", "with",
                     "some", "additional", "stuff"});
-  auto cmd =
-      CreateCommandParser(
-          CreateCommandDefinition().addOption("token", "t", "desc",
-                                              CommandParser::OptionDefinition::Type::Token,
-                                              true)
-          ,
-          args)
-      .parse();
-  ASSERT_TRUE(
-      vectorsAreEqual({ "random", "parameter", "with", "some", "additional",
-        "stuff" }, 0, cmd.extraArgs));
+  auto cmd = CreateCommandParser(
+                 CreateCommandDefinition().addOption(
+                     "token", "t", "desc",
+                     CommandParser::OptionDefinition::Type::Token, true),
+                 args)
+                 .parse();
+  ASSERT_TRUE(vectorsAreEqual(
+      {"random", "parameter", "with", "some", "additional", "stuff"}, 0,
+      cmd.extraArgs));
 }
 
 TEST_F(CommandParserTests, CommandParser_Returns_MultipleCorrectOptions) {
-  auto args = Args({"param1", "param2", "--token", "value", "--boolean", "-boo",
-                    "--bar"});
+  auto args = Args(
+      {"param1", "param2", "--token", "value", "--boolean", "-boo", "--bar"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("token", "t", "desc",
-                                              CommandParser::OptionDefinition::Type::Token,
-                                              true).addOption(
-              "boolean", "b", "desc", CommandParser::OptionDefinition::Type::Boolean,
-              true)
-          ,
+          CreateCommandDefinition()
+              .addOption("token", "t", "desc",
+                         CommandParser::OptionDefinition::Type::Token, true)
+              .addOption("boolean", "b", "desc",
+                         CommandParser::OptionDefinition::Type::Boolean, true),
           args)
-      .parse();
+          .parse();
   ASSERT_EQ(cmd.options.size(), 2);
   ASSERT_NE(cmd.options.find("token"), end(cmd.options));
   ASSERT_NE(cmd.options.find("boolean"), end(cmd.options));
@@ -103,38 +94,34 @@ TEST_F(CommandParserTests, CommandParser_Returns_MultipleCorrectOptions) {
 
 TEST_F(CommandParserTests,
        CommandParser_Returns_CorrectArgs_WithMultipleOptions) {
-  auto args = Args({"param1", "param2", "--token", "value", "--boolean", "-boo",
-                    "--bar"});
+  auto args = Args(
+      {"param1", "param2", "--token", "value", "--boolean", "-boo", "--bar"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("token", "t", "desc",
-                                              CommandParser::OptionDefinition::Type::Token,
-                                              true)
-                                   .addOption("boolean", "b", "desc",
-                                              CommandParser::OptionDefinition::Type::Boolean,
-                                              true),
+          CreateCommandDefinition()
+              .addOption("token", "t", "desc",
+                         CommandParser::OptionDefinition::Type::Token, true)
+              .addOption("boolean", "b", "desc",
+                         CommandParser::OptionDefinition::Type::Boolean, true),
           args)
-      .parse();
+          .parse();
   ASSERT_TRUE(
-      vectorsAreEqual(cmd.extraArgs, 0, { "param1", "param2", "-boo", "--bar" }
-      ));
+      vectorsAreEqual(cmd.extraArgs, 0, {"param1", "param2", "-boo", "--bar"}));
 }
 
 TEST_F(CommandParserTests,
        CommandParser_Returns_CorrectOptionValues_WithMultipleOptions) {
-  auto args = Args({"param1", "param2", "--token", "value", "--boolean", "-boo",
-                    "--bar"});
+  auto args = Args(
+      {"param1", "param2", "--token", "value", "--boolean", "-boo", "--bar"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("token", "t", "desc",
-                                              CommandParser::OptionDefinition::Type::Token,
-                                              true)
-                                   .addOption(
-                                       "boolean", "b", "desc",
-                                       CommandParser::OptionDefinition::Type::Boolean,
-                                       true),
+          CreateCommandDefinition()
+              .addOption("token", "t", "desc",
+                         CommandParser::OptionDefinition::Type::Token, true)
+              .addOption("boolean", "b", "desc",
+                         CommandParser::OptionDefinition::Type::Boolean, true),
           args)
-      .parse();
+          .parse();
   ASSERT_EQ(cmd.options["token"].text, "value");
   ASSERT_EQ(cmd.options["boolean"].boolean, true);
 }
@@ -144,14 +131,14 @@ TEST_F(CommandParserTests, CommandParser_Returns_CorrectArgs_WithMultiToken) {
                     "param6", "--token", "param7"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("multi", "m", "desc",
-                                              CommandParser::OptionDefinition::Type::MultiToken,
-                                              true)
-                                   .addOption("token", "t", "desc",
-                                              CommandParser::OptionDefinition::Type::Token,
-                                              true),
+          CreateCommandDefinition()
+              .addOption("multi", "m", "desc",
+                         CommandParser::OptionDefinition::Type::MultiToken,
+                         true)
+              .addOption("token", "t", "desc",
+                         CommandParser::OptionDefinition::Type::Token, true),
           args)
-      .parse();
+          .parse();
   ASSERT_EQ(cmd.options["multi"].text, "param4 param5 param6");
 }
 
@@ -161,15 +148,14 @@ TEST_F(CommandParserTests,
                     "param6", "--token", "param7", "param8"});
   auto cmd =
       CreateCommandParser(
-          CreateCommandDefinition().addOption("multi", "m", "desc",
-                                              CommandParser::OptionDefinition::Type::MultiToken,
-                                              true)
-                                   .addOption("token", "t", "desc",
-                                              CommandParser::OptionDefinition::Type::Token,
-                                              true)
-          ,
+          CreateCommandDefinition()
+              .addOption("multi", "m", "desc",
+                         CommandParser::OptionDefinition::Type::MultiToken,
+                         true)
+              .addOption("token", "t", "desc",
+                         CommandParser::OptionDefinition::Type::Token, true),
           args)
-      .parse();
+          .parse();
   ASSERT_EQ(cmd.options["token"].text, "param7");
 }
 
@@ -180,29 +166,27 @@ TEST_F(CommandParserTests,
   auto cmd =
       CreateCommandParser(
           CreateCommandDefinition()
-          .addOption("multi", "m", "desc",
-                     CommandParser::OptionDefinition::Type::MultiToken, true)
-          .addOption("token", "t", "desc",
-                     CommandParser::OptionDefinition::Type::Token, true),
+              .addOption("multi", "m", "desc",
+                         CommandParser::OptionDefinition::Type::MultiToken,
+                         true)
+              .addOption("token", "t", "desc",
+                         CommandParser::OptionDefinition::Type::Token, true),
           args)
-      .parse();
-  ASSERT_TRUE(
-      vectorsAreEqual(cmd.extraArgs, 0, { "param1", "param2", "param3", "param8"
-        }));
+          .parse();
+  ASSERT_TRUE(vectorsAreEqual(cmd.extraArgs, 0,
+                              {"param1", "param2", "param3", "param8"}));
 }
 
 TEST_F(CommandParserTests, CommandParser_Returns_Error_WhenNoParamForToken) {
   auto args = Args({"--token1"});
   auto cmd = CreateCommandParser(
-          CreateCommandDefinition().addOption("token1", "t1", "desc",
-                                              CommandParser::OptionDefinition::Type::Token,
-                                              true)
-          ,
-          args)
-      .parse();
+                 CreateCommandDefinition().addOption(
+                     "token1", "t1", "desc",
+                     CommandParser::OptionDefinition::Type::Token, true),
+                 args)
+                 .parse();
   ASSERT_EQ(cmd.errors[0], "Missing parameter for `token1`");
 }
-
 
 TEST_F(CommandParserTests,
        CommandParser_ReturnsAnError_IfRequiredOptionIsMissing) {
@@ -226,7 +210,8 @@ TEST_F(CommandParserTests,
 TEST_F(CommandParserTests, CommandParser_ParsesIntegersCorrectly) {
   auto args = std::vector<std::string>{"--integer", "1"};
   auto def = CreateCommandDefinition().addOption(
-      "integer", "i", "desc", CommandParser::OptionDefinition::Type::Integer, true);
+      "integer", "i", "desc", CommandParser::OptionDefinition::Type::Integer,
+      true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_EQ(parser.parse().options["integer"].integer, 1);
@@ -235,28 +220,30 @@ TEST_F(CommandParserTests, CommandParser_ParsesIntegersCorrectly) {
 TEST_F(CommandParserTests, CommandParser_ReturnsError_IfIntegerIsTooLarge) {
   auto args = std::vector<std::string>{"--integer", "999999999999999999999999"};
   auto def = CreateCommandDefinition().addOption(
-      "integer", "i", "desc", CommandParser::OptionDefinition::Type::Integer, true);
+      "integer", "i", "desc", CommandParser::OptionDefinition::Type::Integer,
+      true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_TRUE(
-      ETJump::StringUtil::contains(parser.parse().errors[0], "is out of range"
-      ));
+      StringUtils::contains(parser.parse().errors[0], "is out of range"));
 }
 
 TEST_F(CommandParserTests, CommandParser_ReturnsError_IfParamIsNotInteger) {
   auto args = std::vector<std::string>{"--integer", "foobar"};
   auto def = CreateCommandDefinition().addOption(
-      "integer", "i", "desc", CommandParser::OptionDefinition::Type::Integer, true);
+      "integer", "i", "desc", CommandParser::OptionDefinition::Type::Integer,
+      true);
   auto parser = CreateCommandParser(def, args);
 
-  ASSERT_TRUE(ETJump::StringUtil::contains(parser.parse().errors[0],
-    "is not an integer"));
+  ASSERT_TRUE(
+      StringUtils::contains(parser.parse().errors[0], "is not an integer"));
 }
 
 TEST_F(CommandParserTests, CommandParser_ParsesDecimalsCorrectly) {
   auto args = std::vector<std::string>{"--decimal", "1.23"};
   auto def = CreateCommandDefinition().addOption(
-      "decimal", "d", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
+      "decimal", "d", "desc", CommandParser::OptionDefinition::Type::Decimal,
+      true);
   auto parser = CreateCommandParser(def, args);
 
   ASSERT_DOUBLE_EQ(parser.parse().options["decimal"].decimal, 1.23);
@@ -265,21 +252,23 @@ TEST_F(CommandParserTests, CommandParser_ParsesDecimalsCorrectly) {
 TEST_F(CommandParserTests, CommandParser_ReturnsError_IfDecimalIsTooLarge) {
   auto args = std::vector<std::string>{"--decimal", "1.79769e+309"};
   auto def = CreateCommandDefinition().addOption(
-      "decimal", "d", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
+      "decimal", "d", "desc", CommandParser::OptionDefinition::Type::Decimal,
+      true);
   auto parser = CreateCommandParser(def, args);
 
-  ASSERT_TRUE(ETJump::StringUtil::contains(parser.parse().errors[0],
-    "is out of range"));
+  ASSERT_TRUE(
+      StringUtils::contains(parser.parse().errors[0], "is out of range"));
 }
 
 TEST_F(CommandParserTests, CommandParser_ReturnsError_IfParamIsNotDecimal) {
   auto args = std::vector<std::string>{"--decimal", "foobar"};
   auto def = CreateCommandDefinition().addOption(
-      "decimal", "d", "desc", CommandParser::OptionDefinition::Type::Decimal, true);
+      "decimal", "d", "desc", CommandParser::OptionDefinition::Type::Decimal,
+      true);
   auto parser = CreateCommandParser(def, args);
 
-  ASSERT_TRUE(ETJump::StringUtil::contains(parser.parse().errors[0],
-    "is not a decimal"));
+  ASSERT_TRUE(
+      StringUtils::contains(parser.parse().errors[0], "is not a decimal"));
 }
 
 TEST_F(CommandParserTests, CommandParser_ParsesDatesCorrectly) {
@@ -298,9 +287,8 @@ TEST_F(CommandParserTests, CommandParser_ReturnsError_IfDateIsNotValid) {
       "date", "d", "desc", CommandParser::OptionDefinition::Type::Date, true);
   auto parser = CreateCommandParser(def, args);
 
-  ASSERT_TRUE(
-      StringUtil::contains(parser.parse().errors[0],
-        "does not match the expected format"));
+  ASSERT_TRUE(StringUtils::contains(parser.parse().errors[0],
+                                    "does not match the expected format"));
 }
 
 TEST_F(CommandParserTests, CommandParser_HandlesPositionalArgumentsCorrectly) {
@@ -318,7 +306,9 @@ TEST_F(CommandParserTests, CommandParser_HandlesPositionalArgumentsCorrectly) {
   ASSERT_EQ(parser.parse().options["field-b"].text, "b");
 }
 
-TEST_F(CommandParserTests, CommandParser_HandlesPositionalArgumentsCorrectly_IfSomeArePassedExplicitly) {
+TEST_F(
+    CommandParserTests,
+    CommandParser_HandlesPositionalArgumentsCorrectly_IfSomeArePassedExplicitly) {
   auto args = std::vector<std::string>{"--field-b", "b", "a"};
   auto def =
       CreateCommandDefinition()
@@ -333,10 +323,12 @@ TEST_F(CommandParserTests, CommandParser_HandlesPositionalArgumentsCorrectly_IfS
   ASSERT_EQ(parser.parse().options["field-b"].text, "b");
 }
 
-TEST_F(CommandParserTests, CommandParser_ShouldNotCrash_IfNoParametersArePassed) {
+TEST_F(CommandParserTests,
+       CommandParser_ShouldNotCrash_IfNoParametersArePassed) {
   auto args = std::vector<std::string>{};
   auto def = CreateCommandDefinition().addOption(
-      "field-a", "fa", "desc", CommandParser::OptionDefinition::Type::Token, false, 0);
+      "field-a", "fa", "desc", CommandParser::OptionDefinition::Type::Token,
+      false, 0);
 
   auto parser = CreateCommandParser(def, args);
 

--- a/tests/string_utilities_tests.cpp
+++ b/tests/string_utilities_tests.cpp
@@ -1,8 +1,6 @@
 #include <gtest/gtest.h>
 #include "../src/game/etj_string_utilities.h"
 
-using namespace ETJump;
-
 class StringUtilitiesTests : public testing::Test {
   void SetUp() override {}
 
@@ -14,7 +12,7 @@ TEST_F(StringUtilitiesTests,
   std::string inputStr{"  foo bar"};
   std::string expectedStr{"foo bar"};
 
-  auto outputStr = trimStart(inputStr);
+  auto outputStr = StringUtils::trimStart(inputStr);
 
   EXPECT_EQ(outputStr, expectedStr);
 }
@@ -23,7 +21,7 @@ TEST_F(StringUtilitiesTests, trimEnd_ShouldRemoveWhitespaceFromTheEndOfString) {
   std::string inputStr{"foo bar  "};
   std::string expectedStr{"foo bar"};
 
-  auto outputStr = trimEnd(inputStr);
+  auto outputStr = StringUtils::trimEnd(inputStr);
 
   EXPECT_EQ(outputStr, expectedStr);
 }
@@ -33,7 +31,7 @@ TEST_F(StringUtilitiesTests,
   std::string inputStr{"   foo bar  "};
   std::string expectedStr{"foo bar"};
 
-  auto outputStr = trim(inputStr);
+  auto outputStr = StringUtils::trim(inputStr);
 
   EXPECT_EQ(outputStr, expectedStr);
 }
@@ -45,7 +43,7 @@ TEST_F(StringUtilitiesTests,
   std::vector<std::string> expectedSplits{"Lorem ipsum \ndolor sit amet, \n",
                                           "consectetur \nadipisicing elit. \n",
                                           "Tenetur, fuga!"};
-  auto splits = wrapWords(input, '\n', 40);
+  auto splits = StringUtils::wrapWords(input, '\n', 40);
   EXPECT_EQ(splits.size(), expectedSplits.size());
   for (int i = 0; i < static_cast<int>(splits.size()); i++) {
     EXPECT_EQ(splits[i], expectedSplits[i]);
@@ -59,7 +57,7 @@ TEST_F(StringUtilitiesTests,
   std::vector<std::string> expectedSplits{
       "Lorem ipsum dolor sit amet, consectetur ",
       "adipisicing elit. Tenetur, fuga!"};
-  auto splits = wrapWords(input, '\n', 40);
+  auto splits = StringUtils::wrapWords(input, '\n', 40);
   EXPECT_EQ(splits.size(), expectedSplits.size());
   for (int i = 0; i < static_cast<int>(splits.size()); i++) {
     EXPECT_EQ(splits[i], expectedSplits[i]);
@@ -73,7 +71,7 @@ TEST_F(StringUtilitiesTests,
   std::vector<std::string> expectedSplits{
       "Lorem ipsum \ndolor sit amet, \n", "consectetur \n",
       "adipisicing elit. \n", "Tenetur, fuga!"};
-  auto splits = wrapWords(input, '\n', 31);
+  auto splits = StringUtils::wrapWords(input, '\n', 31);
   EXPECT_EQ(splits.size(), expectedSplits.size());
   for (int i = 0; i < static_cast<int>(splits.size()); i++) {
     EXPECT_EQ(splits[i], expectedSplits[i]);
@@ -83,176 +81,176 @@ TEST_F(StringUtilitiesTests,
 TEST_F(StringUtilitiesTests,
        toLowerCase_ShouldConvertStringIntoLowercasedCopy) {
   std::string input = "HELLO WORLD";
-  auto fixedString = StringUtil::toLowerCase(input);
+  auto fixedString = StringUtils::toLowerCase(input);
   EXPECT_EQ(fixedString, "hello world");
 }
 
 TEST_F(StringUtilitiesTests,
        toUpperCase_ShouldConvertStringIntoUppercasedCopy) {
   std::string input = "hello world";
-  auto fixedString = StringUtil::toUpperCase(input);
+  auto fixedString = StringUtils::toUpperCase(input);
   EXPECT_EQ(fixedString, "HELLO WORLD");
 }
 
 TEST_F(StringUtilitiesTests,
        eraseLast_ShouldEraseLastSubstringOccurenceFromInputStringCopy) {
   std::string input = "hello world, hello world";
-  auto fixedString = StringUtil::eraseLast(input, "hello");
+  auto fixedString = StringUtils::eraseLast(input, "hello");
   EXPECT_EQ(fixedString, "hello world,  world");
 }
 
 TEST_F(StringUtilitiesTests,
        join_ShouldConcatenateStringChunksIntoOneDelimitedPiece) {
   std::vector<std::string> input = {"hello world", "hello world"};
-  auto fixedString = StringUtil::join(input, ", ");
+  auto fixedString = StringUtils::join(input, ", ");
   EXPECT_EQ(fixedString, "hello world, hello world");
 }
 
 TEST_F(StringUtilitiesTests, countExtraPadding_ShouldWorkCorrectly) {
-  EXPECT_EQ(StringUtil::countExtraPadding("123", 10), 10);
-  EXPECT_EQ(StringUtil::countExtraPadding("^1123", 10), 12);
-  EXPECT_EQ(StringUtil::countExtraPadding("^^1123", 10), 12);
-  EXPECT_EQ(StringUtil::countExtraPadding("^1t^2e^3s^4t", 10), 18);
+  EXPECT_EQ(StringUtils::countExtraPadding("123", 10), 10);
+  EXPECT_EQ(StringUtils::countExtraPadding("^1123", 10), 12);
+  EXPECT_EQ(StringUtils::countExtraPadding("^^1123", 10), 12);
+  EXPECT_EQ(StringUtils::countExtraPadding("^1t^2e^3s^4t", 10), 18);
 }
 
 TEST_F(StringUtilitiesTests, iEqual_ShouldWorkCorrectly) {
   // basic case-insensitive comparison
-  EXPECT_EQ(StringUtil::iEqual("FOO", "foo"), true);
-  EXPECT_EQ(StringUtil::iEqual("FOO", "bar"), false);
+  EXPECT_EQ(StringUtils::iEqual("FOO", "foo"), true);
+  EXPECT_EQ(StringUtils::iEqual("FOO", "bar"), false);
 
   // case-insensitive comparison with sanitization
-  EXPECT_EQ(StringUtil::iEqual("FOO", "^1foo", true), true);
-  EXPECT_EQ(StringUtil::iEqual("^2FOO", "^1foo", true), true);
-  EXPECT_EQ(StringUtil::iEqual("^2FOO", "^1bar", true), false);
+  EXPECT_EQ(StringUtils::iEqual("FOO", "^1foo", true), true);
+  EXPECT_EQ(StringUtils::iEqual("^2FOO", "^1foo", true), true);
+  EXPECT_EQ(StringUtils::iEqual("^2FOO", "^1bar", true), false);
 
   // case-insensitive comparison without sanitization
-  EXPECT_EQ(StringUtil::iEqual("FOO", "^1foo"), false);
+  EXPECT_EQ(StringUtils::iEqual("FOO", "^1foo"), false);
 
   // empty strings comparison
-  EXPECT_EQ(StringUtil::iEqual("", ""), true);
-  EXPECT_EQ(StringUtil::iEqual("", "foo"), false);
-  EXPECT_EQ(StringUtil::iEqual("foo", ""), false);
+  EXPECT_EQ(StringUtils::iEqual("", ""), true);
+  EXPECT_EQ(StringUtils::iEqual("", "foo"), false);
+  EXPECT_EQ(StringUtils::iEqual("foo", ""), false);
 
   // different lengths
-  EXPECT_EQ(StringUtil::iEqual("FOO", "FOOBAR"), false);
-  EXPECT_EQ(StringUtil::iEqual("FOOBAR", "FOO"), false);
+  EXPECT_EQ(StringUtils::iEqual("FOO", "FOOBAR"), false);
+  EXPECT_EQ(StringUtils::iEqual("FOOBAR", "FOO"), false);
 
   // mixed case with color codes
-  EXPECT_EQ(StringUtil::iEqual("^1FoO", "^2fOo", true), true);
-  EXPECT_EQ(StringUtil::iEqual("^1FoO", "^2BaR", true), false);
+  EXPECT_EQ(StringUtils::iEqual("^1FoO", "^2fOo", true), true);
+  EXPECT_EQ(StringUtils::iEqual("^1FoO", "^2BaR", true), false);
 
   // no sanitization parameter specified
   // (default behavior should be case-insensitive)
-  EXPECT_EQ(StringUtil::iEqual("FoO", "foO"), true);
-  EXPECT_EQ(StringUtil::iEqual("FoO", "BaR"), false);
+  EXPECT_EQ(StringUtils::iEqual("FoO", "foO"), true);
+  EXPECT_EQ(StringUtils::iEqual("FoO", "BaR"), false);
 }
 
 TEST_F(StringUtilitiesTests, normalizeNumberString_ValidInput) {
-  EXPECT_EQ(StringUtil::normalizeNumberString("123"), "123");
-  EXPECT_EQ(StringUtil::normalizeNumberString("123.456"), "123.456");
-  EXPECT_EQ(StringUtil::normalizeNumberString("-123"), "-123");
-  EXPECT_EQ(StringUtil::normalizeNumberString("-123.456"), "-123.456");
-  EXPECT_EQ(StringUtil::normalizeNumberString("1e10"), "10000000000");
-  EXPECT_EQ(StringUtil::normalizeNumberString("1e-10"), "0.0000000001");
-  EXPECT_EQ(StringUtil::normalizeNumberString("123.4560000"), "123.456");
+  EXPECT_EQ(StringUtils::normalizeNumberString("123"), "123");
+  EXPECT_EQ(StringUtils::normalizeNumberString("123.456"), "123.456");
+  EXPECT_EQ(StringUtils::normalizeNumberString("-123"), "-123");
+  EXPECT_EQ(StringUtils::normalizeNumberString("-123.456"), "-123.456");
+  EXPECT_EQ(StringUtils::normalizeNumberString("1e10"), "10000000000");
+  EXPECT_EQ(StringUtils::normalizeNumberString("1e-10"), "0.0000000001");
+  EXPECT_EQ(StringUtils::normalizeNumberString("123.4560000"), "123.456");
 }
 
 TEST_F(StringUtilitiesTests, normalizeNumberString_EdgeCases) {
-  EXPECT_EQ(StringUtil::normalizeNumberString(""), "");
-  EXPECT_EQ(StringUtil::normalizeNumberString("0"), "0");
-  EXPECT_EQ(StringUtil::normalizeNumberString("0.0"), "0");
-  EXPECT_EQ(StringUtil::normalizeNumberString("-0"), "-0");
-  EXPECT_EQ(StringUtil::normalizeNumberString("0.0000000001"), "0.0000000001");
-  EXPECT_EQ(StringUtil::normalizeNumberString("-0.0000000001"),
+  EXPECT_EQ(StringUtils::normalizeNumberString(""), "");
+  EXPECT_EQ(StringUtils::normalizeNumberString("0"), "0");
+  EXPECT_EQ(StringUtils::normalizeNumberString("0.0"), "0");
+  EXPECT_EQ(StringUtils::normalizeNumberString("-0"), "-0");
+  EXPECT_EQ(StringUtils::normalizeNumberString("0.0000000001"), "0.0000000001");
+  EXPECT_EQ(StringUtils::normalizeNumberString("-0.0000000001"),
             "-0.0000000001");
 }
 
 TEST_F(StringUtilitiesTests, normalizeNumberString_InvalidInput) {
-  EXPECT_EQ(StringUtil::normalizeNumberString("abc"), "");
-  EXPECT_EQ(StringUtil::normalizeNumberString("123abc"), "123");
-  EXPECT_EQ(StringUtil::normalizeNumberString("123.456.789"), "123.456");
-  EXPECT_EQ(StringUtil::normalizeNumberString("."), "");
+  EXPECT_EQ(StringUtils::normalizeNumberString("abc"), "");
+  EXPECT_EQ(StringUtils::normalizeNumberString("123abc"), "123");
+  EXPECT_EQ(StringUtils::normalizeNumberString("123.456.789"), "123.456");
+  EXPECT_EQ(StringUtils::normalizeNumberString("."), "");
 }
 
 TEST_F(StringUtilitiesTests, normalizeNumberString_PrecisionAndRounding) {
-  EXPECT_EQ(StringUtil::normalizeNumberString("123.4567890123456789"),
+  EXPECT_EQ(StringUtils::normalizeNumberString("123.4567890123456789"),
             "123.4567890123");
   // rounds up
-  EXPECT_EQ(StringUtil::normalizeNumberString("123.45678901235"),
+  EXPECT_EQ(StringUtils::normalizeNumberString("123.45678901235"),
             "123.4567890124");
 }
 
 TEST_F(StringUtilitiesTests,
        normalizeNumberString_LeadingZerosAndDecimalPoint) {
-  EXPECT_EQ(StringUtil::normalizeNumberString("0123.4500"), "123.45");
-  EXPECT_EQ(StringUtil::normalizeNumberString("0123.0"), "123");
+  EXPECT_EQ(StringUtils::normalizeNumberString("0123.4500"), "123.45");
+  EXPECT_EQ(StringUtils::normalizeNumberString("0123.0"), "123");
 }
 
 TEST_F(StringUtilitiesTests,
        normalizeNumberString_TrailingZerosAndDecimalPoint) {
-  EXPECT_EQ(StringUtil::normalizeNumberString("123.4500"), "123.45");
-  EXPECT_EQ(StringUtil::normalizeNumberString("123.0"), "123");
+  EXPECT_EQ(StringUtils::normalizeNumberString("123.4500"), "123.45");
+  EXPECT_EQ(StringUtils::normalizeNumberString("123.0"), "123");
 }
 
 TEST_F(StringUtilitiesTests, removeTrailingChars_NoTrailingChars) {
   std::string input = "aaa";
-  ETJump::StringUtil::removeTrailingChars(input, ' ');
+  StringUtils::removeTrailingChars(input, ' ');
   EXPECT_EQ(input, "aaa");
 
   input = "aaa aaa";
-  ETJump::StringUtil::removeTrailingChars(input, ' ');
+  StringUtils::removeTrailingChars(input, ' ');
   EXPECT_EQ(input, "aaa aaa");
 }
 
 TEST_F(StringUtilitiesTests, removeTrailingChars_WithTrailingChars) {
   std::string input = "aaa   ";
-  ETJump::StringUtil::removeTrailingChars(input, ' ');
+  StringUtils::removeTrailingChars(input, ' ');
   EXPECT_EQ(input, "aaa");
 }
 
 TEST_F(StringUtilitiesTests, removeTrailingChars_AllCharsToRemove) {
   std::string input = "   ";
-  ETJump::StringUtil::removeTrailingChars(input, ' ');
+  StringUtils::removeTrailingChars(input, ' ');
   EXPECT_TRUE(input.empty());
 }
 
 TEST_F(StringUtilitiesTests, removeTrailingChars_EmptyString) {
   std::string input;
-  ETJump::StringUtil::removeTrailingChars(input, ' ');
+  StringUtils::removeTrailingChars(input, ' ');
   EXPECT_TRUE(input.empty());
 }
 
 TEST_F(StringUtilitiesTests, removeLeadingChars_NoLeadingChars) {
   std::string input = "aaa";
-  ETJump::StringUtil::removeLeadingChars(input, ' ');
+  StringUtils::removeLeadingChars(input, ' ');
   EXPECT_EQ(input, "aaa");
 
   input = "aaa aaa";
-  ETJump::StringUtil::removeLeadingChars(input, ' ');
+  StringUtils::removeLeadingChars(input, ' ');
   EXPECT_EQ(input, "aaa aaa");
 }
 
 TEST_F(StringUtilitiesTests, removeLeadingChars_WithLeadingChars) {
   std::string input = "   aaa";
-  ETJump::StringUtil::removeLeadingChars(input, ' ');
+  StringUtils::removeLeadingChars(input, ' ');
   EXPECT_EQ(input, "aaa");
 }
 
 TEST_F(StringUtilitiesTests, removeLeadingChars_AllCharsToRemove) {
   std::string input = "   ";
-  ETJump::StringUtil::removeLeadingChars(input, ' ');
+  StringUtils::removeLeadingChars(input, ' ');
   EXPECT_TRUE(input.empty());
 }
 
 TEST_F(StringUtilitiesTests, removeLeadingChars_EmptyString) {
   std::string input{};
-  ETJump::StringUtil::removeLeadingChars(input, ' ');
+  StringUtils::removeLeadingChars(input, ' ');
   EXPECT_TRUE(input.empty());
 }
 
 TEST_F(StringUtilitiesTests, sortStrings_SortNoCase) {
   std::vector<std::string> vec = {"A", "c", "d", "B"};
-  ETJump::StringUtil::sortStrings(vec, true);
+  StringUtils::sortStrings(vec, true);
 
   ASSERT_EQ(vec[0], "A");
   ASSERT_EQ(vec[1], "B");
@@ -262,7 +260,7 @@ TEST_F(StringUtilitiesTests, sortStrings_SortNoCase) {
 
 TEST_F(StringUtilitiesTests, sortStrings_SortNoCase_DuplicatesKeepOrder) {
   std::vector<std::string> vec = {"a", "B", "A", "b"};
-  ETJump::StringUtil::sortStrings(vec, true);
+  StringUtils::sortStrings(vec, true);
 
   ASSERT_EQ(vec[0], "a");
   ASSERT_EQ(vec[1], "A");
@@ -272,7 +270,7 @@ TEST_F(StringUtilitiesTests, sortStrings_SortNoCase_DuplicatesKeepOrder) {
 
 TEST_F(StringUtilitiesTests, sortStrings_SortWithCase) {
   std::vector<std::string> vec = {"AB", "Ab", "aA", "aC", "AA", "Ba"};
-  ETJump::StringUtil::sortStrings(vec, false);
+  StringUtils::sortStrings(vec, false);
 
   ASSERT_EQ(vec[0], "AA");
   ASSERT_EQ(vec[1], "AB");
@@ -285,96 +283,96 @@ TEST_F(StringUtilitiesTests, sortStrings_SortWithCase) {
 TEST_F(StringUtilitiesTests, truncate_BasicTruncate) {
   const std::string in = "^1test^2test";
 
-  ASSERT_EQ(StringUtil::truncate(in, 4), "^1test");
-  ASSERT_EQ(StringUtil::truncate(in, 2), "^1te");
-  ASSERT_EQ(StringUtil::truncate(in, 8), "^1test^2test");
-  ASSERT_EQ(StringUtil::truncate(in, 10), "^1test^2test");
-  ASSERT_EQ(StringUtil::truncate(in, 11), "^1test^2test");
-  ASSERT_EQ(StringUtil::truncate(in, 12), "^1test^2test");
-  ASSERT_EQ(StringUtil::truncate(in, 13), "^1test^2test");
+  ASSERT_EQ(StringUtils::truncate(in, 4), "^1test");
+  ASSERT_EQ(StringUtils::truncate(in, 2), "^1te");
+  ASSERT_EQ(StringUtils::truncate(in, 8), "^1test^2test");
+  ASSERT_EQ(StringUtils::truncate(in, 10), "^1test^2test");
+  ASSERT_EQ(StringUtils::truncate(in, 11), "^1test^2test");
+  ASSERT_EQ(StringUtils::truncate(in, 12), "^1test^2test");
+  ASSERT_EQ(StringUtils::truncate(in, 13), "^1test^2test");
 }
 
 TEST_F(StringUtilitiesTests, truncate_InvalidInput) {
   const std::string in = "^1test^2test";
 
-  ASSERT_EQ(StringUtil::truncate(in, -1), "^1test^2test");
-  ASSERT_EQ(StringUtil::truncate("", 10), "");
+  ASSERT_EQ(StringUtils::truncate(in, -1), "^1test^2test");
+  ASSERT_EQ(StringUtils::truncate("", 10), "");
 }
 
 TEST_F(StringUtilitiesTests, truncate_LenIsInColorCode) {
   const std::string in = "^1test^2test";
 
-  ASSERT_EQ(StringUtil::truncate(in, 5), "^1test^2t");
-  ASSERT_EQ(StringUtil::truncate(in, 6), "^1test^2te");
+  ASSERT_EQ(StringUtils::truncate(in, 5), "^1test^2t");
+  ASSERT_EQ(StringUtils::truncate(in, 6), "^1test^2te");
 }
 
 TEST_F(StringUtilitiesTests, truncate_MultipleCarets) {
   const std::string in = "^^1test^^^2test";
 
-  ASSERT_EQ(StringUtil::truncate(in, 1), "^");
-  ASSERT_EQ(StringUtil::truncate(in, 3), "^^1te");
-  ASSERT_EQ(StringUtil::truncate(in, 6), "^^1test^");
-  ASSERT_EQ(StringUtil::truncate(in, 7), "^^1test^^");
-  ASSERT_EQ(StringUtil::truncate(in, 9), "^^1test^^^2te");
+  ASSERT_EQ(StringUtils::truncate(in, 1), "^");
+  ASSERT_EQ(StringUtils::truncate(in, 3), "^^1te");
+  ASSERT_EQ(StringUtils::truncate(in, 6), "^^1test^");
+  ASSERT_EQ(StringUtils::truncate(in, 7), "^^1test^^");
+  ASSERT_EQ(StringUtils::truncate(in, 9), "^^1test^^^2te");
 }
 
 TEST_F(StringUtilitiesTests, sanitize_basicSanitize) {
-  ASSERT_EQ(sanitize("^1test ^2test"), "test test");
-  ASSERT_EQ(sanitize("test TEST"), "test TEST");
-  ASSERT_EQ(sanitize("test^1 TEST"), "test TEST");
-  ASSERT_EQ(sanitize("test test^1"), "test test");
+  ASSERT_EQ(StringUtils::sanitize("^1test ^2test"), "test test");
+  ASSERT_EQ(StringUtils::sanitize("test TEST"), "test TEST");
+  ASSERT_EQ(StringUtils::sanitize("test^1 TEST"), "test TEST");
+  ASSERT_EQ(StringUtils::sanitize("test test^1"), "test test");
 }
 
 TEST_F(StringUtilitiesTests, sanitize_lowercasesCorrectly) {
-  ASSERT_EQ(sanitize("^1TEST ^2test", true), "test test");
-  ASSERT_EQ(sanitize("Test TEST", true), "test test");
-  ASSERT_EQ(sanitize("TEST^1 teST", true), "test test");
-  ASSERT_EQ(sanitize("TEST TeSt^1", true), "test test");
+  ASSERT_EQ(StringUtils::sanitize("^1TEST ^2test", true), "test test");
+  ASSERT_EQ(StringUtils::sanitize("Test TEST", true), "test test");
+  ASSERT_EQ(StringUtils::sanitize("TEST^1 teST", true), "test test");
+  ASSERT_EQ(StringUtils::sanitize("TEST TeSt^1", true), "test test");
 }
 
 TEST_F(StringUtilitiesTests, sanitize_handlesControlCharacters) {
   const std::string in = "^1te\x19=st ^2TEST";
 
-  ASSERT_EQ(sanitize(in), "te=st TEST");
-  ASSERT_EQ(sanitize(in, true, false), "te\x19=st test");
+  ASSERT_EQ(StringUtils::sanitize(in), "te=st TEST");
+  ASSERT_EQ(StringUtils::sanitize(in, true, false), "te\x19=st test");
 }
 
 TEST_F(StringUtilitiesTests, sanitize_multipleCarets) {
   const std::string in = "^^1test ^^^2TEST";
 
-  ASSERT_EQ(sanitize(in), "^test ^^TEST");
-  ASSERT_EQ(sanitize(in, true), "^test ^^test");
+  ASSERT_EQ(StringUtils::sanitize(in), "^test ^^TEST");
+  ASSERT_EQ(StringUtils::sanitize(in, true), "^test ^^test");
 }
 
 TEST_F(StringUtilitiesTests, sanitize_handlesEndingCarets) {
-  ASSERT_EQ(sanitize("test test^"), "test test^");
-  ASSERT_EQ(sanitize("test test^^"), "test test^^");
+  ASSERT_EQ(StringUtils::sanitize("test test^"), "test test^");
+  ASSERT_EQ(StringUtils::sanitize("test test^^"), "test test^^");
 }
 
 TEST_F(StringUtilitiesTests, stripExtension_stripsCorrectly) {
   std::string in = "test.dat";
-  StringUtil::stripExtension(in);
+  StringUtils::stripExtension(in);
 
   ASSERT_EQ(in, "test");
 }
 
 TEST_F(StringUtilitiesTests, stripExtension_handlesEmptyString) {
   std::string in = "";
-  StringUtil::stripExtension(in);
+  StringUtils::stripExtension(in);
 
   ASSERT_EQ(in, "");
 }
 
 TEST_F(StringUtilitiesTests, stripExtension_stripsOnlyLastExt) {
   std::string in = "test.dat.dat";
-  StringUtil::stripExtension(in);
+  StringUtils::stripExtension(in);
 
   ASSERT_EQ(in, "test.dat");
 }
 
 TEST_F(StringUtilitiesTests, stripExtension_noExtIsUnmodified) {
   std::string in = "test";
-  StringUtil::stripExtension(in);
+  StringUtils::stripExtension(in);
 
   ASSERT_EQ(in, "test");
 }


### PR DESCRIPTION
* All functions inside `etj_string_utilities.cpp/h` are now inside `StringUtils` namespace. Previously, some of them were inside `ETJump`, some inside `StringUtil`, some inside both.
* Renamed `stringFormat` to `format`, as the namespacing makes it quite clear what it's doing.