### PR TITLE
Add spawnflag 4 to func_static_client for fireteam teamjump mode syncing

### DIFF
--- a/src/game/etj_func_static_client.cpp
+++ b/src/game/etj_func_static_client.cpp
@@ -23,10 +23,12 @@
  */
 
 #include "etj_func_static_client.h"
+#include "etj_entity_utilities_shared.h"
 
 namespace ETJump {
 inline constexpr int32_t SF_START_INVIS = 1 << 0;
 inline constexpr int32_t SF_GIB_INSIDE = 1 << 1;
+inline constexpr int32_t SF_FT_TEAMJUMP_SYNC = 1 << 2;
 
 /*
  * 'ent->s.effect1Time' and 'ent->s.effect2Time' are treated as boolean
@@ -145,5 +147,26 @@ bool FuncStaticClient::activatorIsInsideEnt(const gentity_t *self,
   }
 
   return false;
+}
+
+void FuncStaticClient::syncToFireteamLeaderState(const int32_t clientNum,
+                                                 const int32_t leaderNum) {
+  for (int32_t i = MAX_CLIENTS + BODY_QUEUE_SIZE; i < level.num_entities; i++) {
+    gentity_t *ent = &g_entities[i];
+
+    if (ent->s.eType != ET_STATIC_CLIENT) {
+      continue;
+    }
+
+    if (!(ent->spawnflags & SF_FT_TEAMJUMP_SYNC)) {
+      continue;
+    }
+
+    if (EntityUtilsShared::funcStaticClientIsHidden(&ent->s, leaderNum)) {
+      turnOff(ent, clientNum);
+    } else {
+      turnOn(ent, clientNum);
+    }
+  }
 }
 } // namespace ETJump

--- a/src/game/etj_func_static_client.h
+++ b/src/game/etj_func_static_client.h
@@ -34,5 +34,6 @@ public:
   static void turnOn(gentity_t *self, int32_t clientNum);
   static void turnOff(gentity_t *self, int32_t clientNum);
   static bool activatorIsInsideEnt(const gentity_t *self, int32_t clientNum);
+  static void syncToFireteamLeaderState(int32_t clientNum, int32_t leaderNum);
 };
 } // namespace ETJump

--- a/src/game/g_fireteams.cpp
+++ b/src/game/g_fireteams.cpp
@@ -1,3 +1,4 @@
+#include "etj_func_static_client.h"
 #include "g_local.h"
 #include "etj_printer.h"
 #include "etj_string_utilities.h"
@@ -324,6 +325,11 @@ void G_AddClientToFireteam(int entityNum, int leaderNum) {
         Printer::console(otherEnt,
                          "Your portals have been reset due to ^3'portalteam' "
                          "^7setting of the current map.\n");
+      }
+
+      if (ft->teamJumpMode) {
+        ETJump::FuncStaticClient::syncToFireteamLeaderState(entityNum,
+                                                            leaderNum);
       }
 
       G_UpdateFireteamConfigString(ft);
@@ -779,6 +785,13 @@ void setFireteamTeamjumpMode(fireteamData_t *ft, const bool teamjumpMode) {
     }
 
     Printer::popup(ft->joinOrder[i], msg);
+
+    // sync 'func_static_client' entities for members to match leader's state,
+    // if we're enabling teamjump mode
+    if (i != 0 && ft->teamJumpMode) {
+      FuncStaticClient::syncToFireteamLeaderState(ft->joinOrder[i],
+                                                  ft->joinOrder[0]);
+    }
   }
 }
 


### PR DESCRIPTION
If set, the state of the entity will be synced to match the fireteam leader's state whenever teamjump mode gets enabled, or a player joins the fireteam when teamjump mode is enabled. This guarantees that any entities that might be toggled via `target_ftrelay` never end up in a state where they are in a different state for some of the fireteam members, requiring the players to manually fix the state by turning off teamjump mode, or by leaving the fireteam, changing the state, and re-joining.

refs #1824, #1839