### PR TITLE
Delete portals fired on func_static_client when it's turned off

### DIFF
--- a/src/game/etj_portalgun.cpp
+++ b/src/game/etj_portalgun.cpp
@@ -98,6 +98,8 @@ void Portal::spawn(gentity_t *ent, const float scale, const Type type,
     portal->linkedPortal->think(portal->linkedPortal);
   }
 
+  portal->free = free;
+
   portal->r.ownerNum = ent->s.number;
   portal->parent = ent;
 
@@ -113,6 +115,10 @@ void Portal::spawn(gentity_t *ent, const float scale, const Type type,
   // rather than using the shared cvar, we can simply set 'portalteam'
   // value to an entitystate field that we can check on client
   portal->s.teamNum = level.portalTeam;
+
+  if (tr.entityNum < ENTITYNUM_MAX_NORMAL) {
+    portal->portalParentEntity = &g_entities[tr.entityNum];
+  }
 
   trap_LinkEntity(portal);
 }
@@ -136,7 +142,18 @@ void Portal::think(gentity_t *self) {
     }
   }
 
-  // we should think *every* frame to ensure up-to-date positons
+  // TODO: make this more generic for other entities that might disappear
+  // during runtime, such as 'func_static', 'func_explosive' etc.
+  // also, add possibility to move the portals along with movers?
+  if (self->portalParentEntity &&
+      self->portalParentEntity->s.eType == ET_STATIC_CLIENT &&
+      EntityUtilsShared::funcStaticClientIsHidden(&self->portalParentEntity->s,
+                                                  self->r.ownerNum)) {
+    G_FreeEntity(self);
+    return;
+  }
+
+  // we should think *every* frame to ensure up-to-date positions
   self->nextthink = level.time + level.frameTime;
 }
 
@@ -206,6 +223,30 @@ void Portal::touch(gentity_t *self, gentity_t *other) {
   EntityUtilsShared::portalTeleport(&other->client->ps, &other->s, &self->s,
                                     &other->client->pers.cmd, level.time,
                                     other->client->teleportBitFlipped);
+}
+
+void Portal::free(gentity_t *self) {
+  gentity_t *owner = &g_entities[self->r.ownerNum];
+
+  if (self->s.eType == ET_PORTAL_BLUE) {
+    owner->portalBlue = nullptr;
+
+    if (owner->portalRed) {
+      owner->portalRed->linkedPortal = nullptr;
+      // clear destination so prediction will not try to teleport
+      VectorClear(owner->portalRed->s.origin2);
+      VectorClear(owner->portalRed->s.angles2);
+    }
+  } else {
+    owner->portalRed = nullptr;
+
+    if (owner->portalBlue) {
+      owner->portalBlue->linkedPortal = nullptr;
+      // clear destination so prediction will not try to teleport
+      VectorClear(owner->portalBlue->s.origin2);
+      VectorClear(owner->portalBlue->s.angles2);
+    }
+  }
 }
 
 void Portalgun::spawn(gentity_t *ent) {

--- a/src/game/etj_portalgun.h
+++ b/src/game/etj_portalgun.h
@@ -38,6 +38,7 @@ public:
                     vec3_t end, const vec3_t angles);
   static void think(gentity_t *self);
   static void touch(gentity_t *self, gentity_t *other);
+  static void free(gentity_t *self);
 };
 
 class Portalgun {

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -596,6 +596,9 @@ struct gentity_s {
   // Zero - other portal so we know where to go
   // when someone goes in a team portal
   gentity_t *linkedPortal;
+  // the entity that the portal was fired onto, used to delete a portal
+  // that was fired onto 'func_static_client' that gets turned off
+  gentity_t *portalParentEntity;
 
   int runIndex;
   char runName[MAX_TIMERUN_NAME_LENGTH];


### PR DESCRIPTION
When a client turns off `func_static_client`, any portals that are fired on it will be deleted, so that they don't float in the air.

refs #1824, #1839 