### PR TITLE
Fix CGaz 2 not explicitly calculating opt angle

### DIFF
--- a/src/cgame/etj_cgaz_v2.cpp
+++ b/src/cgame/etj_cgaz_v2.cpp
@@ -157,6 +157,7 @@ void CGazV2::updateCGaz2(const CGazData::State &s) {
   cgaz2.velAngle = AngleNormalize180(s.pm.ps->viewangles[YAW] -
                                      AngleNormalize180(RAD2DEG(s.velAngle)));
   cgaz2.velAngle = DEG2RAD(cgaz2.velAngle);
+  cgaz2.optAngle = updateOptAngle(s);
   cgaz2.velSize = etj_CGaz2FixedSpeed.value > 0
                       ? etj_CGaz2FixedSpeed.value / 5.0f
                       : std::min(s.vf / 5.0f, SCREEN_HEIGHT / 2.0f);
@@ -446,14 +447,14 @@ void CGazV2::renderCGaz2() const {
 
   if (cgaz2.drawSides) {
     const float velAngleSinL =
-        (cgaz2.velSize / 2) * std::sin(cgaz2.velAngle - cgaz1.optAngle);
+        (cgaz2.velSize / 2) * std::sin(cgaz2.velAngle - cgaz2.optAngle);
     const float velAngleCosL =
-        (cgaz2.velSize / 2) * std::cos(cgaz2.velAngle - cgaz1.optAngle);
+        (cgaz2.velSize / 2) * std::cos(cgaz2.velAngle - cgaz2.optAngle);
 
     const float velAngleSinR =
-        (cgaz2.velSize / 2) * std::sin(cgaz2.velAngle + cgaz1.optAngle);
+        (cgaz2.velSize / 2) * std::sin(cgaz2.velAngle + cgaz2.optAngle);
     const float velAngleCosR =
-        (cgaz2.velSize / 2) * std::cos(cgaz2.velAngle + cgaz1.optAngle);
+        (cgaz2.velSize / 2) * std::cos(cgaz2.velAngle + cgaz2.optAngle);
 
     if (cgaz2.highRes) {
       drawLineWu(x, cgaz2.y, x + velAngleSinL, cgaz2.y - velAngleCosL,

--- a/src/cgame/etj_cgaz_v2.h
+++ b/src/cgame/etj_cgaz_v2.h
@@ -86,6 +86,7 @@ private:
 
   struct CGaz2 {
     float velAngle;
+    float optAngle;
     float velSize;
 
     float y;


### PR DESCRIPTION
Relied on CGaz 1 calculating it, which broke CGaz 2 completely if CGaz 1 wasn't drawn. I happened to test this with `etj_drawCGaz 3` when refactoring so never caught this.

refs #1921 