### PR TITLE
Setup CI for dev branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ETJump CI/CD
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [master, dev]
     tags-ignore:
       - "*"
     paths-ignore:
@@ -15,7 +15,7 @@ on:
       - VERSION.txt
       - release.sh
   pull_request:
-    branches: [master]
+    branches: [master, dev]
     paths-ignore:
       - docs/*
       - .gitignore
@@ -176,7 +176,7 @@ jobs:
             etjump-artifacts-macos-x86_64
 
   package:
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
     runs-on: ubuntu-22.04
     needs: [Windows, Linux, macOS-universal]
 


### PR DESCRIPTION
This accommodates the creation of `dev` branch. This is the new default branch, and where upcoming features will live. `master` is considered stable, and will only receive bug fixes, and is always ready to release a new patch, should critical bugs arise. `master` should be merged into `dev` whenever there are pushes - for now I'll handle this manually, but I'll explore potential automated options later.

The CI/CD now runs on push/PR on both `master` and `dev`, but only `dev` runs the package step, such that latest release is always a development build. Dev server setup should not need changing, as it just checks for `latest` tag, which `dev` will publish into.

Updating changelog will become a bit weird with this I guess, but that's a minor inconvenience.

This commit should be merged into both `master` and `dev`, so that both branches have an up-to-date build pipeline.