### PR TITLE
Fix various coloring errors on prints

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -1438,8 +1438,10 @@ bool Kick(gentity_t *ent, Arguments argv) {
 
   int timeout = 0;
   if (argv->size() >= 3) {
-    if (!ToInt(argv->at(2), timeout)) {
-      Printer::chat(ent, "^3kick: ^7invalid timeout '" + argv->at(2) +
+    const std::string timeoutArg = StringUtils::sanitize(argv->at(2));
+
+    if (!ToInt(timeoutArg, timeout)) {
+      Printer::chat(ent, "^3kick: ^7invalid timeout '" + timeoutArg +
                              "' specified.");
       return false;
     }
@@ -1674,7 +1676,7 @@ static bool Map(gentity_t *ent, Arguments argv) {
     return false;
   }
 
-  std::string requestedMap = StringUtils::toLowerCase(argv->at(1));
+  const std::string requestedMap = StringUtils::sanitize(argv->at(1), true);
 
   if (!FileSystem::exists("maps/" + requestedMap + ".bsp")) {
     Printer::chat(ent, "^3map: ^7'" + requestedMap + "' is not on the server.");
@@ -2257,14 +2259,16 @@ bool deleteToken(gentity_t *ent, Arguments argv) {
     }
 
     auto num = 1;
+    const std::string numArg = StringUtils::sanitize((*argv)[3]);
+
     try {
-      num = std::stoi((*argv)[3]);
+      num = std::stoi(numArg);
     } catch (const std::invalid_argument &) {
-      Printer::chat(ent, "^3tokens: ^7" + (*argv)[3] + " is not a number.");
+      Printer::chat(ent, "^3tokens: ^7'" + numArg + "' is not a number.");
       return false;
     } catch (const std::out_of_range &) {
-      Printer::chat(ent, "^3tokens: ^7" + (*argv)[3] +
-                             " is out of range (too large).");
+      Printer::chat(ent, "^3tokens: ^7'" + numArg +
+                             "' is out of range (too large).");
       return false;
     }
 

--- a/src/game/g_cmds.cpp
+++ b/src/game/g_cmds.cpp
@@ -3829,7 +3829,7 @@ bool allowQuickFollow(gentity_t *ent, gentity_t *traceEnt) {
   if (!G_AllowFollow(ent, traceEnt)) {
     auto clientNum = ClientNum(ent);
     std::string specLockMsg = StringUtils::format(
-        "%s is speclocked.", traceEnt->client->pers.netname);
+        "%s ^7is speclocked.", traceEnt->client->pers.netname);
     Printer::popup(clientNum, specLockMsg);
     return false;
   }


### PR DESCRIPTION
* map argument for `!map` was not sanitized
* `timeout` argument for `!kick` was not sanitized
* target token for `!token delete` was not sanitized
* speclock message when trying to quick follow was getting colored from the target client's name

fixes #1941 