### PR TITLE
Approximate alpha for non-axial lines on Wu's line algorithm

### DIFF
--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -182,7 +182,7 @@ range_t AnglesToRange(float start, float end, float yaw, float fov) {
 }
 
 void drawLineDDA(float x0, float y0, float x1, float y1, const vec4_t color) {
-  drawLineDDA(x0, y0, x1, y1, 1, 1, color);
+  drawLineDDA(x0, y0, x1, y1, 1, color);
 }
 
 // line drawing using Digital Differential Analyzer with slight modifications
@@ -190,7 +190,7 @@ void drawLineDDA(float x0, float y0, float x1, float y1, const vec4_t color) {
 // we use euclidean distance to endpoint rather than dominant axis
 // to determine the next step for the line, as this tends to produce
 // better results when drawing to the virtual grid and scaling from there
-void drawLineDDA(float x0, float y0, float x1, float y1, float w, float h,
+void drawLineDDA(float x0, float y0, float x1, float y1, float w,
                  const vec4_t color) {
   float len{};
   float stepX{};
@@ -215,7 +215,7 @@ void drawLineDDA(float x0, float y0, float x1, float y1, float w, float h,
   } else if (y0 == y1) {
     y0 = std::clamp(y0, 0.0f, scrH);
 
-    CG_DrawPic(std::min(x0, x1), y0 - (h / 2.0f), std::abs(x0 - x1), h,
+    CG_DrawPic(std::min(x0, x1), y0 - (w / 2.0f), std::abs(x0 - x1), w,
                cgs.media.whiteShader);
   } else {
     len = ((x1 - x0) * (x1 - x0)) + ((y1 - y0) * (y1 - y0));
@@ -226,7 +226,7 @@ void drawLineDDA(float x0, float y0, float x1, float y1, float w, float h,
     while (i < len) {
       // only draw pixels that are in the screen space
       if (x0 >= 0 && x0 <= scrW && y0 >= 0 && y0 <= scrH) {
-        CG_DrawPic(x0 - (w / 2.0f), y0 - (h / 2.0f), w, h,
+        CG_DrawPic(x0 - (w / 2.0f), y0 - (w / 2.0f), w, w,
                    cgs.media.whiteShader);
       }
 
@@ -240,7 +240,7 @@ void drawLineDDA(float x0, float y0, float x1, float y1, float w, float h,
 }
 
 void drawLineWu(float x0, float y0, float x1, float y1, const vec4_t color) {
-  drawLineWu(x0, y0, x1, y1, 1, 1, color);
+  drawLineWu(x0, y0, x1, y1, 1, color);
 }
 
 // anti-aliased line drawing using Xiaolin Wu's line algorithm
@@ -248,7 +248,7 @@ void drawLineWu(float x0, float y0, float x1, float y1, const vec4_t color) {
 // NOTE: this is a relatively expensive function, as it draws
 // the lines at higher resolution (up to 1080 vertical pixels),
 // rather than using the virtual grid for pixel coordinates
-void drawLineWu(float x0, float y0, float x1, float y1, float w, float h,
+void drawLineWu(float x0, float y0, float x1, float y1, float w,
                 const vec4_t color) {
   float renderScale = 1.0f;
 
@@ -257,10 +257,9 @@ void drawLineWu(float x0, float y0, float x1, float y1, float w, float h,
     trap_R_SetColor(c);
 
     const float halfW = w / (2.0f * renderScale);
-    const float halfH = h / (2.0f * renderScale);
     drawPicNoScale((static_cast<float>(x) / renderScale) - halfW,
-                   (static_cast<float>(y) / renderScale) - halfH,
-                   w / renderScale, h / renderScale, cgs.media.whiteShader);
+                   (static_cast<float>(y) / renderScale) - halfW,
+                   w / renderScale, w / renderScale, cgs.media.whiteShader);
   };
 
   const auto fpart = [](const float x) { return x - std::floor(x); };
@@ -297,7 +296,6 @@ void drawLineWu(float x0, float y0, float x1, float y1, float w, float h,
     y1 *= renderScale;
 
     w *= renderScale;
-    h *= renderScale;
   }
 
   // for axial lines, we can use a single draw call
@@ -322,11 +320,11 @@ void drawLineWu(float x0, float y0, float x1, float y1, float w, float h,
     y0 /= renderScale;
     x0 /= renderScale;
     x1 /= renderScale;
-    h /= renderScale;
+    w /= renderScale;
 
     trap_R_SetColor(color);
-    drawPicNoScale(std::min(x0, x1), y0 - (h / (2.0f * renderScale)),
-                   std::abs(x0 - x1), h, cgs.media.whiteShader);
+    drawPicNoScale(std::min(x0, x1), y0 - (w / (2.0f * renderScale)),
+                   std::abs(x0 - x1), w, cgs.media.whiteShader);
     trap_R_SetColor(nullptr);
     return;
   }
@@ -506,9 +504,9 @@ void DrawTriangle(float x, float y, float w, float h, float lineW, float angle,
   }
 
   // draw outer edges clockwise, starting from p1
-  drawLineDDA(p1.x, p1.y, p2.x, p2.y, lineW, lineW, color);
-  drawLineDDA(p2.x, p2.y, p3.x, p3.y, lineW, lineW, color);
-  drawLineDDA(p3.x, p3.y, p1.x, p1.y, lineW, lineW, color);
+  drawLineDDA(p1.x, p1.y, p2.x, p2.y, lineW, color);
+  drawLineDDA(p2.x, p2.y, p3.x, p3.y, lineW, color);
+  drawLineDDA(p3.x, p3.y, p1.x, p1.y, lineW, color);
 }
 
 /*

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -253,7 +253,14 @@ void drawLineWu(float x0, float y0, float x1, float y1, float w,
   float renderScale = 1.0f;
 
   const auto putPixel = [&](int32_t x, int32_t y, float brightness) {
-    vec4_t c = {color[0], color[1], color[2], color[3] * brightness};
+    // rough approximation for alpha to account for pixel overlap,
+    // when line thickness is > 1px
+    // not mathematically perfect, but should look good enough in most cases
+    const float alphaScale =
+        color[3] < 1.0f
+            ? std::min(brightness * (1.0f / ((w * 0.5f) / renderScale)), 1.0f)
+            : 1.0f;
+    vec4_t c = {color[0], color[1], color[2], color[3] * alphaScale};
     trap_R_SetColor(c);
 
     const float halfW = w / (2.0f * renderScale);

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2843,9 +2843,9 @@ void CG_FillAngleYawExt(float start, float end, float yaw, float y, float h,
                         float fov, vec4_t const color, bool borderOnly,
                         float borderThickness);
 void drawLineDDA(float x0, float y0, float x1, float y1, const vec4_t color);
-void drawLineDDA(float x0, float y0, float x1, float y1, float w, float h,
+void drawLineDDA(float x0, float y0, float x1, float y1, float w,
                  const vec4_t color);
-void drawLineWu(float x0, float y0, float x1, float y1, float w, float h,
+void drawLineWu(float x0, float y0, float x1, float y1, float w,
                 const vec4_t color);
 void drawLineWu(float x0, float y0, float x1, float y1, const vec4_t color);
 void DrawTriangle(float x, float y, float w, float h, float lineW, float angle,

--- a/src/cgame/etj_cgaz.cpp
+++ b/src/cgame/etj_cgaz.cpp
@@ -399,7 +399,7 @@ void CGaz::render() const {
       if (highRes) {
         drawLineWu(scx, scy, scx + (mult * static_cast<float>(cmd.rightmove)),
                    scy - (mult * static_cast<float>(cmd.forwardmove)),
-                   thickness[1], thickness[1], CGaz2Colors[1]);
+                   thickness[1], CGaz2Colors[1]);
       } else {
         drawLineDDA(scx, scy, scx + (mult * static_cast<float>(cmd.rightmove)),
                     scy - (mult * static_cast<float>(cmd.forwardmove)),
@@ -433,7 +433,7 @@ void CGaz::render() const {
       if (highRes) {
         drawLineWu(scx, scy, scx + (dirSize * std::sin(drawVel)),
                    scy - (dirSize * std::cos(drawVel)), thickness[0],
-                   thickness[0], CGaz2Colors[0]);
+                   CGaz2Colors[0]);
       } else {
         drawLineDDA(scx, scy, scx + (dirSize * std::sin(drawVel)),
                     scy - (dirSize * std::cos(drawVel)), CGaz2Colors[0]);
@@ -446,10 +446,10 @@ void CGaz::render() const {
       if (highRes) {
         drawLineWu(scx, scy, scx + (velSize * std::sin(drawVel + drawOpt)),
                    scy - (velSize * std::cos(drawVel + drawOpt)), thickness[0],
-                   thickness[0], CGaz2Colors[0]);
+                   CGaz2Colors[0]);
         drawLineWu(scx, scy, scx + (velSize * std::sin(drawVel - drawOpt)),
                    scy - (velSize * std::cos(drawVel - drawOpt)), thickness[0],
-                   thickness[0], CGaz2Colors[0]);
+                   CGaz2Colors[0]);
       } else {
         drawLineDDA(scx, scy, scx + (velSize * std::sin(drawVel + drawOpt)),
                     scy - (velSize * std::cos(drawVel + drawOpt)),

--- a/src/cgame/etj_crosshair_drawer.cpp
+++ b/src/cgame/etj_crosshair_drawer.cpp
@@ -78,26 +78,24 @@ void CrosshairDrawer::drawCross(const crosshair_t &crosshair,
 
 void CrosshairDrawer::drawDiagCross(const crosshair_t &crosshair) {
   // top-left -> bottom-right
-  drawLineDDA(
-      crosshair.x - (crosshair.w * 0.5f), crosshair.y - (crosshair.h * 0.5f),
-      crosshair.x + (crosshair.w * 0.5f), crosshair.y + (crosshair.h * 0.5f),
-      crosshair.t, crosshair.t, crosshair.color);
+  drawLineDDA(crosshair.x - (crosshair.w * 0.5f),
+              crosshair.y - (crosshair.h * 0.5f),
+              crosshair.x + (crosshair.w * 0.5f),
+              crosshair.y + (crosshair.h * 0.5f), crosshair.t, crosshair.color);
   // top-right -> bottom-left
   drawLineDDA(
       crosshair.x + (crosshair.w * 0.5f), crosshair.y - (crosshair.h * 0.5f),
       crosshair.x - (crosshair.w * 0.5f), crosshair.y + (crosshair.h * 0.5f),
-      crosshair.t, crosshair.t, crosshair.colorAlt);
+      crosshair.t, crosshair.colorAlt);
 }
 
 void CrosshairDrawer::drawV(const crosshair_t &crosshair) {
   // left line
   drawLineDDA(crosshair.x, crosshair.y, crosshair.x - (crosshair.w * 0.5f),
-              crosshair.y + crosshair.h, crosshair.t, crosshair.t,
-              crosshair.color);
+              crosshair.y + crosshair.h, crosshair.t, crosshair.color);
   // right line
   drawLineDDA(crosshair.x, crosshair.y, crosshair.x + (crosshair.w * 0.5f),
-              crosshair.y + crosshair.h, crosshair.t, crosshair.t,
-              crosshair.colorAlt);
+              crosshair.y + crosshair.h, crosshair.t, crosshair.colorAlt);
 }
 
 void CrosshairDrawer::drawTriangle(const crosshair_t &crosshair,


### PR DESCRIPTION
Due to pixel overlap on lines thicker than > 1px, drawing non-axial lines produced incorrect alpha results when using Wu's line drawing algorithm. This made thick lines effectively opaque, even when the line was supposed to be slightly transparent. The drawing now scales the alpha based off the line thickness, to approximate the alpha to be at least pretty close visually to what it's supposed to be. This isn't a mathematically correct solution, but based of my testing, it's visually close enough in most cases.

refs #1864 