### PR TITLE
Fix spectator vote counter not resetting for yes votes in some scenarios

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+# ETJump 3.5.1
+
+## Fixed
+* some worldspawn keys were working incorrectly if the map explicitly had the key set at it's default value [#1898](https://github.com/etjump/etjump/pull/1898)
+* vote counts for spectators who voted "yes" on a failed vote were not correctly reset on next vote [#1905](https://github.com/etjump/etjump/pull/1905)
+* fireteam `propose/warn/kick` menu actions interacted with wrong client when multiple pages were present [#1904](https://github.com/etjump/etjump/pull/1904)
+* area indicators (save/prone/noclip) ignored crouch/prone when determining if player touched an area brush [#1903](https://github.com/etjump/etjump/pull/1903)
+* listbox item (replay menu, map vote menu etc.) click areas were slightly offset vertically [#1899](https://github.com/etjump/etjump/pull/1899)
+
 # ETJump 3.5.0
 
 ## Added

--- a/src/game/g_client.cpp
+++ b/src/game/g_client.cpp
@@ -2846,6 +2846,7 @@ void ClientDisconnect(int clientNum) {
                   level.voteInfo.voteString, ent->client->pers.netname);
       resetVote();
       level.voteInfo.voteYes = 0;
+      level.voteInfo.voteYesSpectators = 0;
       level.voteInfo.voteNo = level.numConnectedClients;
       level.voteInfo.voteNoSpectators = 0;
     } else if (ent->client->ps.eFlags & EF_VOTED) {

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -2751,9 +2751,9 @@ void Cmd_CallVote_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue) {
     level.voteInfo.voteYes = 0;
   } else {
     level.voteInfo.voteYes = 1;
-    if (ent->client->sess.sessionTeam == TEAM_SPECTATOR) {
-      level.voteInfo.voteYesSpectators = 1;
-    }
+    level.voteInfo.voteYesSpectators =
+        ent->client->sess.sessionTeam == TEAM_SPECTATOR ? 1 : 0;
+
     trap_SendServerCommand(clientNum, "voted yes");
   }
 


### PR DESCRIPTION
Spectator vote counts for "yes" votes were not reset correctly if the client who started a vote was not spectator, and the previous vote ended in a failure, either by timeout or caller disconnecting.

refs #1793 