### PR TITLE
Add etj_speed/MaxSpeedPrecision

### DIFF
--- a/assets/ui/etjump_settings_hud1_maxspeed.menu
+++ b/assets/ui/etjump_settings_hud1_maxspeed.menu
@@ -54,7 +54,7 @@ menuDef {
     SIDEBUTTON          (13, "MISC", close MENU_NAME; open etjump_settings_hud1_misc)
 
     SUBWINDOW(SETTINGS_SUBW_X, SETTINGS_SUBW_Y, SETTINGS_SUBW_W, SETTINGS_SUBW_H, "MAX SPEED")
-    
+
         YESNO               (SETTINGS_ITEM_POS(1), "Draw max speed:", 0.2, SETTINGS_ITEM_H, "etj_drawMaxSpeed", "Draw max speed after previous load session\netj_drawMaxSpeed")
         CVARINTLABEL        (SETTINGS_ITEM_POS(2), "etj_maxSpeedX", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(2), "Max speed X:", 0.2, SETTINGS_ITEM_H, etj_maxSpeedX 320 0 640 10, "Sets X position of max speed\netj_maxSpeedX")
@@ -62,6 +62,8 @@ menuDef {
         SLIDER              (SETTINGS_ITEM_POS(3), "Max speed Y:", 0.2, SETTINGS_ITEM_H, etj_maxSpeedY 300 0 480 10, "Sets Y position of max speed\netj_maxSpeedY")
         CVARINTLABEL        (SETTINGS_ITEM_POS(4), "etj_maxSpeedDuration", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(4), "Max speed duration:", 0.2, SETTINGS_ITEM_H, etj_maxSpeedDuration 2000 0 15000 250, "How long in milliseconds to display max speed\netj_maxSpeedDuration")
+        CVARINTLABEL        (SETTINGS_ITEM_POS(5), "etj_maxSpeedPrecision", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(5), "Max speed precision:", 0.2, SETTINGS_ITEM_H, etj_maxSpeedPrecision 0 0 6 1, "Number of decimals to display on max speed\netj_maxSpeedPrecision")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/assets/ui/etjump_settings_hud1_speed2.menu
+++ b/assets/ui/etjump_settings_hud1_speed2.menu
@@ -67,6 +67,8 @@ menuDef {
         MULTI               (SETTINGS_ITEM_POS(7), "Accel-based color:", 0.2, SETTINGS_ITEM_H, "etj_speedColorUsesAccel", cvarFloatList { "Off" 0 "Simple" 1 "Advanced" 2 }, "Color ETJump speed meter based on accel/decel\nNote: advanced coloring is disabled while spectating\nand on demo playback if acceleration cannot be reliably measured\n(demo was recorded without sv_fps/snaps 125)\netj_speedColorUsesAccel")
         YESNO               (SETTINGS_ITEM_POS(8), "Speed meter shadow:", 0.2, SETTINGS_ITEM_H, "etj_speedShadow", "Draw shadow on ETJump speed meter\netj_speedShadow")
         MULTI               (SETTINGS_ITEM_POS(9), "Speed meter align:", 0.2, SETTINGS_ITEM_H, "etj_speedAlign", cvarFloatList { "Center" 0 "Left" 1 "Right" 2 }, "Sets alignment of ETJump speed meter\netj_speedAlign")
+        CVARINTLABEL        (SETTINGS_ITEM_POS(10), "etj_speedPrecision", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
+        SLIDER              (SETTINGS_ITEM_POS(10), "Speed precision:", 0.2, SETTINGS_ITEM_H, etj_speedPrecision 0 0 6 1, "Number of decimals to display on ETJump speed meter\netj_speedPrecision")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2409,12 +2409,15 @@ extern vmCvar_t etj_speedSize;
 extern vmCvar_t etj_speedColor;
 extern vmCvar_t etj_speedAlpha;
 extern vmCvar_t etj_speedShadow;
+extern vmCvar_t etj_speedColorUsesAccel;
+extern vmCvar_t etj_speedAlign;
+extern vmCvar_t etj_speedPrecision;
+
 extern vmCvar_t etj_drawMaxSpeed;
 extern vmCvar_t etj_maxSpeedX;
 extern vmCvar_t etj_maxSpeedY;
 extern vmCvar_t etj_maxSpeedDuration;
-extern vmCvar_t etj_speedColorUsesAccel;
-extern vmCvar_t etj_speedAlign;
+extern vmCvar_t etj_maxSpeedPrecision;
 
 extern vmCvar_t etj_drawAccel;
 extern vmCvar_t etj_accelX;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -351,12 +351,15 @@ vmCvar_t etj_speedSize;
 vmCvar_t etj_speedColor;
 vmCvar_t etj_speedAlpha;
 vmCvar_t etj_speedShadow;
+vmCvar_t etj_speedColorUsesAccel;
+vmCvar_t etj_speedAlign;
+vmCvar_t etj_speedPrecision;
+
 vmCvar_t etj_drawMaxSpeed;
 vmCvar_t etj_maxSpeedX;
 vmCvar_t etj_maxSpeedY;
 vmCvar_t etj_maxSpeedDuration;
-vmCvar_t etj_speedColorUsesAccel;
-vmCvar_t etj_speedAlign;
+vmCvar_t etj_maxSpeedPrecision;
 
 vmCvar_t etj_drawAccel;
 vmCvar_t etj_accelX;
@@ -987,12 +990,15 @@ cvarTable_t cvarTable[] = {
     {&etj_speedColor, "etj_speedColor", "White", CVAR_ARCHIVE},
     {&etj_speedAlpha, "etj_speedAlpha", "1.0", CVAR_ARCHIVE},
     {&etj_speedShadow, "etj_speedShadow", "0", CVAR_ARCHIVE},
+    {&etj_speedColorUsesAccel, "etj_speedColorUsesAccel", "0", CVAR_ARCHIVE},
+    {&etj_speedAlign, "etj_speedAlign", "0", CVAR_ARCHIVE},
+    {&etj_speedPrecision, "etj_speedPrecision", "0", CVAR_ARCHIVE},
+
     {&etj_drawMaxSpeed, "etj_drawMaxSpeed", "0", CVAR_ARCHIVE},
     {&etj_maxSpeedX, "etj_maxSpeedX", "320", CVAR_ARCHIVE},
     {&etj_maxSpeedY, "etj_maxSpeedY", "300", CVAR_ARCHIVE},
     {&etj_maxSpeedDuration, "etj_maxSpeedDuration", "2000", CVAR_ARCHIVE},
-    {&etj_speedColorUsesAccel, "etj_speedColorUsesAccel", "0", CVAR_ARCHIVE},
-    {&etj_speedAlign, "etj_speedAlign", "0", CVAR_ARCHIVE},
+    {&etj_maxSpeedPrecision, "etj_maxSpeedPrecision", "0", CVAR_ARCHIVE},
 
     {&etj_drawAccel, "etj_drawAccel", "0", CVAR_ARCHIVE},
     {&etj_accelX, "etj_accelX", "320", CVAR_ARCHIVE},

--- a/src/cgame/etj_drawspeed2_v2.cpp
+++ b/src/cgame/etj_drawspeed2_v2.cpp
@@ -134,26 +134,34 @@ void DrawSpeed2::setupAccelColor(const PmoveUtilsV2::State &s,
 }
 
 std::string DrawSpeed2::getSpeedString() const {
+  const int32_t precision = std::clamp(etj_speedPrecision.integer, 0, 6);
+
   switch (static_cast<Style>(etj_drawSpeed2.integer)) {
     case Style::SPEED_MAX:
-      return StringUtils::format("%.0f %.0f", currentSpeed, maxSpeed);
+      return StringUtils::format("%.*f %.*f", precision, currentSpeed,
+                                 precision, maxSpeed);
     case Style::SPEED_MAX_COLOR:
-      return StringUtils::format("%.0f ^z%.0f", currentSpeed, maxSpeed);
+      return StringUtils::format("%.*f ^z%.*f", precision, currentSpeed,
+                                 precision, maxSpeed);
     case Style::SPEED_MAX_PARENTHESIS:
-      return StringUtils::format("%.0f (%.0f)", currentSpeed, maxSpeed);
+      return StringUtils::format("%.*f (%.*f)", precision, currentSpeed,
+                                 precision, maxSpeed);
     case Style::SPEED_MAX_COLOR_PARENTHESIS:
-      return StringUtils::format("%.0f ^z(%.0f)", currentSpeed, maxSpeed);
+      return StringUtils::format("%.*f ^z(%.*f)", precision, currentSpeed,
+                                 precision, maxSpeed);
     case Style::SPEED_MAX_COLOR_BRACKETS:
-      return StringUtils::format("%.0f ^z[%.0f]", currentSpeed, maxSpeed);
+      return StringUtils::format("%.*f ^z[%.*f]", precision, currentSpeed,
+                                 precision, maxSpeed);
     case Style::SPEED_MAX_PIPE:
-      return StringUtils::format("%.0f | %.0f", currentSpeed, maxSpeed);
+      return StringUtils::format("%.*f | %.*f", precision, currentSpeed,
+                                 precision, maxSpeed);
     case Style::SPEED_TEXT:
-      return StringUtils::format("Speed: %.0f", currentSpeed);
+      return StringUtils::format("Speed: %.*f", precision, currentSpeed);
     case Style::SPEED_TENS:
       return StringUtils::format("%02i",
                                  static_cast<int>(currentSpeed) / 10 % 10 * 10);
     default:
-      return StringUtils::format("%.0f", currentSpeed);
+      return StringUtils::format("%.*f", precision, currentSpeed);
   }
 }
 

--- a/src/cgame/etj_maxspeed.cpp
+++ b/src/cgame/etj_maxspeed.cpp
@@ -95,7 +95,8 @@ void DisplayMaxSpeed::render() const {
   auto size = 0.1f;
   size *= etj_speedSize.value;
 
-  auto str = va("%0.f", displayMaxSpeed);
+  const int32_t precision = std::clamp(etj_maxSpeedPrecision.integer, 0, 6);
+  auto str = va("%.*f", precision, displayMaxSpeed);
   float w;
   switch (etj_speedAlign.integer) {
     case 1: // left align


### PR DESCRIPTION
Allows specifying the number of decimals to display on `etj_drawSpeed2` and `etj_drawMaxSpeed`. Valid range for both is **0-6**.