### PR TITLE
Fix area indicators using wrong height for trace

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1275,6 +1275,11 @@ typedef struct {
 
   // to prevent teleport bit getting flipped multiple times per frame
   bool teleportBitFlipped;
+
+  // matches 'pm->maxs', which accounts for crouch & prone, unlike 'ps->maxs'
+  // this should be used in capsule traces as maxs for area traces,
+  // since 'cg_pmove.maxs' is not setup properly when interpolating
+  vec3_t pmoveMaxs;
 } cg_t;
 
 inline constexpr int NUM_FUNNEL_SPRITES = 21;

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -2072,6 +2072,8 @@ void CG_DrawActiveFrame(int serverTime, stereoFrame_t stereoView,
   // update cg.predictedPlayerState
   CG_PredictPlayerState();
 
+  ETJump::setPmoveMaxs(&cg.snap->ps);
+
   DEBUGTIME
 
   // OSP -- MV handling

--- a/src/cgame/etj_areaindicator_drawable.cpp
+++ b/src/cgame/etj_areaindicator_drawable.cpp
@@ -114,7 +114,7 @@ bool AreaIndicator::beforeRender() {
     // this is a bit wasteful if none of the indicators are being drawn,
     // but we need to do a trace for prone print always,
     // and I'd rather not complicate the logic based around that
-    CG_TraceCapsule(&trace, ps->origin, ps->mins, ps->maxs, ps->origin,
+    CG_TraceCapsule(&trace, ps->origin, ps->mins, cg.pmoveMaxs, ps->origin,
                     ps->clientNum, indicator.traceContents);
 
     if (indicator.traceContents == CONTENTS_NOPRONE) {

--- a/src/cgame/etj_player_bbox.cpp
+++ b/src/cgame/etj_player_bbox.cpp
@@ -213,9 +213,9 @@ void PlayerBBox::setupBBoxExtents(const centity_t *cent, BBox &box) {
   VectorCopy(playerMaxs, box.maxs);
 
   if (cent->currentState.eFlags & EF_CROUCHING) {
-    box.maxs[2] -= CROUCH_MAXS_OFFSET_Z;
+    box.maxs[2] = CROUCH_MAXS_Z;
   } else if (cent->currentState.eFlags & (EF_PRONE | EF_PRONE_MOVING)) {
-    box.maxs[2] -= PRONE_MAXS_OFFSET_Z;
+    box.maxs[2] = PRONE_MAXS_Z;
   }
 }
 

--- a/src/cgame/etj_player_bbox.h
+++ b/src/cgame/etj_player_bbox.h
@@ -56,15 +56,6 @@ class PlayerBBox {
 
   std::shared_ptr<CvarUpdateHandler> cvarUpdate;
 
-  // there's no real easy way to determine these for other players,
-  // both crouch and prone use ps.crouchMaxZ for maxs[2] but it's calculated
-  // differently based off stance, and since the result is not stored
-  // in entitystate, it's simpler to just use hardcoded values
-  // these are always correct anyway, there's no variation in any scenario
-
-  static constexpr int CROUCH_MAXS_OFFSET_Z = 24;
-  static constexpr int PRONE_MAXS_OFFSET_Z = 32;
-
   void setupListeners();
   static void setupBBoxExtents(const centity_t *cent, BBox &box);
   static bool bottomOnly(const int &pType);

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -296,4 +296,24 @@ void resetCustomvoteInfo() {
 
   trap_SendConsoleCommand("uiResetCustomvotes\n");
 }
+
+void setPmoveMaxs(const playerState_t *ps) {
+  if (!ps) {
+    return;
+  }
+
+  // if we're not interpolating, 'cg_pmove.maxs' is setup correctly
+  if (!cg.demoPlayback && !(ps->pm_flags & PMF_FOLLOW)) {
+    VectorCopy(cg_pmove.maxs, cg.pmoveMaxs);
+    return;
+  }
+
+  VectorCopy(ps->maxs, cg.pmoveMaxs);
+
+  if (ps->eFlags & EF_CROUCHING) {
+    cg.pmoveMaxs[2] = CROUCH_MAXS_Z;
+  } else if (ps->eFlags & (EF_PRONE | EF_PRONE_MOVING)) {
+    cg.pmoveMaxs[2] = PRONE_MAXS_Z;
+  }
+}
 } // namespace ETJump

--- a/src/cgame/etj_utilities.h
+++ b/src/cgame/etj_utilities.h
@@ -108,4 +108,6 @@ playerState_t *getValidPlayerState();
 void resetTransitionEffects();
 
 void resetCustomvoteInfo();
+
+void setPmoveMaxs(const playerState_t *ps);
 } // namespace ETJump

--- a/src/game/bg_misc.cpp
+++ b/src/game/bg_misc.cpp
@@ -50,11 +50,6 @@ const int skillLevels[NUM_SKILL_LEVELS] = {
         //	200		// reaching level 5
 };
 
-vec3_t playerMins = {-18, -18, -24};
-vec3_t playerMaxs = {18, 18, 48};
-vec3_t playerlegsProneMins = {-13.5f, -13.5f, -24.f};
-vec3_t playerlegsProneMaxs = {13.5f, 13.5f, -14.4f};
-
 int numSplinePaths;
 splinePath_t splinePaths[MAX_SPLINE_PATHS];
 

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -87,10 +87,19 @@ inline constexpr int CROUCH_VIEWHEIGHT = 16;
 inline constexpr int DEAD_VIEWHEIGHT = -16;
 inline constexpr int PRONE_VIEWHEIGHT = -8;
 
-extern vec3_t playerMins;
-extern vec3_t playerMaxs;
-extern vec3_t playerlegsProneMins;
-extern vec3_t playerlegsProneMaxs;
+inline constexpr vec3_t playerMins = {-18, -18, -24};
+inline constexpr vec3_t playerMaxs = {18, 18, 48};
+inline constexpr vec3_t playerlegsProneMins = {-13.5f, -13.5f, -24.f};
+inline constexpr vec3_t playerlegsProneMaxs = {13.5f, 13.5f, -14.4f};
+
+// there's no real easy way to determine these for other players,
+// both crouch and prone use ps.crouchMaxZ for maxs[2] but it's calculated
+// differently based off stance, and since the result is not stored
+// in entitystate, it's simpler to just use hardcoded values
+// these are always correct anyway, there's no variation in any scenario
+
+inline constexpr int32_t CROUCH_MAXS_Z = playerMaxs[2] - 24;
+inline constexpr int32_t PRONE_MAXS_Z = playerMaxs[2] - 32;
 
 // RF, on fire effects
 inline constexpr int FIRE_FLASH_TIME = 2000;

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1650,7 +1650,6 @@ qboolean StuckInClient(gentity_t *self) {
   return (qfalse);
 }
 
-extern vec3_t playerMins, playerMaxs;
 inline constexpr float WR_PUSHAMOUNT = 25.0f;
 
 void WolfRevivePushEnt(gentity_t *self, gentity_t *other) {

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -3352,9 +3352,6 @@ void Cmd_SetCameraOrigin_f(gentity_t *ent) {
 
 extern gentity_t *BotFindEntityForName(char *name);
 
-extern vec3_t playerMins;
-extern vec3_t playerMaxs;
-
 qboolean G_TankIsOccupied(gentity_t *ent) {
   if (!ent->tankLink) {
     return qfalse;


### PR DESCRIPTION
`ps->maxs` does not account for crouch/prone.

fixes #1900 
