### PR TITLE
Add support for extended console command completions

### DIFF
--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(cgame MODULE
 	"etj_client_commands_handler.cpp"
 	"etj_client_rtv_handler.cpp"
 	"etj_color_parser.cpp"
+	"etj_command_complete_ext.cpp"
 	"etj_console_shader.cpp"
 	"etj_consolecommands.cpp"
 	"etj_crosshair.cpp"

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 
 #include "cg_local.h"
+#include "etj_command_complete_ext.h"
 #include "etj_cvar_update_handler.h"
 #include "etj_demo_compatibility.h"
 #include "etj_utilities.h"
@@ -78,6 +79,9 @@ extern "C" FN_PUBLIC intptr_t vmMain(int command, intptr_t arg0, intptr_t arg1,
       return (g_waitingForKey && g_bindItem) ? qtrue : qfalse;
     case CG_MESSAGERECEIVED:
       return -1;
+    case CG_CONSOLE_COMPLETE_ARGUMENT:
+      // qboolean for API compatibility
+      return ETJump::CommandCompletions::completeArgument() ? qtrue : qfalse;
     default:
       CG_Error("vmMain: unknown command %i", command);
       break;

--- a/src/cgame/cg_public.h
+++ b/src/cgame/cg_public.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../game/q_shared.h"
+#include "../game/etj_syscalls.h"
 
 // allow a lot of command backups for very fast systems
 // multiple commands may be combined into a single packet, so this
@@ -301,8 +302,7 @@ typedef enum {
   //	void (*CG_EventHandling)(int type, qboolean fForced);
 
   CG_GET_TAG,
-  //	qboolean CG_GetTag( int clientNum, char *tagname, orientation_t
-  //*or );
+  //	qboolean CG_GetTag( int clientNum, char *tagname, orientation_t *or );
 
   CG_CHECKEXECKEY,
 
@@ -310,10 +310,15 @@ typedef enum {
 
   // zinx
   CG_MESSAGERECEIVED,
-  //	void (*CG_MessageReceived)( const char *buf, int buflen, int
-  // serverTime
-  //);
-  // -zinx
+  //	void (*CG_MessageReceived)( const char *buf, int buflen, int serverTime
+  //); -zinx
+
+  // padding for engine extensions VM_Calls, matching ET: Legacy padding
+  // ETe does not currently have any extensions that add new exports to cgame
+  CG_ETJUMP_CUSTOM = MOD_EXPORT_PADDING,
+
+  CG_CONSOLE_COMPLETE_ARGUMENT,
+  // bool ETJump::CommandCompletions::completeArgument();
 
 } cgameExport_t;
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -2158,7 +2158,7 @@ static const char *addChatModifications(char *text, const int clientNum,
 
     if (etj_highlight.integer &
         static_cast<int>(ChatHighlightFlags::HIGHLIGHT_FLASH)) {
-      SyscallExt::trap_SysFlashWindowETLegacy(
+      SyscallExt::trap_SysFlashWindow(
           SyscallExt::FlashWindowState::SDL_FLASH_UNTIL_FOCUSED);
     }
   }

--- a/src/cgame/cg_syscalls.cpp
+++ b/src/cgame/cg_syscalls.cpp
@@ -933,26 +933,38 @@ bool SyscallExt::trap_GetValue(char *value, const int size, const char *key) {
 }
 
 // ET: Legacy - flash client window
-void SyscallExt::trap_SysFlashWindowETLegacy(const FlashWindowState state) {
-  if (cgame.platform.syscallExt
-          ->cgameExtensions[cgame.platform.syscallExt->flashWindowETLegacy]) {
-    SystemCall(
-        cgame.platform.syscallExt
-            ->cgameExtensions[cgame.platform.syscallExt->flashWindowETLegacy],
-        static_cast<int>(state));
+void SyscallExt::trap_SysFlashWindow(const FlashWindowState state) {
+  const int32_t trap =
+      cgame.platform.syscallExt
+          ->cgameExtensions[cgame.platform.syscallExt->flashWindowETLegacy];
+
+  if (trap) {
+    SystemCall(trap, static_cast<int>(state));
   }
 }
 
 void SyscallExt::trap_CmdBackup_Ext() {
-  if (cgame.platform.syscallExt
-          ->cgameExtensions[cgame.platform.syscallExt->cmdBackupExt]) {
+  const int32_t trap =
+      cgame.platform.syscallExt
+          ->cgameExtensions[cgame.platform.syscallExt->cmdBackupExt];
+
+  if (trap) {
     cg.cmdBackup = CMD_BACKUP_EXT;
     cg.cmdMask = CMD_MASK_EXT;
-    SystemCall(cgame.platform.syscallExt
-                   ->cgameExtensions[cgame.platform.syscallExt->cmdBackupExt]);
+    SystemCall(trap);
   } else {
     cg.cmdBackup = CMD_BACKUP;
     cg.cmdMask = CMD_MASK;
+  }
+}
+
+void SyscallExt::trap_CommandComplete(const char *value) {
+  const int32_t trap =
+      cgame.platform.syscallExt
+          ->cgameExtensions[cgame.platform.syscallExt->commandComplete];
+
+  if (trap) {
+    SystemCall(trap, value);
   }
 }
 

--- a/src/cgame/etj_command_complete_ext.cpp
+++ b/src/cgame/etj_command_complete_ext.cpp
@@ -22,33 +22,23 @@
  * SOFTWARE.
  */
 
-#pragma once
+#include "etj_command_complete_ext.h"
 
-#ifdef GAMEDLL
-  #include "q_shared.h"
-#else
-  #include "../game/q_shared.h"
-#endif
+namespace ETJump::CommandCompletions {
+bool completeArgument() {
+  // TODO: implement this - look for commands that want additional completions
+  // in e.g. std::unordered_map<std::string, std::function>, where the key
+  // is the command, and value is a function pointer to the completion
+  // implementation. The implementation itself is responsible for providing
+  // valid arguments, and calling 'trap_CommandComplete' for all the arguments
+  // that are supported by the base command. The implementations may also call
+  // additional completion requests for commands which take more than one
+  // argument, and can do this contextually (e.g. if first argument is "foo",
+  // provide a different set of completions for second argument).
+  // The syscall itself does not give context on which command is requesting
+  // autocomplete, we must call 'CG_Argv' here first to see which completion
+  // we're looking for.
 
-#if defined(__linux__) || defined(__APPLE__)
-  #define FN_PUBLIC __attribute__((visibility("default")))
-#elif defined(_WIN32)
-  #define FN_PUBLIC __declspec(dllexport)
-#else
-  #error "Unsupported compiler"
-#endif
-
-inline constexpr intptr_t VM_CALL_END = -1337;
-inline constexpr int32_t MOD_EXPORT_PADDING = 1337;
-
-#define SystemCall(...) ExpandSyscall(__VA_ARGS__, VM_CALL_END)
-
-extern intptr_t(QDECL *vmSyscall)(intptr_t arg, ...);
-extern "C" FN_PUBLIC void dllEntry(intptr_t(QDECL *syscallptr)(intptr_t arg,
-                                                               ...));
-
-template <typename T, typename... Types>
-intptr_t ExpandSyscall(T syscallArg, Types... args) {
-  // C-style casts here for simplicity, to handle all types of arguments
-  return vmSyscall((intptr_t)syscallArg, (intptr_t)args...);
+  return false;
 }
+} // namespace ETJump::CommandCompletions

--- a/src/cgame/etj_command_complete_ext.h
+++ b/src/cgame/etj_command_complete_ext.h
@@ -24,31 +24,6 @@
 
 #pragma once
 
-#ifdef GAMEDLL
-  #include "q_shared.h"
-#else
-  #include "../game/q_shared.h"
-#endif
-
-#if defined(__linux__) || defined(__APPLE__)
-  #define FN_PUBLIC __attribute__((visibility("default")))
-#elif defined(_WIN32)
-  #define FN_PUBLIC __declspec(dllexport)
-#else
-  #error "Unsupported compiler"
-#endif
-
-inline constexpr intptr_t VM_CALL_END = -1337;
-inline constexpr int32_t MOD_EXPORT_PADDING = 1337;
-
-#define SystemCall(...) ExpandSyscall(__VA_ARGS__, VM_CALL_END)
-
-extern intptr_t(QDECL *vmSyscall)(intptr_t arg, ...);
-extern "C" FN_PUBLIC void dllEntry(intptr_t(QDECL *syscallptr)(intptr_t arg,
-                                                               ...));
-
-template <typename T, typename... Types>
-intptr_t ExpandSyscall(T syscallArg, Types... args) {
-  // C-style casts here for simplicity, to handle all types of arguments
-  return vmSyscall((intptr_t)syscallArg, (intptr_t)args...);
+namespace ETJump::CommandCompletions {
+bool completeArgument();
 }

--- a/src/cgame/etj_servercommands.cpp
+++ b/src/cgame/etj_servercommands.cpp
@@ -65,7 +65,7 @@ static void customvoteList(const Arguments &args) {
 static void pmFlashWindow() {
   if (etj_highlight.integer &
       static_cast<int>(ChatHighlightFlags::HIGHLIGHT_FLASH)) {
-    SyscallExt::trap_SysFlashWindowETLegacy(
+    SyscallExt::trap_SysFlashWindow(
         SyscallExt::FlashWindowState::SDL_FLASH_UNTIL_FOCUSED);
   }
 }

--- a/src/game/etj_syscall_ext_shared.h
+++ b/src/game/etj_syscall_ext_shared.h
@@ -35,10 +35,12 @@ public:
 #ifdef CGAMEDLL
   const char *flashWindowETLegacy = "trap_SysFlashWindow_Legacy";
   const char *cmdBackupExt = "trap_CmdBackup_Ext_Legacy";
+  const char *commandComplete = "trap_CommandComplete_Legacy";
 
   std::unordered_map<const char *, int> cgameExtensions = {
       {flashWindowETLegacy, 0},
       {cmdBackupExt, 0},
+      {commandComplete, 0},
   };
 
   // defined by SDL2
@@ -48,8 +50,9 @@ public:
     SDL_FLASH_UNTIL_FOCUSED = 2,
   };
 
-  static void trap_SysFlashWindowETLegacy(FlashWindowState state);
+  static void trap_SysFlashWindow(FlashWindowState state);
   static void trap_CmdBackup_Ext();
+  static void trap_CommandComplete(const char *value);
 #endif
 
   // entry point for extensions


### PR DESCRIPTION
Implements ET: Legacy console command completion extension, which allows the mod to provide contextual console command completion. This makes console provide native tab completion suggestions for any console command, as long as the mod provides the valid command arguments to the engine via syscalls.

This is a "skeleton" implementation for now, no actual commands are handled yet.