### PR TITLE
Fix old spectator info data sometimes staying on screen

### DIFF
--- a/src/cgame/cg_playerstate.cpp
+++ b/src/cgame/cg_playerstate.cpp
@@ -280,7 +280,7 @@ void CG_Respawn(qboolean revived) {
     // clear spectatorinfo lists on team switch, so we don't carry over
     // the data from the client we just spectated, if switching from spec
     if (oldTeam == TEAM_SPECTATOR) {
-      ETJump::SpectatorInfoData::clearData();
+      ETJump::cgame.hud.spectatorInfoData->clearData();
     }
 
     oldTeam = cgs.clientinfo[cg.clientNum].team;

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -734,7 +734,7 @@ static void CG_ConfigStringModified(void) {
     }
   } else if (num >= CS_PLAYERS && num < CS_PLAYERS + MAX_CLIENTS) {
     CG_NewClientInfo(num - CS_PLAYERS);
-    ETJump::SpectatorInfoData::updateSpectatorData(num - CS_PLAYERS);
+    ETJump::cgame.hud.spectatorInfoData->update(num - CS_PLAYERS);
   } else if (num >= CS_DLIGHTS && num < CS_DLIGHTS + MAX_DLIGHT_CONFIGSTRINGS) {
     CG_SetupDlightstyles();
   } else if (num >= shaderStateCs && num < shaderStateCs + shaderStateCsMax) {
@@ -2239,13 +2239,13 @@ static void CG_ServerCommand(void) {
   }
   if (!strcmp(cmd, "sc0")) {
     CG_ParseScore(true);
-    ETJump::SpectatorInfoData::updateSpectatorData(std::nullopt);
+    ETJump::cgame.hud.spectatorInfoData->update(std::nullopt);
     return;
   }
 
   if (!strcmp(cmd, "sc1")) {
     CG_ParseScore(false);
-    ETJump::SpectatorInfoData::updateSpectatorData(std::nullopt);
+    ETJump::cgame.hud.spectatorInfoData->update(std::nullopt);
     return;
   }
 

--- a/src/cgame/etj_cgame.h
+++ b/src/cgame/etj_cgame.h
@@ -107,11 +107,13 @@ struct Visuals {
 
 class AccelColor;
 class CHSDataHandler;
+class SpectatorInfoData;
 class TimerunView;
 
 struct HUD {
   std::shared_ptr<AccelColor> accelColor;
   std::shared_ptr<CHSDataHandler> chsDataHandler;
+  std::shared_ptr<SpectatorInfoData> spectatorInfoData;
 
   std::vector<std::unique_ptr<IRenderable>> renderables;
   std::unique_ptr<TimerunView> timerunView;

--- a/src/cgame/etj_main.cpp
+++ b/src/cgame/etj_main.cpp
@@ -60,6 +60,7 @@
 #include "etj_savepos.h"
 #include "etj_servercommands.h"
 #include "etj_snaphud.h"
+#include "etj_spectatorinfo_data.h"
 #include "etj_spectatorinfo_drawable.h"
 #include "etj_speed_drawable.h"
 #include "etj_strafe_quality_drawable.h"
@@ -261,6 +262,7 @@ static void initHUD() {
   cgame.hud.accelColor = std::make_unique<AccelColor>();
   cgame.hud.chsDataHandler = std::make_unique<CHSDataHandler>(
       cgame.core.cvarUpdate, cgame.core.consoleCommands);
+  cgame.hud.spectatorInfoData = std::make_shared<SpectatorInfoData>();
 
   cgame.hud.renderables.emplace_back(
       std::make_unique<CHS>(cgame.core.cvarUpdate, cgame.hud.chsDataHandler));
@@ -281,8 +283,8 @@ static void initHUD() {
       cgame.core.consoleCommands, cgame.core.serverCommands,
       cgame.core.cvarUpdate));
   cgame.hud.renderables.emplace_back(std::make_unique<QuickFollowDrawer>());
-  cgame.hud.renderables.emplace_back(
-      std::make_unique<SpectatorInfo>(cgame.core.cvarUpdate));
+  cgame.hud.renderables.emplace_back(std::make_unique<SpectatorInfo>(
+      cgame.core.cvarUpdate, cgame.hud.spectatorInfoData));
   cgame.hud.renderables.emplace_back(std::make_unique<AreaIndicator>());
 
   if (etj_CGazOnTop.integer) {

--- a/src/cgame/etj_spectatorinfo_data.cpp
+++ b/src/cgame/etj_spectatorinfo_data.cpp
@@ -25,12 +25,10 @@
 #include <algorithm>
 
 #include "etj_spectatorinfo_data.h"
+#include "cg_local.h"
 
 namespace ETJump {
-std::vector<int32_t> SpectatorInfoData::activeSpectators;
-std::vector<int32_t> SpectatorInfoData::inactiveSpectators;
-
-void SpectatorInfoData::updateSpectatorData(std::optional<int32_t> clientNum) {
+void SpectatorInfoData::update(std::optional<int32_t> clientNum) {
   if (clientNum.has_value()) {
     const int32_t cnum = clientNum.value();
     const char *cs = CG_ConfigString(CS_PLAYERS + cnum);
@@ -76,13 +74,22 @@ void SpectatorInfoData::updateSpectatorData(std::optional<int32_t> clientNum) {
   }
 }
 
+void SpectatorInfoData::clearData() {
+  activeSpectators.clear();
+  inactiveSpectators.clear();
+}
+
+const std::vector<int32_t> &SpectatorInfoData::getActiveSpectators() const {
+  return activeSpectators;
+}
+
+const std::vector<int32_t> &SpectatorInfoData::getInactiveSpectators() const {
+  return inactiveSpectators;
+}
+
 void SpectatorInfoData::removeClientFromList(std::vector<int32_t> &v,
                                              const int32_t clientNum) {
   v.erase(std::remove(v.begin(), v.end(), clientNum), v.end());
 }
 
-void SpectatorInfoData::clearData() {
-  activeSpectators.clear();
-  inactiveSpectators.clear();
-}
 } // namespace ETJump

--- a/src/cgame/etj_spectatorinfo_data.h
+++ b/src/cgame/etj_spectatorinfo_data.h
@@ -28,20 +28,24 @@
 #include <optional>
 #include <vector>
 
-#include "cg_local.h"
-
 namespace ETJump {
 class SpectatorInfoData {
 public:
-  static std::vector<int32_t> activeSpectators;
-  static std::vector<int32_t> inactiveSpectators;
+  SpectatorInfoData() = default;
+  ~SpectatorInfoData() = default;
 
   // If 'clientNum' has value, then this is a 'CS_PLAYERS' update.
   // This handles removing client from the lists if they disconnected.
-  static void updateSpectatorData(std::optional<int32_t> clientNum);
-  static void clearData();
+  void update(std::optional<int32_t> clientNum);
+  void clearData();
+
+  [[nodiscard]] const std::vector<int32_t> &getActiveSpectators() const;
+  [[nodiscard]] const std::vector<int32_t> &getInactiveSpectators() const;
 
 private:
   static void removeClientFromList(std::vector<int32_t> &v, int32_t clientNum);
+
+  std::vector<int32_t> activeSpectators;
+  std::vector<int32_t> inactiveSpectators;
 };
 } // namespace ETJump

--- a/src/cgame/etj_spectatorinfo_drawable.cpp
+++ b/src/cgame/etj_spectatorinfo_drawable.cpp
@@ -23,14 +23,16 @@
  */
 
 #include "etj_spectatorinfo_drawable.h"
+#include "cg_local.h"
 #include "etj_cvar_update_handler.h"
 #include "etj_spectatorinfo_data.h"
 #include "etj_utilities.h"
 
 namespace ETJump {
 SpectatorInfo::SpectatorInfo(
-    const std::shared_ptr<CvarUpdateHandler> &cvarUpdate)
-    : cvarUpdate(cvarUpdate) {
+    const std::shared_ptr<CvarUpdateHandler> &cvarUpdate,
+    const std::shared_ptr<SpectatorInfoData> &specInfoData)
+    : cvarUpdate(cvarUpdate), specInfoData(specInfoData) {
   startListeners();
   setTextSize(etj_spectatorInfoScale);
   setRowHeight();
@@ -120,8 +122,11 @@ void SpectatorInfo::render() const {
     }
   };
 
-  const size_t totalClients = SpectatorInfoData::activeSpectators.size() +
-                              SpectatorInfoData::inactiveSpectators.size();
+  const auto &activeSpectators = specInfoData->getActiveSpectators();
+  const auto &inactiveSpectators = specInfoData->getInactiveSpectators();
+
+  const size_t totalClients =
+      activeSpectators.size() + inactiveSpectators.size();
   const size_t max = etj_spectatorInfoMaxClients.integer < 0
                          ? totalClients
                          : std::min(etj_spectatorInfoMaxClients.integer,
@@ -129,27 +134,24 @@ void SpectatorInfo::render() const {
 
   // simple case, draw all spectators
   if (totalClients <= max) {
-    for (const auto &client : SpectatorInfoData::activeSpectators) {
+    for (const auto &client : activeSpectators) {
       drawRow(cgs.clientinfo[client].name, colorWhite);
     }
 
-    for (const auto &client : SpectatorInfoData::inactiveSpectators) {
+    for (const auto &client : inactiveSpectators) {
       drawRow(cgs.clientinfo[client].name, inactiveColor);
     }
   } else {
-    const size_t activeDrawCount =
-        std::min(SpectatorInfoData::activeSpectators.size(), max);
+    const size_t activeDrawCount = std::min(activeSpectators.size(), max);
     const size_t inactiveDrawCount =
         activeDrawCount >= max ? 0 : max - activeDrawCount;
 
     for (size_t i = 0; i < activeDrawCount; i++) {
-      drawRow(cgs.clientinfo[SpectatorInfoData::activeSpectators[i]].name,
-              colorWhite);
+      drawRow(cgs.clientinfo[activeSpectators[i]].name, colorWhite);
     }
 
     for (size_t i = 0; i < inactiveDrawCount; i++) {
-      drawRow(cgs.clientinfo[SpectatorInfoData::inactiveSpectators[i]].name,
-              inactiveColor);
+      drawRow(cgs.clientinfo[inactiveSpectators[i]].name, inactiveColor);
     }
 
     const auto remaining = static_cast<int>(totalClients - max);

--- a/src/cgame/etj_spectatorinfo_drawable.h
+++ b/src/cgame/etj_spectatorinfo_drawable.h
@@ -29,6 +29,7 @@
 
 namespace ETJump {
 class CvarUpdateHandler;
+class SpectatorInfoData;
 
 class SpectatorInfo : public IRenderable {
   CvarValue::Scale scale{};
@@ -45,6 +46,7 @@ class SpectatorInfo : public IRenderable {
   static constexpr vec4_t inactiveColor = {1.0f, 1.0f, 1.0f, 0.33f};
 
   std::shared_ptr<CvarUpdateHandler> cvarUpdate;
+  std::shared_ptr<SpectatorInfoData> specInfoData;
 
   static bool canSkipDraw();
   void startListeners();
@@ -55,7 +57,8 @@ class SpectatorInfo : public IRenderable {
   static float getTextOffset(const char *name, float fontWidth);
 
 public:
-  explicit SpectatorInfo(const std::shared_ptr<CvarUpdateHandler> &cvarUpdate);
+  SpectatorInfo(const std::shared_ptr<CvarUpdateHandler> &cvarUpdate,
+                const std::shared_ptr<SpectatorInfoData> &specInfoData);
   ~SpectatorInfo() override;
 
   bool beforeRender() override;


### PR DESCRIPTION
Because spectator info data was all static, there was a possible edge case where invalid data could be visible on screen. This was most noticeable when watching multiple demos in a row, where the spectator info data from the previous demo would carry over to the next demo, because `clearData()` was only called on respawn, if old team was spectator.

The spectator info data class is now a non-static object, which gets passed to the spectator info drawable as a constructor parameter, so it will always be freshly initialized on init.

refs #1718 