### PR TITLE
Disallow "maps" as value for g_mapScriptDir

### DIFF
--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -1561,6 +1561,15 @@ void G_UpdateCvars(void) {
               }
             }
           }
+        } else if (cv->vmCvar == &g_mapScriptDir) {
+          // prevent admins from setting this to the directory where the game
+          // normally loads mapscripts from, so default mapscripts won't get
+          // loaded as "custom" mapscripts
+          if (!Q_stricmp(g_mapScriptDir.string, "maps")) {
+            G_Printf(S_COLOR_YELLOW "WARNING: ^7illegal ^3'g_mapScriptDir' "
+                                    "^7value, resetting to default\n");
+            trap_Cvar_Set(cv->cvarName, cv->defaultString);
+          }
         } else {
           fToggles =
               (G_checkServerToggle(cv->vmCvar) || fToggles) ? qtrue : qfalse;


### PR DESCRIPTION
Prevents default mapscripts from being detected and loaded as "custom" mapscripts.