### PR TITLE
Fix !kick not concatenating arguments for 'reason'

### DIFF
--- a/src/game/etj_commands.cpp
+++ b/src/game/etj_commands.cpp
@@ -1446,8 +1446,10 @@ bool Kick(gentity_t *ent, Arguments argv) {
   }
 
   std::string reason;
+
   if (argv->size() >= 4) {
-    reason = argv->at(3);
+    const auto reasonArgs = Container::skipFirstN(*argv, 3);
+    reason = StringUtils::join(reasonArgs, " ");
   }
 
   trap_DropClient(ClientNum(target), reason.c_str(), timeout);


### PR DESCRIPTION
`!kick 1 100 foo bar` resulted in the kick message being just `foo`, the rest of the arguments are now concatenated to build the kick message, similar to how `!ban` works.