### PR TITLE
Add snaphud cropping

### DIFF
--- a/assets/ui/etjump_settings_hud2_snaphud.menu
+++ b/assets/ui/etjump_settings_hud2_snaphud.menu
@@ -70,6 +70,9 @@ menuDef {
         CVARFLOATLABEL      (SETTINGS_ITEM_POS(12), "etj_snapHUDBorderThickness", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(12), "Border thickness:", 0.2, SETTINGS_ITEM_H, etj_snapHUDBorderThickness 1 0.1 10 0.1, "Thickness of snapzone borders when using border-only snaphud\netj_snapHUDBorderThickness")
         YESNO               (SETTINGS_ITEM_POS(13), "Color 1 is active zone:", 0.2, SETTINGS_ITEM_H, "etj_snapHUDActiveIsPrimary", "Always use primary color for currently active snapzone and flip colors when switching zones\netj_snapHUDActiveIsPrimary")
+        MULTI               (SETTINGS_ITEM_POS(14), "Crop snaphud:", 0.2, SETTINGS_ITEM_H, "etj_snapHUDCrop", cvarFloatList { "No" 0 "When strafing" 1 "Always" 2 }, "Crop snaphud drawing from crosshair against the current strafe direction\netj_snapHUDCrop")
+        // this should technically be a numericfield, but it does not allow for whitespace,	and I'm not sure if it's a good idea to allow that
+        CACHEDEDITFIELD_EXT (SETTINGS_EF_POS(15), "Crop offsets:", 0.2, SETTINGS_ITEM_H, "etj_snapHUDCropOffsets", SETTINGS_EF_MAXCHARS, SETTINGS_EF_MAXPAINTCHARS, "Offset the cropping point from center/edge of the screen, respectively\nYou must give this cvar two values, separated by space\netj_snapHUDCropOffsets")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/assets/ui/menumacros_ext.h
+++ b/assets/ui/menumacros_ext.h
@@ -121,15 +121,15 @@
                        EDITFIELD_CVAR, EDITFIELD_MAXCHARS,                     \
                        EDITFIELD_MAXPAINTCHARS, EDITFIELD_TOOLTIP )            \
   itemDef {                                                                    \
-    name            "efback"##EDITFIELD_TEXT                                   \
-    group           GROUP_NAME                                                 \
-    rect            $evalfloat(EDITFIELD_X + .5 * EDITFIELD_W + 6)             \
-                    $evalfloat(EDITFIELD_Y)                                    \
-                    $evalfloat(.5 * EDITFIELD_TEXTBOX_W - 6)                   \
-                    $evalfloat(EDITFIELD_H)                                    \
-    style           WINDOW_STYLE_FILLED                                        \
-    backcolor       .5 .5 .5 .2                                                \
-    visible         1                                                          \
+    name              "efback"##EDITFIELD_TEXT                                 \
+    group             GROUP_NAME                                               \
+    rect              $evalfloat(EDITFIELD_X + .5 * EDITFIELD_W + 6)           \
+                      $evalfloat(EDITFIELD_Y)                                  \
+                      $evalfloat(.5 * EDITFIELD_TEXTBOX_W - 6)                 \
+                      $evalfloat(EDITFIELD_H)                                  \
+    style             WINDOW_STYLE_FILLED                                      \
+    backcolor         .5 .5 .5 .2                                              \
+    visible           1                                                        \
     decoration                                                                 \
   }                                                                            \
                                                                                \
@@ -154,22 +154,105 @@
     tooltip           EDITFIELD_TOOLTIP                                        \
   }
 
+// cached editfield
+#define CACHEDEDITFIELD( EDITFIELD_X, EDITFIELD_Y, EDITFIELD_W, EDITFIELD_H,   \
+                         EDITFIELD_TEXT, EDITFIELD_TEXT_SCALE,                 \
+                         EDITFIELD_TEXT_ALIGN_Y, EDITFIELD_CVAR,               \
+                         EDITFIELD_MAXCHARS, EDITFIELD_MAXPAINTCHARS,          \
+                         EDITFIELD_TOOLTIP )                                   \
+  itemDef {                                                                    \
+    name              "efback"##EDITFIELD_TEXT                                 \
+    group             GROUP_NAME                                               \
+    rect              $evalfloat(EDITFIELD_X + .5 * EDITFIELD_W + 6)           \
+                      $evalfloat(EDITFIELD_Y)                                  \
+                      $evalfloat(.5 * EDITFIELD_W - 6)                         \
+                      $evalfloat(EDITFIELD_H)                                  \
+    style             WINDOW_STYLE_FILLED                                      \
+    backcolor         .5 .5 .5 .2                                              \
+    visible           1                                                        \
+    decoration                                                                 \
+  }                                                                            \
+                                                                               \
+  itemDef {                                                                    \
+    name              "ef"##EDITFIELD_TEXT                                     \
+    group             GROUP_NAME                                               \
+    rect              $evalfloat(EDITFIELD_X) $evalfloat(EDITFIELD_Y)          \
+                      $evalfloat(EDITFIELD_W) $evalfloat(EDITFIELD_H)          \
+    type              ITEM_TYPE_EDITFIELD                                      \
+    text              EDITFIELD_TEXT                                           \
+    textfont          UI_FONT_COURBD_21                                        \
+    textstyle         ITEM_TEXTSTYLE_SHADOWED                                  \
+    textscale         EDITFIELD_TEXT_SCALE                                     \
+    textalign         ITEM_ALIGN_RIGHT                                         \
+    textalignx        $evalfloat(0.5 * EDITFIELD_W)                            \
+    textaligny        EDITFIELD_TEXT_ALIGN_Y                                   \
+    forecolor         .6 .6 .6 1                                               \
+    cvar              EDITFIELD_CVAR                                           \
+    maxChars          EDITFIELD_MAXCHARS                                       \
+    maxPaintChars     EDITFIELD_MAXPAINTCHARS                                  \
+    visible           1                                                        \
+    tooltip           EDITFIELD_TOOLTIP                                        \
+    cacheCvar                                                                  \
+  }
+
+// cached editfield with an adjustable textbox width
+#define CACHEDEDITFIELD_EXT( EDITFIELD_X, EDITFIELD_Y, EDITFIELD_W,            \
+                             EDITFIELD_H, EDITFIELD_TEXTBOX_W, EDITFIELD_TEXT, \
+                             EDITFIELD_TEXT_SCALE, EDITFIELD_TEXT_ALIGN_Y,     \
+                             EDITFIELD_CVAR, EDITFIELD_MAXCHARS,               \
+                             EDITFIELD_MAXPAINTCHARS, EDITFIELD_TOOLTIP )      \
+  itemDef {                                                                    \
+    name              "efback"##EDITFIELD_TEXT                                 \
+    group             GROUP_NAME                                               \
+    rect              $evalfloat(EDITFIELD_X + .5 * EDITFIELD_W + 6)           \
+                      $evalfloat(EDITFIELD_Y)                                  \
+                      $evalfloat(.5 * EDITFIELD_TEXTBOX_W - 6)                 \
+                      $evalfloat(EDITFIELD_H)                                  \
+    style             WINDOW_STYLE_FILLED                                      \
+    backcolor         .5 .5 .5 .2                                              \
+    visible           1                                                        \
+    decoration                                                                 \
+  }                                                                            \
+                                                                               \
+  itemDef {                                                                    \
+    name              "ef"##EDITFIELD_TEXT                                     \
+    group             GROUP_NAME                                               \
+    rect              $evalfloat(EDITFIELD_X) $evalfloat(EDITFIELD_Y)          \
+                      $evalfloat(EDITFIELD_W) $evalfloat(EDITFIELD_H)          \
+    type              ITEM_TYPE_EDITFIELD                                      \
+    text              EDITFIELD_TEXT                                           \
+    textfont          UI_FONT_COURBD_21                                        \
+    textstyle         ITEM_TEXTSTYLE_SHADOWED                                  \
+    textscale         EDITFIELD_TEXT_SCALE                                     \
+    textalign         ITEM_ALIGN_RIGHT                                         \
+    textalignx        $evalfloat(0.5 * EDITFIELD_W)                            \
+    textaligny        EDITFIELD_TEXT_ALIGN_Y                                   \
+    forecolor         .6 .6 .6 1                                               \
+    cvar              EDITFIELD_CVAR                                           \
+    maxChars          EDITFIELD_MAXCHARS                                       \
+    maxPaintChars     EDITFIELD_MAXPAINTCHARS                                  \
+    visible           1                                                        \
+    tooltip           EDITFIELD_TOOLTIP                                        \
+    cacheCvar                                                                  \
+  }
+
 // numericfield with an adjustable textbox width
 #define NUMERICFIELD_EXT( NUMERICFIELD_X, NUMERICFIELD_Y, NUMERICFIELD_W,      \
                           NUMERICFIELD_H, NUMERICFIELD_TEXTBOX_W,              \
                           NUMERICFIELD_TEXT, NUMERICFIELD_TEXT_SCALE,          \
                           NUMERICFIELD_TEXT_ALIGN_Y, NUMERICFIELD_CVAR,        \
-                          NUMERICFIELD_MAXCHARS, NUMERICFIELD_TOOLTIP )        \
+                          NUMERICFIELD_MAXCHARS, NUMERICFIELD_MAXPAINTCHARS,   \
+                          NUMERICFIELD_TOOLTIP )                               \
   itemDef {                                                                    \
-    name            "nfback"##NUMERICFIELD_TEXT                                \
-    group           GROUP_NAME                                                 \
-    rect            $evalfloat(NUMERICFIELD_X + .5 * NUMERICFIELD_W + 6)       \
-                    $evalfloat(NUMERICFIELD_Y)                                 \
-                    $evalfloat(.5 * NUMERICFIELD_TEXTBOX_W - 6)                \
-                    $evalfloat(NUMERICFIELD_H)                                 \
-    style           WINDOW_STYLE_FILLED                                        \
-    backcolor       .5 .5 .5 .2                                                \
-    visible         1                                                          \
+    name              "nfback"##NUMERICFIELD_TEXT                              \
+    group             GROUP_NAME                                               \
+    rect              $evalfloat(NUMERICFIELD_X + .5 * NUMERICFIELD_W + 6)     \
+                      $evalfloat(NUMERICFIELD_Y)                               \
+                      $evalfloat(.5 * NUMERICFIELD_TEXTBOX_W - 6)              \
+                      $evalfloat(NUMERICFIELD_H)                               \
+    style             WINDOW_STYLE_FILLED                                      \
+    backcolor         .5 .5 .5 .2                                              \
+    visible           1                                                        \
     decoration                                                                 \
   }                                                                            \
                                                                                \
@@ -189,8 +272,95 @@
     forecolor         .6 .6 .6 1                                               \
     cvar              NUMERICFIELD_CVAR                                        \
     maxChars          NUMERICFIELD_MAXCHARS                                    \
+    maxChars          NUMERICFIELD_MAXPAINTCHARS                               \
     visible           1                                                        \
     tooltip           NUMERICFIELD_TOOLTIP                                     \
+  }
+
+// cached numericfield
+#define CACHEDNUMERICFIELD( NUMERICFIELD_X, NUMERICFIELD_Y, NUMERICFIELD_W,    \
+                            NUMERICFIELD_H, NUMERICFIELD_TEXT,                 \
+                            NUMERICFIELD_TEXT_SCALE,                           \
+                            NUMERICFIELD_TEXT_ALIGN_Y, NUMERICFIELD_CVAR,      \
+                            NUMERICFIELD_MAXCHARS, NUMERICFIELD_MAXPAINTCHARS, \
+                            NUMERICFIELD_TOOLTIP )                             \
+  itemDef {                                                                    \
+    name              "nfback"##NUMERICFIELD_TEXT                              \
+    group             GROUP_NAME                                               \
+    rect              $evalfloat(NUMERICFIELD_X + .5 * NUMERICFIELD_W + 6)     \
+                      $evalfloat(NUMERICFIELD_Y)                               \
+                      $evalfloat(.5 * NUMERICFIELD_W - 6)                      \
+                      $evalfloat(NUMERICFIELD_H)                               \
+    style             WINDOW_STYLE_FILLED                                      \
+    backcolor         .5 .5 .5 .2                                              \
+    visible           1                                                        \
+    decoration                                                                 \
+  }                                                                            \
+                                                                               \
+  itemDef {                                                                    \
+    name              "nf"##NUMERICFIELD_TEXT                                  \
+    group             GROUP_NAME                                               \
+    rect              $evalfloat(NUMERICFIELD_X) $evalfloat(NUMERICFIELD_Y)    \
+                      $evalfloat(NUMERICFIELD_W) $evalfloat(NUMERICFIELD_H)    \
+    type              ITEM_TYPE_NUMERICFIELD                                   \
+    text              NUMERICFIELD_TEXT                                        \
+    textfont          UI_FONT_COURBD_21                                        \
+    textstyle         ITEM_TEXTSTYLE_SHADOWED                                  \
+    textscale         NUMERICFIELD_TEXT_SCALE                                  \
+    textalign         ITEM_ALIGN_RIGHT                                         \
+    textalignx        $evalfloat(0.5 * NUMERICFIELD_W)                         \
+    textaligny        NUMERICFIELD_TEXT_ALIGN_Y                                \
+    forecolor         .6 .6 .6 1                                               \
+    cvar              NUMERICFIELD_CVAR                                        \
+    maxChars          NUMERICFIELD_MAXCHARS                                    \
+    maxChars          NUMERICFIELD_MAXPAINTCHARS                               \
+    visible           1                                                        \
+    tooltip           NUMERICFIELD_TOOLTIP                                     \
+    cacheCvar                                                                  \
+  }
+
+// cached numericfield with an adjustable textbox width
+#define CACHEDNUMERICFIELD_EXT( NUMERICFIELD_X, NUMERICFIELD_Y,                \
+                                NUMERICFIELD_W, NUMERICFIELD_H,                \
+                                NUMERICFIELD_TEXTBOX_W, NUMERICFIELD_TEXT,     \
+                                NUMERICFIELD_TEXT_SCALE,                       \
+                                NUMERICFIELD_TEXT_ALIGN_Y, NUMERICFIELD_CVAR,  \
+                                NUMERICFIELD_MAXCHARS,                         \
+                                NUMERICFIELD_MAXPAINTCHARS,                    \
+                                NUMERICFIELD_TOOLTIP )                         \
+  itemDef {                                                                    \
+    name              "nfback"##NUMERICFIELD_TEXT                              \
+    group             GROUP_NAME                                               \
+    rect              $evalfloat(NUMERICFIELD_X + .5 * NUMERICFIELD_W + 6)     \
+                      $evalfloat(NUMERICFIELD_Y)                               \
+                      $evalfloat(.5 * NUMERICFIELD_TEXTBOX_W - 6)              \
+                      $evalfloat(NUMERICFIELD_H)                               \
+    style             WINDOW_STYLE_FILLED                                      \
+    backcolor         .5 .5 .5 .2                                              \
+    visible           1                                                        \
+    decoration                                                                 \
+  }                                                                            \
+                                                                               \
+  itemDef {                                                                    \
+    name              "nf"##NUMERICFIELD_TEXT                                  \
+    group             GROUP_NAME                                               \
+    rect              $evalfloat(NUMERICFIELD_X) $evalfloat(NUMERICFIELD_Y)    \
+                      $evalfloat(NUMERICFIELD_W) $evalfloat(NUMERICFIELD_H)    \
+    type              ITEM_TYPE_NUMERICFIELD                                   \
+    text              NUMERICFIELD_TEXT                                        \
+    textfont          UI_FONT_COURBD_21                                        \
+    textstyle         ITEM_TEXTSTYLE_SHADOWED                                  \
+    textscale         NUMERICFIELD_TEXT_SCALE                                  \
+    textalign         ITEM_ALIGN_RIGHT                                         \
+    textalignx        $evalfloat(0.5 * NUMERICFIELD_W)                         \
+    textaligny        NUMERICFIELD_TEXT_ALIGN_Y                                \
+    forecolor         .6 .6 .6 1                                               \
+    cvar              NUMERICFIELD_CVAR                                        \
+    maxChars          NUMERICFIELD_MAXCHARS                                    \
+    maxChars          NUMERICFIELD_MAXPAINTCHARS                               \
+    visible           1                                                        \
+    tooltip           NUMERICFIELD_TOOLTIP                                     \
+    cacheCvar                                                                  \
   }
 
 // dropdown menu

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -85,7 +85,8 @@ CG_FillAngleYawExt
 */
 void CG_FillAngleYawExt(float start, float end, float yaw, float y, float h,
                         float fov, vec4_t const color, bool borderOnly,
-                        float borderThickness) {
+                        float borderThickness, std::optional<float> minX,
+                        std::optional<float> maxX) {
   // don't try to draw lines with no width
   if (start == end) {
     return;
@@ -100,21 +101,61 @@ void CG_FillAngleYawExt(float start, float end, float yaw, float y, float h,
     return;
   }
 
+  const bool cropMin = minX.has_value();
+  const bool cropMax = maxX.has_value();
+
   if (!range.split) {
+    // quick early exit if everything is cropped
+    if ((cropMin && range.x2 < minX.value()) ||
+        (cropMax && range.x1 > maxX.value())) {
+      return;
+    }
+
+    const float x = cropMin ? std::max(minX.value(), range.x1) : range.x1;
+    const float w =
+        cropMax ? std::min(maxX.value(), range.x2) - x : range.x2 - x;
+
     if (borderOnly) {
-      CG_DrawRect_FixedBorder(range.x1, y, range.x2 - range.x1, h,
-                              borderThickness, color);
+      CG_DrawRect_FixedBorder(x, y, w, h, borderThickness, color);
     } else {
-      CG_FillRect(range.x1, y, range.x2 - range.x1, h, color);
+      CG_FillRect(x, y, w, h, color);
     }
   } else {
+    const bool drawStart = (!cropMin || (cropMin && minX.value() < range.x1));
+    const bool drawEnd = (!cropMax || (cropMax && maxX.value() < range.x2));
+
     if (borderOnly) {
-      CG_DrawRect_FixedBorder(0, y, range.x1, h, borderThickness, color);
-      CG_DrawRect_FixedBorder(range.x2, y, SCREEN_WIDTH - range.x2, h,
-                              borderThickness, color);
+      if (drawStart) {
+        const float x = cropMin ? std::max(minX.value(), 0.0f) : 0.0f;
+        const float w = cropMax ? std::min(maxX.value(), range.x1) : range.x1;
+
+        CG_DrawRect_FixedBorder(x, y, w, h, borderThickness, color);
+      }
+
+      if (drawEnd) {
+        const float x = cropMin ? std::max(minX.value(), range.x2) : range.x2;
+        const float w = cropMax
+                            ? SCREEN_WIDTH - std::min(maxX.value(), range.x2)
+                            : SCREEN_WIDTH - range.x2;
+
+        CG_DrawRect_FixedBorder(x, y, w, h, borderThickness, color);
+      }
     } else {
-      CG_FillRect(0, y, range.x1, h, color);
-      CG_FillRect(range.x2, y, SCREEN_WIDTH - range.x2, h, color);
+      if (drawStart) {
+        const float x = cropMin ? std::max(minX.value(), 0.0f) : 0.0f;
+        const float w = cropMax ? std::min(maxX.value(), range.x1) : range.x1;
+
+        CG_FillRect(x, y, w, h, color);
+      }
+
+      if (drawEnd) {
+        const float x = cropMin ? std::max(minX.value(), range.x2) : range.x2;
+        const float w = cropMax
+                            ? SCREEN_WIDTH - std::min(maxX.value(), range.x2)
+                            : SCREEN_WIDTH - range.x2;
+
+        CG_FillRect(x, y, w, h, color);
+      }
     }
   }
 }
@@ -126,7 +167,8 @@ CG_FillAngleYaw
 */
 void CG_FillAngleYaw(float start, float end, float yaw, float y, float h,
                      float fov, const vec4_t color) {
-  CG_FillAngleYawExt(start, end, yaw, y, h, fov, color, false, 1);
+  CG_FillAngleYawExt(start, end, yaw, y, h, fov, color, false, 1, std::nullopt,
+                     std::nullopt);
 }
 
 /*

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -14,6 +14,8 @@
 #ifndef CG_LOCAL_H
 #define CG_LOCAL_H
 
+#include <optional>
+
 #include "../game/q_shared.h"
 #include "../game/bg_public.h"
 #include "../ui/ui_shared.h"
@@ -2696,6 +2698,8 @@ extern vmCvar_t etj_snapHUDTrueness;
 extern vmCvar_t etj_snapHUDEdgeThickness;
 extern vmCvar_t etj_snapHUDBorderThickness;
 extern vmCvar_t etj_snapHUDActiveIsPrimary;
+extern vmCvar_t etj_snapHUDCrop;
+extern vmCvar_t etj_snapHUDCropOffsets;
 
 extern vmCvar_t etj_gunSway;
 extern vmCvar_t etj_drawScoreboardInactivity;
@@ -2842,6 +2846,12 @@ qboolean CG_GetWeaponTag(int clientNum, const char *tagname,
 void CG_EncodeQP(const char *in, char *out, int maxlen);
 void CG_DecodeQP(char *line);
 
+namespace ETJump {
+const char *cvarName(const vmCvar_t *cvar);
+const char *cvarDefaultString(const vmCvar_t *cvar);
+void resetCvar(const vmCvar_t *cvar);
+} // namespace ETJump
+
 //
 // cg_view.c
 //
@@ -2879,7 +2889,8 @@ void CG_FillAngleYaw(float start, float end, float yaw, float y, float h,
                      float fov, vec4_t const color);
 void CG_FillAngleYawExt(float start, float end, float yaw, float y, float h,
                         float fov, vec4_t const color, bool borderOnly,
-                        float borderThickness);
+                        float borderThickness, std::optional<float> minX,
+                        std::optional<float> maxX);
 void drawLineDDA(float x0, float y0, float x1, float y1, const vec4_t color);
 void drawLineDDA(float x0, float y0, float x1, float y1, float w,
                  const vec4_t color);

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -634,6 +634,8 @@ vmCvar_t etj_snapHUDTrueness;
 vmCvar_t etj_snapHUDEdgeThickness;
 vmCvar_t etj_snapHUDBorderThickness;
 vmCvar_t etj_snapHUDActiveIsPrimary;
+vmCvar_t etj_snapHUDCrop;
+vmCvar_t etj_snapHUDCropOffsets;
 
 vmCvar_t etj_gunSway;
 vmCvar_t etj_drawScoreboardInactivity;
@@ -1274,6 +1276,8 @@ cvarTable_t cvarTable[] = {
      CVAR_ARCHIVE},
     {&etj_snapHUDActiveIsPrimary, "etj_snapHUDActiveIsPrimary", "0",
      CVAR_ARCHIVE},
+    {&etj_snapHUDCrop, "etj_snapHUDCrop", "0", CVAR_ARCHIVE},
+    {&etj_snapHUDCropOffsets, "etj_snapHUDCropOffsets", "0 0", CVAR_ARCHIVE},
 
     {&etj_gunSway, "etj_gunSway", "1", CVAR_ARCHIVE},
     {&etj_drawScoreboardInactivity, "etj_drawScoreboardInactivity", "1",
@@ -4320,3 +4324,47 @@ void CG_DecodeQP(char *line) {
   }
   *o = '\0';
 }
+
+// TODO: these should be somewhere else but because the cvar table is here,
+// they are here for now. Relocate!
+namespace ETJump {
+static const cvarTable_t *findCvar(const vmCvar_t *cvar) {
+  const auto *const vmCvar = std::find_if(
+      std::begin(cvarTable), std::end(cvarTable),
+      [cvar](const cvarTable_t &entry) { return entry.vmCvar == cvar; });
+
+  if (vmCvar != std::end(cvarTable)) {
+    return vmCvar;
+  }
+
+  return nullptr;
+}
+
+const char *cvarName(const vmCvar_t *cvar) {
+  const cvarTable_t *vmCvar = findCvar(cvar);
+
+  if (vmCvar) {
+    return vmCvar->cvarName;
+  }
+
+  return "";
+}
+
+const char *cvarDefaultString(const vmCvar_t *cvar) {
+  const cvarTable_t *vmCvar = findCvar(cvar);
+
+  if (vmCvar) {
+    return vmCvar->defaultString;
+  }
+
+  return "";
+}
+
+void resetCvar(const vmCvar_t *cvar) {
+  const cvarTable_t *vmCvar = findCvar(cvar);
+
+  if (vmCvar) {
+    trap_Cvar_Set(vmCvar->cvarName, vmCvar->defaultString);
+  }
+}
+} // namespace ETJump

--- a/src/cgame/etj_cvar_parser.h
+++ b/src/cgame/etj_cvar_parser.h
@@ -41,6 +41,11 @@ public:
     float x;
     float y;
   };
+
+  struct Pair {
+    float val1;
+    float val2;
+  };
 };
 
 class CvarValueParser {

--- a/src/cgame/etj_snaphud_data.cpp
+++ b/src/cgame/etj_snaphud_data.cpp
@@ -258,6 +258,7 @@ void SnaphudData::airMove() {
 void SnaphudData::accelerate(const float wishspeed, const float accel) {
   const float a =
       std::min(accel * wishspeed * PmoveUtilsV2::PM_FRAMETIME, MAX_SNAP_ACCEL);
+  s.wishspeed = wishspeed;
 
   if (s.a != a) {
     updateState(a);

--- a/src/cgame/etj_snaphud_data.h
+++ b/src/cgame/etj_snaphud_data.h
@@ -37,6 +37,7 @@ public:
   struct State {
     std::vector<float> snapAngles;
     float a;
+    float wishspeed;
     vec2_t wishvel;
 
     PmoveUtilsV2::PmoveSingleResult result;

--- a/src/cgame/etj_snaphud_v2.cpp
+++ b/src/cgame/etj_snaphud_v2.cpp
@@ -45,6 +45,8 @@ SnaphudV2::SnaphudV2(const std::shared_ptr<SnaphudData> &snaphudData,
                                             snaphud.colors[2]);
   cgame.utils.colorParser->parseColorString(etj_snapHUDHLColor2.string,
                                             snaphud.colors[3]);
+
+  parseCropOffset(&etj_snapHUDCropOffsets);
   startListeners();
 }
 
@@ -53,6 +55,7 @@ SnaphudV2::~SnaphudV2() {
   cvarUpdate->unsubscribe(&etj_snapHUDColor2);
   cvarUpdate->unsubscribe(&etj_snapHUDHLColor1);
   cvarUpdate->unsubscribe(&etj_snapHUDHLColor2);
+  cvarUpdate->unsubscribe(&etj_snapHUDCropOffsets);
 }
 
 void SnaphudV2::startListeners() {
@@ -71,6 +74,55 @@ void SnaphudV2::startListeners() {
   cvarUpdate->subscribe(&etj_snapHUDHLColor2, [this](const vmCvar_t *cvar) {
     cgame.utils.colorParser->parseColorString(cvar->string, snaphud.colors[3]);
   });
+
+  cvarUpdate->subscribe(&etj_snapHUDCropOffsets, [this](const vmCvar_t *cvar) {
+    parseCropOffset(cvar);
+  });
+}
+
+void SnaphudV2::parseCropOffset(const vmCvar_t *cvar) {
+  // FIXME: THIS IS BAD
+  // this should not be here, it should be in 'etj_cvar_parser.h' - however,
+  // it's practically impossible to make cgame link properly in that case,
+  // because of 'ui_shared.cpp'. Therefore, this code is here now, until
+  // cvartable stuff is refactored to be shared between modules, or we need
+  // another cvar to take 2 values like this.
+  std::vector<std::string> components;
+  components.reserve(2);
+
+  const auto parserError = [&cvar]() {
+    Com_Printf(S_COLOR_YELLOW "Cvar '%s' requires at least two components, "
+                              "setting default value\n",
+               cvarName(cvar));
+    resetCvar(cvar);
+  };
+
+  if (cvar->string[0] == '\0' || StringUtils::isWhiteSpace(cvar->string)) {
+    parserError();
+    components = StringUtils::split(cvarDefaultString(cvar), " ");
+  } else {
+    components = StringUtils::split(cvar->string, " ");
+  }
+
+  // remove any empty components - if user inputs a string like "  2   3  ",
+  // 'split()' gives us empty elements
+  components.erase(
+      std::remove_if(components.begin(), components.end(),
+                     [](const std::string_view s) { return s.empty(); }),
+      components.end());
+
+  if (components.size() < 2) {
+    parserError();
+    components = StringUtils::split(cvarDefaultString(cvar), " ");
+  }
+
+  // cap to non-widescreen screen center and adjust to widescreen as
+  // necessary, so the cvar value makes more sense for the user
+  snaphud.cropOffset.val1 = std::clamp(Q_atof(components[0]), 0.0f, 320.0f);
+  snaphud.cropOffset.val2 = std::clamp(Q_atof(components[1]), 0.0f, 320.0f);
+
+  ETJump_AdjustPosition(&snaphud.cropOffset.val1);
+  ETJump_AdjustPosition(&snaphud.cropOffset.val2);
 }
 
 void SnaphudV2::updateSnaphud(const SnaphudData::State &s) {
@@ -102,6 +154,34 @@ void SnaphudV2::updateSnaphud(const SnaphudData::State &s) {
     default:
       snaphud.borderOnly = false;
       break;
+  }
+
+  switch (static_cast<CropStyle>(etj_snapHUDCrop.integer)) {
+    default:
+    case CropStyle::OFF:
+      snaphud.minX = std::nullopt;
+      snaphud.maxX = std::nullopt;
+      break;
+    case CropStyle::IF_STRAFING:
+      // NOTE: use stats to determine input, because snaphud has default input
+      if (!(s.pm.ps->stats[STAT_USERCMD_MOVE] &
+            (UMOVE_FORWARD | UMOVE_BACKWARD)) &&
+          !(s.pm.ps->stats[STAT_USERCMD_MOVE] & (UMOVE_RIGHT | UMOVE_LEFT))) {
+        snaphud.minX = std::nullopt;
+        snaphud.maxX = std::nullopt;
+        break;
+      }
+
+      [[fallthrough]];
+    case CropStyle::ALWAYS:
+      const bool rightStrafe = PmoveUtilsV2::rightStrafe(
+          PmoveUtilsV2::strafingForwards(s.pm, s.wishspeed, s.wishvel),
+          s.pm.cmd);
+
+      snaphud.minX = rightStrafe ? SCREEN_CENTER_X - snaphud.cropOffset.val1
+                                 : 0.0f + snaphud.cropOffset.val2;
+      snaphud.maxX = rightStrafe ? SCREEN_WIDTH - snaphud.cropOffset.val2
+                                 : SCREEN_CENTER_X + snaphud.cropOffset.val1;
   }
 
   buildSnapZones(s);
@@ -157,16 +237,19 @@ void SnaphudV2::render() const {
     }
 
     if (snaphud.style == SnaphudStyle::EDGE) {
-      CG_FillAngleYaw(zone.start, zone.start + snaphud.edgeThickness,
-                      snaphud.yaw, snaphud.y, snaphud.h, snaphud.fov,
-                      snaphud.colors[colorIndex]);
-      CG_FillAngleYaw(zone.end, zone.end - snaphud.edgeThickness, snaphud.yaw,
-                      snaphud.y, snaphud.h, snaphud.fov,
-                      snaphud.colors[colorIndex]);
+      CG_FillAngleYawExt(zone.start, zone.start + snaphud.edgeThickness,
+                         snaphud.yaw, snaphud.y, snaphud.h, snaphud.fov,
+                         snaphud.colors[colorIndex], false,
+                         snaphud.borderThickness, snaphud.minX, snaphud.maxX);
+      CG_FillAngleYawExt(zone.end, zone.end - snaphud.edgeThickness,
+                         snaphud.yaw, snaphud.y, snaphud.h, snaphud.fov,
+                         snaphud.colors[colorIndex], false,
+                         snaphud.borderThickness, snaphud.minX, snaphud.maxX);
     } else {
       CG_FillAngleYawExt(zone.start, zone.end, snaphud.yaw, snaphud.y,
                          snaphud.h, snaphud.fov, snaphud.colors[colorIndex],
-                         snaphud.borderOnly, snaphud.borderThickness);
+                         snaphud.borderOnly, snaphud.borderThickness,
+                         snaphud.minX, snaphud.maxX);
     }
   }
 }

--- a/src/cgame/etj_snaphud_v2.h
+++ b/src/cgame/etj_snaphud_v2.h
@@ -27,6 +27,7 @@
 #include <memory>
 #include <vector>
 
+#include "etj_cvar_parser.h"
 #include "etj_irenderable.h"
 #include "etj_pmove_utils_v2.h"
 #include "etj_snaphud_data.h"
@@ -45,6 +46,7 @@ public:
   void render() const override;
 
 private:
+  void parseCropOffset(const vmCvar_t *cvar);
   void updateSnaphud(const SnaphudData::State &s);
   void buildSnapZones(const SnaphudData::State &s);
 
@@ -59,6 +61,12 @@ private:
     NORMAL = 1,
     EDGE = 2,
     BORDER = 3,
+  };
+
+  enum class CropStyle {
+    OFF = 0,
+    IF_STRAFING = 1,
+    ALWAYS = 2,
   };
 
   struct Snapzone {
@@ -80,6 +88,11 @@ private:
     bool borderOnly;
     float borderThickness;
     float edgeThickness;
+
+    // val1 = center, val2 = edge
+    CvarValue::Pair cropOffset;
+    std::optional<float> minX;
+    std::optional<float> maxX;
 
     std::vector<Snapzone> zones;
     std::array<vec4_t, 4> colors;

--- a/src/game/etj_string_utilities.cpp
+++ b/src/game/etj_string_utilities.cpp
@@ -284,6 +284,11 @@ bool endsWith(const std::string &str, const std::string &suffix) {
          0;
 }
 
+bool isWhiteSpace(const std::string_view s) {
+  return std::all_of(s.cbegin(), s.cend(),
+                     [](const char c) { return std::isspace(c); });
+}
+
 bool iEqual(const std::string_view str1, const std::string_view str2,
             bool sanitized) {
   if (sanitized) {

--- a/src/game/etj_string_utilities.h
+++ b/src/game/etj_string_utilities.h
@@ -109,6 +109,9 @@ bool contains(const std::string &str, const T &text) {
   return str.find(text) != std::string::npos;
 }
 
+// true if string is empty or contains just whitespace
+bool isWhiteSpace(std::string_view s);
+
 // case-insensitive string comparison, optionally with sanitized strings
 bool iEqual(std::string_view str1, std::string_view str2,
             bool sanitized = false);

--- a/src/game/q_shared.cpp
+++ b/src/game/q_shared.cpp
@@ -748,6 +748,12 @@ float Q_atof(const char *str) {
   return (std::isfinite(f) ? f : 0);
 }
 
+float Q_atof(const std::string &str) { return Q_atof(str.c_str()); }
+
+float Q_atof(const std::string_view str) {
+  return Q_atof(std::string{str}.c_str());
+}
+
 int32_t Q_atoi(const char *str) {
   return static_cast<int32_t>(std::strtol(str, nullptr, 10));
 }

--- a/src/game/q_shared.h
+++ b/src/game/q_shared.h
@@ -669,9 +669,11 @@ void Vector4Scale(const vec4_t in, vec_t scale, vec4_t out);
 void VectorRotate(vec3_t in, vec3_t matrix[3], vec3_t out);
 int Q_log2(int val);
 float Q_atof(const char *str);
+float Q_atof(const std::string &str);
+float Q_atof(std::string_view str);
 int32_t Q_atoi(const char *str);
 int32_t Q_atoi(const std::string &str);
-int32_t Q_atoi(const std::string_view str);
+int32_t Q_atoi(std::string_view str);
 float Q_acos(float c);
 
 int Q_rand(int *seed);

--- a/src/ui/ui_shared.cpp
+++ b/src/ui/ui_shared.cpp
@@ -3318,6 +3318,12 @@ static void colorPickerStartCapture(itemDef_t *item, int key) {
   // std::function with captures to a C-style function pointer
   captureFunc = &colorPickerDragWrapper;
 }
+
+static void updateCacheCvar(const itemDef_t *item) {
+  if (item && item->cacheCvar && item->cacheCvarValue) {
+    DC->setCVar(item->cvar, item->cacheCvarValue);
+  }
+}
 } // namespace ETJump
 
 qboolean Item_TextField_HandleKey(itemDef_t *item, int key) {
@@ -3325,11 +3331,27 @@ qboolean Item_TextField_HandleKey(itemDef_t *item, int key) {
   int len, charLen, textLen;
   itemDef_t *newItem = NULL;
   editFieldDef_t *editPtr = (editFieldDef_t *)item->typeData;
+  const char *func = __func__;
+
+  const auto updateCvarValue = [item, &func](const char *buf) {
+    if (item->cacheCvar && item->cacheCvarValue) {
+      // need to use the proper function here because we're inside a lambda
+      Q_strncpyz_fn(item->cacheCvarValue, buf, MAX_CVAR_VALUE_STRING, func,
+                    SRC_FILENAME, __LINE__);
+    } else {
+      DC->setCVar(item->cvar, buf);
+    }
+  };
 
   if (item->cvar) {
-
     memset(buff, 0, sizeof(buff));
-    DC->getCVarString(item->cvar, buff, sizeof(buff));
+
+    if (item->cacheCvar && item->cacheCvarValue) {
+      Q_strncpyz(buff, item->cacheCvarValue, sizeof(buff));
+    } else {
+      DC->getCVarString(item->cvar, buff, sizeof(buff));
+    }
+
     len = strlen(buff);
     textLen = etj_chatlen((unsigned char *)buff);
 
@@ -3358,7 +3380,8 @@ qboolean Item_TextField_HandleKey(itemDef_t *item, int key) {
           }
           buff[textLen] = '\0';
         }
-        DC->setCVar(item->cvar, buff);
+
+        updateCvarValue(buff);
         return qtrue;
       }
 
@@ -3390,7 +3413,7 @@ qboolean Item_TextField_HandleKey(itemDef_t *item, int key) {
 
       if (editPtr->maxChars >= textLen + charLen) {
         buff[item->cursorPos] = key;
-        DC->setCVar(item->cvar, buff);
+        updateCvarValue(buff);
 
         if (item->cursorPos < textLen + 1) {
           item->cursorPos++;
@@ -3400,16 +3423,15 @@ qboolean Item_TextField_HandleKey(itemDef_t *item, int key) {
           }
         }
       }
-
     } else {
-
       if (key == K_DEL || key == K_KP_DEL) {
         if (item->cursorPos < len) {
           memmove(buff + item->cursorPos, buff + item->cursorPos + 1,
                   len - item->cursorPos);
           buff[len] = '\0';
-          DC->setCVar(item->cvar, buff);
+          updateCvarValue(buff);
         }
+
         return qtrue;
       }
 
@@ -3465,7 +3487,10 @@ qboolean Item_TextField_HandleKey(itemDef_t *item, int key) {
 
     if (item->multiline) {
       if (key == K_TAB) {
-        newItem = Menu_SetNextCursorItem((menuDef_t *)item->parent);
+        ETJump::updateCacheCvar(g_editItem);
+        newItem =
+            Menu_SetNextCursorItem(static_cast<menuDef_t *>(item->parent));
+
         if (newItem && (newItem->type == ITEM_TYPE_EDITFIELD ||
                         newItem->type == ITEM_TYPE_NUMERICFIELD)) {
           g_editItem = newItem;
@@ -3481,7 +3506,10 @@ qboolean Item_TextField_HandleKey(itemDef_t *item, int key) {
       }
     } else {
       if (key == K_TAB || key == K_DOWNARROW || key == K_KP_DOWNARROW) {
-        newItem = Menu_SetNextCursorItem((menuDef_t *)item->parent);
+        ETJump::updateCacheCvar(g_editItem);
+        newItem =
+            Menu_SetNextCursorItem(static_cast<menuDef_t *>(item->parent));
+
         if (newItem && (newItem->type == ITEM_TYPE_EDITFIELD ||
                         newItem->type == ITEM_TYPE_NUMERICFIELD)) {
           g_editItem = newItem;
@@ -3489,7 +3517,11 @@ qboolean Item_TextField_HandleKey(itemDef_t *item, int key) {
       }
 
       if (key == K_UPARROW || key == K_KP_UPARROW) {
-        newItem = Menu_SetPrevCursorItem((menuDef_t *)item->parent);
+        ETJump::updateCacheCvar(g_editItem);
+
+        newItem =
+            Menu_SetPrevCursorItem(static_cast<menuDef_t *>(item->parent));
+
         if (newItem && (newItem->type == ITEM_TYPE_EDITFIELD ||
                         newItem->type == ITEM_TYPE_NUMERICFIELD)) {
           g_editItem = newItem;
@@ -4123,12 +4155,14 @@ void Menu_HandleKey(menuDef_t *menu, int key, qboolean down) {
       }
     } else { // ITEM_TYPE_EDITFIELD || ITEM_TYPE_NUMERICFIELD
       if (!Item_TextField_HandleKey(g_editItem, key)) {
+        ETJump::updateCacheCvar(g_editItem);
         g_editingField = qfalse;
         g_editItem = nullptr;
         return;
       }
 
       if (key == K_MOUSE1 || key == K_MOUSE2 || key == K_MOUSE3) {
+        ETJump::updateCacheCvar(g_editItem);
         g_editingField = qfalse;
         g_editItem = nullptr;
         Display_MouseMove(nullptr, DC->cursor.virtX, DC->cursor.virtY);
@@ -4287,6 +4321,12 @@ void Menu_HandleKey(menuDef_t *menu, int key, qboolean down) {
             item->cursorPos = 0;
             g_editingField = qtrue;
             g_editItem = item;
+
+            if (item->cvar && item->cacheCvar && item->cacheCvarValue) {
+              char buf[MAX_CVAR_VALUE_STRING]{};
+              DC->getCVarString(item->cvar, buf, sizeof(buf));
+              Q_strncpyz(item->cacheCvarValue, buf, MAX_CVAR_VALUE_STRING);
+            }
           }
         } else if (item->type == ITEM_TYPE_COMBO) {
           if (Rect_ContainsPoint(&item->window.rect, cursorX, cursorY)) {
@@ -4782,7 +4822,12 @@ static void Item_TextMultiline_Paint(itemDef_t *item) {
     Item_Text_Paint(item);
   }
 
-  DC->getCVarString(item->cvar, buff, sizeof(buff));
+  if (g_editItem && g_editItem == item && item->cacheCvar &&
+      item->cacheCvarValue) {
+    Q_strncpyz(buff, item->cacheCvarValue, sizeof(buff));
+  } else {
+    DC->getCVarString(item->cvar, buff, sizeof(buff));
+  }
 
   // wraps texts and handles caret position
   Item_Text_DrawAutoWrapped(
@@ -4803,7 +4848,10 @@ void Item_TextField_Paint(itemDef_t *item) {
 
   Item_Text_Paint(item);
 
-  if (item->cvar) {
+  if (g_editItem && g_editItem == item && item->cacheCvar &&
+      item->cacheCvarValue) {
+    Q_strncpyz(buff, item->cacheCvarValue, sizeof(buff));
+  } else if (item->cvar) {
     DC->getCVarString(item->cvar, buff, sizeof(buff));
   }
 

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -371,7 +371,7 @@ typedef struct itemDef_s {
 
   textScroll_t textScroll;
 
-  // update cvar value only when itemCapture ends
+  // sliders & editfields - update cvar value only when itemCapture/edit ends
   bool cacheCvar;
   // allocated if 'cacheCvar' is used on an item, 'MAX_CVAR_VALUE_STRING' bytes
   char *cacheCvarValue;


### PR DESCRIPTION
* `etj_snapHUDCrop 0-2` - allows users to crop the screen coordinates where snaphud is being drawn. The default behavior is to crop everything from the center of the screen, against the current strafe direction (so if player is strafing right, everything left of the crosshair will not draw, and vice versa). If the value is 1, the crop is only performed when strafing, value 2 crops always.
* `etj_snapHUDCropOffsets <center> <edge>` - offsets the cropping points from the center/edge of the screen against the current strafe direction, respectively. When offset is applied to the center, more of snaphud will draw on the cropped side of the screen center. When offset is applied to the edge, the snaphud drawing cuts off before the edge of the screen. The values can be combined as such that the entire snaphud can be made "cropped and centered", e.g. by setting `<center>` to 200, and `<edge>` to 320 - 200 = 120. Valid range for both values is **0.0 - 320.0**

Some examples, strafe direction is left on all pictures:

Default crop:
<img width="1920" height="1080" alt="2026-07-22-132617-long" src="https://github.com/user-attachments/assets/427dd65d-7f8e-40c8-a9ad-db9e3bdfcbf5" />

`etj_snapHUDCropOffsets 100 0`
<img width="1920" height="1080" alt="2026-07-22-132627-long" src="https://github.com/user-attachments/assets/d85acaeb-407f-4a33-b685-11385b8c9b5f" />

`etj_snapHUDCropOffsets 100 100`
<img width="1920" height="1080" alt="2026-07-22-132632-long" src="https://github.com/user-attachments/assets/c031f9d3-d60f-46c0-ba9f-58096d98a6a5" />

`etj_snapHUDCropOffsets 200 120`, "centered and cropped"
<img width="1920" height="1080" alt="2026-07-22-132645-long" src="https://github.com/user-attachments/assets/d53f0c36-e34a-41c9-af6f-cc29ae99fe2d" />
