### PR TITLE
Fix lagometer snapshot rate breaking with server time reset

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * vote counts for spectators who voted "yes" on a failed vote were not correctly reset on next vote [#1905](https://github.com/etjump/etjump/pull/1905)
 * fireteam `propose/warn/kick` menu actions interacted with wrong client when multiple pages were present [#1904](https://github.com/etjump/etjump/pull/1904)
 * area indicators (save/prone/noclip) ignored crouch/prone when determining if player touched an area brush [#1903](https://github.com/etjump/etjump/pull/1903)
+* lagometer client snapshot rate would start to drift down if server timestamp was reset on map changes [#1907](https://github.com/etjump/etjump/pull/1907)
 * listbox item (replay menu, map vote menu etc.) click areas were slightly offset vertically [#1899](https://github.com/etjump/etjump/pull/1899)
 
 # ETJump 3.5.0

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -603,6 +603,14 @@ void CG_AddLagometerSnapshotInfo(snapshot_t *snap) {
     return;
   }
 
+  // if server is resetting time on map changes ('sv_server/leveltimeReset'),
+  // the snapshot timestamp is in the past -> reset all stats as the
+  // sampling period is no longer valid - we're effectively restarting
+  // with no previous valid data
+  if (snap->serverTime < sampledStat.lastSampleTime) {
+    std::memset(&sampledStat, 0, sizeof(sampledStat));
+  }
+
   // add this snapshot's info
   // demo playback displays snapshot delta values instead of ping (ala ETPro)
   // https://bani.anime.net/banimod/forums/viewtopic.php?t=6381


### PR DESCRIPTION
When the server resets level time on map changes, lagometer would start sampling from snapshots which have a timestamp in the past, which broke the sample counting. In case the server runs with level time reset, also reset the sampling period.

Edit: there's no real reason for this to be static I guess, could move to some struct that gets memset normally on init, so this would not be an issue to begin with.

refs #1331 