### PR TITLE
Fix RTV status not initializing correctly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * some worldspawn keys were working incorrectly if the map explicitly had the key set at it's default value [#1898](https://github.com/etjump/etjump/pull/1898)
 * `etj_CGaz1DrawSnapZone` was drawing only up to CGaz max angle instead to the end of the snapzone [#1906](https://github.com/etjump/etjump/pull/1906)
 * vote counts for spectators who voted "yes" on a failed vote were not correctly reset on next vote [#1905](https://github.com/etjump/etjump/pull/1905)
+* players could not vote in RTV or see the RTV menu in some scenarios [#1908](https://github.com/etjump/etjump/pull/1908)
 * fireteam `propose/warn/kick` menu actions interacted with wrong client when multiple pages were present [#1904](https://github.com/etjump/etjump/pull/1904)
 * area indicators (save/prone/noclip) ignored crouch/prone when determining if player touched an area brush [#1903](https://github.com/etjump/etjump/pull/1903)
 * lagometer client snapshot rate would start to drift down if server timestamp was reset on map changes [#1907](https://github.com/etjump/etjump/pull/1907)

--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -1424,8 +1424,8 @@ qboolean CG_ConsoleCommand(void) {
     return qtrue;
   }
 
-  return ETJump::cgame.handlers.consoleCommands->check(cmd, arguments) ? qtrue
-                                                                       : qfalse;
+  return ETJump::cgame.core.consoleCommands->check(cmd, arguments) ? qtrue
+                                                                   : qfalse;
 }
 
 /*

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -2227,9 +2227,9 @@ static void CG_DrawVote() {
 
     const bool canVote = cgs.clientinfo[cg.clientNum].team != TEAM_SPECTATOR ||
                          etj_spectatorVote.integer;
-    const bool isRtvVote = ETJump::cgame.handlers.rtv->rtvVoteActive();
+    const bool isRtvVote = ETJump::cgame.systems.rtv->rtvVoteActive();
     const ETJump::RtvVoteCountInfo rtvYesVotes =
-        ETJump::cgame.handlers.rtv->getRtvYesVotes();
+        ETJump::cgame.systems.rtv->getRtvYesVotes();
 
     const auto formatVoteStr = [&isRtvVote,
                                 &rtvYesVotes](const std::string &str) {

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -1835,7 +1835,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       trap_S_StartSound(nullptr, es->number, CHAN_VOICE,
                         CG_CustomSound(es->number, "*jump1.wav"));
       if (clientNum == cg.predictedPlayerState.clientNum) {
-        ETJump::cgame.handlers.entityEvents->check(EV_JUMP, cent);
+        ETJump::cgame.core.entityEvents->check(EV_JUMP, cent);
       }
       break;
     case EV_TAUNT:
@@ -2760,8 +2760,8 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
       }
 
       // should refactor users to playereventshandler
-      ETJump::cgame.handlers.entityEvents->check(EV_LOAD_TELEPORT, cent);
-      ETJump::cgame.handlers.playerEvents->check("load", {});
+      ETJump::cgame.core.entityEvents->check(EV_LOAD_TELEPORT, cent);
+      ETJump::cgame.core.playerEvents->check("load", {});
       trap_SendConsoleCommand("resetJumpSpeeds\n");
       trap_SendConsoleCommand("resetStrafeQuality\n");
       trap_SendConsoleCommand("resetUpmoveMeter\n");

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1443,8 +1443,8 @@ void CG_UpdateCvars(void) {
 
         // if we're in the loading screen and just drawing a frame on that,
         // we haven't finished initialization and this might be null
-        if (ETJump::cgame.handlers.cvarUpdate) {
-          ETJump::cgame.handlers.cvarUpdate->check(cv->vmCvar);
+        if (ETJump::cgame.core.cvarUpdate) {
+          ETJump::cgame.core.cvarUpdate->check(cv->vmCvar);
         }
       }
     }
@@ -3925,13 +3925,6 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum,
 
   CG_RegisterCvars();
 
-  // NOTE: The main handlers must be created before any ETJump objects
-  // are created! All C++ modules should get these as constructor params
-  // to subscribe to console commands, server commands, cvar updates etc,
-  // and not reach for the global pointers. They exists because they are still
-  // used in various places outside of C++ objects, in legacy C code.
-  ETJump::initHandlers();
-
   CG_InitConsoleCommands();
 
   // get the gamestate from the client system
@@ -3941,6 +3934,13 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum,
 
   CG_ParseServerinfo();
   CG_ParseSysteminfo();
+
+  // NOTE: The core systems must be created before any ETJump objects
+  // are created! All C++ modules should get these as constructor params
+  // to subscribe to console commands, server commands, cvar updates etc,
+  // and not reach for the global pointers. They exists because they are still
+  // used in various places outside of C++ objects, in legacy C code.
+  ETJump::initCore();
 
   // we need demo compatibility object asap, once server info is parsed,
   // so we can get the mod version

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -664,7 +664,7 @@ static void CG_ConfigStringModified(void) {
   } else if (num == CS_VOTE_TIME) {
     cgs.voteTime = Q_atoi(str);
 
-    if (!ETJump::cgame.handlers.rtv->rtvVoteActive()) {
+    if (!ETJump::cgame.systems.rtv->rtvVoteActive()) {
       ETJump::ClientRtvHandler::resetRtvEventHandler();
     }
 
@@ -674,9 +674,9 @@ static void CG_ConfigStringModified(void) {
     // 'callvote rtv' command, the check for rtvVoteActive might return false
     // therefore also check if strlen > 13 (rtvMaps 'str' len should always be
     // higher)
-    if (ETJump::cgame.handlers.rtv->rtvVoteActive() || strlen(str) > 13) {
-      ETJump::cgame.handlers.rtv->setRtvConfigStrings(str);
-      ETJump::cgame.handlers.rtv->countRtvVotes();
+    if (ETJump::cgame.systems.rtv->rtvVoteActive() || strlen(str) > 13) {
+      ETJump::cgame.systems.rtv->setRtvConfigStrings(str);
+      ETJump::cgame.systems.rtv->countRtvVotes();
     } else {
       setVoteCounts();
     }
@@ -686,7 +686,7 @@ static void CG_ConfigStringModified(void) {
     cgs.voteModified = qtrue;
   } else if (num == CS_VOTE_STRING) {
     Q_strncpyz(cgs.voteString, str, sizeof(cgs.voteString));
-    ETJump::cgame.handlers.rtv->setRtvVoteStatus();
+    ETJump::cgame.systems.rtv->setRtvVoteStatus();
   } else if (num == CS_INTERMISSION) {
     cg.intermissionStarted = Q_atoi(str) ? qtrue : qfalse;
   } else if (num == CS_SCREENFADE) {
@@ -1046,7 +1046,7 @@ static void CG_MapRestart(void) {
   trap_Cvar_Set("cg_thirdPerson", "0");
 
   if (cg.hasTimerun) {
-    ETJump::cgame.handlers.timerun->reset();
+    ETJump::cgame.systems.timerun->reset();
   }
 }
 // NERVE - SMF
@@ -2818,7 +2818,7 @@ static void CG_ServerCommand(void) {
     arguments.emplace_back(buf);
   }
 
-  if (ETJump::cgame.handlers.serverCommands->check(cmd, arguments)) {
+  if (ETJump::cgame.core.serverCommands->check(cmd, arguments)) {
     return;
   }
 

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -1875,7 +1875,7 @@ qboolean CG_CullPointAndRadius(const vec3_t pt, vec_t radius) {
 
 namespace ETJump {
 static void runFrameEnd() {
-  cgame.handlers.awaitedCommand->runFrame();
+  cgame.core.awaitedCommand->runFrame();
   cgame.utils.eventLoop->run();
   cgame.visuals.trickjumpLines->runFrame();
 

--- a/src/cgame/etj_cgame.h
+++ b/src/cgame/etj_cgame.h
@@ -33,20 +33,14 @@ class EntityEventsHandler;
 class PlayerEventsHandler;
 class AwaitedCommandHandler;
 class CvarUpdateHandler;
-class ClientRtvHandler;
-class CustomCommandMenu;
-class Timerun;
 
-struct Handlers {
+struct Core {
   std::shared_ptr<ClientCommandsHandler> serverCommands;
   std::shared_ptr<ClientCommandsHandler> consoleCommands;
   std::shared_ptr<EntityEventsHandler> entityEvents;
   std::shared_ptr<PlayerEventsHandler> playerEvents;
   std::unique_ptr<AwaitedCommandHandler> awaitedCommand;
   std::shared_ptr<CvarUpdateHandler> cvarUpdate;
-  std::unique_ptr<ClientRtvHandler> rtv;
-  std::unique_ptr<CustomCommandMenu> customCommandMenu;
-  std::shared_ptr<Timerun> timerun;
 };
 
 class ClientAuthentication;
@@ -57,6 +51,16 @@ struct Platform {
   std::unique_ptr<ClientAuthentication> authentication;
   std::unique_ptr<OperatingSystem> operatingSystem;
   std::unique_ptr<SyscallExt> syscallExt;
+};
+
+class ClientRtvHandler;
+class CustomCommandMenu;
+class Timerun;
+
+struct Systems {
+  std::unique_ptr<ClientRtvHandler> rtv;
+  std::unique_ptr<CustomCommandMenu> customCommandMenu;
+  std::shared_ptr<Timerun> timerun;
 };
 
 class DemoCompatibility;
@@ -114,10 +118,11 @@ struct HUD {
 };
 
 struct CGameContext {
-  Handlers handlers;
+  Core core;
   Demo demo;
 
   Platform platform;
+  Systems systems;
   Utils utils;
   UI ui;
   Visuals visuals;

--- a/src/cgame/etj_consolecommands.cpp
+++ b/src/cgame/etj_consolecommands.cpp
@@ -189,25 +189,25 @@ getOptCommand(const std::string &commandPrefix,
 }
 
 void registerCommands() {
-  cgame.handlers.consoleCommands->subscribe(
+  cgame.core.consoleCommands->subscribe(
       "ftSaveLimitSet", [](const auto &) { ftSaveLimitSet(); }, false);
 
-  cgame.handlers.consoleCommands->subscribe(
+  cgame.core.consoleCommands->subscribe(
       "forceMaplistRefresh", [](const auto &) { forceMaplistRefresh(); },
       false);
 
-  cgame.handlers.consoleCommands->subscribe(
+  cgame.core.consoleCommands->subscribe(
       "forceCustomvoteRefresh", [](const auto &) { forceCustomvoteRefresh(); },
       false);
 
-  cgame.handlers.consoleCommands->subscribe(
+  cgame.core.consoleCommands->subscribe(
       "uiRequestCustomvotes", [](const auto &) { uiRequestCustomvotes(); },
       false);
 
-  cgame.handlers.consoleCommands->subscribe(
+  cgame.core.consoleCommands->subscribe(
       "uiChatMenuOpen", [](const auto &args) { uiChatMenuOpen(args); }, false);
 
-  cgame.handlers.consoleCommands->subscribe(
+  cgame.core.consoleCommands->subscribe(
       "printMapCustomizationInfo",
       [](const auto &) { printMapCustomizationInfo(); });
 }

--- a/src/cgame/etj_custom_command_menu_drawable.cpp
+++ b/src/cgame/etj_custom_command_menu_drawable.cpp
@@ -176,7 +176,7 @@ void CustomCommandMenuDrawable::setupPanels() {
 }
 
 void CustomCommandMenuDrawable::commandMenuTitleDraw(panel_button_t *button) {
-  const auto &commands = cgame.handlers.customCommandMenu->getCustomCommands();
+  const auto &commands = cgame.systems.customCommandMenu->getCustomCommands();
   std::string title = "CUSTOM COMMANDS";
 
   if (!commands.empty()) {
@@ -191,7 +191,7 @@ void CustomCommandMenuDrawable::commandMenuTitleDraw(panel_button_t *button) {
 
 void CustomCommandMenuDrawable::commandMenuTextDraw(panel_button_t *button) {
   float y = button->rect.y;
-  const auto &commands = cgame.handlers.customCommandMenu->getCustomCommands();
+  const auto &commands = cgame.systems.customCommandMenu->getCustomCommands();
 
   if (commands.empty()) {
     CG_Text_Paint_Ext(button->rect.x, y, button->font->scalex,
@@ -282,7 +282,7 @@ qboolean CustomCommandMenuDrawable::checkExecKey(const int32_t key,
 
   // this corresponds to the actual menu item number, not 0-indexed selection
   int32_t realKey = key - '0';
-  const auto &commands = cgame.handlers.customCommandMenu->getCustomCommands();
+  const auto &commands = cgame.systems.customCommandMenu->getCustomCommands();
 
   if (commands.empty()) {
     return qfalse;

--- a/src/cgame/etj_local.h
+++ b/src/cgame/etj_local.h
@@ -117,7 +117,7 @@ enum class ChatMessageType {
 };
 
 void init();
-void initHandlers();
+void initCore();
 void initDemo();
 void shutdown();
 // performs one-time actions slightly delayed from actual cgame init,

--- a/src/cgame/etj_main.cpp
+++ b/src/cgame/etj_main.cpp
@@ -126,27 +126,17 @@ void delayedInit() {
   }
 }
 
-void initHandlers() {
-  cgame.handlers.serverCommands =
-      std::make_shared<ClientCommandsHandler>(nullptr);
-  cgame.handlers.consoleCommands =
+void initCore() {
+  cgame.core.serverCommands = std::make_shared<ClientCommandsHandler>(nullptr);
+  cgame.core.consoleCommands =
       std::make_shared<ClientCommandsHandler>(trap_AddCommand);
-  cgame.handlers.entityEvents = std::make_shared<EntityEventsHandler>();
-  cgame.handlers.playerEvents = std::make_shared<PlayerEventsHandler>();
+  cgame.core.entityEvents = std::make_shared<EntityEventsHandler>();
+  cgame.core.playerEvents = std::make_shared<PlayerEventsHandler>();
 
-  cgame.handlers.awaitedCommand = std::make_unique<AwaitedCommandHandler>(
-      cgame.handlers.consoleCommands, cgame.handlers.playerEvents);
+  cgame.core.awaitedCommand = std::make_unique<AwaitedCommandHandler>(
+      cgame.core.consoleCommands, cgame.core.playerEvents);
 
-  cgame.handlers.cvarUpdate = std::make_shared<CvarUpdateHandler>();
-
-  cgame.handlers.rtv =
-      std::make_unique<ClientRtvHandler>(cgame.handlers.serverCommands);
-
-  cgame.handlers.customCommandMenu = std::make_unique<CustomCommandMenu>(
-      cgame.handlers.cvarUpdate, cgame.handlers.consoleCommands);
-
-  cgame.handlers.timerun = std::make_shared<Timerun>(
-      cgame.handlers.playerEvents, cgame.handlers.serverCommands);
+  cgame.core.cvarUpdate = std::make_shared<CvarUpdateHandler>();
 }
 
 static void initPlatform() {
@@ -155,7 +145,7 @@ static void initPlatform() {
         trap_SendClientCommand(command.c_str());
       },
       [](const std::string &message) { CG_Printf(message.c_str()); },
-      [] { return OperatingSystem::getHwid(); }, cgame.handlers.serverCommands);
+      [] { return OperatingSystem::getHwid(); }, cgame.core.serverCommands);
 
   cgame.platform.operatingSystem = std::make_unique<OperatingSystem>();
 
@@ -163,19 +153,30 @@ static void initPlatform() {
     OperatingSystem::minimize();
   };
 
-  cgame.handlers.consoleCommands->subscribe("min", minimize);
-  cgame.handlers.consoleCommands->subscribe("minimize", minimize);
+  cgame.core.consoleCommands->subscribe("min", minimize);
+  cgame.core.consoleCommands->subscribe("minimize", minimize);
 
   cgame.platform.syscallExt = std::make_unique<SyscallExt>();
   cgame.platform.syscallExt->setupExtensions();
   SyscallExt::trap_CmdBackup_Ext();
 }
 
+static void initSystems() {
+  cgame.systems.rtv =
+      std::make_unique<ClientRtvHandler>(cgame.core.serverCommands);
+
+  cgame.systems.customCommandMenu = std::make_unique<CustomCommandMenu>(
+      cgame.core.cvarUpdate, cgame.core.consoleCommands);
+
+  cgame.systems.timerun = std::make_shared<Timerun>(cgame.core.playerEvents,
+                                                    cgame.core.serverCommands);
+}
+
 void initDemo() {
   cgame.demo.compatibility =
-      std::make_unique<DemoCompatibility>(cgame.handlers.consoleCommands);
+      std::make_unique<DemoCompatibility>(cgame.core.consoleCommands);
   cgame.demo.autoDemoRecorder = std::make_unique<AutoDemoRecorder>(
-      cgame.handlers.playerEvents, cgame.handlers.consoleCommands);
+      cgame.core.playerEvents, cgame.core.consoleCommands);
 }
 
 static void initCvarUnlockers() {
@@ -198,33 +199,33 @@ static void initCvarUnlockers() {
   };
 
   for (const auto &[shadow, target] : cvars) {
-    cgame.utils.cvarUnlocker.emplace_back(std::make_unique<CvarUnlocker>(
-        cgame.handlers.cvarUpdate, shadow, target));
+    cgame.utils.cvarUnlocker.emplace_back(
+        std::make_unique<CvarUnlocker>(cgame.core.cvarUpdate, shadow, target));
   }
 }
 
 static void initUtils() {
-  assert(cgame.handlers.timerun != nullptr);
+  assert(cgame.systems.timerun != nullptr);
 
   cgame.utils.eventLoop = std::make_unique<EventLoop>();
   initCvarUnlockers();
-  cgame.utils.savePos = std::make_unique<SavePos>(cgame.handlers.timerun);
+  cgame.utils.savePos = std::make_unique<SavePos>(cgame.systems.timerun);
   cgame.utils.colorParser = std::make_unique<ColorParser>();
   cgame.utils.trace = std::make_unique<TraceUtils>();
-  cgame.utils.pmove = std::make_unique<PmoveUtils>(cgame.handlers.cvarUpdate);
+  cgame.utils.pmove = std::make_unique<PmoveUtils>(cgame.core.cvarUpdate);
 }
 
 static void initUserInterface() {
   cgame.ui.consoleShader = std::make_unique<ConsoleShader>();
 
   cgame.ui.renderables.emplace_back(std::make_unique<RtvDrawable>());
-  cgame.ui.renderables.emplace_back(std::make_unique<CustomCommandMenuDrawable>(
-      cgame.handlers.consoleCommands));
+  cgame.ui.renderables.emplace_back(
+      std::make_unique<CustomCommandMenuDrawable>(cgame.core.consoleCommands));
 }
 
 static void initTrickjumpLines() {
   cgame.visuals.trickjumpLines = std::make_unique<TrickjumpLines>(
-      cgame.handlers.serverCommands, cgame.handlers.consoleCommands);
+      cgame.core.serverCommands, cgame.core.consoleCommands);
 
   // Check if load TJL on connection is enable
   if (etj_tjlAlwaysLoadTJL.integer == 1) {
@@ -248,9 +249,9 @@ static void initTrickjumpLines() {
 
 static void initVisuals() {
   cgame.visuals.leavesRemapper =
-      std::make_unique<LeavesRemapper>(cgame.handlers.cvarUpdate);
+      std::make_unique<LeavesRemapper>(cgame.core.cvarUpdate);
   cgame.visuals.playerBBox =
-      std::make_unique<PlayerBBox>(cgame.handlers.cvarUpdate);
+      std::make_unique<PlayerBBox>(cgame.core.cvarUpdate);
   initTrickjumpLines();
 }
 
@@ -259,58 +260,58 @@ static void initHUD() {
 
   cgame.hud.accelColor = std::make_unique<AccelColor>();
   cgame.hud.chsDataHandler = std::make_unique<CHSDataHandler>(
-      cgame.handlers.cvarUpdate, cgame.handlers.consoleCommands);
+      cgame.core.cvarUpdate, cgame.core.consoleCommands);
 
-  cgame.hud.renderables.emplace_back(std::make_unique<CHS>(
-      cgame.handlers.cvarUpdate, cgame.hud.chsDataHandler));
+  cgame.hud.renderables.emplace_back(
+      std::make_unique<CHS>(cgame.core.cvarUpdate, cgame.hud.chsDataHandler));
   cgame.hud.renderables.emplace_back(std::make_unique<OverbounceWatcher>(
-      cgame.handlers.consoleCommands, cgame.handlers.cvarUpdate));
+      cgame.core.consoleCommands, cgame.core.cvarUpdate));
   cgame.hud.renderables.emplace_back(std::make_unique<OverbounceDetector>());
   cgame.hud.renderables.emplace_back(std::make_unique<DisplayMaxSpeed>(
-      cgame.handlers.entityEvents, cgame.handlers.cvarUpdate));
+      cgame.core.entityEvents, cgame.core.cvarUpdate));
   cgame.hud.renderables.emplace_back(std::make_unique<DrawSpeed>(
-      cgame.handlers.cvarUpdate, cgame.handlers.consoleCommands));
+      cgame.core.cvarUpdate, cgame.core.consoleCommands));
   cgame.hud.renderables.emplace_back(
-      std::make_unique<AccelMeter>(cgame.handlers.cvarUpdate));
+      std::make_unique<AccelMeter>(cgame.core.cvarUpdate));
   cgame.hud.renderables.emplace_back(std::make_unique<StrafeQuality>(
-      cgame.handlers.cvarUpdate, cgame.handlers.consoleCommands,
-      cgame.handlers.playerEvents));
+      cgame.core.cvarUpdate, cgame.core.consoleCommands,
+      cgame.core.playerEvents));
   cgame.hud.renderables.emplace_back(std::make_unique<JumpSpeeds>(
-      cgame.handlers.entityEvents, cgame.handlers.playerEvents,
-      cgame.handlers.consoleCommands, cgame.handlers.serverCommands,
-      cgame.handlers.cvarUpdate));
+      cgame.core.entityEvents, cgame.core.playerEvents,
+      cgame.core.consoleCommands, cgame.core.serverCommands,
+      cgame.core.cvarUpdate));
   cgame.hud.renderables.emplace_back(std::make_unique<QuickFollowDrawer>());
   cgame.hud.renderables.emplace_back(
-      std::make_unique<SpectatorInfo>(cgame.handlers.cvarUpdate));
+      std::make_unique<SpectatorInfo>(cgame.core.cvarUpdate));
   cgame.hud.renderables.emplace_back(std::make_unique<AreaIndicator>());
 
   if (etj_CGazOnTop.integer) {
     cgame.hud.renderables.emplace_back(
-        std::make_unique<Snaphud>(cgame.handlers.cvarUpdate));
+        std::make_unique<Snaphud>(cgame.core.cvarUpdate));
     cgame.hud.renderables.emplace_back(
-        std::make_unique<CGaz>(cgame.handlers.cvarUpdate));
+        std::make_unique<CGaz>(cgame.core.cvarUpdate));
   } else {
     cgame.hud.renderables.emplace_back(
-        std::make_unique<CGaz>(cgame.handlers.cvarUpdate));
+        std::make_unique<CGaz>(cgame.core.cvarUpdate));
     cgame.hud.renderables.emplace_back(
-        std::make_unique<Snaphud>(cgame.handlers.cvarUpdate));
+        std::make_unique<Snaphud>(cgame.core.cvarUpdate));
   }
 
   cgame.hud.renderables.emplace_back(std::make_unique<UpperRight>());
   cgame.hud.renderables.emplace_back(std::make_unique<UpmoveMeter>(
-      cgame.handlers.cvarUpdate, cgame.handlers.consoleCommands,
-      cgame.handlers.playerEvents));
+      cgame.core.cvarUpdate, cgame.core.consoleCommands,
+      cgame.core.playerEvents));
 
   cgame.hud.renderables.emplace_back(
-      std::make_unique<KeySetSystem>(&etj_drawKeys, cgame.handlers.cvarUpdate));
+      std::make_unique<KeySetSystem>(&etj_drawKeys, cgame.core.cvarUpdate));
 
   // FIXME: move to renderables
   ETJump_ClearDrawables();
-  cgame.hud.timerunView = std::make_unique<TimerunView>(
-      cgame.handlers.timerun, cgame.handlers.cvarUpdate);
+  cgame.hud.timerunView = std::make_unique<TimerunView>(cgame.systems.timerun,
+                                                        cgame.core.cvarUpdate);
 
   cgame.hud.renderables.emplace_back(
-      std::make_unique<Crosshair>(cgame.handlers.cvarUpdate));
+      std::make_unique<Crosshair>(cgame.core.cvarUpdate));
 }
 
 void init() {
@@ -322,6 +323,7 @@ void init() {
                                      " init...\n");
 
   initPlatform();
+  initSystems();
   initUtils();
   initUserInterface();
   initVisuals();

--- a/src/cgame/etj_rtv_drawable.cpp
+++ b/src/cgame/etj_rtv_drawable.cpp
@@ -137,7 +137,7 @@ void RtvDrawable::drawMenuTitleText(panel_button_t *button) {
 void RtvDrawable::drawMenuText(panel_button_t *button) {
   float y = button->rect.y;
   const auto arrSize = static_cast<int>(rtvMenuStrings.size());
-  auto rtvMaps = cgame.handlers.rtv->getRtvMaps();
+  const auto *const rtvMaps = cgame.systems.rtv->getRtvMaps();
 
   for (int i = 0; i < arrSize; i++) {
     // skip empty entries
@@ -154,7 +154,7 @@ void RtvDrawable::drawMenuText(panel_button_t *button) {
       str += StringUtils::format(": %i(%i)", cgs.voteNo, cgs.voteNoSpectators);
     } else {
       str += StringUtils::format(": %i(%i)",
-                                 cgame.handlers.rtv->getTotalVotesForMap(i),
+                                 cgame.systems.rtv->getTotalVotesForMap(i),
                                  (*rtvMaps)[i].voteCountInfo.spectatorCount);
     }
 
@@ -184,8 +184,7 @@ qboolean RtvDrawable::checkExecKey(int key, qboolean doAction) {
     // so 0 = 'Keep current map'
     int selection = key - '0';
 
-    if (selection >
-            static_cast<int>(cgame.handlers.rtv->getRtvMaps()->size()) &&
+    if (selection > static_cast<int>(cgame.systems.rtv->getRtvMaps()->size()) &&
         selection != 0) {
       return qfalse;
     }
@@ -212,7 +211,7 @@ bool RtvDrawable::beforeRender() {
     return false;
   }
 
-  auto rtvMaps = cgame.handlers.rtv->getRtvMaps();
+  auto rtvMaps = cgame.systems.rtv->getRtvMaps();
   std::fill_n(rtvMenuStrings.begin(), rtvMenuStrings.size() - 1, "");
 
   for (size_t i = 0; i < rtvMaps->size(); i++) {
@@ -233,7 +232,7 @@ bool RtvDrawable::canSkipDraw() {
     return true;
   }
 
-  if (!cgame.handlers.rtv->rtvVoteActive()) {
+  if (!cgame.systems.rtv->rtvVoteActive()) {
     return true;
   }
 

--- a/src/cgame/etj_servercommands.cpp
+++ b/src/cgame/etj_servercommands.cpp
@@ -118,29 +118,29 @@ static void callvote(const Arguments &args) {
 }
 
 void registerCommands() {
-  cgame.handlers.serverCommands->subscribe(
+  cgame.core.serverCommands->subscribe(
       "maplist", [](const auto &args) { maplist(args); }, false);
 
-  cgame.handlers.serverCommands->subscribe(
+  cgame.core.serverCommands->subscribe(
       "forceCustomvoteRefresh", [](const auto &) { forceCustomvoteRefresh(); },
       false);
 
-  cgame.handlers.serverCommands->subscribe(
+  cgame.core.serverCommands->subscribe(
       "numcustomvotes", [](const auto &args) { numCustomvotes(args); }, false);
 
-  cgame.handlers.serverCommands->subscribe(
+  cgame.core.serverCommands->subscribe(
       "customvotelist", [](const auto &args) { customvoteList(args); }, false);
 
-  cgame.handlers.serverCommands->subscribe(
+  cgame.core.serverCommands->subscribe(
       "pmFlashWindow", [](const auto &) { pmFlashWindow(); }, false);
 
-  cgame.handlers.serverCommands->subscribe(
+  cgame.core.serverCommands->subscribe(
       "resetStrafeQuality", [](const auto &) { resetStrafeQuality(); }, false);
 
-  cgame.handlers.serverCommands->subscribe(
+  cgame.core.serverCommands->subscribe(
       "savePrint", [](const auto &args) { savePrint(args); }, false);
 
-  cgame.handlers.serverCommands->subscribe(
+  cgame.core.serverCommands->subscribe(
       "callvote", [](const auto &args) { callvote(args); }, false);
 }
 } // namespace ETJump::ServerCommands

--- a/src/cgame/etj_utilities.cpp
+++ b/src/cgame/etj_utilities.cpp
@@ -273,7 +273,7 @@ bool showingScores() {
 }
 
 void onPlayerRespawn(bool revived) {
-  cgame.handlers.playerEvents->check("respawn", {revived ? "1" : "0"});
+  cgame.core.playerEvents->check("respawn", {revived ? "1" : "0"});
 }
 
 playerState_t *getValidPlayerState() {


### PR DESCRIPTION
If a previous RTV vote failed, and a client either connected after that, or performed a `vid_restart`, RTV status would not get correctly set, because the initialization happened too early in the init chain. When the constructor was called, `cgs.voteString` was not yet parsed from configstrings. This, combined with the fact that configstring updates that don't change the value are ignored on the server, did not correctly set the RTV status for the client, causing them to be unable to see the RTV menu, and could only vote "No" on it.

RTV, custom command menu and timeruns are now split from the "Handlers" struct into their own "Systems" struct. The old "Handlers" struct is now called "Core". The "Core" struct is also now initialized after configstrings are fetched, should we ever need to read them in any of the core systems.

refs #1894 