### PR TITLE
Chat menu fixes

### DIFF
--- a/assets/ui/ingame_messagemode.menu
+++ b/assets/ui/ingame_messagemode.menu
@@ -108,7 +108,7 @@ menuDef
 		maxChars		200
 		maxPaintChars	200
 		visible			1
-		tooltip			"Enter text here - press ESCAPE twice to cancel"
+		tooltip			"Enter text here"
 		hOffset         "ui_mtOffset"
 		multiline
 		onEsc { close ingame_messagemode }

--- a/assets/ui/ingame_messagemode.menu
+++ b/assets/ui/ingame_messagemode.menu
@@ -2,244 +2,255 @@
 
 // Defines //
 
-#define WINDOW_X		0
-#define WINDOW_Y		0
-#define WINDOW_WIDTH	640
-#define WINDOW_HEIGHT	480
-#define GROUP_NAME		"grpMessageMode"
+#define WINDOW_X				0
+#define WINDOW_Y				0
+#define WINDOW_WIDTH		640
+#define WINDOW_HEIGHT		480
+#define GROUP_NAME			"grpMessageMode"
 
 // Macros //
 
 #include "ui/menumacros.h"
-		
+
 // Ingame MessageMode Menu //
-	
+
 menuDef
 {
-	name		"ingame_messagemode"
-	visible		0
-	fullscreen	0
-	rect		WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
-	style		WINDOW_STYLE_FILLED
-	// popup
-	// modal
-	
-	onOpen
-	{
+	name							"ingame_messagemode"
+	visible						0
+	fullscreen				0
+	rect							WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
+	style							WINDOW_STYLE_FILLED
+
+	onOpen {
 		closeAllOtherMenus ;
 		setEditFocus "inChatMessageText" ;	// note this depends on the macro + item name
 		exec "uiChatMenuOpen 1"
 	}
-	
-	onESC
-	{
-		close ingame_messagemode ;
+
+	onESC {
+		close ingame_messagemode
 	}
-	
-	onEnter
-	{
+
+	onEnter {
 		close ingame_messagemode ;
-		exec messageSend ;
+		exec messageSend
 	}
-	
+
 // Subwindows //
 
-#define SUBWINDOW_WIDTH		320
-#define SUBWINDOW_HEIGHT	80
-#define SUBWINDOW_X			.5*(WINDOW_WIDTH-SUBWINDOW_WIDTH)
-#define SUBWINDOW_Y			320	// .5*(WINDOW_HEIGHT-SUBWINDOW_HEIGHT)	
-	
-    // subwindow black
-	itemDef {																									
-		name		"subwindowblackSEND MESSAGE"														
-		group		GROUP_NAME																					
-		rect		$evalfloat(SUBWINDOW_X) $evalfloat(SUBWINDOW_Y) $evalfloat(SUBWINDOW_WIDTH) $evalfloat(SUBWINDOW_HEIGHT)	
-		style		WINDOW_STYLE_FILLED																			
-		backcolor	0 0 0 .85																					
-		border		WINDOW_BORDER_FULL																			
-		bordercolor	.5 .5 .5 .5																					
-		visible		1																							
+#define SUBWINDOW_WIDTH			320
+#define SUBWINDOW_HEIGHT		80
+#define SUBWINDOW_X					.5*(WINDOW_WIDTH-SUBWINDOW_WIDTH)
+#define SUBWINDOW_Y					320	// .5*(WINDOW_HEIGHT-SUBWINDOW_HEIGHT)
+
+	// subwindow black
+	itemDef {
+		name						"subwindowblackSEND MESSAGE"
+		group						GROUP_NAME
+		rect						$evalfloat(SUBWINDOW_X) $evalfloat(SUBWINDOW_Y)
+										$evalfloat(SUBWINDOW_WIDTH) $evalfloat(SUBWINDOW_HEIGHT)
+		style						WINDOW_STYLE_FILLED
+		backcolor				0 0 0 .85
+		border					WINDOW_BORDER_FULL
+		bordercolor			.5 .5 .5 .5
+		visible					1
+		hOffset					"ui_mtOffset"
 		decoration
-		hOffset     "ui_mtOffset"																			
-	}																											
-																												
-	itemDef {																									
-		name		"subwindowblacktitleSEND MESSAGE"															
-		group		GROUP_NAME																					
-		rect		$evalfloat((SUBWINDOW_X)+2) $evalfloat((SUBWINDOW_Y)+2) $evalfloat((SUBWINDOW_WIDTH)-4) 12
-		text		"SEND MESSAGE"																			
-		textfont	UI_FONT_ARIBLK_16																			
-		textscale	.19																							
-		textalignx	3																							
-		textaligny	10																							
-		style		WINDOW_STYLE_FILLED																			
-		backcolor	.16 .2 .17 .8																				
-		forecolor	.6 .6 .6 1																					
-		visible		1																							
-		decoration																								
+	}
+
+	itemDef {
+		name						"subwindowblacktitleSEND MESSAGE"
+		group						GROUP_NAME
+		rect						$evalfloat((SUBWINDOW_X)+2) $evalfloat((SUBWINDOW_Y)+2)
+										$evalfloat((SUBWINDOW_WIDTH)-4) 12
+		text						"SEND MESSAGE"
+		textfont				UI_FONT_ARIBLK_16
+		textscale				.19
+		textalignx			3
+		textaligny			10
+		style						WINDOW_STYLE_FILLED
+		backcolor				.16 .2 .17 .8
+		forecolor				.6 .6 .6 1
+		visible					1
+		decoration
 	}
 	// end subwindow black
 
 	// editor's background
 	itemDef {
-		name		"efleftbackSay:"
-		group		GROUP_NAME
-		rect		$evalfloat((SUBWINDOW_X+8)) $evalfloat(SUBWINDOW_Y+20) $evalfloat(SUBWINDOW_WIDTH-16) $evalfloat(22)
-		style		WINDOW_STYLE_FILLED
-		backcolor	.5 .5 .5 .2
-		visible		1
+		name						"efleftbackSay:"
+		group						GROUP_NAME
+		rect						$evalfloat((SUBWINDOW_X+8)) $evalfloat(SUBWINDOW_Y+20)
+										$evalfloat(SUBWINDOW_WIDTH-16) $evalfloat(22)
+		style						WINDOW_STYLE_FILLED
+		backcolor				.5 .5 .5 .2
+		visible					1
+		hOffset					"ui_mtOffset"
 		decoration
-		hOffset     "ui_mtOffset"
 	}
-	
- 	// multiline texteditor
+
+	// multiline texteditor
 	itemDef {
-		name			"inChatMessageText"
-      	group			GROUP_NAME
-      	rect			$evalfloat(SUBWINDOW_X+10) $evalfloat(SUBWINDOW_Y+20) $evalfloat(SUBWINDOW_WIDTH-28) $evalfloat(22)
-		type			ITEM_TYPE_EDITFIELD
-		textfont		UI_FONT_COURBD_21
-		textstyle		ITEM_TEXTSTYLE_SHADOWED
-		textscale		.2
-		textaligny		8
-		forecolor		.6 .6 .6 1
-		cursorColor     0.7 0.7 0.7 1
-		cvar			"cg_messageText"
-		maxChars		200
-		maxPaintChars	200
-		visible			1
-		tooltip			"Enter text here"
-		hOffset         "ui_mtOffset"
+		name						"inChatMessageText"
+		group						GROUP_NAME
+		rect						$evalfloat(SUBWINDOW_X+10) $evalfloat(SUBWINDOW_Y+20)
+										$evalfloat(SUBWINDOW_WIDTH-28) $evalfloat(22)
+		type						ITEM_TYPE_EDITFIELD
+		textfont				UI_FONT_COURBD_21
+		textstyle				ITEM_TEXTSTYLE_SHADOWED
+		textscale				.2
+		textaligny			8
+		forecolor				.6 .6 .6 1
+		cursorColor			0.7 0.7 0.7 1
+		cvar						"cg_messageText"
+		maxChars				200
+		maxPaintChars		200
+		visible					1
+		tooltip					"Enter text here"
+		hOffset					"ui_mtOffset"
 		multiline
-		onEsc { close ingame_messagemode }
-    }
-	
+
+		onEsc {
+			close ingame_messagemode
+		}
+	}
+
 	// multi "send to:"
-	itemDef {															
-		name			"multileftTo:"								
-      	group			GROUP_NAME										
-		rect			$evalfloat(SUBWINDOW_X+8) $evalfloat(SUBWINDOW_Y+44) $evalfloat((SUBWINDOW_WIDTH)-12) $evalfloat(10)	
-		type			ITEM_TYPE_MULTI									
-		text			"To:"										
-		textfont		UI_FONT_COURBD_21								
-		textstyle		ITEM_TEXTSTYLE_SHADOWED							
-		textscale		.2								
-		textaligny		8								
-		forecolor		.6 .6 .6 1										
-		cvar			"cg_messageType"										
-		cvarFloatList   { "All" 1 "Team" 2 "Fireteam" 3 "Admin" 4 }
-		visible			1												
-		tooltip			"Select the desitnation for your text (all, team, fireteam or admin)"
-		yOffset         "ui_mtOffset"					
-																		
-		mouseEnter {													
-			setitemcolor "multileftTo:" forecolor .9 .9 .9 1 ;		
-		}																
-																		
-		mouseExit {														
-			setitemcolor "multileftTo:" forecolor .6 .6 .6 1 ;		
-		}																
-																		
-		action {														
-			play "sound/menu/filter.wav" ;								
-		}																
-    }
-
-	// measure text length of the specific cvar 
 	itemDef {
-		name			"measureText"
-		text            "chars left: "
-      	group			GROUP_NAME
-		rect			$evalfloat(SUBWINDOW_X+SUBWINDOW_WIDTH-8) $evalfloat(SUBWINDOW_Y+44) 0 0
-		type			ITEM_TYPE_TEXT
-		textfont		UI_FONT_COURBD_21
-		textstyle		ITEM_TEXTSTYLE_SHADOWED
-		textscale		0.2
-		textalign		ITEM_ALIGN_RIGHT
-		textalignx		0
-		textaligny		8
-		forecolor		.6 .6 .6 1
-		cvar			"cg_messageText"
-		cvarLength
-		visible			1
-		decoration
-        yOffset        "ui_mtOffset"
-    }
-	
-	// cancel
-	itemDef {															
-		name		"bttnCANCEL"									
-		group		GROUP_NAME											
-		rect		$evalfloat(SUBWINDOW_X+6) $evalfloat(SUBWINDOW_Y+SUBWINDOW_HEIGHT-24) $evalfloat(.5*(SUBWINDOW_WIDTH-18)) $evalfloat(18)					
-		type		ITEM_TYPE_BUTTON									
-		text		"CANCEL"											
-		textfont	UI_FONT_COURBD_30									
-		textscale	.3									
-		textalign	ITEM_ALIGN_CENTER									
-		textalignx	$evalfloat(0.5*(.5*(SUBWINDOW_WIDTH-18)))							
-		textaligny	14									
-		style		WINDOW_STYLE_FILLED									
-		backcolor	.3 .3 .3 .4											
-		forecolor	.6 .6 .6 1											
-		border		WINDOW_BORDER_FULL									
-		bordercolor	.1 .1 .1 .5											
-		visible		1													
-		yOffset     "ui_mtOffset"
+		name						"multileftTo:"
+		group						GROUP_NAME
+		rect						$evalfloat(SUBWINDOW_X+8) $evalfloat(SUBWINDOW_Y+44)
+										$evalfloat((SUBWINDOW_WIDTH)-12) $evalfloat(10)
+		type						ITEM_TYPE_MULTI
+		text						"To:"
+		textfont				UI_FONT_COURBD_21
+		textstyle				ITEM_TEXTSTYLE_SHADOWED
+		textscale				.2
+		textaligny			8
+		forecolor				.6 .6 .6 1
+		cvar						"cg_messageType"
+		visible					1
+		tooltip					"Select the desitnation for your text (all, team, fireteam or admin)"
+		yOffset					"ui_mtOffset"
 
-		mouseEnter {													
-			setitemcolor "bttnCANCEL" forecolor .9 .9 .9 1 ;		
-			setitemcolor "bttnCANCEL" backcolor .5 .5 .5 .4		
-		}																
-																		
-		mouseExit {														
-			setitemcolor "bttnCANCEL" forecolor .6 .6 .6 1 ;		
-			setitemcolor "bttnCANCEL" backcolor .3 .3 .3 .4		
-		}																
-																		
-		action {														
-			setitemcolor "bttnCANCEL" forecolor .6 .6 .6 1 ;		
-			setitemcolor "bttnCANCEL" backcolor .3 .3 .3 .4 ;	
-			play "sound/menu/select.wav" ;								
-			close ingame_messagemode ;												
-		}																
+		cvarFloatList {
+			"All" 1
+			"Team" 2
+			"Fireteam" 3
+			"Admin" 4
+		}
+
+		mouseEnter {
+			setitemcolor "multileftTo:" forecolor .9 .9 .9 1 ;
+		}
+
+		mouseExit {
+			setitemcolor "multileftTo:" forecolor .6 .6 .6 1 ;
+		}
+
+		action {
+			play "sound/menu/filter.wav" ;
+		}
+	}
+
+	// measure text length of the specific cvar
+	itemDef {
+		name						"measureText"
+		text						"chars left: "
+		group						GROUP_NAME
+		rect						$evalfloat(SUBWINDOW_X+SUBWINDOW_WIDTH-8) $evalfloat(SUBWINDOW_Y+44) 0 0
+		type						ITEM_TYPE_TEXT
+		textfont				UI_FONT_COURBD_21
+		textstyle				ITEM_TEXTSTYLE_SHADOWED
+		textscale				0.2
+		textalign				ITEM_ALIGN_RIGHT
+		textalignx			0
+		textaligny			8
+		forecolor				.6 .6 .6 1
+		cvar						"cg_messageText"
+		visible					1
+		yOffset					"ui_mtOffset"
+		decoration
+		cvarLength
+	}
+
+	// cancel
+	itemDef {
+		name						"bttnCANCEL"
+		group						GROUP_NAME
+		rect						$evalfloat(SUBWINDOW_X+6) $evalfloat(SUBWINDOW_Y+SUBWINDOW_HEIGHT-24)
+										$evalfloat(.5*(SUBWINDOW_WIDTH-18)) $evalfloat(18)
+		type						ITEM_TYPE_BUTTON
+		text						"CANCEL"
+		textfont				UI_FONT_COURBD_30
+		textscale				.3
+		textalign				ITEM_ALIGN_CENTER
+		textalignx			$evalfloat(0.5*(.5*(SUBWINDOW_WIDTH-18)))
+		textaligny			14
+		style						WINDOW_STYLE_FILLED
+		backcolor				.3 .3 .3 .4
+		forecolor				.6 .6 .6 1
+		border					WINDOW_BORDER_FULL
+		bordercolor			.1 .1 .1 .5
+		visible					1
+		yOffset					"ui_mtOffset"
+
+		mouseEnter {
+			setitemcolor "bttnCANCEL" forecolor .9 .9 .9 1 ;
+			setitemcolor "bttnCANCEL" backcolor .5 .5 .5 .4
+		}
+
+		mouseExit {
+			setitemcolor "bttnCANCEL" forecolor .6 .6 .6 1 ;
+			setitemcolor "bttnCANCEL" backcolor .3 .3 .3 .4
+		}
+
+		action {
+			setitemcolor "bttnCANCEL" forecolor .6 .6 .6 1 ;
+			setitemcolor "bttnCANCEL" backcolor .3 .3 .3 .4 ;
+			play "sound/menu/select.wav" ;
+			close ingame_messagemode ;
+		}
 	}
 
 	// send
-	itemDef {															
-		name		"bttnSEND"									
-		group		GROUP_NAME											
-		rect		$evalfloat(SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6) $evalfloat(SUBWINDOW_Y+SUBWINDOW_HEIGHT-24) $evalfloat(.5*(SUBWINDOW_WIDTH-18)) $evalfloat(18)	
-		type		ITEM_TYPE_BUTTON									
-		text		"SEND"											
-		textfont	UI_FONT_COURBD_30									
-		textscale	.3									
-		textalign	ITEM_ALIGN_CENTER									
-		textalignx	$evalfloat(0.5*(.5*(SUBWINDOW_WIDTH-18)))							
-		textaligny	14									
-		style		WINDOW_STYLE_FILLED									
-		backcolor	.3 .3 .3 .4											
-		forecolor	.6 .6 .6 1											
-		border		WINDOW_BORDER_FULL									
-		bordercolor	.1 .1 .1 .5											
-		visible		1
-		yOffset    "ui_mtOffset"													
-																		
-		mouseEnter {													
-			setitemcolor "bttnSEND" forecolor .9 .9 .9 1 ;		
-			setitemcolor "bttnSEND" backcolor .5 .5 .5 .4		
-		}																
-																		
-		mouseExit {														
-			setitemcolor "bttnSEND" forecolor .6 .6 .6 1 ;		
-			setitemcolor "bttnSEND" backcolor .3 .3 .3 .4		
-		}																
-																		
-		action {														
-			setitemcolor "bttnSEND" forecolor .6 .6 .6 1 ;		
-			setitemcolor "bttnSEND" backcolor .3 .3 .3 .4 ;	
-			play "sound/menu/select.wav" ;								
-			close ingame_messagemode ; 
-			exec messageSend ;												
-		}																
+	itemDef {
+		name						"bttnSEND"
+		group						GROUP_NAME
+		rect						$evalfloat(SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6) $evalfloat(SUBWINDOW_Y+SUBWINDOW_HEIGHT-24)
+										$evalfloat(.5*(SUBWINDOW_WIDTH-18)) $evalfloat(18)
+		type						ITEM_TYPE_BUTTON
+		text						"SEND"
+		textfont				UI_FONT_COURBD_30
+		textscale				.3
+		textalign				ITEM_ALIGN_CENTER
+		textalignx			$evalfloat(0.5*(.5*(SUBWINDOW_WIDTH-18)))
+		textaligny			14
+		style						WINDOW_STYLE_FILLED
+		backcolor				.3 .3 .3 .4
+		forecolor				.6 .6 .6 1
+		border					WINDOW_BORDER_FULL
+		bordercolor			.1 .1 .1 .5
+		visible					1
+		yOffset					"ui_mtOffset"
+
+		mouseEnter {
+			setitemcolor "bttnSEND" forecolor .9 .9 .9 1 ;
+			setitemcolor "bttnSEND" backcolor .5 .5 .5 .4
+		}
+
+		mouseExit {
+			setitemcolor "bttnSEND" forecolor .6 .6 .6 1 ;
+			setitemcolor "bttnSEND" backcolor .3 .3 .3 .4
+		}
+
+		action {
+			setitemcolor "bttnSEND" forecolor .6 .6 .6 1 ;
+			setitemcolor "bttnSEND" backcolor .3 .3 .3 .4 ;
+			play "sound/menu/select.wav" ;
+			close ingame_messagemode ;
+			exec messageSend
+		}
 	}
 }

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -4436,8 +4436,8 @@ static float GetCharWidth(const char *symbol, float scale, fontInfo_t *font) {
   return out * scale * font->glyphScale;
 }
 
-void Item_Text_DrawAutoWrapped(itemDef_t *item, const char *textPtr,
-                               qboolean hasCursor) {
+static void Item_Text_DrawAutoWrapped(itemDef_t *item, const char *textPtr,
+                                      bool hasCursor) {
   const char *p, *newLinePtr;
   char buff[1024], cursor;
   int len, newLine, cursorPos, startLine, previousLine;
@@ -4767,8 +4767,8 @@ void Item_Text_Paint(itemDef_t *item) {
                textPtr, 0, 0, item->textStyle);
 }
 
-void Item_TextMultiline_Paint(itemDef_t *item) {
-  char buff[1024];
+static void Item_TextMultiline_Paint(itemDef_t *item) {
+  char buff[MAX_CVAR_VALUE_STRING]{};
 
   if (!item->cvar) {
     return;
@@ -4781,7 +4781,8 @@ void Item_TextMultiline_Paint(itemDef_t *item) {
   DC->getCVarString(item->cvar, buff, sizeof(buff));
 
   // wraps texts and handles caret position
-  Item_Text_DrawAutoWrapped(item, buff, qtrue);
+  Item_Text_DrawAutoWrapped(
+      item, buff, ((item->window.flags & WINDOW_HASFOCUS) && g_editingField));
 }
 
 void Item_TextField_Paint(itemDef_t *item) {


### PR DESCRIPTION
* Fix tooltip incorrectly stating you have to press `ESC` twice to cancel
* Fix multiline textboxes unconditionally drawing the cursor, even when the field was not focused

refs #74 