### PR TITLE
Add in-game menu to send private messages

### DIFF
--- a/assets/ui/ingame_privatemessage.menu
+++ b/assets/ui/ingame_privatemessage.menu
@@ -1,0 +1,259 @@
+#include "ui/menudef.h"
+
+// Defines //
+
+#define WINDOW_X			0
+#define WINDOW_Y			0
+#define WINDOW_WIDTH	640
+#define WINDOW_HEIGHT	480
+
+#define MENU_NAME			"ingame_privatemessage"
+#define GROUP_NAME		"grpPrivateMessage"
+
+// Macros //
+
+#include "ui/menumacros.h"
+
+// Private Message Menu //
+
+menuDef
+{
+	name				MENU_NAME
+	visible			0
+	fullscreen	0
+	rect				WINDOW_X WINDOW_Y WINDOW_WIDTH WINDOW_HEIGHT
+	style				WINDOW_STYLE_FILLED
+
+	onOpen {
+		closeAllOtherMenus ;
+		setEditFocus "inPrivateMessageRecipient" ;	// note this depends on the macro + item name
+		setcvar ui_mtOffset 0 ; // resets the message box height (does not automatically happen as we don't focus on it on open)
+		exec "uiChatMenuOpen 1"
+	}
+
+	onESC	{
+		close MENU_NAME
+	}
+
+	onEnter {
+		close MENU_NAME ;
+		exec messageSend
+	}
+
+// Subwindows //
+
+#define SUBWINDOW_WIDTH		320
+#define SUBWINDOW_HEIGHT	122
+#define SUBWINDOW_X				.5*(WINDOW_WIDTH-SUBWINDOW_WIDTH)
+#define SUBWINDOW_Y				300	// .5*(WINDOW_HEIGHT-SUBWINDOW_HEIGHT)
+
+	// subwindow black
+	itemDef {
+		name						"subwindowblackSEND PRIVATE MESSAGE"
+		group						GROUP_NAME
+		rect						$evalfloat(SUBWINDOW_X) $evalfloat(SUBWINDOW_Y)
+										$evalfloat(SUBWINDOW_WIDTH) $evalfloat(SUBWINDOW_HEIGHT)
+		style						WINDOW_STYLE_FILLED
+		backcolor				0 0 0 .85
+		border					WINDOW_BORDER_FULL
+		bordercolor			.5 .5 .5 .5
+		visible					1
+		hOffset					"ui_mtOffset"
+		decoration
+	}
+
+	itemDef {
+		name						"subwindowblacktitleSEND PRIVATE MESSAGE"
+		group						GROUP_NAME
+		rect						$evalfloat((SUBWINDOW_X)+2) $evalfloat((SUBWINDOW_Y)+2)
+										$evalfloat((SUBWINDOW_WIDTH)-4) 12
+		text						"SEND PRIVATE MESSAGE"
+		textfont				UI_FONT_ARIBLK_16
+		textscale				.19
+		textalignx			3
+		textaligny			10
+		style						WINDOW_STYLE_FILLED
+		backcolor				.16 .2 .17 .8
+		forecolor				.6 .6 .6 1
+		visible					1
+		decoration
+	}
+	// end subwindow black
+
+	// editor's background
+	itemDef {
+		name						"efleftbackMessage:"
+		group						GROUP_NAME
+		rect						$evalfloat((SUBWINDOW_X+8)) $evalfloat(SUBWINDOW_Y+62)
+										$evalfloat(SUBWINDOW_WIDTH-16) $evalfloat(22)
+		style						WINDOW_STYLE_FILLED
+		backcolor				.5 .5 .5 .2
+		visible					1
+		hOffset					"ui_mtOffset"
+		decoration
+	}
+
+	// recipient's label
+	LABEL							(SUBWINDOW_X+8, SUBWINDOW_Y+18, SUBWINDOW_WIDTH-16, 11, "To:", .2, ITEM_ALIGN_LEFT, 0, 8)
+
+	// recipient's background
+	itemDef {
+		name						"efleftbackRecipient:"
+		group						GROUP_NAME
+		rect						$evalfloat((SUBWINDOW_X+8)) $evalfloat(SUBWINDOW_Y+32)
+										$evalfloat(SUBWINDOW_WIDTH-16) $evalfloat(11)
+		style						WINDOW_STYLE_FILLED
+		backcolor				.5 .5 .5 .2
+		visible					1
+		decoration
+	}
+
+	// recipient texteditor
+	itemDef {
+		name						"inPrivateMessageRecipient"
+		group						GROUP_NAME
+		// text needs to be set, otherwise the cvar string will draw twice
+		// this is not needed for the message box, as multiline text boxes are handled differently
+		text						""
+		rect						$evalfloat(SUBWINDOW_X+10) $evalfloat(SUBWINDOW_Y+32)
+										$evalfloat(SUBWINDOW_WIDTH-28) $evalfloat(11)
+		type						ITEM_TYPE_EDITFIELD
+		textfont				UI_FONT_COURBD_21
+		textstyle				ITEM_TEXTSTYLE_SHADOWED
+		textscale				.2
+		textaligny			8
+		forecolor				.6 .6 .6 1
+		cursorColor			0.7 0.7 0.7 1
+		cvar						"etj_privateMessageTo"
+		maxChars				35
+		maxPaintChars		35
+		visible					1
+		tooltip					"Enter recipients name or client number here\nPartial name matching is supported"
+	}
+
+	// editor's label
+	LABEL							(SUBWINDOW_X+8, SUBWINDOW_Y+48, SUBWINDOW_WIDTH-16, 11, "Message:", .2, ITEM_ALIGN_LEFT, 0, 8)
+
+	// multiline texteditor
+	itemDef {
+		name						"inPrivateMessageText"
+		group						GROUP_NAME
+		rect						$evalfloat(SUBWINDOW_X+10) $evalfloat(SUBWINDOW_Y+62)
+										$evalfloat(SUBWINDOW_WIDTH-28) $evalfloat(22)
+		type						ITEM_TYPE_EDITFIELD
+		textfont				UI_FONT_COURBD_21
+		textstyle				ITEM_TEXTSTYLE_SHADOWED
+		textscale				.2
+		textaligny			8
+		forecolor				.6 .6 .6 1
+		cursorColor			0.7 0.7 0.7 1
+		cvar						"cg_messageText"
+		maxChars				200
+		maxPaintChars		200
+		visible					1
+		tooltip					"Enter message here"
+		hOffset					"ui_mtOffset"
+		multiline
+	}
+
+	// measure text length of the specific cvar
+	itemDef {
+		name						"measureText"
+		text						"chars left: "
+		group						GROUP_NAME
+		rect						$evalfloat(SUBWINDOW_X+SUBWINDOW_WIDTH-8) $evalfloat(SUBWINDOW_Y+86)
+										0 0
+		type						ITEM_TYPE_TEXT
+		textfont				UI_FONT_COURBD_21
+		textstyle				ITEM_TEXTSTYLE_SHADOWED
+		textscale				0.2
+		textalign				ITEM_ALIGN_RIGHT
+		textalignx			0
+		textaligny			8
+		forecolor				.6 .6 .6 1
+		cvar						"cg_messageText"
+		visible					1
+		yOffset					"ui_mtOffset"
+		decoration
+		cvarLength
+	}
+
+	// cancel
+	itemDef {
+		name						"bttnCANCEL"
+		group						GROUP_NAME
+		rect						$evalfloat(SUBWINDOW_X+6) $evalfloat(SUBWINDOW_Y+SUBWINDOW_HEIGHT-24)
+										$evalfloat(.5*(SUBWINDOW_WIDTH-18)) $evalfloat(18)
+		type						ITEM_TYPE_BUTTON
+		text						"CANCEL"
+		textfont				UI_FONT_COURBD_30
+		textscale				.3
+		textalign				ITEM_ALIGN_CENTER
+		textalignx			$evalfloat(0.5*(.5*(SUBWINDOW_WIDTH-18)))
+		textaligny			14
+		style						WINDOW_STYLE_FILLED
+		backcolor				.3 .3 .3 .4
+		forecolor				.6 .6 .6 1
+		border					WINDOW_BORDER_FULL
+		bordercolor			.1 .1 .1 .5
+		visible					1
+		yOffset					"ui_mtOffset"
+
+		mouseEnter {
+			setitemcolor "bttnCANCEL" forecolor .9 .9 .9 1 ;
+			setitemcolor "bttnCANCEL" backcolor .5 .5 .5 .4
+		}
+
+		mouseExit {
+			setitemcolor "bttnCANCEL" forecolor .6 .6 .6 1 ;
+			setitemcolor "bttnCANCEL" backcolor .3 .3 .3 .4
+		}
+
+		action {
+			setitemcolor "bttnCANCEL" forecolor .6 .6 .6 1 ;
+			setitemcolor "bttnCANCEL" backcolor .3 .3 .3 .4 ;
+			play "sound/menu/select.wav" ;
+			close MENU_NAME ;
+		}
+	}
+
+	// send
+	itemDef {
+		name						"bttnSEND"
+		group						GROUP_NAME
+		rect						$evalfloat(SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6) $evalfloat(SUBWINDOW_Y+SUBWINDOW_HEIGHT-24)
+										$evalfloat(.5*(SUBWINDOW_WIDTH-18)) $evalfloat(18)
+		type						ITEM_TYPE_BUTTON
+		text						"SEND"
+		textfont				UI_FONT_COURBD_30
+		textscale				.3
+		textalign				ITEM_ALIGN_CENTER
+		textalignx			$evalfloat(0.5*(.5*(SUBWINDOW_WIDTH-18)))
+		textaligny			14
+		style						WINDOW_STYLE_FILLED
+		backcolor				.3 .3 .3 .4
+		forecolor				.6 .6 .6 1
+		border					WINDOW_BORDER_FULL
+		bordercolor			.1 .1 .1 .5
+		visible					1
+		yOffset					"ui_mtOffset"
+
+		mouseEnter {
+			setitemcolor "bttnSEND" forecolor .9 .9 .9 1 ;
+			setitemcolor "bttnSEND" backcolor .5 .5 .5 .4
+		}
+
+		mouseExit {
+			setitemcolor "bttnSEND" forecolor .6 .6 .6 1 ;
+			setitemcolor "bttnSEND" backcolor .3 .3 .3 .4
+		}
+
+		action {
+			setitemcolor "bttnSEND" forecolor .6 .6 .6 1 ;
+			setitemcolor "bttnSEND" backcolor .3 .3 .3 .4 ;
+			play "sound/menu/select.wav" ;
+			close MENU_NAME ;
+			exec messageSend ;
+		}
+	}
+}

--- a/assets/ui/menus.txt
+++ b/assets/ui/menus.txt
@@ -68,6 +68,7 @@
 	loadMenu { "ui/ingame_vote_customvote.menu" }
 	loadMenu { "ui/ingame_disconnect.menu" }
 	loadMenu { "ui/ingame_messagemode.menu" }
+	loadMenu { "ui/ingame_privatemessage.menu" }
 	loadMenu { "ui/ingame_tapout.menu" }
 	loadMenu { "ui/ingame_tapoutlms.menu" }
 

--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -455,17 +455,27 @@ inline constexpr int MSGTYPE_ALL = 1;
 inline constexpr int MSGTYPE_TEAM = 2;
 inline constexpr int MSGTYPE_BUDDY = 3;
 inline constexpr int MSGTYPE_ADMIN = 4;
+inline constexpr int MSGTYPE_PRIVATE = 5;
 
 // ydnar: say, team say, etc
-static void CG_MessageMode_f(void) {
-  char cmd[64];
+static void CG_MessageMode_f() {
+  char cmd[64]{};
 
   if (cgs.eventHandling != CGAME_EVENT_NONE) {
     return;
   }
 
   // get the actual command
-  trap_Argv(0, cmd, 64);
+  trap_Argv(0, cmd, sizeof(cmd));
+
+  // private message
+  if (!Q_stricmp(cmd, "privateMessage")) {
+    trap_Cvar_Set("cg_messageType", std::to_string(MSGTYPE_PRIVATE).c_str());
+    trap_Cvar_Set("cg_messageText", "");
+    trap_Cvar_Set("etj_privateMessageTo", "");
+    trap_UI_Popup(UIMENU_INGAME_PRIVATE_MESSAGE);
+    return;
+  }
 
   // team say
   if (!Q_stricmp(cmd, "messagemode2")) {
@@ -533,6 +543,16 @@ static void CG_MessageSend_f(void) {
     case MSGTYPE_ADMIN:
       trap_SendConsoleCommand(va("enc_say_admin \"%s\"\n", messageTextEncoded));
       break;
+    case MSGTYPE_PRIVATE: {
+      char messageTo[MAX_NAME_LENGTH]{};
+      trap_Cvar_VariableStringBuffer("etj_privateMessageTo", messageTo,
+                                     sizeof(messageTo));
+
+      trap_SendConsoleCommand(
+          va("enc_m \"%s\" \"%s\"\n", messageTo, messageTextEncoded));
+      trap_Cvar_Set("etj_privateMessageTo", "");
+      break;
+    }
     default:
       trap_SendConsoleCommand(va("enc_say \"%s\"\n", messageTextEncoded));
       break;
@@ -1277,6 +1297,7 @@ static const consoleCommand_t noDemoCommands[] = {
     {"messageMode2", CG_MessageMode_f},
     {"messageMode3", CG_MessageMode_f},
     {"adminChat", CG_MessageMode_f},
+    {"privateMessage", CG_MessageMode_f},
     {"messageSend", CG_MessageSend_f},
 
     {"openlimbomenu", CG_LimboMenu_f},
@@ -1574,4 +1595,7 @@ void CG_InitConsoleCommands() {
   trap_AddCommand("generateMotd");
 
   trap_AddCommand("dumpEntities");
+
+  trap_AddCommand("m");
+  trap_AddCommand("enc_m");
 }

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2545,6 +2545,8 @@ typedef enum {
 
   // fireteam savelimit input box
   UIMENU_INGAME_FT_SAVELIMIT,
+
+  UIMENU_INGAME_PRIVATE_MESSAGE,
 } uiMenuCommand_t;
 
 void BG_AdjustAAGunMuzzleForBarrel(vec_t *origin, vec_t *forward, vec_t *right,

--- a/src/game/etj_printer.cpp
+++ b/src/game/etj_printer.cpp
@@ -87,26 +87,29 @@ void Printer::consoleAll(const std::string &message) {
   }
 }
 
-void Printer::chat(int clientNum, const std::string &message) {
+void Printer::chat(int clientNum, const std::string &message, bool enc) {
   if (clientNum == CONSOLE_CLIENT_NUMBER) {
     G_Printf("%s\n", message.c_str());
   } else {
-    trap_SendServerCommand(clientNum, va("chat \"%s\"", message.c_str()));
+    trap_SendServerCommand(
+        clientNum, va("%s \"%s\"", enc ? "enc_chat" : "chat", message.c_str()));
   }
 }
 
-void Printer::chat(const gentity_t *ent, const std::string &message) {
+void Printer::chat(const gentity_t *ent, const std::string &message, bool enc) {
   const int clientNum = ent ? ClientNum(ent) : CONSOLE_CLIENT_NUMBER;
-  chat(clientNum, message);
+  chat(clientNum, message, enc);
 }
 
-void Printer::chat(const gclient_t *client, const std::string &message) {
+void Printer::chat(const gclient_t *client, const std::string &message,
+                   bool enc) {
   const int clientNum = client ? ClientNum(client) : CONSOLE_CLIENT_NUMBER;
-  chat(clientNum, message);
+  chat(clientNum, message, enc);
 }
 
-void Printer::chatAll(const std::string &message) {
-  trap_SendServerCommand(-1, va("chat \"%s\"", message.c_str()));
+void Printer::chatAll(const std::string &message, bool enc) {
+  trap_SendServerCommand(
+      -1, va("%s \"%s\"", enc ? "enc_chat" : "chat", message.c_str()));
 
   if (g_dedicated.integer) {
     G_Printf("%s\n", message.c_str());

--- a/src/game/etj_printer.h
+++ b/src/game/etj_printer.h
@@ -89,15 +89,17 @@ public:
    * @param clientNum The client to send the message to
    * @param message The message to be sent
    */
-  static void chat(int clientNum, const std::string &message);
-  static void chat(const gentity_t *ent, const std::string &message);
-  static void chat(const gclient_t *client, const std::string &message);
+  static void chat(int clientNum, const std::string &message, bool enc = false);
+  static void chat(const gentity_t *ent, const std::string &message,
+                   bool enc = false);
+  static void chat(const gclient_t *client, const std::string &message,
+                   bool enc = false);
 
   /**
    * Sends a chat message to everyone in server and to server console.
    * @param message The message to be sent
    */
-  static void chatAll(const std::string &message);
+  static void chatAll(const std::string &message, bool enc = false);
 
   /**
    * Prints a popup message. If client num is -1 sends to console

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -4573,8 +4573,11 @@ void Cmd_PrivateMessage_f(gentity_t *ent) {
   char *msg = nullptr;
   auto selfNum = ClientNum(ent);
 
+  trap_Argv(0, cmd, sizeof(cmd));
+
   if (trap_Argc() < 3) {
-    Printer::console(selfNum, "^7usage: ^3m ^7<name> <message>.\n");
+    Printer::console(selfNum, StringUtils::format(
+                                  "^7usage: ^3%s ^7<name> <message>\n", cmd));
     return;
   }
 
@@ -4582,6 +4585,8 @@ void Cmd_PrivateMessage_f(gentity_t *ent) {
     Printer::console(selfNum, "^3NOTE: ^7You are muted.\n");
     return;
   }
+
+  const bool enc = !Q_stricmp(cmd, "enc_m");
 
   trap_Argv(1, cmd, sizeof(cmd));
   if ((clientNum = ClientNumberFromString(ent, cmd)) == -1) {
@@ -4594,7 +4599,7 @@ void Cmd_PrivateMessage_f(gentity_t *ent) {
   if (!ent) {
     msg = ConcatArgs(2);
     Printer::chat(ClientNum(other),
-                  va("^7Private message from server console: ^3%s", msg));
+                  va("^7Private message from server console: ^3%s", msg), enc);
     trap_SendServerCommand(otherNum, "pmFlashWindow");
 
     G_Printf("Private message to %s^7: ^3%s\n", other->client->pers.netname,
@@ -4604,13 +4609,17 @@ void Cmd_PrivateMessage_f(gentity_t *ent) {
 
   if (!COM_BitCheck(other->client->sess.ignoreClients, ClientNum(ent))) {
     msg = ConcatArgs(2);
-    Printer::chat(otherNum, va("^7Private message from %s^7: ^3%s",
-                               ent->client->pers.netname, msg));
+    Printer::chat(
+        otherNum,
+        va("^7Private message from %s^7: ^3%s", ent->client->pers.netname, msg),
+        enc);
     trap_SendServerCommand(otherNum, "pmFlashWindow");
 
     if (ent) {
-      Printer::chat(selfNum, va("^7Private message to %s^7: ^3%s",
-                                other->client->pers.netname, msg));
+      Printer::chat(selfNum,
+                    va("^7Private message to %s^7: ^3%s",
+                       other->client->pers.netname, msg),
+                    enc);
 
       if (ent->client->sess.inactive) {
         ETJump::InactivityTimer::clearClientInactivity(ent);
@@ -4951,6 +4960,7 @@ static const command_t anyTimeCommands[] = {
     {"ws", qfalse, Cmd_WeaponStat_f},
     {"rs", qfalse, Cmd_ResetSetup_f},
     {"m", qtrue, Cmd_PrivateMessage_f},
+    {"enc_m", qtrue, Cmd_PrivateMessage_f},
     {"nogoto", qfalse, Cmd_noGoto_f},
     {"nocall", qfalse, Cmd_noCall_f},
     {"rtvVote", qfalse, Cmd_Vote_f},

--- a/src/ui/ui_main.cpp
+++ b/src/ui/ui_main.cpp
@@ -7376,9 +7376,11 @@ void _UI_SetActiveMenu(const uiMenuCommand_t menu) {
 
     // ydnar: say, team say, etc
     case UIMENU_INGAME_MESSAGEMODE:
-      // trap_Cvar_Set( "cl_paused", "1" );
+    case UIMENU_INGAME_PRIVATE_MESSAGE:
       trap_Key_SetCatcher(KEYCATCH_UI);
-      Menus_OpenByName("ingame_messagemode");
+      Menus_OpenByName((menu == UIMENU_INGAME_MESSAGEMODE)
+                           ? "ingame_messagemode"
+                           : "ingame_privatemessage");
 
       // special case for chat, we don't really want the cursor to be
       // in the middle of the screen, it would be annoying to have the cursor


### PR DESCRIPTION
Console command `privateMessage` now opens a new menu which allows sending private messages to players. It has a field for the recipient, as well as a similar multiline textbox as the regular chat window has. This menu sends an encoded message (via new `enc_m` command), so it's now possible to send private messages containing extended ASCII characters, like it's possible with other chat messages.

<img width="532" height="216" alt="image" src="https://github.com/user-attachments/assets/062b3c4c-00e6-4137-aaaa-828dec726a21" />

<img width="1329" height="793" alt="image" src="https://github.com/user-attachments/assets/049d063f-fd39-4879-a144-276a921e23b8" />

refs #264 
