### PR TITLE
Remove useless surfaceFlags field from gentity_t

### DIFF
--- a/src/game/bg_pmove.cpp
+++ b/src/game/bg_pmove.cpp
@@ -46,14 +46,6 @@ pml_t pml;
 
 int c_pmove = 0;
 
-#ifdef GAMEDLL
-
-// In just the GAME DLL, we want to store the groundtrace surface stuff,
-// so we don't have to keep tracing.
-void ClientStoreSurfaceFlags(int clientNum, int surfaceFlags);
-
-#endif
-
 /*
 ===============
 PM_AddEvent
@@ -1697,13 +1689,6 @@ Returns an event number apropriate for the groundsurface
 ================
 */
 static int PM_FootstepForSurface(void) {
-#ifdef GAMEDLL
-  // In just the GAME DLL, we want to store the groundtrace surface
-  // stuff, so we don't have to keep tracing.
-  ClientStoreSurfaceFlags(pm->ps->clientNum, pm->groundTrace.surfaceFlags);
-
-#endif // GAMEDLL
-
   return BG_FootstepForSurface(pm->groundTrace.surfaceFlags);
 }
 

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2230,9 +2230,6 @@ void ClientBegin(int clientNum) {
   // count current clients and rank for scoreboard
   CalculateRanks();
 
-  // No surface determined yet.
-  ent->surfaceFlags = 0;
-
   OnClientBegin(ent);
   if (level.hasTimerun) {
     trap_SendServerCommand(clientNum, "hasTimerun 1");
@@ -2898,11 +2895,4 @@ void ClientDisconnect(int clientNum) {
   ETJump::progressionTrackers->saveClientProgression(ent);
 
   ETJump::EntityUtilities::clearPortals(ent);
-}
-
-// In just the GAME DLL, we want to store the groundtrace surface stuff,
-// so we don't have to keep tracing.
-void ClientStoreSurfaceFlags(int clientNum, int surfaceFlags) {
-  // Store the surface flags
-  g_entities[clientNum].surfaceFlags = surfaceFlags;
 }

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -562,9 +562,6 @@ struct gentity_s {
   //		@ARNOUT - does this screw up the save game?
   g_serverEntity_t *serverEntity;
 
-  // What sort of surface are we standing on?
-  int surfaceFlags;
-
   char tagBuffer[16];
 
   // bleh - ugly


### PR DESCRIPTION
Unused and unnecessary. Could be technically used to skip a trace on server to determine the type of surface a client is standing on, but in practice this doesn't really come up anywhere other than physics stuff, which is of course done in pmove.