### PR TITLE
High-res CGaz 2 line thickness tweaks

### DIFF
--- a/assets/ui/etjump_settings_hud2_cgaz.menu
+++ b/assets/ui/etjump_settings_hud2_cgaz.menu
@@ -77,8 +77,10 @@ menuDef {
         YESNO               (SETTINGS_ITEM_POS(19), "Draw midline:", 0.2, SETTINGS_ITEM_H, "etj_CGaz1DrawMidline", "Draw the middle point in-between min and max angles on CGaz 1\netj_CGaz1DrawMidline")
         COMBO               (SETTINGS_COMBO_POS(20), "Midline color:", 0.2, SETTINGS_ITEM_H, "etj_CGaz1MidlineColor", COLOR_LIST, uiScript uiPreviousMenu MENU_NAME, "Sets midline color of CGaz 1\netj_CGaz1MidlineColor")
         YESNO               (SETTINGS_ITEM_POS(21), "High resolution CGaz2:", 0.2, SETTINGS_ITEM_H, "etj_CGaz2HighRes", "Enable high-resolution, anti-aliased drawing for CGaz2\nThis might cause rendering bugs on some clients\netj_CGaz2HighRes")
-        CVARFLOATLABEL      (SETTINGS_ITEM_POS(22), "etj_CGaz2Thickness", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
-        SLIDER              (SETTINGS_ITEM_POS(22), "CGaz 2 line thickness:", 0.2, SETTINGS_ITEM_H, etj_CGaz2Thickness 2 0.5 5 0.1, "Line thickness for CGaz2, requires etj_CGaz2HighRes to apply\netj_CGaz2Thickness")
+        CVARFLOATLABEL      (SETTINGS_ITEM_POS(22), "etj_CGaz2Thickness1", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(22), "CGaz 2 primary thickness:", 0.2, SETTINGS_ITEM_H, etj_CGaz2Thickness1 2 0.5 10 0.1, "Line thickness for velocity direction/angle lines on CGaz2, requires etj_CGaz2HighRes to apply\netj_CGaz2Thickness1")
+        CVARFLOATLABEL      (SETTINGS_ITEM_POS(23), "etj_CGaz2Thickness2", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(23), "CGaz 2 secondary thickness:", 0.2, SETTINGS_ITEM_H, etj_CGaz2Thickness2 2 0.5 10 0.1, "Line thickness for wishdir direction lines CGaz2, requires etj_CGaz2HighRes to apply\netj_CGaz2Thickness2")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -210,12 +210,12 @@ void drawLineDDA(float x0, float y0, float x1, float y1, float w, float h,
   if (x0 == x1) {
     x0 = std::clamp(x0, 0.0f, scrW);
 
-    CG_DrawPic(x0, std::min(y0, y1), w, std::abs(y0 - y1),
+    CG_DrawPic(x0 - (w / 2.0f), std::min(y0, y1), w, std::abs(y0 - y1),
                cgs.media.whiteShader);
   } else if (y0 == y1) {
     y0 = std::clamp(y0, 0.0f, scrH);
 
-    CG_DrawPic(std::min(x0, x1), y0, std::abs(x0 - x1), h,
+    CG_DrawPic(std::min(x0, x1), y0 - (h / 2.0f), std::abs(x0 - x1), h,
                cgs.media.whiteShader);
   } else {
     len = ((x1 - x0) * (x1 - x0)) + ((y1 - y0) * (y1 - y0));
@@ -226,7 +226,8 @@ void drawLineDDA(float x0, float y0, float x1, float y1, float w, float h,
     while (i < len) {
       // only draw pixels that are in the screen space
       if (x0 >= 0 && x0 <= scrW && y0 >= 0 && y0 <= scrH) {
-        CG_DrawPic(x0, y0, w, h, cgs.media.whiteShader);
+        CG_DrawPic(x0 - (w / 2.0f), y0 - (h / 2.0f), w, h,
+                   cgs.media.whiteShader);
       }
 
       x0 += stepX;
@@ -254,9 +255,12 @@ void drawLineWu(float x0, float y0, float x1, float y1, float w, float h,
   const auto putPixel = [&](int32_t x, int32_t y, float brightness) {
     vec4_t c = {color[0], color[1], color[2], color[3] * brightness};
     trap_R_SetColor(c);
-    drawPicNoScale(static_cast<float>(x) / renderScale,
-                   static_cast<float>(y) / renderScale, w / renderScale,
-                   h / renderScale, cgs.media.whiteShader);
+
+    const float halfW = w / (2.0f * renderScale);
+    const float halfH = h / (2.0f * renderScale);
+    drawPicNoScale((static_cast<float>(x) / renderScale) - halfW,
+                   (static_cast<float>(y) / renderScale) - halfH,
+                   w / renderScale, h / renderScale, cgs.media.whiteShader);
   };
 
   const auto fpart = [](const float x) { return x - std::floor(x); };
@@ -306,8 +310,8 @@ void drawLineWu(float x0, float y0, float x1, float y1, float w, float h,
     w /= renderScale;
 
     trap_R_SetColor(color);
-    drawPicNoScale(x0, std::min(y0, y1), w, std::abs(y0 - y1),
-                   cgs.media.whiteShader);
+    drawPicNoScale(x0 - (w / (2.0f * renderScale)), std::min(y0, y1), w,
+                   std::abs(y0 - y1), cgs.media.whiteShader);
     trap_R_SetColor(nullptr);
     return;
   }
@@ -321,8 +325,8 @@ void drawLineWu(float x0, float y0, float x1, float y1, float w, float h,
     h /= renderScale;
 
     trap_R_SetColor(color);
-    drawPicNoScale(std::min(x0, x1), y0, std::abs(x0 - x1), h,
-                   cgs.media.whiteShader);
+    drawPicNoScale(std::min(x0, x1), y0 - (h / (2.0f * renderScale)),
+                   std::abs(x0 - x1), h, cgs.media.whiteShader);
     trap_R_SetColor(nullptr);
     return;
   }

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2373,7 +2373,8 @@ extern vmCvar_t etj_CGaz2WishDirUniformLength;
 extern vmCvar_t etj_CGaz1DrawMidLine;
 extern vmCvar_t etj_CGaz1MidlineColor;
 extern vmCvar_t etj_CGaz2HighRes;
-extern vmCvar_t etj_CGaz2Thickness;
+extern vmCvar_t etj_CGaz2Thickness1;
+extern vmCvar_t etj_CGaz2Thickness2;
 
 extern vmCvar_t etj_drawOB;
 // Aciz: movable drawOB

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -312,7 +312,8 @@ vmCvar_t etj_CGaz2WishDirUniformLength;
 vmCvar_t etj_CGaz1DrawMidLine;
 vmCvar_t etj_CGaz1MidlineColor;
 vmCvar_t etj_CGaz2HighRes;
-vmCvar_t etj_CGaz2Thickness;
+vmCvar_t etj_CGaz2Thickness1;
+vmCvar_t etj_CGaz2Thickness2;
 
 vmCvar_t etj_drawOB;
 // Aciz: movable drawOB
@@ -927,7 +928,8 @@ cvarTable_t cvarTable[] = {
     {&etj_CGaz1MidlineColor, "etj_CGaz1MidlineColor", "1.0 0.5 0.0 0.75",
      CVAR_ARCHIVE},
     {&etj_CGaz2HighRes, "etj_CGaz2HighRes", "0", CVAR_ARCHIVE},
-    {&etj_CGaz2Thickness, "etj_CGaz2Thickness", "2.0", CVAR_ARCHIVE},
+    {&etj_CGaz2Thickness1, "etj_CGaz2Thickness1", "2.0", CVAR_ARCHIVE},
+    {&etj_CGaz2Thickness2, "etj_CGaz2Thickness2", "2.0", CVAR_ARCHIVE},
 
     {&cl_yawspeed, "cl_yawspeed", "0", CVAR_ARCHIVE},
     {&cl_freelook, "cl_freelook", "1", CVAR_ARCHIVE},

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -65,7 +65,9 @@ CGaz::CGaz(const std::shared_ptr<CvarUpdateHandler> &cvarUpdate)
   cgame.utils.colorParser->parseColorString(etj_CGaz2Color2.string,
                                             CGaz2Colors[1]);
 
-  setThickness(&etj_CGaz2Thickness);
+  setThickness(&etj_CGaz2Thickness1);
+  setThickness(&etj_CGaz2Thickness2);
+
   startListeners();
 }
 
@@ -78,7 +80,8 @@ CGaz::~CGaz() {
 
   cvarUpdate->unsubscribe(&etj_CGaz2Color1);
   cvarUpdate->unsubscribe(&etj_CGaz2Color2);
-  cvarUpdate->unsubscribe(&etj_CGaz2Thickness);
+  cvarUpdate->unsubscribe(&etj_CGaz2Thickness1);
+  cvarUpdate->unsubscribe(&etj_CGaz2Thickness2);
 }
 
 void CGaz::startListeners() {
@@ -112,12 +115,19 @@ void CGaz::startListeners() {
     cgame.utils.colorParser->parseColorString(cvar->string, CGaz2Colors[1]);
   });
 
-  cvarUpdate->subscribe(&etj_CGaz2Thickness,
+  cvarUpdate->subscribe(&etj_CGaz2Thickness1,
+                        [this](const vmCvar_t *cvar) { setThickness(cvar); });
+
+  cvarUpdate->subscribe(&etj_CGaz2Thickness2,
                         [this](const vmCvar_t *cvar) { setThickness(cvar); });
 }
 
 void CGaz::setThickness(const vmCvar_t *cvar) {
-  thickness = std::clamp(cvar->value, 0.5f, 5.0f);
+  if (cvar == &etj_CGaz2Thickness1) {
+    thickness[0] = std::clamp(cvar->value, 0.5f, 10.0f);
+  } else if (cvar == &etj_CGaz2Thickness2) {
+    thickness[1] = std::clamp(cvar->value, 0.5f, 10.0f);
+  }
 }
 
 void CGaz::UpdateCGaz1(vec3_t wishvel, const int8_t uCmdScale) const {
@@ -389,7 +399,7 @@ void CGaz::render() const {
       if (highRes) {
         drawLineWu(scx, scy, scx + (mult * static_cast<float>(cmd.rightmove)),
                    scy - (mult * static_cast<float>(cmd.forwardmove)),
-                   thickness, thickness, CGaz2Colors[1]);
+                   thickness[1], thickness[1], CGaz2Colors[1]);
       } else {
         drawLineDDA(scx, scy, scx + (mult * static_cast<float>(cmd.rightmove)),
                     scy - (mult * static_cast<float>(cmd.forwardmove)),
@@ -422,8 +432,8 @@ void CGaz::render() const {
 
       if (highRes) {
         drawLineWu(scx, scy, scx + (dirSize * std::sin(drawVel)),
-                   scy - (dirSize * std::cos(drawVel)), thickness, thickness,
-                   CGaz2Colors[0]);
+                   scy - (dirSize * std::cos(drawVel)), thickness[0],
+                   thickness[0], CGaz2Colors[0]);
       } else {
         drawLineDDA(scx, scy, scx + (dirSize * std::sin(drawVel)),
                     scy - (dirSize * std::cos(drawVel)), CGaz2Colors[0]);
@@ -435,11 +445,11 @@ void CGaz::render() const {
 
       if (highRes) {
         drawLineWu(scx, scy, scx + (velSize * std::sin(drawVel + drawOpt)),
-                   scy - (velSize * std::cos(drawVel + drawOpt)), thickness,
-                   thickness, CGaz2Colors[0]);
+                   scy - (velSize * std::cos(drawVel + drawOpt)), thickness[0],
+                   thickness[0], CGaz2Colors[0]);
         drawLineWu(scx, scy, scx + (velSize * std::sin(drawVel - drawOpt)),
-                   scy - (velSize * std::cos(drawVel - drawOpt)), thickness,
-                   thickness, CGaz2Colors[0]);
+                   scy - (velSize * std::cos(drawVel - drawOpt)), thickness[0],
+                   thickness[0], CGaz2Colors[0]);
       } else {
         drawLineDDA(scx, scy, scx + (velSize * std::sin(drawVel + drawOpt)),
                     scy - (velSize * std::cos(drawVel + drawOpt)),

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -370,8 +370,8 @@ void CGaz::render() const {
   // Dzikie Weze's 2D-CGaz
   if (etj_drawCGaz.integer & 2) {
     const usercmd_t cmd = pm->cmd;
-    float scx = SCREEN_CENTER_X - 0.5f; // -0.5 since thickness is 1px
-    const float scy = SCREEN_CENTER_Y - 0.5f;
+    float scx = SCREEN_CENTER_X;
+    const float scy = SCREEN_CENTER_Y;
 
     if (etj_stretchCgaz.integer) {
       ETJump_EnableWidthScale(false);

--- a/src/cgame/etj_cgaz.h
+++ b/src/cgame/etj_cgaz.h
@@ -74,7 +74,7 @@ private:
   vec4_t CGaz2Colors[2]{};
   vec4_t CGaz1MidlineColor{};
 
-  float thickness{};
+  std::array<float, 2> thickness{};
 
   [[nodiscard]] bool canSkipDraw() const;
   void UpdateCGaz1(vec3_t wishvel, int8_t uCmdScale) const;

--- a/src/cgame/etj_crosshair_drawer.cpp
+++ b/src/cgame/etj_crosshair_drawer.cpp
@@ -78,39 +78,33 @@ void CrosshairDrawer::drawCross(const crosshair_t &crosshair,
 
 void CrosshairDrawer::drawDiagCross(const crosshair_t &crosshair) {
   // top-left -> bottom-right
-  drawLineDDA(crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
-              crosshair.y - (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
-              crosshair.x + (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
-              crosshair.y + (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
-              crosshair.t, crosshair.t, crosshair.color);
+  drawLineDDA(
+      crosshair.x - (crosshair.w * 0.5f), crosshair.y - (crosshair.h * 0.5f),
+      crosshair.x + (crosshair.w * 0.5f), crosshair.y + (crosshair.h * 0.5f),
+      crosshair.t, crosshair.t, crosshair.color);
   // top-right -> bottom-left
-  drawLineDDA(crosshair.x + (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
-              crosshair.y - (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
-              crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
-              crosshair.y + (crosshair.h * 0.5f) - (crosshair.t * 0.5f),
-              crosshair.t, crosshair.t, crosshair.colorAlt);
+  drawLineDDA(
+      crosshair.x + (crosshair.w * 0.5f), crosshair.y - (crosshair.h * 0.5f),
+      crosshair.x - (crosshair.w * 0.5f), crosshair.y + (crosshair.h * 0.5f),
+      crosshair.t, crosshair.t, crosshair.colorAlt);
 }
 
 void CrosshairDrawer::drawV(const crosshair_t &crosshair) {
   // left line
-  drawLineDDA(crosshair.x - (crosshair.t * 0.5f),
-              crosshair.y - (crosshair.t * 0.5f),
-              crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
-              crosshair.y + crosshair.h - (crosshair.t * 0.5f), crosshair.t,
-              crosshair.t, crosshair.color);
+  drawLineDDA(crosshair.x, crosshair.y, crosshair.x - (crosshair.w * 0.5f),
+              crosshair.y + crosshair.h, crosshair.t, crosshair.t,
+              crosshair.color);
   // right line
-  drawLineDDA(crosshair.x - (crosshair.t * 0.5f),
-              crosshair.y - (crosshair.t * 0.5f),
-              crosshair.x + (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
-              crosshair.y + crosshair.h - (crosshair.t * 0.5f), crosshair.t,
-              crosshair.t, crosshair.colorAlt);
+  drawLineDDA(crosshair.x, crosshair.y, crosshair.x + (crosshair.w * 0.5f),
+              crosshair.y + crosshair.h, crosshair.t, crosshair.t,
+              crosshair.colorAlt);
 }
 
 void CrosshairDrawer::drawTriangle(const crosshair_t &crosshair,
                                    const bool fill) {
-  DrawTriangle(crosshair.x - (crosshair.w * 0.5f) - (crosshair.t * 0.5f),
-               crosshair.y - (crosshair.t * 0.5f), crosshair.w, crosshair.h,
-               crosshair.t, 0, fill, crosshair.color, crosshair.colorAlt);
+  DrawTriangle(crosshair.x - (crosshair.w * 0.5f), crosshair.y, crosshair.w,
+               crosshair.h, crosshair.t, 0, fill, crosshair.color,
+               crosshair.colorAlt);
 }
 
 void CrosshairDrawer::drawTOutline(crosshair_t &crosshair, qhandle_t shader,


### PR DESCRIPTION
* velocity & wishdir lines now have separate thickness cvars (`etj_CGaz2Thickness1/2`)
* max line thickness raised from __5__ to __10__
* fixed lines not centering correctly on crosshair (especially noticeable with thicker lines)

refs #1864 