### PR TITLE
Fix ClientCommand/CvarUpdate/EntityEvent unsubscribe methods

### DIFF
--- a/src/cgame/etj_client_commands_handler.cpp
+++ b/src/cgame/etj_client_commands_handler.cpp
@@ -63,7 +63,7 @@ bool ETJump::ClientCommandsHandler::subscribe(
 bool ETJump::ClientCommandsHandler::unsubscribe(const std::string &command) {
   auto lowercasedCommand = StringUtils::toLowerCase(command);
   auto callback = _callbacks.find(lowercasedCommand);
-  if (callback != end(_callbacks)) {
+  if (callback == end(_callbacks)) {
     return false;
   }
 

--- a/src/cgame/etj_cvar_update_handler.cpp
+++ b/src/cgame/etj_cvar_update_handler.cpp
@@ -48,7 +48,7 @@ bool ETJump::CvarUpdateHandler::subscribe(
 
 bool ETJump::CvarUpdateHandler::unsubscribe(const vmCvar_t *target) {
   auto callback = callbacks.find(target->handle);
-  if (callback != end(callbacks)) {
+  if (callback == end(callbacks)) {
     return false;
   }
   callbacks.erase(callback);

--- a/src/cgame/etj_entity_events_handler.cpp
+++ b/src/cgame/etj_entity_events_handler.cpp
@@ -62,7 +62,7 @@ bool ETJump::EntityEventsHandler::subscribe(
 bool ETJump::EntityEventsHandler::unsubscribe(const std::string &eventName) {
   auto lowercasedCommand = StringUtils::toLowerCase(eventName);
   auto callback = _callbacks.find(lowercasedCommand);
-  if (callback != end(_callbacks)) {
+  if (callback == end(_callbacks)) {
     return false;
   }
 


### PR DESCRIPTION
Yeah so these have been broken for like 10 years or so, but because our object handling was very poopoo for many many years before I collected everything into the `CGameContext` struct and did a proper shutdown on it, in correct order, these never really consistently caused bugs.