### PR TITLE
Fix memory management for cached UI sliders

### DIFF
--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -3627,7 +3627,8 @@ static void Scroll_Slider_ThumbFunc(void *p) {
   }
 
   if (scrollInfo.item->cacheCvar) {
-    scrollInfo.item->cacheCvarValue = va("%f", value);
+    Q_strncpyz(scrollInfo.item->cacheCvarValue, va("%f", value),
+               MAX_CVAR_VALUE_STRING);
     return;
   }
 
@@ -3767,7 +3768,7 @@ qboolean Item_Slider_HandleKey(itemDef_t *item, int key, qboolean down) {
 
   // always update cache cvar value on click if it exists
   if (item->cacheCvar) {
-    item->cacheCvarValue = va("%f", value);
+    Q_strncpyz(item->cacheCvarValue, va("%f", value), MAX_CVAR_VALUE_STRING);
   }
 
   if (item->cvar) {
@@ -3792,7 +3793,6 @@ qboolean Item_HandleKey(itemDef_t *item, int key, qboolean down) {
         itemCapture->cacheCvarValue && scrollInfo.item &&
         scrollInfo.item->cacheCvarValue) {
       DC->setCVar(scrollInfo.item->cvar, scrollInfo.item->cacheCvarValue);
-      scrollInfo.item->cacheCvarValue = nullptr;
     }
 
     itemCapture = nullptr;
@@ -7877,8 +7877,11 @@ qboolean ItemParse_tooltipAbove(itemDef_t *item, int handle) {
   return qtrue;
 }
 
-qboolean ItemParse_cacheCvar(itemDef_t *item, int handle) {
+static qboolean ItemParse_cacheCvar(itemDef_t *item, int handle) {
   item->cacheCvar = true;
+  // allocated this in the main UI memory pool, as the string pool
+  // is really intended for immutable, fixed width strings
+  item->cacheCvarValue = static_cast<char *>(UI_Alloc(MAX_CVAR_VALUE_STRING));
   return qtrue;
 }
 

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -371,8 +371,10 @@ typedef struct itemDef_s {
 
   textScroll_t textScroll;
 
-  bool cacheCvar; // update cvar value only when itemCapture ends
-  const char *cacheCvarValue;
+  // update cvar value only when itemCapture ends
+  bool cacheCvar;
+  // allocated if 'cacheCvar' is used on an item, 'MAX_CVAR_VALUE_STRING' bytes
+  char *cacheCvarValue;
 } itemDef_t;
 
 typedef struct {


### PR DESCRIPTION
I was not cooking with this

This was "working" because the sliders re-allocate the memory every frame until mouse is released, and `va` has a static buffer that never had time to wrap around to make the address invalid, but this is obviously bad and it should have it's own, dedicated memory.

refs #1466 