### PR TITLE
Fix data handler initialization for renderables

### DIFF
--- a/src/cgame/etj_main.cpp
+++ b/src/cgame/etj_main.cpp
@@ -259,10 +259,10 @@ static void initVisuals() {
 static void initHUD() {
   assert(cgame.utils.pmoveV2 != nullptr);
 
-  cgame.hud.chsDataHandler = std::make_unique<CHSDataHandler>(
+  cgame.hud.chsDataHandler = std::make_shared<CHSDataHandler>(
       cgame.core.cvarUpdate, cgame.core.consoleCommands);
-  cgame.hud.cgazDataHandler = std::make_unique<CGazData>();
-  cgame.hud.snaphudDataHandler = std::make_unique<SnaphudData>();
+  cgame.hud.cgazDataHandler = std::make_shared<CGazData>();
+  cgame.hud.snaphudDataHandler = std::make_shared<SnaphudData>();
 
   cgame.hud.renderables.emplace_back(
       std::make_unique<CHS>(cgame.core.cvarUpdate, cgame.hud.chsDataHandler));


### PR DESCRIPTION
These are shared pointers, not unique pointers, so init them with `make_shared` rather than `make_unique`. This was technically fine because `shared_ptr` has a special move constructor that transfers ownership for unique pointers, but this is just more correct in this scenario.