### PR TITLE
Add documentation link to ETJump menu

### DIFF
--- a/assets/ui/etjump.menu
+++ b/assets/ui/etjump.menu
@@ -2,8 +2,8 @@
 
 #define WINDOW_X		16
 #define WINDOW_Y		16
-#define WINDOW_WIDTH	128
-#define WINDOW_HEIGHT	154
+#define WINDOW_WIDTH	160
+#define WINDOW_HEIGHT	176
 #define GROUP_NAME		"groupETJumpSettings"
 
 #include "ui/menumacros.h"
@@ -26,11 +26,12 @@ menuDef {
 		open MAIN_MENU
 	}
 
-	WINDOW("ETJUMP", 94)
+	WINDOW("ETJUMP", 50)
 
 	BUTTON(6, 32, WINDOW_WIDTH - 12, 18, "SETTINGS", .3, 14, close etjump; open etjump_settings_general_gameplay)
 	BUTTON(6, 56, WINDOW_WIDTH - 12, 18, "CONTROLS", .3, 14, close etjump; open etjump_controls)
 	BUTTON(6, 80, WINDOW_WIDTH - 12, 18, "CHANGELOG", .3, 14, close etjump; open etjump_changelog_background; open etjump_changelog)
-	BUTTON(6, 104, WINDOW_WIDTH - 12, 18, "CREDITS", .3, 14, close etjump; open etjump_credits)
-	BUTTON(6, 128, WINDOW_WIDTH - 12, 18, "BACK", .3, 14, close etjump; open MAIN_MENU)
+	BUTTON(6, 104, WINDOW_WIDTH - 12, 18, "DOCUMENTATION", .3, 14, open etjump_popup_documentation)
+	BUTTON(6, 128, WINDOW_WIDTH - 12, 18, "CREDITS", .3, 14, close etjump; open etjump_credits)
+	BUTTON(6, 152, WINDOW_WIDTH - 12, 18, "BACK", .3, 14, close etjump; open MAIN_MENU)
 }

--- a/assets/ui/etjump_popup_documentation.menu
+++ b/assets/ui/etjump_popup_documentation.menu
@@ -1,0 +1,58 @@
+#include "ui/menudef.h"
+#include "ui/menudef_ext.h"
+#include "ui/menumacros.h"
+#include "ui/menumacros_ext.h"
+
+#define MENU_NAME "etjump_popup_documentation"
+#define GROUP_NAME "groupETJumpSettings"
+
+#define SUBWINDOW_WIDTH			210
+#define SUBWINDOW_HEIGHT		72
+#define SUBWINDOW_X					0.5 * (WINDOW_WIDTH - SUBWINDOW_WIDTH)
+#define SUBWINDOW_Y					0.5 * (WINDOW_HEIGHT - SUBWINDOW_HEIGHT)
+
+menuDef {
+		name				MENU_NAME
+		visible			0
+		fullscreen	0
+		rect				0 0 640 480
+		style				WINDOW_STYLE_FILLED
+		popup
+
+		fadeClamp   0.5
+		fadeAmount  0.075
+
+		onOpen {
+			setcvar ui_finalURL "https://etjump.readthedocs.io/en/latest/" ;
+			setitemcolor background backcolor 0 0 0 0 ;
+			fadein background
+		}
+
+		onESC {
+			clearcvar ui_finalURL ;
+			close MENU_NAME ;
+			open etjump
+		}
+
+		itemDef {
+			name        "background"
+			rect        0 0 640 480
+			style       WINDOW_STYLE_FILLED
+			background  "ui/assets/fadebox.tga"
+			backcolor   0 0 0 0
+			visible     1
+			decoration
+		}
+
+		SUBWINDOWBLACK( SUBWINDOW_X, SUBWINDOW_Y, SUBWINDOW_WIDTH, SUBWINDOW_HEIGHT, "OPEN DOCUMENTATION" )
+#ifdef VET
+			LABEL( SUBWINDOW_X + 4, SUBWINDOW_Y + 20, (SUBWINDOW_WIDTH) - 8, 10, "Close the game and open ETJump documentation in your browser?", .2, ITEM_ALIGN_CENTER, .5 * ((SUBWINDOW_WIDTH) - 8), 8 )
+#else
+			LABEL( SUBWINDOW_X + 4, SUBWINDOW_Y + 20, (SUBWINDOW_WIDTH) - 8, 10, "Open ETJump documentation in your browser?", .2, ITEM_ALIGN_CENTER, .5 * ((SUBWINDOW_WIDTH) - 8), 8 )
+#endif
+			BUTTON( SUBWINDOW_X + 6, SUBWINDOW_Y + SUBWINDOW_HEIGHT - 24, (SUBWINDOW_WIDTH - 18) / 2, 18, "BACK", .3, 14, close MENU_NAME ; open etjump )
+			BUTTON( SUBWINDOW_X + SUBWINDOW_WIDTH - 6 - ((SUBWINDOW_WIDTH - 18) / 2), SUBWINDOW_Y + SUBWINDOW_HEIGHT - 24, (SUBWINDOW_WIDTH - 18) / 2, 18, "OK", .3, 14,
+							uiScript validate_openURL ;
+							close MENU_NAME ;
+							open etjump )
+}

--- a/assets/ui/menus.txt
+++ b/assets/ui/menus.txt
@@ -1,7 +1,7 @@
 // menu defs
-// 
-{	
-	loadMenu { "ui/global.menu" }	
+//
+{
+	loadMenu { "ui/global.menu" }
 	loadMenu { "ui/main.menu" }
 	loadMenu { "ui/profile.menu" }
 	loadMenu { "ui/profile_create.menu" }
@@ -39,7 +39,7 @@
 
 	// popups
 	loadMenu { "ui/popup_errormessage.menu" }
-	loadMenu { "ui/popup_errormessage_pb.menu" }	
+	loadMenu { "ui/popup_errormessage_pb.menu" }
 	loadMenu { "ui/popup_hostgameerrormessage.menu" }
 	loadMenu { "ui/popup_autoupdate.menu" }
 	loadMenu { "ui/popup_password.menu" }
@@ -78,6 +78,7 @@
 	loadMenu { "ui/etjump_controls.menu" }
 	loadMenu { "ui/etjump_credits.menu" }
 	loadMenu { "ui/etjump_changelog.menu" }
+	loadMenu { "ui/etjump_popup_documentation.menu" }
 
 	loadMenu { "ui/ingame_ft_savelimit.menu" }
 


### PR DESCRIPTION
`trap_openURL` will close the game on 2.60b and up until very recently, on ETe as well, but I am assuming people regularly update their clients so the menu will only warn about closing the game on 2.60b.