### PR TITLE
Fix undefined behavior with /m on server console

### DIFF
--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -4571,7 +4571,7 @@ void Cmd_PrivateMessage_f(gentity_t *ent) {
   char cmd[MAX_TOKEN_CHARS] = "\0";
   gentity_t *other = nullptr;
   char *msg = nullptr;
-  auto selfNum = ClientNum(ent);
+  auto selfNum = ent ? ClientNum(ent) : Printer::CONSOLE_CLIENT_NUMBER;
 
   if (trap_Argc() < 3) {
     Printer::console(selfNum, "^7usage: ^3m ^7<name> <message>.\n");


### PR DESCRIPTION
If server console tried to send a private message with too few arguments, `ClientNum` was called on a null pointer.