### PR TITLE
Fix 2px offset in listbox item click position

### DIFF
--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -2492,7 +2492,7 @@ void Item_ListBox_MouseEnter(itemDef_t *item, const float x, const float y,
     r.h = item->window.rect.h - static_cast<float>(listPtr->drawPadding);
     if (Rect_ContainsPoint(&r, x, y)) {
       listPtr->cursorPos =
-          static_cast<int>((y - 2 - r.y) / listPtr->elementHeight) +
+          static_cast<int>((y - r.y) / listPtr->elementHeight) +
           listPtr->startPos;
       if (listPtr->cursorPos > listPtr->endPos) {
         listPtr->cursorPos = listPtr->endPos;


### PR DESCRIPTION
All listbox items were internally treated to be 2px higher than they really were. This is probably some leftover from an earlier design in the vanilla code, and isn't as noticeable with the default cursor, but it became much more noticeable with our alternative mouse cursors, which have a much sharper tip and feel more accurate to click.