### PR TITLE
Add record-details command

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -1549,6 +1549,7 @@ void CG_InitConsoleCommands() {
   trap_AddCommand("times");
   trap_AddCommand("ranks");
   trap_AddCommand("top");
+  trap_AddCommand("record-details");
   trap_AddCommand("rankings");
   trap_AddCommand("seasons");
   trap_AddCommand("loadcheckpoints");

--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -559,6 +559,111 @@ bool Records(gentity_t *ent, Arguments argv) {
   return true;
 }
 
+static bool recordDetails(gentity_t *ent, Arguments argv) {
+  if (!ent) {
+    return false;
+  }
+
+  const int32_t clientNum = ClientNum(ent);
+
+  const auto *const desc = R"(Prints details about a timerun record.
+    /record-details --season <season name> --map <map name --run <run name> --rank <rank>
+
+    Has a shorthand format of:
+    /record-details <run name>
+    /record-details <run name> <rank>
+    /record-details <map name> <run name> <rank>
+    /record-details <season name> <map name> <run name> <rank>)";
+
+  const auto def =
+      ETJump::CommandParser::CommandDefinition::create("record-details", desc)
+          .addOption("season", "s",
+                     "Season to print record details from. Default is the "
+                     "overall season.",
+                     ETJump::CommandParser::OptionDefinition::Type::MultiToken,
+                     false)
+          .addOption(
+              "map", "m",
+              "Map to print record details from. Default is the current map.",
+              ETJump::CommandParser::OptionDefinition::Type::MultiToken, false)
+          .addOption("run", "r", "Run to print record details from.",
+                     ETJump::CommandParser::OptionDefinition::Type::MultiToken,
+                     false)
+          .addOption("rank", "rk",
+                     "Rank to print record details from. Default is rank 1.",
+                     ETJump::CommandParser::OptionDefinition::Type::Integer,
+                     false);
+
+  const auto args = Container::skipFirstN(*argv, 1);
+  const auto optCommand =
+      ETJump::getOptCommand("record-details", clientNum, def, &args);
+
+  if (!optCommand.has_value()) {
+    return false;
+  }
+
+  const auto &command = optCommand.value();
+
+  const auto optSeason = command.getOptional("season");
+  const auto optMap = command.getOptional("map");
+  const auto optRun = command.getOptional("run");
+  const auto optRank = command.getOptional("rank");
+
+  std::string season;
+  std::string map;
+  std::string run;
+  int32_t rank = 1;
+
+  if (command.extraArgs.size() >= 4) {
+    season = command.extraArgs[0];
+    map = command.extraArgs[1];
+    run = command.extraArgs[2];
+    rank = Q_atoi(command.extraArgs[3]);
+  } else if (command.extraArgs.size() >= 3) {
+    map = command.extraArgs[0];
+    run = command.extraArgs[1];
+    rank = Q_atoi(command.extraArgs[2]);
+  } else if (command.extraArgs.size() >= 2) {
+    run = command.extraArgs[0];
+    rank = Q_atoi(command.extraArgs[1]);
+  } else if (command.extraArgs.size() >= 1) {
+    run = command.extraArgs[0];
+  }
+
+  if (run.empty()) {
+    if (!optRun.has_value()) {
+      Printer::chat(clientNum, "^3record-details: ^7operation failed. Check "
+                               "console for more information.");
+      Printer::console(clientNum, "Required option `run` was not specified.\n");
+      return false;
+    }
+
+    run = optRun.value().text;
+  }
+
+  if (season.empty()) {
+    season = optSeason.has_value() ? optSeason.value().text : "default";
+  }
+
+  // if the user provided no map, we want to set the query to use exact
+  // map name, so no partial matches are implicitly done against the current map
+  bool exactMap = false;
+
+  if (map.empty()) {
+    map = optMap.has_value() ? optMap.value().text : level.rawmapname;
+    exactMap = !optMap.has_value();
+  }
+
+  if (optRank.has_value()) {
+    rank = optRank.value().integer;
+  }
+
+  game.timerunV2->recordDetails({clientNum, std::move(season), std::move(map),
+                                 std::move(run), rank, exactMap});
+
+  return true;
+}
+
 bool LoadCheckpoints(gentity_t *ent, Arguments argv) {
   // these are console commands but to make them more accessible
   // they were also made admin commands
@@ -2855,6 +2960,8 @@ Commands::Commands() {
       AdminCommandPair(ClientCommands::Records, CommandFlags::BASIC);
   adminCommands_["top"] =
       AdminCommandPair(ClientCommands::Records, CommandFlags::BASIC);
+  adminCommands_["record-details"] =
+      AdminCommandPair(ClientCommands::recordDetails, CommandFlags::BASIC);
   adminCommands_["rankings"] =
       AdminCommandPair(ClientCommands::Rankings, CommandFlags::BASIC);
   adminCommands_["loadcheckpoints"] =
@@ -2885,6 +2992,7 @@ Commands::Commands() {
   commands_["times"] = ClientCommands::Records;
   commands_["ranks"] = ClientCommands::Records;
   commands_["top"] = ClientCommands::Records;
+  commands_["record-details"] = ClientCommands::recordDetails;
   commands_["loadcheckpoints"] = ClientCommands::LoadCheckpoints;
   commands_["load-checkpoints"] = ClientCommands::LoadCheckpoints;
   commands_["rankings"] = ClientCommands::Rankings;

--- a/src/game/etj_timerun_models.h
+++ b/src/game/etj_timerun_models.h
@@ -119,4 +119,13 @@ struct CompareCheckpointsParams {
   int32_t rankCmp{};
   bool exactMap;
 };
+
+struct RecordDetailsParams {
+  int32_t clientNum{};
+  std::string season;
+  std::string map;
+  std::string run;
+  int32_t rank{};
+  bool exactMap;
+};
 } // namespace ETJump::Timerun

--- a/src/game/etj_timerun_repository.cpp
+++ b/src/game/etj_timerun_repository.cpp
@@ -665,6 +665,88 @@ TimerunRepository::getRecord(const std::string &map, const std::string &run,
   return record;
 }
 
+std::vector<Timerun::Record> TimerunRepository::getRecordFromSeason(
+    const int32_t seasonId, const std::string &map, const std::string &run,
+    const int32_t rank, const bool exactMap) {
+  std::vector<Timerun::Record> records;
+
+  const auto maps = getMapsForName(map, exactMap);
+  bool exactMapFound = false;
+
+  if (maps.size() > 1) {
+    for (const auto &m : maps) {
+      if (m == map) {
+        exactMapFound = true;
+        break;
+      }
+    }
+
+    if (!exactMapFound) {
+      std::string error = StringUtils::format(
+          "^3record-details: ^7found %d maps matching ^3%s^7\n", maps.size(),
+          map);
+
+      const int perRow = 3;
+      int i = 0;
+      for (const auto &m : maps) {
+        if (i != 0 && i % perRow == 0) {
+          error += "\n";
+        }
+
+        error += StringUtils::format("%-22s", m);
+        ++i;
+      }
+
+      throw std::runtime_error(error);
+    }
+  }
+
+  const std::string resolvedMap = maps.empty() ? map : maps[0];
+
+  const std::string runPlaceHolder = "lsanitize(run) like ?";
+  const std::vector<std::string> runs =
+      getRunsForName(!maps.empty() ? maps[0] : map, run, false, true);
+  const std::string runBinder = runs.size() == 1 ? runs[0] : "%" + run + "%";
+
+  const std::string query = StringUtils::format(R"(
+  select *
+    from (
+      select
+        season_id,
+        map,
+        run,
+        user_id,
+        time,
+        checkpoints,
+        record_date,
+        player_name,
+        metadata,
+        rank() over (partition by season_id, map, run order by time asc) as record_rank
+      FROM record
+      where
+        season_id=? and map=? and %s
+    ) as ranked_records
+    where record_rank = ?;
+  )",
+                                                runPlaceHolder);
+
+  auto binder = _database->sql << query;
+  binder << seasonId << resolvedMap << runBinder << rank;
+
+  binder >> [&records](int32_t seasonId, const std::string &map,
+                       const std::string &runName, int32_t userId, int32_t time,
+                       const std::string &checkpointsString,
+                       const std::string &recordDate,
+                       const std::string &playerName,
+                       const std::string &metadataString) {
+    records.emplace_back(getRecordFromStandardQueryResult(
+        seasonId, map, runName, userId, time, checkpointsString, recordDate,
+        playerName, metadataString));
+  };
+
+  return records;
+}
+
 std::vector<Timerun::Season> TimerunRepository::getSeasons() {
   std::vector<Timerun::Season> seasons;
 

--- a/src/game/etj_timerun_repository.h
+++ b/src/game/etj_timerun_repository.h
@@ -72,6 +72,10 @@ public:
                                                  bool exact);
   std::optional<Timerun::Record> getRecord(const std::string &map,
                                            const std::string &run, int rank);
+  std::vector<Timerun::Record> getRecordFromSeason(int32_t seasonId,
+                                                   const std::string &map,
+                                                   const std::string &run,
+                                                   int32_t rank, bool exactMap);
   std::vector<Timerun::Season> getSeasons();
   void deleteSeason(const std::string &name);
   std::vector<Timerun::Checkpoints>

--- a/src/game/etj_timerun_v2.cpp
+++ b/src/game/etj_timerun_v2.cpp
@@ -1544,6 +1544,141 @@ void TimerunV2::compareCheckpoints(
       });
 }
 
+class RecordDetailsResult : public SynchronizationContext::ResultBase {
+public:
+  RecordDetailsResult(std::vector<Timerun::Season> seasons,
+                      std::vector<Timerun::Record> records)
+      : seasons(std::move(seasons)), records(std::move(records)) {}
+
+  std::vector<Timerun::Season> seasons;
+  std::vector<Timerun::Record> records;
+};
+
+void TimerunV2::recordDetails(const Timerun::RecordDetailsParams &params) {
+  const std::string func = __func__;
+
+  const auto task = [this, params]() {
+    std::vector<Timerun::Record> records;
+    std::vector<Timerun::Season> seasons =
+        _repository->getSeasonsForName(params.season, false);
+
+    // TODO: resolve map/run name here, instead of in 'getRecordFromSeason',
+    // as we now run the same map/run matching code for each season
+    for (const auto &season : seasons) {
+      const auto seasonRecords = _repository->getRecordFromSeason(
+          season.id, params.map, params.run, params.rank, params.exactMap);
+
+      records.insert(records.end(), seasonRecords.cbegin(),
+                     seasonRecords.cend());
+    }
+
+    return std::make_unique<RecordDetailsResult>(seasons, records);
+  };
+
+  const auto callback = [this, params, func](const std::unique_ptr<
+                                             SynchronizationContext::ResultBase>
+                                                 result) {
+    const auto *const r = dynamic_cast<RecordDetailsResult *>(result.get());
+
+    if (r == nullptr) {
+      _logger->error("%s: failed to fetch details for record(s) for player %i: "
+                     "RecordDetailsResult is NULL",
+                     func, params.clientNum);
+      throw std::runtime_error(StringUtils::format(
+          "%s: unable to fetch details for record(s). This is a bug, "
+          "please report this to the developers.",
+          func));
+    }
+
+    // 'records' is empty in this case too, but by checking 'seasons' first,
+    // we can determine if the user provided incorrect season name
+    if (r->seasons.empty()) {
+      throw std::runtime_error(StringUtils::format(
+          "No seasons found matching '%s^7'.", params.season));
+    }
+
+    if (r->records.empty()) {
+      throw std::runtime_error("No records found matching given parameters.");
+    }
+
+    const auto seasonNameFromId = [this, &r, &func](const int32_t seasonId) {
+      for (const auto &season : r->seasons) {
+        if (season.id == seasonId) {
+          return season.name;
+        }
+      }
+
+      // this should never happen
+      _logger->error("%s: failed to find a name for season ID %i", func,
+                     seasonId);
+      throw std::runtime_error("Failed to find a valid season name. This is a "
+                               "bug, please report this to the developers.");
+    };
+
+    std::string msg;
+    constexpr int32_t MSG_PAD = 13;
+
+    const auto getRow = [MSG_PAD](const std::string_view k,
+                                  const std::string_view v) {
+      return StringUtils::format(" ^2%-*s ^7%s\n", MSG_PAD, k, v);
+    };
+
+    for (const auto &record : r->records) {
+      msg += "^2Detailed record information\n";
+      msg +=
+          "^g-------------------------------------------------------------\n";
+
+      msg += getRow("Player:", record.playerName);
+      msg += getRow("User ID:", std::to_string(record.userId));
+      msg += getRow("Season:", seasonNameFromId(record.seasonId));
+      msg += getRow("Map:", record.map);
+      msg += getRow("Run:", record.run);
+      msg += getRow("Rank", rankToString(params.rank));
+      msg += getRow("Time:", TimeUtils::millisToString(record.time));
+
+      if (record.checkpoints[0] == TIMERUN_CHECKPOINT_NOT_SET) {
+        msg += getRow("Checkpoints:", "N/A");
+      } else {
+        for (size_t i = 0; i < record.checkpoints.size(); i++) {
+          if (record.checkpoints[i] == TIMERUN_CHECKPOINT_NOT_SET) {
+            break;
+          }
+
+          if (i == 0) {
+            msg += getRow("Checkpoints:",
+                          TimeUtils::millisToString(record.checkpoints[i]));
+          } else {
+            msg += getRow("", TimeUtils::millisToString(record.checkpoints[i]));
+          }
+        }
+      }
+
+      msg += getRow("Record date:", record.recordDate.toDateTimeString());
+
+      // NOTE: this obviously needs updating if more metadata is added
+      for (const auto &[name, data] : record.metadata) {
+        if (name == "mod_version") {
+          if (StringUtils::startsWith(data, "unknown")) {
+            msg += getRow("Mod version:", "N/A");
+          } else {
+            msg += getRow("Mod version:", "ETJump " + data);
+          }
+        }
+      }
+
+      msg += "\n";
+    }
+
+    Printer::console(params.clientNum, msg);
+  };
+
+  const auto error = [params, func](const std::runtime_error &e) {
+    Printer::console(params.clientNum, StringUtils::format("%s\n", e.what()));
+  };
+
+  _sc->postTask(task, callback, error);
+}
+
 int32_t TimerunV2::getRunStartTime(const int32_t clientNum) const {
   return _players[clientNum]->startTime.value_or(0);
 }

--- a/src/game/etj_timerun_v2.h
+++ b/src/game/etj_timerun_v2.h
@@ -111,6 +111,7 @@ public:
   void deleteSeason(int clientNum, const std::string &name);
   void listCheckpoints(const Timerun::ListCheckpointsParams &params);
   void compareCheckpoints(const Timerun::CompareCheckpointsParams &params);
+  void recordDetails(const Timerun::RecordDetailsParams &params);
 
   [[nodiscard]] int32_t getRunStartTime(int32_t clientNum) const;
 


### PR DESCRIPTION
```
record-details --season <season name> --map <map name --run <run name> --rank <rank>

record-details <run name>
record-details <run name> <rank>
record-details <map name> <run name> <rank>
record-details <season name> <map name> <run name> <rank>
```

Prints out all information about a specific timerun record, that is currently stored in the timerun database. Available as both admin and console command.

<img width="508" height="469" alt="2026-06-26-113039_hyprshot" src="https://github.com/user-attachments/assets/038d0140-d92c-4bc8-893f-320162f9609f" />
