### PR TITLE
Allow deleting portals inside func_static_client when it turns solid

### DIFF
--- a/src/game/etj_func_static_client.cpp
+++ b/src/game/etj_func_static_client.cpp
@@ -29,6 +29,7 @@ namespace ETJump {
 inline constexpr int32_t SF_START_INVIS = 1 << 0;
 inline constexpr int32_t SF_GIB_INSIDE = 1 << 1;
 inline constexpr int32_t SF_FT_TEAMJUMP_SYNC = 1 << 2;
+inline constexpr int32_t SF_CONSUME_PORTALS = 1 << 3;
 
 /*
  * 'ent->s.effect1Time' and 'ent->s.effect2Time' are treated as boolean
@@ -117,6 +118,10 @@ void FuncStaticClient::turnOn(gentity_t *self, const int32_t clientNum) {
     G_Damage(g_entities + clientNum, self, self, nullptr, nullptr, 9999,
              DAMAGE_NO_PROTECTION, MOD_CRUSH);
   }
+
+  if (self->spawnflags & SF_CONSUME_PORTALS) {
+    deleteTouchingPortals(self, clientNum);
+  }
 }
 
 void FuncStaticClient::turnOff(gentity_t *self, const int32_t clientNum) {
@@ -167,6 +172,26 @@ void FuncStaticClient::syncToFireteamLeaderState(const int32_t clientNum,
     } else {
       turnOn(ent, clientNum);
     }
+  }
+}
+
+void FuncStaticClient::deleteTouchingPortals(const gentity_t *self,
+                                             const int32_t clientNum) {
+  const gentity_t *activator = g_entities + clientNum;
+
+  // we check against the portal origin instead of bbox, otherwise it's
+  // possible to fire portals next to the entity while it's solid,
+  // which then get deleted when it's toggled, which feels very wrong
+  if (activator->portalBlue &&
+      trap_EntityContact(activator->portalBlue->r.currentOrigin,
+                         activator->portalBlue->r.currentOrigin, self)) {
+    G_FreeEntity(activator->portalBlue);
+  }
+
+  if (activator->portalRed &&
+      trap_EntityContact(activator->portalRed->r.currentOrigin,
+                         activator->portalRed->r.currentOrigin, self)) {
+    G_FreeEntity(activator->portalRed);
   }
 }
 } // namespace ETJump

--- a/src/game/etj_func_static_client.h
+++ b/src/game/etj_func_static_client.h
@@ -35,5 +35,6 @@ public:
   static void turnOff(gentity_t *self, int32_t clientNum);
   static bool activatorIsInsideEnt(const gentity_t *self, int32_t clientNum);
   static void syncToFireteamLeaderState(int32_t clientNum, int32_t leaderNum);
+  static void deleteTouchingPortals(const gentity_t *self, int32_t clientNum);
 };
 } // namespace ETJump


### PR DESCRIPTION
When `spawnflag 8` is set, any portals that are inside of the entity get deleted when it turns solid.

fixes #1839
refs #1824 