### PR TITLE
Allow specifying directory for map-specific autoexecs

### DIFF
--- a/assets/ui/etjump_settings_general_client.menu
+++ b/assets/ui/etjump_settings_general_client.menu
@@ -48,11 +48,12 @@ menuDef {
 
         MULTI               (SETTINGS_ITEM_POS(1), "Max FPS:", 0.2, SETTINGS_ITEM_H, "com_maxfps", cvarFloatList { "43" 43 "76" 76 "125" 125 "250" 250 "333" 333 }, "Sets the FPS limit\ncom_maxfps")
         MULTI               (SETTINGS_ITEM_POS(2), "Memory limit:", 0.2, SETTINGS_ITEM_H, "com_hunkmegs", cvarFloatList { "56MB" 56 "64MB" 64 "128MB" 128 "256MB" 256 "512MB" 512 }, "How much memory the client is allowed to use (restart required)\ncom_hunkmegs")
+        EDITFIELD_EXT       (SETTINGS_EF_POS(3), "Map autoexec directory:", 0.2, SETTINGS_ITEM_H, "etj_mapAutoexecDir", SETTINGS_EF_MAXCHARS, SETTINGS_EF_MAXPAINTCHARS, "Directory to execute map-specific autoexec files from (including 'autoexec_default.cfg')\nLeave blank to execute from the root of 'etjump' directory\netj_mapAutoexecDir")
 
 #ifdef VET
-        MULTI               (SETTINGS_ITEM_POS(3), "Rendering primitives:", 0.2, SETTINGS_ITEM_H, "r_primitives", cvarFloatList { "Auto" 0 "Multiple glArrayElement" 1 "Single glDrawElements" 2 }, "Sets rendering primitives mode (ET 2.60b only)\nSetting this to 'Single glDrawElements' is recommended on modern systems for best performance\nr_primitives")
+        MULTI               (SETTINGS_ITEM_POS(4), "Rendering primitives:", 0.2, SETTINGS_ITEM_H, "r_primitives", cvarFloatList { "Auto" 0 "Multiple glArrayElement" 1 "Single glDrawElements" 2 }, "Sets rendering primitives mode (ET 2.60b only)\nSetting this to 'Single glDrawElements' is recommended on modern systems for best performance\nr_primitives")
 #else
-        COMBO_BIT           (SETTINGS_COMBO_POS(3), "Use quiet exec:", 0.2, SETTINGS_ITEM_H, "etj_useExecQuiet", cvarFloatList { "Map autoexec" 1 "Team autoexec" 2 }, none, "Use 'execq' when executing autoexec configs\netj_useExecQuiet")
+        COMBO_BIT           (SETTINGS_COMBO_POS(4), "Use quiet exec:", 0.2, SETTINGS_ITEM_H, "etj_useExecQuiet", cvarFloatList { "Map autoexec" 1 "Team autoexec" 2 }, none, "Use 'execq' when executing autoexec configs\netj_useExecQuiet")
 #endif
 
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2765,6 +2765,7 @@ extern vmCvar_t etj_onDemoPlaybackEnd;
 extern vmCvar_t etj_HUD_noLerp;
 
 extern vmCvar_t etj_useExecQuiet;
+extern vmCvar_t etj_mapAutoexecDir;
 
 extern vmCvar_t etj_hideFlamethrowerEffects;
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -702,6 +702,7 @@ vmCvar_t etj_onDemoPlaybackEnd;
 vmCvar_t etj_HUD_noLerp;
 
 vmCvar_t etj_useExecQuiet;
+vmCvar_t etj_mapAutoexecDir;
 
 vmCvar_t etj_hideFlamethrowerEffects;
 
@@ -1329,6 +1330,7 @@ cvarTable_t cvarTable[] = {
 
     {&etj_HUD_noLerp, "etj_HUD_noLerp", "0", CVAR_ARCHIVE},
     {&etj_useExecQuiet, "etj_useExecQuiet", "0", CVAR_ARCHIVE},
+    {&etj_mapAutoexecDir, "etj_mapAutoexecDir", "", CVAR_ARCHIVE},
 
     {&etj_hideFlamethrowerEffects, "etj_hideFlamethrowerEffects", "0",
      CVAR_ARCHIVE},
@@ -4108,11 +4110,16 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum,
   ETJump::initVoteTally();
 
   // map-specific autoexec
-  const auto mapConfig = va("autoexec_%s", cgs.rawmapname);
+  const auto *const path = etj_mapAutoexecDir.string[0] != '\0'
+                               ? va("%s/", etj_mapAutoexecDir.string)
+                               : "";
+  auto *const mapConfig = va("%sautoexec_%s", path, cgs.rawmapname);
+
   if (ETJump::configFileExists(mapConfig)) {
     ETJump::execFile(mapConfig, ETJump::ExecFileType::MAP_AUTOEXEC);
-  } else if (ETJump::configFileExists("autoexec_default")) {
-    ETJump::execFile("autoexec_default", ETJump::ExecFileType::MAP_AUTOEXEC);
+  } else if (ETJump::configFileExists(va("%sautoexec_default", path))) {
+    ETJump::execFile(va("%sautoexec_default", path),
+                     ETJump::ExecFileType::MAP_AUTOEXEC);
   }
 
   if (!Q_stricmp(cgs.rawmapname, "solstice") ||

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2127,6 +2127,8 @@ extern vmCvar_t g_adminChat;
 extern vmCvar_t g_chatReplay;
 extern vmCvar_t g_chatReplayMaxMessageAge;
 
+extern vmCvar_t g_mapAutoexecDir;
+
 void trap_Printf(const char *fmt);
 [[noreturn]] void trap_Error(const char *fmt);
 int trap_Milliseconds(void);

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -278,6 +278,8 @@ vmCvar_t g_adminChat;
 vmCvar_t g_chatReplay;
 vmCvar_t g_chatReplayMaxMessageAge;
 
+vmCvar_t g_mapAutoexecDir;
+
 // ETLegacy server browser integration
 // os support - this SERVERINFO cvar specifies supported client operating
 // systems on server
@@ -535,6 +537,8 @@ cvarTable_t gameCvarTable[] = {
     {&g_chatReplay, "g_chatReplay", "1", CVAR_ARCHIVE},
     {&g_chatReplayMaxMessageAge, "g_chatReplayMaxMessageAge", "5",
      CVAR_ARCHIVE | CVAR_LATCH},
+
+    {&g_mapAutoexecDir, "g_mapAutoexecDir", "", CVAR_ARCHIVE},
 };
 
 // bk001129 - made static to avoid aliasing
@@ -1624,21 +1628,27 @@ void G_wipeCvars(void) {
 }
 
 void G_ExecMapSpecificConfig() {
-  int len;
-  fileHandle_t f;
+  int len = 0;
+  fileHandle_t f = 0;
+  const auto *const path = g_mapAutoexecDir.string[0] != '\0'
+                               ? va("%s/", g_mapAutoexecDir.string)
+                               : "";
 
-  len = trap_FS_FOpenFile(va("autoexec_%s.cfg", level.rawmapname), &f, FS_READ);
+  const char *filename = va("%sautoexec_%s.cfg", path, level.rawmapname);
+  len = trap_FS_FOpenFile(filename, &f, FS_READ);
+
   if (len > 0) {
     // autoexec_mapname.cfg file found
-    trap_SendConsoleCommand(EXEC_APPEND,
-                            va("exec autoexec_%s.cfg\n", level.rawmapname));
+    trap_SendConsoleCommand(EXEC_APPEND, va("exec %s\n", filename));
     return;
   }
 
-  len = trap_FS_FOpenFile("autoexec_default.cfg", &f, FS_READ);
+  filename = va("%sautoexec_default.cfg", path);
+  len = trap_FS_FOpenFile(filename, &f, FS_READ);
+
   if (len > 0) {
     // autoexec_default.cfg file found
-    trap_SendConsoleCommand(EXEC_APPEND, "exec autoexec_default.cfg\n");
+    trap_SendConsoleCommand(EXEC_APPEND, va("exec %s\n", filename));
   }
 }
 


### PR DESCRIPTION
`etj_mapAutoexecDir` (client) or `g_mapAutoexecDir` (server) allows placing map-specific autoexec files elsewhere other than the root of `etjump` directory. Blank value (default) looks in the root.