### PR TITLE
Fix fireteam propose/warn/kick menu keyhandling with multiple pages

### DIFF
--- a/src/cgame/cg_fireteams.cpp
+++ b/src/cgame/cg_fireteams.cpp
@@ -1134,12 +1134,12 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
       }
 
       if (CG_CountPlayersNF() > (cgs.ftMenuModeEx + 1) * 8) {
-        if (i == 0) {
+        if (i == 9) {
           cgs.ftMenuModeEx++;
         }
       }
       if (cgs.ftMenuModeEx) {
-        if (i == 9) {
+        if (i == 8) {
           cgs.ftMenuModeEx--;
         }
       }
@@ -1210,12 +1210,12 @@ qboolean CG_FireteamCheckExecKey(int key, qboolean doaction) {
         case ETJump::FTMenuPos::FT_MENUPOS_KICK:
         case ETJump::FTMenuPos::FT_MENUPOS_WARN:
           if (CG_CountPlayersSF() > (cgs.ftMenuModeEx + 1) * 8) {
-            if (i == 0) {
+            if (i == 9) {
               cgs.ftMenuModeEx++;
             }
           }
           if (cgs.ftMenuModeEx) {
-            if (i == 9) {
+            if (i == 8) {
               cgs.ftMenuModeEx--;
             }
           }


### PR DESCRIPTION
Off by one error in key checks caused pages to become inaccessible and commands to be sent to wrong clients.

fixes #1901 