### PR TITLE
Fix selfkill loading save slot after inactivity drop

### DIFF
--- a/src/game/etj_save_system.cpp
+++ b/src/game/etj_save_system.cpp
@@ -736,6 +736,15 @@ void SaveSystem::loadOnceTeamQuickDeployPosition(gentity_t *ent,
   }
 }
 
+void SaveSystem::invalidateTeamQuickDeployPosition(gentity_t *ent,
+                                                   const team_t team) {
+  auto *const validSave = getValidTeamQuickDeploySave(ent, team);
+
+  if (validSave) {
+    validSave->isValid = false;
+  }
+}
+
 SaveSystem::SavePosition *SaveSystem::getValidTeamSaveForSlot(gentity_t *ent,
                                                               const team_t team,
                                                               const int slot) {

--- a/src/game/etj_save_system.h
+++ b/src/game/etj_save_system.h
@@ -127,6 +127,7 @@ public:
 
   void storeTeamQuickDeployPosition(gentity_t *ent, team_t team);
   void loadOnceTeamQuickDeployPosition(gentity_t *ent, team_t team);
+  void invalidateTeamQuickDeployPosition(gentity_t *ent, team_t team);
 
 private:
   // Saves backup position

--- a/src/game/g_active.cpp
+++ b/src/game/g_active.cpp
@@ -1514,6 +1514,14 @@ void SpectatorClientEndFrame(gentity_t *ent) {
         ent->client->inactivityPos.team = TEAM_FREE;
         DirectTeleport(ent, ent->client->inactivityPos.savedPos,
                        ent->client->inactivityPos.savedAngles);
+
+        // invalidate quick deploy position, otherwise the next self kill
+        // will load that instead of spawning us at a spawn point if autoload
+        // is enabled, as this gets called in limbo as well, and we have not
+        // used up the saved autoload slot yet from the team switch
+        // that was triggered via inactivity drop
+        ETJump::saveSystem->invalidateTeamQuickDeployPosition(
+            ent, ent->client->sess.sessionTeam);
       } else if (ent->client->pers.autoLoad) {
         ETJump::saveSystem->loadOnceTeamQuickDeployPosition(
             ent, ent->client->sess.sessionTeam);


### PR DESCRIPTION
When the client was dropped to spectators from inactivity, the save system stored an autoload slot normally as a team switch was executed. This slot would normally get used up immediately and invalidated as the player joins back to the team. However, if the client was dropped to spectators from inactivity, and joined back to a team, the slot would never get invalidated, as the game loaded the position at the time of inactivity instead. The next self kill would then load the autoload position, as `SpectatorClientEndFrame` gets called in limbo as well.

The autoload slot is now invalidated after the player joins back to a team after inactivity drop.

fixes #1868 
refs #1748 