### PR TITLE
Fix potential out of bounds read on empty listboxes

### DIFF
--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -2604,6 +2604,10 @@ qboolean Item_ListBox_HandleKey(itemDef_t *item, int key, qboolean down,
   int count = DC->feederCount(item->special);
   int max, viewmax;
 
+  if (count == 0) {
+    return qfalse;
+  }
+
   if (force || (Rect_ContainsPoint(&item->window.rect, DC->cursor.virtX,
                                    DC->cursor.virtY) &&
                 item->window.flags & WINDOW_HASFOCUS)) {


### PR DESCRIPTION
If a listbox had no entries, scrolling down/right would send a negative index to `DC->feederSelection`, which with most feeders is an out of bounds access, as they are typically stored as an array. This is easily reproducible in the server browser, as it does not automatically refresh, and therefore has 0 entires - all you need to do is scroll down or press down arrow, and you'll get an out of bounds read.

If a listbox doesn't have entries, just ignore keyhandling, as no key would do anything anyway.