### PR TITLE
Custom command menu tweaks

### DIFF
--- a/assets/ui/etjump_settings_general_ui.menu
+++ b/assets/ui/etjump_settings_general_ui.menu
@@ -58,6 +58,7 @@ menuDef {
         YESNO               (SETTINGS_ITEM_POS(8), "Auto close custom command menu:", 0.2, SETTINGS_ITEM_H, etj_ccMenu_autoClose, "Automatically close custom command menu after a command is executed\netj_ccMenu_autoClose")
         CVARFLOATLABEL      (SETTINGS_ITEM_POS(9), "etj_ccMenu_width", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(9), "Custom command menu width:", 0.2, SETTINGS_ITEM_H, etj_ccMenu_width 204 204 620 2, "Sets the width of the custom command menu\netj_ccMenu_width")
+        YESNO               (SETTINGS_ITEM_POS(10), "Browse custom commands with 'open':", 0.2, SETTINGS_ITEM_H, etj_ccMenu_browseWithOpen, "Browse to next page of custom command menu instead of closing it when\nit's already open, and 'openCustomCommandMenu' is executed again\netj_ccMenu_browseWithOpen")
 
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)

--- a/assets/ui/etjump_settings_general_ui.menu
+++ b/assets/ui/etjump_settings_general_ui.menu
@@ -56,6 +56,8 @@ menuDef {
         EDITFIELD_EXT       (SETTINGS_EF_POS(6), "Custom command file:", 0.2, SETTINGS_ITEM_H, "etj_ccMenu_filename", SETTINGS_EF_MAXCHARS, SETTINGS_EF_MAXPAINTCHARS, "File to load custom commands from, without file extension\nThis must be a .dat file\netj_ccMenu_filename")
         YESNO               (SETTINGS_ITEM_POS(7), "Remember custom command menu page:", 0.2, SETTINGS_ITEM_H, etj_ccMenu_rememberPage, "Remember the last opened page when opening the custom command menu\netj_ccMenu_rememberPage")
         YESNO               (SETTINGS_ITEM_POS(8), "Auto close custom command menu:", 0.2, SETTINGS_ITEM_H, etj_ccMenu_autoClose, "Automatically close custom command menu after a command is executed\netj_ccMenu_autoClose")
+        CVARFLOATLABEL      (SETTINGS_ITEM_POS(9), "etj_ccMenu_width", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(9), "Custom command menu width:", 0.2, SETTINGS_ITEM_H, etj_ccMenu_width 204 204 620 2, "Sets the width of the custom command menu\netj_ccMenu_width")
 
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2771,6 +2771,7 @@ extern vmCvar_t etj_hideFlamethrowerEffects;
 extern vmCvar_t etj_ccMenu_filename;
 extern vmCvar_t etj_ccMenu_rememberPage;
 extern vmCvar_t etj_ccMenu_autoClose;
+extern vmCvar_t etj_ccMenu_width;
 
 //
 // cg_main.c

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2772,6 +2772,7 @@ extern vmCvar_t etj_ccMenu_filename;
 extern vmCvar_t etj_ccMenu_rememberPage;
 extern vmCvar_t etj_ccMenu_autoClose;
 extern vmCvar_t etj_ccMenu_width;
+extern vmCvar_t etj_ccMenu_browseWithOpen;
 
 //
 // cg_main.c

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -709,6 +709,7 @@ vmCvar_t etj_ccMenu_filename;
 vmCvar_t etj_ccMenu_rememberPage;
 vmCvar_t etj_ccMenu_autoClose;
 vmCvar_t etj_ccMenu_width;
+vmCvar_t etj_ccMenu_browseWithOpen;
 
 typedef struct {
   vmCvar_t *vmCvar;
@@ -1339,6 +1340,8 @@ cvarTable_t cvarTable[] = {
     {&etj_ccMenu_rememberPage, "etj_ccMenu_rememberPage", "0", CVAR_ARCHIVE},
     {&etj_ccMenu_autoClose, "etj_ccMenu_autoClose", "1", CVAR_ARCHIVE},
     {&etj_ccMenu_width, "etj_ccMenu_width", "204", CVAR_ARCHIVE},
+    {&etj_ccMenu_browseWithOpen, "etj_ccMenu_browseWithOpen", "0",
+     CVAR_ARCHIVE},
 };
 
 int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -708,6 +708,7 @@ vmCvar_t etj_hideFlamethrowerEffects;
 vmCvar_t etj_ccMenu_filename;
 vmCvar_t etj_ccMenu_rememberPage;
 vmCvar_t etj_ccMenu_autoClose;
+vmCvar_t etj_ccMenu_width;
 
 typedef struct {
   vmCvar_t *vmCvar;
@@ -1337,6 +1338,7 @@ cvarTable_t cvarTable[] = {
      CVAR_ARCHIVE},
     {&etj_ccMenu_rememberPage, "etj_ccMenu_rememberPage", "0", CVAR_ARCHIVE},
     {&etj_ccMenu_autoClose, "etj_ccMenu_autoClose", "1", CVAR_ARCHIVE},
+    {&etj_ccMenu_width, "etj_ccMenu_width", "204", CVAR_ARCHIVE},
 };
 
 int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);

--- a/src/cgame/etj_custom_command_menu_drawable.cpp
+++ b/src/cgame/etj_custom_command_menu_drawable.cpp
@@ -325,12 +325,22 @@ qboolean CustomCommandMenuDrawable::checkExecKey(const int32_t key,
     return qtrue;
   }
 
-  if (key < '0' || key > '9') {
+  if ((key < '0' || key > '9') && key != K_LEFTARROW && key != K_RIGHTARROW) {
     return qfalse;
   }
 
   // this corresponds to the actual menu item number, not 0-indexed selection
-  int32_t realKey = key - '0';
+  int32_t realKey = -1;
+
+  // a bit hacky but simplifies keyhandling greatly
+  if (key == K_LEFTARROW) {
+    realKey = '9' - '0';
+  } else if (key == K_RIGHTARROW) {
+    realKey = 0;
+  } else {
+    realKey = key - '0';
+  }
+
   const auto &commands = cgame.systems.customCommandMenu->getCustomCommands();
 
   if (commands.empty()) {

--- a/src/cgame/etj_custom_command_menu_drawable.cpp
+++ b/src/cgame/etj_custom_command_menu_drawable.cpp
@@ -145,6 +145,16 @@ CustomCommandMenuDrawable::~CustomCommandMenuDrawable() {
 void CustomCommandMenuDrawable::setupListeners() {
   consoleCommands->subscribe(
       "openCustomCommandMenu", [](const std::vector<std::string> &args) {
+        if (cg.showCustomCommandMenu && etj_ccMenu_browseWithOpen.integer) {
+          if (currentPage == CUSTOM_COMMAND_MENU_MAX_PAGES) {
+            currentPage = 1;
+          } else {
+            currentPage++;
+          }
+
+          return;
+        }
+
         if (args.empty()) {
           openMenu(currentPage);
         } else {

--- a/src/cgame/etj_custom_command_menu_drawable.cpp
+++ b/src/cgame/etj_custom_command_menu_drawable.cpp
@@ -26,6 +26,7 @@
 #include "cg_local.h"
 #include "etj_client_commands_handler.h"
 #include "etj_custom_command_menu.h"
+#include "etj_cvar_update_handler.h"
 #include "etj_utilities.h"
 
 #include "../game/etj_string_utilities.h"
@@ -36,8 +37,11 @@ inline constexpr uint8_t MENU_NEXT = 9;
 inline constexpr uint8_t MENU_NEXT_KEY = 0;
 inline constexpr uint8_t MENU_PREV = 8;
 inline constexpr uint8_t MENU_PREV_KEY = 9;
+
 // to prevent long names from overflowing in the menu
-inline constexpr size_t MAX_COMNMAND_NAME_LEN = 28;
+inline constexpr size_t DEFAULT_CMD_NAME_LEN = 28;
+inline constexpr float DEFAULT_MENU_WIDTH = 204.0f;
+inline constexpr float MAX_MENU_WIDTH = 620.0f;
 
 static panel_button_text_t commandMenuTitleFont = {
     0.19f, 0.19f, {0.6f, 0.6f, 0.6f, 1.f}, 0, 0, &cgs.media.limboFont1_lo,
@@ -55,7 +59,7 @@ static panel_button_text_t commandMenuFont = {
 static panel_button_t commandMenuTopBorder = {
     nullptr,
     "",
-    {10, 129, 204, 136},
+    {10, 129, DEFAULT_MENU_WIDTH, 136},
     // set color, r, g, b, a, draw rect
     {1, static_cast<int32_t>(255 * 0.5f), static_cast<int32_t>(255 * 0.5f),
      static_cast<int32_t>(255 * 0.5f), static_cast<int32_t>(255 * 0.5f), 1, 0,
@@ -70,7 +74,7 @@ static panel_button_t commandMenuTopBorder = {
 static panel_button_t commandMenuTopBorderBack = {
     "white",
     "",
-    {11, 130, 202, 134},
+    {11, 130, DEFAULT_MENU_WIDTH - 2, 134},
     // set color, r, g, b, a
     {1, 0, 0, 0, static_cast<int32_t>(255 * 0.75f), 0, 0, 0},
     nullptr,
@@ -83,7 +87,7 @@ static panel_button_t commandMenuTopBorderBack = {
 static panel_button_t commandMenuTopBorderInner = {
     "white",
     "",
-    {12, 131, 200, 12},
+    {12, 131, DEFAULT_MENU_WIDTH - 4, 12},
     // set color, r, g, b, a
     {1, 41, 51, 43, 204, 0, 0, 0},
     nullptr,
@@ -96,7 +100,7 @@ static panel_button_t commandMenuTopBorderInner = {
 static panel_button_t commandMenuTopBorderInnerText = {
     nullptr,
     "",
-    {15, 141, 200, 12},
+    {15, 141, DEFAULT_MENU_WIDTH - 4, 12},
     {0, 0, 0, 0, 0, 0, 0, 0},
     &commandMenuTitleFont,
     nullptr,
@@ -119,18 +123,23 @@ static panel_button_t commandMenuItemText = {
 
 static std::vector<panel_button_t> commandMenuPanels;
 uint8_t CustomCommandMenuDrawable::currentPage = 1;
+size_t CustomCommandMenuDrawable::maxChars = DEFAULT_CMD_NAME_LEN;
 
 CustomCommandMenuDrawable::CustomCommandMenuDrawable(
-    const std::shared_ptr<ClientCommandsHandler> &consoleCommands)
-    : consoleCommands(consoleCommands) {
+    const std::shared_ptr<ClientCommandsHandler> &consoleCommands,
+    const std::shared_ptr<CvarUpdateHandler> &cvarUpdate)
+    : consoleCommands(consoleCommands), cvarUpdate(cvarUpdate) {
   setupListeners();
-  setupPanels();
+  // this ends up calling 'setupPanels' so no need to call it manually here
+  resizePanels(
+      std::clamp(etj_ccMenu_width.value, DEFAULT_MENU_WIDTH, MAX_MENU_WIDTH));
 }
 
 CustomCommandMenuDrawable::~CustomCommandMenuDrawable() {
   commandMenuPanels.clear();
 
   consoleCommands->unsubscribe("openCustomCommandMenu");
+  cvarUpdate->unsubscribe(&etj_ccMenu_width);
 }
 
 void CustomCommandMenuDrawable::setupListeners() {
@@ -142,6 +151,10 @@ void CustomCommandMenuDrawable::setupListeners() {
           openMenu(static_cast<uint8_t>(Q_atoi(args[0])));
         }
       });
+
+  cvarUpdate->subscribe(&etj_ccMenu_width, [](const vmCvar_t *cvar) {
+    resizePanels(std::clamp(cvar->value, DEFAULT_MENU_WIDTH, MAX_MENU_WIDTH));
+  });
 }
 
 void CustomCommandMenuDrawable::openMenu(const uint8_t page) {
@@ -173,6 +186,43 @@ void CustomCommandMenuDrawable::setupPanels() {
   commandMenuPanels.push_back(commandMenuItemText);
 
   BG_PanelButtonsSetup(commandMenuPanels);
+}
+
+void CustomCommandMenuDrawable::resizePanels(const float width) {
+  commandMenuTopBorder.rect.w = width;
+  commandMenuTopBorderBack.rect.w = width - 2;
+  commandMenuTopBorderInner.rect.w = width - 4;
+  commandMenuTopBorderInnerText.rect.w = width - 4;
+
+  computeMaxChars();
+
+  // editing the existing vector items would be a bit awkward as the sizing
+  // isn't consistent between buttons, so just rebuild the entire thing
+  commandMenuPanels.clear();
+  setupPanels();
+}
+
+void CustomCommandMenuDrawable::computeMaxChars() {
+  char text[MAX_STRING_CHARS]{};
+  Q_strncpyz(text, "1. A", sizeof(text));
+  const auto &btn = commandMenuItemText;
+  const float margin =
+      ((btn.rect.x - commandMenuTopBorder.rect.x) * 2) + btn.rect.x;
+  float width = 0;
+
+  while (true) {
+    width = static_cast<float>(
+        CG_Text_Width_Ext(text, btn.font->scalex, 0, btn.font->font));
+
+    if (width > commandMenuTopBorderInnerText.rect.w - margin) {
+      text[strlen(text) - 1] = '\0';
+      maxChars =
+          MaxCharsForWidth(text, btn.font->scalex, width, btn.font->font);
+      break;
+    }
+
+    Q_strcat(text, sizeof(text), "A");
+  }
 }
 
 void CustomCommandMenuDrawable::commandMenuTitleDraw(panel_button_t *button) {
@@ -248,8 +298,7 @@ void CustomCommandMenuDrawable::commandMenuTextDraw(panel_button_t *button) {
         s += "Next page";
         break;
       default:
-        s += StringUtils::truncate(commands.at(currentPage)[i].name,
-                                   MAX_COMNMAND_NAME_LEN);
+        s += StringUtils::truncate(commands.at(currentPage)[i].name, maxChars);
         break;
     }
 

--- a/src/cgame/etj_custom_command_menu_drawable.h
+++ b/src/cgame/etj_custom_command_menu_drawable.h
@@ -30,11 +30,13 @@
 
 namespace ETJump {
 class ClientCommandsHandler;
+class CvarUpdateHandler;
 
 class CustomCommandMenuDrawable : public IRenderable {
 public:
-  explicit CustomCommandMenuDrawable(
-      const std::shared_ptr<ClientCommandsHandler> &consoleCommands);
+  CustomCommandMenuDrawable(
+      const std::shared_ptr<ClientCommandsHandler> &consoleCommands,
+      const std::shared_ptr<CvarUpdateHandler> &cvarUpdate);
   ~CustomCommandMenuDrawable() override;
 
   bool beforeRender() override;
@@ -49,12 +51,16 @@ public:
 
 private:
   static uint8_t currentPage;
+  static size_t maxChars;
 
   std::shared_ptr<ClientCommandsHandler> consoleCommands;
+  std::shared_ptr<CvarUpdateHandler> cvarUpdate;
 
   void setupListeners();
   static void openMenu(uint8_t page);
   static void setupPanels();
+  static void resizePanels(float width);
+  static void computeMaxChars();
   static bool canSkipDraw();
 };
 } // namespace ETJump

--- a/src/cgame/etj_main.cpp
+++ b/src/cgame/etj_main.cpp
@@ -219,8 +219,8 @@ static void initUserInterface() {
   cgame.ui.consoleShader = std::make_unique<ConsoleShader>();
 
   cgame.ui.renderables.emplace_back(std::make_unique<RtvDrawable>());
-  cgame.ui.renderables.emplace_back(
-      std::make_unique<CustomCommandMenuDrawable>(cgame.core.consoleCommands));
+  cgame.ui.renderables.emplace_back(std::make_unique<CustomCommandMenuDrawable>(
+      cgame.core.consoleCommands, cgame.core.cvarUpdate));
 }
 
 static void initTrickjumpLines() {


### PR DESCRIPTION
* `etj_ccMenu_width` can be used to set the width of the menu (**204** - **620** range). Text truncation is automatically recalculated when the size is adjusted.
* Left/right arrow keys can now be used to navigate to previous/next pages, respectively
* `etj_ccMenu_browseWithOpen` allows browsing to the next page when the `openCustomCommandMenu` is executed again. This allows for fast, one way browsing with a single keybind.
  * Small caveat with this is that the action happens on the console command, not key event, meaning that manually typing the command in console also browses the pages. This is because cgame only gets the console command, not the key event itself, when a bind is executed when the menu is open.

refs #1912, #1801