### PR TITLE
Add high-res, anti-aliased drawing for CGaz2

### DIFF
--- a/assets/ui/etjump_settings_hud2_cgaz.menu
+++ b/assets/ui/etjump_settings_hud2_cgaz.menu
@@ -76,6 +76,9 @@ menuDef {
         SLIDER              (SETTINGS_ITEM_POS(18), "CGaz fixed wishdir speed:", 0.2, SETTINGS_ITEM_H, etj_CGaz2WishDirFixedSpeed 0 0 6500 50, "Fixed speed value to use for drawing CGaz 2 wishdir, 0 to use default\netj_CGaz2WishDirFixedSpeed")
         YESNO               (SETTINGS_ITEM_POS(19), "Draw midline:", 0.2, SETTINGS_ITEM_H, "etj_CGaz1DrawMidline", "Draw the middle point in-between min and max angles on CGaz 1\netj_CGaz1DrawMidline")
         COMBO               (SETTINGS_COMBO_POS(20), "Midline color:", 0.2, SETTINGS_ITEM_H, "etj_CGaz1MidlineColor", COLOR_LIST, uiScript uiPreviousMenu MENU_NAME, "Sets midline color of CGaz 1\netj_CGaz1MidlineColor")
+        YESNO               (SETTINGS_ITEM_POS(21), "High resolution CGaz2:", 0.2, SETTINGS_ITEM_H, "etj_CGaz2HighRes", "Enable high-resolution, anti-aliased drawing for CGaz2\netj_CGaz2HighRes")
+        CVARFLOATLABEL      (SETTINGS_ITEM_POS(22), "etj_CGaz2Thickness", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(22), "CGaz 2 line thickness:", 0.2, SETTINGS_ITEM_H, etj_CGaz2Thickness 2 0.5 5 0.1, "Line thickness for CGaz2, requires etj_CGaz2HighRes to apply\netj_CGaz2Thickness")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -181,56 +181,180 @@ range_t AnglesToRange(float start, float end, float yaw, float fov) {
   return ret;
 }
 
-void DrawLine(float x1, float y1, float x2, float y2, const vec4_t color) {
-  DrawLine(x1, y1, x2, y2, 1, 1, color);
+void drawLineDDA(float x0, float y0, float x1, float y1, const vec4_t color) {
+  drawLineDDA(x0, y0, x1, y1, 1, 1, color);
 }
 
-/*
-==============
-DrawLine
-Mainly used for drawing diagonal lines
-==============
-*/
-// Dzikie
-void DrawLine(float x1, float y1, float x2, float y2, float w, float h,
-              const vec4_t color) {
-  float len, stepX, stepY;
+// line drawing using Digital Differential Analyzer with slight modifications
+// https://en.wikipedia.org/wiki/Digital_differential_analyzer_(graphics_algorithm)
+// we use euclidean distance to endpoint rather than dominant axis
+// to determine the next step for the line, as this tends to produce
+// better results when drawing to the virtual grid and scaling from there
+void drawLineDDA(float x0, float y0, float x1, float y1, float w, float h,
+                 const vec4_t color) {
+  float len{};
+  float stepX{};
+  float stepY{};
   float i = 0;
 
-  if (x1 == x2 && y1 == y2) {
+  if (x0 == x1 && y0 == y1) {
     return;
   }
 
-  const auto scrw = static_cast<float>(SCREEN_WIDTH);
-  const auto scrh = static_cast<float>(SCREEN_HEIGHT);
+  const auto scrW = static_cast<float>(SCREEN_WIDTH);
+  const auto scrH = static_cast<float>(SCREEN_HEIGHT);
 
   trap_R_SetColor(color);
 
   // Use a single DrawPic for horizontal or vertical lines
-  if (x1 == x2) {
-    x1 = std::clamp(x1, 0.0f, scrw);
+  if (x0 == x1) {
+    x0 = std::clamp(x0, 0.0f, scrW);
 
-    CG_DrawPic(x1, std::min(y1, y2), w, std::abs(y1 - y2),
+    CG_DrawPic(x0, std::min(y0, y1), w, std::abs(y0 - y1),
                cgs.media.whiteShader);
-  } else if (y1 == y2) {
-    y1 = std::clamp(y1, 0.0f, scrh);
+  } else if (y0 == y1) {
+    y0 = std::clamp(y0, 0.0f, scrH);
 
-    CG_DrawPic(std::min(x1, x2), y1, std::abs(x1 - x2), h,
+    CG_DrawPic(std::min(x0, x1), y0, std::abs(x0 - x1), h,
                cgs.media.whiteShader);
   } else {
-    len = (x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1);
+    len = ((x1 - x0) * (x1 - x0)) + ((y1 - y0) * (y1 - y0));
     len = std::sqrt(len);
-    stepX = (x2 - x1) / len;
-    stepY = (y2 - y1) / len;
+    stepX = (x1 - x0) / len;
+    stepY = (y1 - y0) / len;
 
     while (i < len) {
-      if (x1 >= 0 && x1 <= scrw && y1 >= 0 && y1 <= scrh) {
-        CG_DrawPic(x1, y1, w, h, cgs.media.whiteShader);
+      // only draw pixels that are in the screen space
+      if (x0 >= 0 && x0 <= scrW && y0 >= 0 && y0 <= scrH) {
+        CG_DrawPic(x0, y0, w, h, cgs.media.whiteShader);
       }
-      x1 += stepX;
-      y1 += stepY;
+
+      x0 += stepX;
+      y0 += stepY;
       i++;
     }
+  }
+
+  trap_R_SetColor(nullptr);
+}
+
+void drawLineWu(float x0, float y0, float x1, float y1, const vec4_t color) {
+  drawLineWu(x0, y0, x1, y1, 1, 1, color);
+}
+
+// anti-aliased line drawing using Xiaolin Wu's line algorithm
+// https://en.wikipedia.org/wiki/Xiaolin_Wu's_line_algorithm
+// NOTE: this is a relatively expensive function, as it always draws
+// the lines on real pixel coordinates rather than virtual grid
+void drawLineWu(float x0, float y0, float x1, float y1, const float w,
+                const float h, const vec4_t color) {
+  const auto putPixel = [&](int32_t x, int32_t y, float brightness) {
+    vec4_t c = {color[0], color[1], color[2], color[3] * brightness};
+    trap_R_SetColor(c);
+    drawPicNoScale(static_cast<float>(x), static_cast<float>(y), w, h,
+                   cgs.media.whiteShader);
+  };
+
+  const auto fpart = [](const float x) { return x - std::floor(x); };
+  const auto rfpart = [fpart](const float x) { return 1.0f - fpart(x); };
+  const auto ipart = [](const float x) {
+    return static_cast<int>(std::floor(x));
+  };
+
+  if (x0 == x1 && y0 == y1) {
+    return;
+  }
+
+  // convert the x/y points to real screen coordinates
+  // before we start plotting the line for high resolution drawing
+  CG_AdjustFrom640(&x0, &y0, nullptr, nullptr);
+  CG_AdjustFrom640(&x1, &y1, nullptr, nullptr);
+
+  const auto scrW = static_cast<float>(cgs.glconfig.vidWidth);
+  const auto scrH = static_cast<float>(cgs.glconfig.vidHeight);
+
+  // for axial lines, we can use a single draw call
+  if (x0 == x1) {
+    x0 = std::clamp(x0, 0.0f, scrW);
+
+    trap_R_SetColor(color);
+    drawPicNoScale(x0, std::min(y0, y1), w, std::abs(y0 - y1),
+                   cgs.media.whiteShader);
+    trap_R_SetColor(nullptr);
+    return;
+  }
+
+  if (y0 == y1) {
+    y0 = std::clamp(y0, 0.0f, scrH);
+
+    trap_R_SetColor(color);
+    drawPicNoScale(std::min(x0, x1), y0, std::abs(x0 - x1), h,
+                   cgs.media.whiteShader);
+    trap_R_SetColor(nullptr);
+    return;
+  }
+
+  // determine the direction for drawing, and swap the coordinates around
+  // accordingly, so that we're always drawing right and down
+  const bool steep = std::abs(y1 - y0) > std::abs(x1 - x0);
+
+  if (steep) {
+    std::swap(x0, y0);
+    std::swap(x1, y1);
+  }
+
+  if (x0 > x1) {
+    std::swap(x0, x1);
+    std::swap(y0, y1);
+  }
+
+  const float dx = x1 - x0;
+  const float dy = y1 - y0;
+  const float gradient = (dx == 0.0f) ? 1.0f : dy / dx;
+
+  const auto putEndPixel = [&](const float px, const float py,
+                               const float xGap) {
+    const float xEnd = std::round(px);
+    const float yEnd = py + (gradient * (xEnd - px));
+
+    const auto xPixel = static_cast<int32_t>(xEnd);
+    const int32_t y = ipart(yEnd);
+
+    if (steep) {
+      putPixel(y, xPixel, rfpart(yEnd) * xGap);
+      putPixel(y + 1, xPixel, fpart(yEnd) * xGap);
+    } else {
+      putPixel(xPixel, y, rfpart(yEnd) * xGap);
+      putPixel(xPixel, y + 1, fpart(yEnd) * xGap);
+    }
+
+    return std::pair<int32_t, float>(xPixel, yEnd);
+  };
+
+  // draw and store the end points first
+  const auto [xPixel1, yEnd1] = putEndPixel(x0, y0, rfpart(x0 + 0.5f));
+  float interY = yEnd1 + gradient;
+  const auto [xPixel2, yEnd2] = putEndPixel(x1, y1, fpart(x1 + 0.5f));
+
+  // main loop, plot the line between the start and end points
+  // we bounds check the coordinates and skip anything
+  // that is outside of the screen space
+  for (int x = xPixel1 + 1; x < xPixel2; x++) {
+    if (steep) {
+      if (ipart(interY) >= 0 && ipart(interY) < static_cast<int32_t>(scrW) &&
+          x >= 0 && x < static_cast<int32_t>(scrH)) {
+        putPixel(ipart(interY), x, rfpart(interY));
+        putPixel(ipart(interY) + 1, x, fpart(interY));
+      }
+    } else {
+      if (x >= 0 && x < static_cast<int32_t>(scrW) && ipart(interY) >= 0 &&
+          ipart(interY) < static_cast<int32_t>(scrH)) {
+        putPixel(x, ipart(interY), rfpart(interY));
+        putPixel(x, ipart(interY) + 1, fpart(interY));
+      }
+    }
+
+    interY += gradient;
   }
 
   trap_R_SetColor(nullptr);
@@ -345,9 +469,9 @@ void DrawTriangle(float x, float y, float w, float h, float lineW, float angle,
   }
 
   // draw outer edges clockwise, starting from p1
-  DrawLine(p1.x, p1.y, p2.x, p2.y, lineW, lineW, color);
-  DrawLine(p2.x, p2.y, p3.x, p3.y, lineW, lineW, color);
-  DrawLine(p3.x, p3.y, p1.x, p1.y, lineW, lineW, color);
+  drawLineDDA(p1.x, p1.y, p2.x, p2.y, lineW, lineW, color);
+  drawLineDDA(p2.x, p2.y, p3.x, p3.y, lineW, lineW, color);
+  drawLineDDA(p3.x, p3.y, p1.x, p1.y, lineW, lineW, color);
 }
 
 /*
@@ -541,6 +665,37 @@ void CG_DrawRect_FixedBorder(float x, float y, float width, float height,
   CG_DrawSides_NoScale(x, y, width, height, border);
 
   trap_R_SetColor(NULL);
+}
+
+// coordinates are real pixel coordinates
+void drawPicNoScale(const float x, const float y, float w, float h,
+                    const qhandle_t shader) {
+  float s0{};
+  float s1{};
+  float t0{};
+  float t1{};
+
+  if (w < 0) // flip about vertical
+  {
+    w = -w;
+    s0 = 1;
+    s1 = 0;
+  } else {
+    s0 = 0;
+    s1 = 1;
+  }
+
+  if (h < 0) // flip about horizontal
+  {
+    h = -h;
+    t0 = 1;
+    t1 = 0;
+  } else {
+    t0 = 0;
+    t1 = 1;
+  }
+
+  trap_R_DrawStretchPic(x, y, w, h, s0, t0, s1, t1, shader);
 }
 
 /*

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2372,6 +2372,8 @@ extern vmCvar_t etj_CGaz2WishDirFixedSpeed;
 extern vmCvar_t etj_CGaz2WishDirUniformLength;
 extern vmCvar_t etj_CGaz1DrawMidLine;
 extern vmCvar_t etj_CGaz1MidlineColor;
+extern vmCvar_t etj_CGaz2HighRes;
+extern vmCvar_t etj_CGaz2Thickness;
 
 extern vmCvar_t etj_drawOB;
 // Aciz: movable drawOB
@@ -2839,9 +2841,12 @@ void CG_FillAngleYaw(float start, float end, float yaw, float y, float h,
 void CG_FillAngleYawExt(float start, float end, float yaw, float y, float h,
                         float fov, vec4_t const color, bool borderOnly,
                         float borderThickness);
-void DrawLine(float x1, float y1, float x2, float y2, const vec4_t color);
-void DrawLine(float x1, float y1, float x2, float y2, float w, float h,
-              const vec4_t color);
+void drawLineDDA(float x0, float y0, float x1, float y1, const vec4_t color);
+void drawLineDDA(float x0, float y0, float x1, float y1, float w, float h,
+                 const vec4_t color);
+void drawLineWu(float x0, float y0, float x1, float y1, float w, float h,
+                const vec4_t color);
+void drawLineWu(float x0, float y0, float x1, float y1, const vec4_t color);
 void DrawTriangle(float x, float y, float w, float h, float lineW, float angle,
                   bool fill, const vec4_t color,
                   const vec4_t fillColor = nullptr);
@@ -2849,6 +2854,7 @@ float AngleToScreenX(float angle, float fov);
 range_t AnglesToRange(float start, float end, float yaw, float fov);
 void CG_HorizontalPercentBar(float x, float y, float width, float height,
                              float percent);
+void drawPicNoScale(float x, float y, float w, float h, qhandle_t shader);
 void CG_DrawPic(float x, float y, float width, float height, qhandle_t hShader);
 void CG_DrawPicST(float x, float y, float width, float height, float s0,
                   float t0, float s1, float t1, qhandle_t hShader);

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -311,6 +311,8 @@ vmCvar_t etj_CGaz2WishDirFixedSpeed;
 vmCvar_t etj_CGaz2WishDirUniformLength;
 vmCvar_t etj_CGaz1DrawMidLine;
 vmCvar_t etj_CGaz1MidlineColor;
+vmCvar_t etj_CGaz2HighRes;
+vmCvar_t etj_CGaz2Thickness;
 
 vmCvar_t etj_drawOB;
 // Aciz: movable drawOB
@@ -924,6 +926,8 @@ cvarTable_t cvarTable[] = {
     {&etj_CGaz1DrawMidLine, "etj_CGaz1DrawMidLine", "0", CVAR_ARCHIVE},
     {&etj_CGaz1MidlineColor, "etj_CGaz1MidlineColor", "1.0 0.5 0.0 0.75",
      CVAR_ARCHIVE},
+    {&etj_CGaz2HighRes, "etj_CGaz2HighRes", "1", CVAR_ARCHIVE},
+    {&etj_CGaz2Thickness, "etj_CGaz2Thickness", "2", CVAR_ARCHIVE},
 
     {&cl_yawspeed, "cl_yawspeed", "0", CVAR_ARCHIVE},
     {&cl_freelook, "cl_freelook", "1", CVAR_ARCHIVE},

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -65,6 +65,7 @@ CGaz::CGaz(const std::shared_ptr<CvarUpdateHandler> &cvarUpdate)
   cgame.utils.colorParser->parseColorString(etj_CGaz2Color2.string,
                                             CGaz2Colors[1]);
 
+  setThickness(&etj_CGaz2Thickness);
   startListeners();
 }
 
@@ -77,6 +78,7 @@ CGaz::~CGaz() {
 
   cvarUpdate->unsubscribe(&etj_CGaz2Color1);
   cvarUpdate->unsubscribe(&etj_CGaz2Color2);
+  cvarUpdate->unsubscribe(&etj_CGaz2Thickness);
 }
 
 void CGaz::startListeners() {
@@ -109,6 +111,13 @@ void CGaz::startListeners() {
   cvarUpdate->subscribe(&etj_CGaz2Color2, [this](const vmCvar_t *cvar) {
     cgame.utils.colorParser->parseColorString(cvar->string, CGaz2Colors[1]);
   });
+
+  cvarUpdate->subscribe(&etj_CGaz2Thickness,
+                        [this](const vmCvar_t *cvar) { setThickness(cvar); });
+}
+
+void CGaz::setThickness(const vmCvar_t *cvar) {
+  thickness = std::clamp(cvar->value, 0.5f, 5.0f);
 }
 
 void CGaz::UpdateCGaz1(vec3_t wishvel, const int8_t uCmdScale) const {
@@ -359,6 +368,8 @@ void CGaz::render() const {
       scx -= SCREEN_OFFSET_X;
     }
 
+    const bool highRes = etj_CGaz2HighRes.integer;
+
     // draw movement keys direction
     if (cmd.rightmove || cmd.forwardmove) {
       float mult = 1.0f;
@@ -375,9 +386,15 @@ void CGaz::render() const {
         mult /= sqrt2;
       }
 
-      DrawLine(scx, scy, scx + mult * static_cast<float>(cmd.rightmove),
-               scy - mult * static_cast<float>(cmd.forwardmove),
-               CGaz2Colors[1]);
+      if (highRes) {
+        drawLineWu(scx, scy, scx + (mult * static_cast<float>(cmd.rightmove)),
+                   scy - (mult * static_cast<float>(cmd.forwardmove)),
+                   thickness, thickness, CGaz2Colors[1]);
+      } else {
+        drawLineDDA(scx, scy, scx + (mult * static_cast<float>(cmd.rightmove)),
+                    scy - (mult * static_cast<float>(cmd.forwardmove)),
+                    CGaz2Colors[1]);
+      }
     }
 
     // When under wishspeed velocity, most accel happens when
@@ -386,7 +403,7 @@ void CGaz::render() const {
     const bool drawSides = state.vf > state.wishspeed;
 
     // minline length, either fixed or from current speed
-    float velSize;
+    float velSize{};
 
     if (etj_CGaz2FixedSpeed.value > 0) {
       velSize = etj_CGaz2FixedSpeed.value / 5.0f;
@@ -403,16 +420,34 @@ void CGaz::render() const {
         dirSize = std::min(static_cast<float>(CMDSCALE_DEFAULT), dirSize);
       }
 
-      DrawLine(scx, scy, scx + dirSize * std::sin(drawVel),
-               scy - dirSize * std::cos(drawVel), CGaz2Colors[0]);
+      if (highRes) {
+        drawLineWu(scx, scy, scx + (dirSize * std::sin(drawVel)),
+                   scy - (dirSize * std::cos(drawVel)), thickness, thickness,
+                   CGaz2Colors[0]);
+      } else {
+        drawLineDDA(scx, scy, scx + (dirSize * std::sin(drawVel)),
+                    scy - (dirSize * std::cos(drawVel)), CGaz2Colors[0]);
+      }
     }
 
     if (drawSides) {
       velSize /= 2;
-      DrawLine(scx, scy, scx + velSize * std::sin(drawVel + drawOpt),
-               scy - velSize * std::cos(drawVel + drawOpt), CGaz2Colors[0]);
-      DrawLine(scx, scy, scx + velSize * std::sin(drawVel - drawOpt),
-               scy - velSize * std::cos(drawVel - drawOpt), CGaz2Colors[0]);
+
+      if (highRes) {
+        drawLineWu(scx, scy, scx + (velSize * std::sin(drawVel + drawOpt)),
+                   scy - (velSize * std::cos(drawVel + drawOpt)), thickness,
+                   thickness, CGaz2Colors[0]);
+        drawLineWu(scx, scy, scx + (velSize * std::sin(drawVel - drawOpt)),
+                   scy - (velSize * std::cos(drawVel - drawOpt)), thickness,
+                   thickness, CGaz2Colors[0]);
+      } else {
+        drawLineDDA(scx, scy, scx + (velSize * std::sin(drawVel + drawOpt)),
+                    scy - (velSize * std::cos(drawVel + drawOpt)),
+                    CGaz2Colors[0]);
+        drawLineDDA(scx, scy, scx + (velSize * std::sin(drawVel - drawOpt)),
+                    scy - (velSize * std::cos(drawVel - drawOpt)),
+                    CGaz2Colors[0]);
+      }
     }
 
     if (etj_stretchCgaz.integer) {

--- a/src/cgame/etj_cgaz.h
+++ b/src/cgame/etj_cgaz.h
@@ -74,7 +74,9 @@ private:
   vec4_t CGaz2Colors[2]{};
   vec4_t CGaz1MidlineColor{};
 
-  bool canSkipDraw() const;
+  float thickness{};
+
+  [[nodiscard]] bool canSkipDraw() const;
   void UpdateCGaz1(vec3_t wishvel, int8_t uCmdScale) const;
   void UpdateCGaz2() const;
   static float GetSlickGravity(const playerState_t *ps, const pmove_t *pm);
@@ -85,6 +87,7 @@ private:
   static float UpdateDrawSnap(const playerState_t *ps, const pmove_t *pm);
   static void UpdateDraw(float wishspeed, const playerState_t *ps,
                          const pmove_t *pm);
+  void setThickness(const vmCvar_t *cvar);
   void startListeners();
 
   const playerState_t *ps = &cg.predictedPlayerState;

--- a/src/cgame/etj_crosshair_drawer.cpp
+++ b/src/cgame/etj_crosshair_drawer.cpp
@@ -78,32 +78,32 @@ void CrosshairDrawer::drawCross(const crosshair_t &crosshair,
 
 void CrosshairDrawer::drawDiagCross(const crosshair_t &crosshair) {
   // top-left -> bottom-right
-  DrawLine(crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
-           crosshair.y - (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
-           crosshair.x + (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
-           crosshair.y + (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
-           crosshair.t, crosshair.t, crosshair.color);
+  drawLineDDA(crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+              crosshair.y - (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
+              crosshair.x + (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+              crosshair.y + (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
+              crosshair.t, crosshair.t, crosshair.color);
   // top-right -> bottom-left
-  DrawLine(crosshair.x + (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
-           crosshair.y - (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
-           crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
-           crosshair.y + (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
-           crosshair.t, crosshair.t, crosshair.colorAlt);
+  drawLineDDA(crosshair.x + (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+              crosshair.y - (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
+              crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+              crosshair.y + (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
+              crosshair.t, crosshair.t, crosshair.colorAlt);
 }
 
 void CrosshairDrawer::drawV(const crosshair_t &crosshair) {
   // left line
-  DrawLine(crosshair.x - (crosshair.t * 0.5f),
-           crosshair.y - (crosshair.t * 0.5f),
-           crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
-           crosshair.y + crosshair.h - (crosshair.t * 0.5f), crosshair.t,
-           crosshair.t, crosshair.color);
+  drawLineDDA(crosshair.x - (crosshair.t * 0.5f),
+              crosshair.y - (crosshair.t * 0.5f),
+              crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+              crosshair.y + crosshair.h - (crosshair.t * 0.5f), crosshair.t,
+              crosshair.t, crosshair.color);
   // right line
-  DrawLine(crosshair.x - (crosshair.t * 0.5f),
-           crosshair.y - (crosshair.t * 0.5f),
-           crosshair.x + (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
-           crosshair.y + crosshair.h - (crosshair.t * 0.5f), crosshair.t,
-           crosshair.t, crosshair.colorAlt);
+  drawLineDDA(crosshair.x - (crosshair.t * 0.5f),
+              crosshair.y - (crosshair.t * 0.5f),
+              crosshair.x + (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
+              crosshair.y + crosshair.h - (crosshair.t * 0.5f), crosshair.t,
+              crosshair.t, crosshair.colorAlt);
 }
 
 void CrosshairDrawer::drawTriangle(const crosshair_t &crosshair,


### PR DESCRIPTION
Adds an alternative, high resolution drawing for CGaz2, using Xiaolin Wu's line drawing algorithm. This is an anti-aliased line drawing algorithm, which is performed on real pixel coordinates rather than the virtual grid for accuracy. This new drawing is enabled by default, and can be turned off with the `etj_CGaz2HighRes` cvar. Accommodating this is also `etj_CGaz2Thickness` cvar, which controls the line thickness. This is only applied to the high-res drawing, and defaults to 2, which is visually close to the original drawing. The valid range is 0.5 - 5.0.

This drawing is relatively expensive compared to the old method (about 4-5x slower), but the absolute cost is still quite reasonable (~65000ns on a Ryzen 7 3700X). The more concerning part is the amount of draw calls that this generates, which might cause issues on 2.60b, but oh well, you can't have it all.

Old:
<img width="800" height="800" alt="old" src="https://github.com/user-attachments/assets/96beb8a0-740d-4e08-955c-eaf4e29b0560" />

New:
<img width="800" height="800" alt="new" src="https://github.com/user-attachments/assets/6017f4c4-7d23-4d8e-b5ed-e1ed9bc35b3a" />

fixes #1861 