### PR TITLE
Fix server-side autoexec_mapname leaking a file handle

### DIFF
--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2912,6 +2912,8 @@ inline constexpr char CUSTOMVOTE_CVTEXT[] = "cvtext";
 inline constexpr char CUSTOMVOTE_SERVERMAPS[] = "servermaps";
 inline constexpr char CUSTOMVOTE_OTHERMAPS[] = "othermaps";
 
+inline constexpr char AUTOEXEC_MAP_DEFAULT[] = "autoexec_default.cfg";
+
 enum class CheatCvarFlags {
   None = 0,
   LookYaw = 1,

--- a/src/game/etj_utilities.cpp
+++ b/src/game/etj_utilities.cpp
@@ -24,6 +24,7 @@
 
 #include "etj_utilities.h"
 #include "etj_entity_utilities.h"
+#include "etj_filesystem.h"
 #include "etj_map_statistics.h"
 #include "etj_timerun_v2.h"
 #include "etj_worldspawn.h"
@@ -221,5 +222,16 @@ void Utilities::copyStanceFromClient(gentity_t *self, const gentity_t *target) {
     self->client->ps.eFlags &= ~EF_PRONE;
     self->client->ps.eFlags &= ~EF_PRONE_MOVING;
     self->client->ps.pm_flags &= ~PMF_DUCKED;
+  }
+}
+
+void Utilities::execMapAutoexec() {
+  const char *filename = va("autoexec_%s.cfg", level.rawmapname);
+
+  if (FileSystem::exists(filename)) {
+    trap_SendConsoleCommand(EXEC_APPEND, va("exec %s\n", filename));
+  } else if (FileSystem::exists(ETJump::AUTOEXEC_MAP_DEFAULT)) {
+    trap_SendConsoleCommand(EXEC_APPEND,
+                            va("exec %s\n", ETJump::AUTOEXEC_MAP_DEFAULT));
   }
 }

--- a/src/game/etj_utilities.h
+++ b/src/game/etj_utilities.h
@@ -95,4 +95,9 @@ bool inNoNoclipArea(gentity_t *ent);
  * Copies the target clients stance (crouch/prone/stand)
  */
 void copyStanceFromClient(gentity_t *self, const gentity_t *target);
+
+/**
+ * Executes autoexec file for the current map, if present
+ */
+void execMapAutoexec();
 } // namespace Utilities

--- a/src/game/g_main.cpp
+++ b/src/game/g_main.cpp
@@ -1,5 +1,6 @@
 #include <memory>
 
+#include "etj_utilities.h"
 #include "g_local.h"
 #include "etj_deathrun_system.h"
 #include "etj_database.h"
@@ -1623,25 +1624,6 @@ void G_wipeCvars(void) {
   G_UpdateCvars();
 }
 
-void G_ExecMapSpecificConfig() {
-  int len;
-  fileHandle_t f;
-
-  len = trap_FS_FOpenFile(va("autoexec_%s.cfg", level.rawmapname), &f, FS_READ);
-  if (len > 0) {
-    // autoexec_mapname.cfg file found
-    trap_SendConsoleCommand(EXEC_APPEND,
-                            va("exec autoexec_%s.cfg\n", level.rawmapname));
-    return;
-  }
-
-  len = trap_FS_FOpenFile("autoexec_default.cfg", &f, FS_READ);
-  if (len > 0) {
-    // autoexec_default.cfg file found
-    trap_SendConsoleCommand(EXEC_APPEND, "exec autoexec_default.cfg\n");
-  }
-}
-
 // copies max num chars from beginning of dest into src and returns pointer to
 // new src
 char *strcut(char *dest, char *src, int num) {
@@ -1831,7 +1813,7 @@ void G_InitGame(int levelTime, int randomSeed, int restart) {
   trap_Cvar_Set("mapname", mapName.c_str());
   Q_strncpyz(level.rawmapname, mapName.c_str(), sizeof(level.rawmapname));
 
-  G_ExecMapSpecificConfig();
+  Utilities::execMapAutoexec();
 
   trap_SetConfigstring(CS_SCRIPT_MOVER_NAMES, ""); // clear out
 


### PR DESCRIPTION
Very old bug, present since the initial implementation of map-specific autoexecs on server in 2013.

refs b24abfa9fafd954d5f7e5d25fbe45c711c051b2e