### PR TITLE
Custom command menu tweaks, part 2

### DIFF
--- a/assets/ui/etjump_settings_general_ui.menu
+++ b/assets/ui/etjump_settings_general_ui.menu
@@ -59,6 +59,7 @@ menuDef {
         CVARFLOATLABEL      (SETTINGS_ITEM_POS(9), "etj_ccMenu_width", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(9), "Custom command menu width:", 0.2, SETTINGS_ITEM_H, etj_ccMenu_width 204 204 620 2, "Sets the width of the custom command menu\netj_ccMenu_width")
         YESNO               (SETTINGS_ITEM_POS(10), "Browse custom commands with 'open':", 0.2, SETTINGS_ITEM_H, etj_ccMenu_browseWithOpen, "Browse to next page of custom command menu instead of closing it when\nit's already open, and 'openCustomCommandMenu' is executed again\netj_ccMenu_browseWithOpen")
+        YESNO               (SETTINGS_ITEM_POS(11), "Show empty cust. command menu pages:", 0.2, SETTINGS_ITEM_H, etj_ccMenu_showEmptyPages, "Include empty pages when browsing custom command menu\netj_ccMenu_showEmptyPages")
 
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2774,6 +2774,7 @@ extern vmCvar_t etj_ccMenu_rememberPage;
 extern vmCvar_t etj_ccMenu_autoClose;
 extern vmCvar_t etj_ccMenu_width;
 extern vmCvar_t etj_ccMenu_browseWithOpen;
+extern vmCvar_t etj_ccMenu_showEmptyPages;
 
 //
 // cg_main.c

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -711,6 +711,7 @@ vmCvar_t etj_ccMenu_rememberPage;
 vmCvar_t etj_ccMenu_autoClose;
 vmCvar_t etj_ccMenu_width;
 vmCvar_t etj_ccMenu_browseWithOpen;
+vmCvar_t etj_ccMenu_showEmptyPages;
 
 typedef struct {
   vmCvar_t *vmCvar;
@@ -1343,6 +1344,8 @@ cvarTable_t cvarTable[] = {
     {&etj_ccMenu_autoClose, "etj_ccMenu_autoClose", "1", CVAR_ARCHIVE},
     {&etj_ccMenu_width, "etj_ccMenu_width", "204", CVAR_ARCHIVE},
     {&etj_ccMenu_browseWithOpen, "etj_ccMenu_browseWithOpen", "0",
+     CVAR_ARCHIVE},
+    {&etj_ccMenu_showEmptyPages, "etj_ccMenu_showEmptyPages", "0",
      CVAR_ARCHIVE},
 };
 

--- a/src/cgame/etj_custom_command_menu_drawable.cpp
+++ b/src/cgame/etj_custom_command_menu_drawable.cpp
@@ -140,6 +140,7 @@ CustomCommandMenuDrawable::~CustomCommandMenuDrawable() {
 
   consoleCommands->unsubscribe("openCustomCommandMenu");
   cvarUpdate->unsubscribe(&etj_ccMenu_width);
+  cvarUpdate->unsubscribe(&etj_ccMenu_filename);
 }
 
 void CustomCommandMenuDrawable::setupListeners() {
@@ -164,6 +165,12 @@ void CustomCommandMenuDrawable::setupListeners() {
 
   cvarUpdate->subscribe(&etj_ccMenu_width, [](const vmCvar_t *cvar) {
     resizePanels(std::clamp(cvar->value, DEFAULT_MENU_WIDTH, MAX_MENU_WIDTH));
+  });
+
+  cvarUpdate->subscribe(&etj_ccMenu_filename, [](const vmCvar_t *) {
+    // changing the filename should always reset to page 1, as there's
+    // no real reason to retain the active page between different menus
+    currentPage = 1;
   });
 }
 

--- a/src/cgame/etj_custom_command_menu_drawable.cpp
+++ b/src/cgame/etj_custom_command_menu_drawable.cpp
@@ -25,7 +25,6 @@
 #include "etj_custom_command_menu_drawable.h"
 #include "cg_local.h"
 #include "etj_client_commands_handler.h"
-#include "etj_custom_command_menu.h"
 #include "etj_cvar_update_handler.h"
 #include "etj_utilities.h"
 
@@ -147,12 +146,8 @@ void CustomCommandMenuDrawable::setupListeners() {
   consoleCommands->subscribe(
       "openCustomCommandMenu", [](const std::vector<std::string> &args) {
         if (cg.showCustomCommandMenu && etj_ccMenu_browseWithOpen.integer) {
-          if (currentPage == CUSTOM_COMMAND_MENU_MAX_PAGES) {
-            currentPage = 1;
-          } else {
-            currentPage++;
-          }
-
+          findNextPage(cgame.systems.customCommandMenu->getCustomCommands(),
+                       BrowseDirection::NEXT);
           return;
         }
 
@@ -239,6 +234,50 @@ void CustomCommandMenuDrawable::computeMaxChars() {
     }
 
     Q_strcat(text, sizeof(text), "A");
+  }
+}
+
+void CustomCommandMenuDrawable::findNextPage(const CustomCommandMap &commands,
+                                             const BrowseDirection dir) {
+  assert(dir == BrowseDirection::PREVIOUS || dir == BrowseDirection::NEXT);
+  const auto step = static_cast<int32_t>(dir);
+
+  if (etj_ccMenu_showEmptyPages.integer) {
+    currentPage = ((currentPage - 1 + step + CUSTOM_COMMAND_MENU_MAX_PAGES) %
+                   CUSTOM_COMMAND_MENU_MAX_PAGES) +
+                  1;
+    return;
+  }
+
+  uint8_t next = currentPage;
+
+  while (true) {
+    next = ((next - 1 + step + CUSTOM_COMMAND_MENU_MAX_PAGES) %
+            CUSTOM_COMMAND_MENU_MAX_PAGES) +
+           1;
+
+    if (next == currentPage) {
+      break;
+    }
+
+    // the map might not contain all pages, so verify this page exists
+    if (commands.find(next) != commands.cend()) {
+      // if the page is found, it might still be empty,
+      // if it's just defined in the file, but no commands are defined
+      bool empty = true;
+
+      for (const auto &[name, command] : commands.at(next)) {
+        if (!command.empty() && !name.empty()) {
+          empty = false;
+          break;
+        }
+      }
+
+      if (!empty) {
+        currentPage = next;
+        break;
+      }
+    }
   }
 }
 
@@ -382,20 +421,10 @@ qboolean CustomCommandMenuDrawable::checkExecKey(const int32_t key,
 
   switch (realKey) {
     case MENU_PREV_KEY:
-      if (currentPage == 1) {
-        currentPage = CUSTOM_COMMAND_MENU_MAX_PAGES;
-      } else {
-        currentPage--;
-      }
-
+      findNextPage(commands, BrowseDirection::PREVIOUS);
       break;
     case MENU_NEXT_KEY:
-      if (currentPage == CUSTOM_COMMAND_MENU_MAX_PAGES) {
-        currentPage = 1;
-      } else {
-        currentPage++;
-      }
-
+      findNextPage(commands, BrowseDirection::NEXT);
       break;
     default:
       trap_SendConsoleCommand(

--- a/src/cgame/etj_custom_command_menu_drawable.h
+++ b/src/cgame/etj_custom_command_menu_drawable.h
@@ -24,7 +24,10 @@
 
 #pragma once
 
+#include <map>
+
 #include "etj_irenderable.h"
+#include "etj_custom_command_menu.h"
 
 #include "../ui/ui_shared.h"
 
@@ -50,6 +53,14 @@ public:
   static qboolean checkExecKey(int32_t key, qboolean doAction);
 
 private:
+  using CustomCommandMap =
+      std::map<uint8_t, std::array<CustomCommandMenu::CustomCommand,
+                                   CUSTOM_COMMAND_MENU_PAGE_SIZE>>;
+  enum class BrowseDirection {
+    PREVIOUS = -1,
+    NEXT = 1,
+  };
+
   static uint8_t currentPage;
   static size_t maxChars;
 
@@ -61,6 +72,8 @@ private:
   static void setupPanels();
   static void resizePanels(float width);
   static void computeMaxChars();
+  static void findNextPage(const CustomCommandMap &commands,
+                           BrowseDirection dir);
   static bool canSkipDraw();
 };
 } // namespace ETJump


### PR DESCRIPTION
* Changing `etj_ccMenu_filename` now resets the current page back to 1st page
* Empty pages are skipped by default when browsing, `etj_ccMenu_showEmptyPages` can be used to include them while browsing.

refs #1912, #1801