### PR TITLE
Add etj_jumpSpeedsShowUpmove to display upmove in jump speeds list

### DIFF
--- a/assets/ui/etjump_settings_hud2_jumpspeeds.menu
+++ b/assets/ui/etjump_settings_hud2_jumpspeeds.menu
@@ -72,6 +72,7 @@ menuDef {
         SLIDER              (SETTINGS_ITEM_POS(13), "Max jumps per column:", 0.2, SETTINGS_ITEM_H, etj_jumpSpeedsMaxJumpsPerColumn 5 1 100 1, "Maximum number of jump speeds on a column, when using vertical list style\netj_jumpSpeedsMaxJumpsPerColumn")
         CVARINTLABEL        (SETTINGS_ITEM_POS(14), "etj_jumpSpeedsMaxJumpsPerRow", 0.2, ITEM_ALIGN_RIGHT, $evalfloat(SLIDER_LABEL_X), SETTINGS_ITEM_H)
         SLIDER              (SETTINGS_ITEM_POS(14), "Max jumps per row:", 0.2, SETTINGS_ITEM_H, etj_jumpSpeedsMaxJumpsPerRow 10 1 100 1, "Maximum number of jump speeds on a row, when using horizontal list style\netj_jumpSpeedsMaxJumpsPerRow")
+        YESNO               (SETTINGS_ITEM_POS(15), "Show upmove:", 0.2, SETTINGS_ITEM_H, "etj_jumpSpeedsShowUpmove", "Show upmove times for each jump (full upmove time)\netj_jumpSpeedsShowUpmove")
 
     LOWERBUTTON(1, "BACK", close MENU_NAME; open etjump)
     LOWERBUTTON(2, "WRITE CONFIG", clearfocus; uiScript uiPreviousMenu MENU_NAME; open etjump_settings_popup_writeconfig)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2720,6 +2720,7 @@ extern vmCvar_t etj_jumpSpeedsTextSize;
 extern vmCvar_t etj_jumpSpeedsMaxJumps;
 extern vmCvar_t etj_jumpSpeedsMaxJumpsPerColumn;
 extern vmCvar_t etj_jumpSpeedsMaxJumpsPerRow;
+extern vmCvar_t etj_jumpSpeedsShowUpmove;
 
 // Strafe quality
 extern vmCvar_t etj_drawStrafeQuality;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -656,6 +656,7 @@ vmCvar_t etj_jumpSpeedsTextSize;
 vmCvar_t etj_jumpSpeedsMaxJumps;
 vmCvar_t etj_jumpSpeedsMaxJumpsPerColumn;
 vmCvar_t etj_jumpSpeedsMaxJumpsPerRow;
+vmCvar_t etj_jumpSpeedsShowUpmove;
 
 // Strafe quality
 vmCvar_t etj_drawStrafeQuality;
@@ -1303,6 +1304,7 @@ cvarTable_t cvarTable[] = {
      CVAR_ARCHIVE},
     {&etj_jumpSpeedsMaxJumpsPerRow, "etj_jumpSpeedsMaxJumpsPerRow", "10",
      CVAR_ARCHIVE},
+    {&etj_jumpSpeedsShowUpmove, "etj_jumpSpeedsShowUpmove", "0", CVAR_ARCHIVE},
 
     // Strafe quality
     {&etj_drawStrafeQuality, "etj_drawStrafeQuality", "0", CVAR_ARCHIVE},

--- a/src/cgame/etj_jump_speeds_v2.cpp
+++ b/src/cgame/etj_jump_speeds_v2.cpp
@@ -30,6 +30,7 @@
 #include "etj_demo_compatibility.h"
 #include "etj_entity_events_handler.h"
 #include "etj_player_events_handler.h"
+#include "etj_upmove_meter_data.h"
 #include "etj_utilities.h"
 
 inline constexpr size_t MAX_JUMPS = 100;
@@ -41,10 +42,6 @@ inline constexpr float TEXT_MIN_SIZE = 0.1f;
 inline constexpr float TEXT_MAX_SIZE = 10.0f;
 inline constexpr float DEFAULT_TEXT_SIZE = 0.2f;
 
-// base gap between speeds on horizontal layout
-inline constexpr float BASE_OFFSET_X = 30.0f;
-// base row height on vertical layout
-inline constexpr float BASE_OFFSET_Y = 12.0f;
 // offset for the first jump speed after label on horizontal layout
 inline constexpr float HOR_FIRSTJUMP_OFFSET = 5.0f;
 
@@ -77,6 +74,7 @@ JumpSpeedsV2::~JumpSpeedsV2() {
   cvarUpdate->unsubscribe(&etj_jumpSpeedsFasterColor);
   cvarUpdate->unsubscribe(&etj_jumpSpeedsSlowerColor);
   cvarUpdate->unsubscribe(&etj_jumpSpeedsTextSize);
+  cvarUpdate->unsubscribe(&etj_jumpSpeedsShowUpmove);
 }
 
 void JumpSpeedsV2::startListeners() {
@@ -109,6 +107,9 @@ void JumpSpeedsV2::startListeners() {
   cvarUpdate->subscribe(&etj_jumpSpeedsTextSize, [this](const vmCvar_t *cvar) {
     adjustTextSize(*cvar);
   });
+
+  cvarUpdate->subscribe(&etj_jumpSpeedsShowUpmove,
+                        [this](const vmCvar_t *) { computeTextOffsets(); });
 }
 
 void JumpSpeedsV2::parseColor(const std::string &colorStr, vec4_t &color) {
@@ -137,9 +138,20 @@ void JumpSpeedsV2::computeTextOffsets() {
   const int32_t currentTextHeight =
       CG_Text_Height_Ext(LABEL_TEXT, size.y, 0, &cgs.media.limboFont2);
 
+  static const auto baseOffsetX = static_cast<float>(
+      CG_Text_Width_Ext("99999", DEFAULT_TEXT_SIZE, 0, &cgs.media.limboFont2));
+  static const auto baseOffsetUpmoveX = static_cast<float>(CG_Text_Width_Ext(
+      "9999 (1000)", DEFAULT_TEXT_SIZE, 0, &cgs.media.limboFont2));
+  static const auto baseOffsetY =
+      static_cast<float>(CG_Text_Height_Ext("9", DEFAULT_TEXT_SIZE, 0,
+                                            &cgs.media.limboFont2)) *
+      2;
+
   textYAdjust = static_cast<float>(defaultTextHeight - currentTextHeight);
-  textOffsetX = BASE_OFFSET_X * (size.x / DEFAULT_TEXT_SIZE);
-  rowHeight = BASE_OFFSET_Y * (size.y / DEFAULT_TEXT_SIZE);
+  textOffsetX =
+      (etj_jumpSpeedsShowUpmove.integer ? baseOffsetUpmoveX : baseOffsetX) *
+      (size.x / DEFAULT_TEXT_SIZE);
+  rowHeight = baseOffsetY * (size.y / DEFAULT_TEXT_SIZE);
 
   firstJumpHorOffsetX = static_cast<float>(CG_Text_Width_Ext(
                             LABEL_TEXT, size.x, 0, &cgs.media.limboFont2)) +
@@ -179,6 +191,23 @@ void JumpSpeedsV2::updateJumpSpeeds() {
 
   if (etj_jumpSpeedsMinSpeed.integer > current.speed) {
     current.relation = SpeedRelation::SLOWER;
+  }
+
+  // start polling upmove value for the current jump
+  pollUpmove = true;
+}
+
+void JumpSpeedsV2::updateCurrentUpmove() {
+  // this shouldn't ever be true since events are processed before the HUD
+  // is rendered, therefore we should always have at least one jump
+  // when this gets called
+  assert(!jumpSpeeds.empty());
+
+  const auto &s = cgame.hudData.upmove->getState();
+  jumpSpeeds[jumpSpeeds.size() - 1].upmoveStr = std::to_string(s.fullDelay);
+
+  if (!s.jumping) {
+    pollUpmove = false;
   }
 }
 
@@ -247,6 +276,10 @@ bool JumpSpeedsV2::beforeRender() {
     return false;
   }
 
+  if (pollUpmove) {
+    updateCurrentUpmove();
+  }
+
   maxJumps = std::clamp(etj_jumpSpeedsMaxJumps.integer, 1,
                         static_cast<int32_t>(MAX_JUMPS));
   jumpsPerColumn =
@@ -294,10 +327,18 @@ void JumpSpeedsV2::render() const {
                           : std::max(numJumps - maxJumps, 0) + pos;
 
     setJumpColor(jumpSpeeds[i], color);
+    std::string text;
+
+    if (etj_jumpSpeedsShowUpmove.integer) {
+      text = StringUtils::format("%-4s (%s)", jumpSpeeds[i].speedStr,
+                                 jumpSpeeds[i].upmoveStr);
+    } else {
+      text = jumpSpeeds[i].speedStr;
+    }
 
     if (style & Style::HORIZONTAL) {
-      CG_Text_Paint_Ext(x, y, size.x, size.y, color, jumpSpeeds[i].speedStr, 0,
-                        0, textStyle, &cgs.media.limboFont2);
+      CG_Text_Paint_Ext(x, y, size.x, size.y, color, text, 0, 0, textStyle,
+                        &cgs.media.limboFont2);
 
       if ((pos + 1) % jumpsPerRow == 0) {
         y += rowHeight;
@@ -306,8 +347,8 @@ void JumpSpeedsV2::render() const {
         x += textOffsetX;
       }
     } else {
-      CG_Text_Paint_Ext(x, y, size.x, size.y, color, jumpSpeeds[i].speedStr, 0,
-                        0, textStyle, &cgs.media.limboFont2);
+      CG_Text_Paint_Ext(x, y, size.x, size.y, color, text, 0, 0, textStyle,
+                        &cgs.media.limboFont2);
 
       if ((pos + 1) % jumpsPerColumn == 0) {
         x += baseX + textOffsetX;

--- a/src/cgame/etj_jump_speeds_v2.h
+++ b/src/cgame/etj_jump_speeds_v2.h
@@ -67,6 +67,7 @@ private:
     // store a string representation as well so we don't need to perform
     // int -> string conversions every frame for all jumps when rendering
     std::string speedStr;
+    std::string upmoveStr;
     SpeedRelation relation{};
   };
 
@@ -76,6 +77,7 @@ private:
   void computeTextOffsets();
 
   void updateJumpSpeeds();
+  void updateCurrentUpmove();
   void setSpeedRelation();
   void setJumpColor(const Jump &jump, vec4_t color) const;
 
@@ -104,6 +106,15 @@ private:
   CvarValue::Size size{};
 
   bool resetQueued{};
+  // Because we update jump speeds on the 'EV_JUMP' event, we need to
+  // poll the state of upmove data each frame, and keep updating the
+  // value associated with the current jump, otherwise we'd lose any
+  // post-jump upmove frames. When a new jump is registered, this gets flipped
+  // to 'true', and while it's true, we poll the upmove data each frame,
+  // and update the current upmove value for the tip of the 'jumpSpeeds' deque.
+  // Once the upmove state flips 'jumping' (aka we aren't holding jump anymore)
+  // to 'false', we also flip this to 'false', and stop updating the value.
+  bool pollUpmove{};
 
   vec4_t colorBase{};
   vec4_t colorFaster{};

--- a/src/cgame/etj_pmove_utils_v2.cpp
+++ b/src/cgame/etj_pmove_utils_v2.cpp
@@ -50,6 +50,7 @@ void PmoveUtilsV2::initCvars() {
   hudCvars.emplace_back(&etj_drawAccel);
   hudCvars.emplace_back(&etj_drawStrafeQuality);
   hudCvars.emplace_back(&etj_drawUpmoveMeter);
+  hudCvars.emplace_back(&etj_drawJumpSpeeds);
 
   chsCvars.emplace_back(&etj_drawCHS1);
 

--- a/src/cgame/etj_upmove_meter_data.cpp
+++ b/src/cgame/etj_upmove_meter_data.cpp
@@ -54,7 +54,8 @@ bool UpmoveMeterData::check() {
   // we're not checking for individual CHS info values here,
   // this is trivial enough the compute anyway
   return etj_drawUpmoveMeter.integer || etj_drawCHS1.integer ||
-         etj_drawCHS2.integer || etj_drawCHS3.integer;
+         etj_drawCHS2.integer || etj_drawCHS3.integer ||
+         etj_drawJumpSpeeds.integer;
 }
 
 void UpmoveMeterData::runFrame() {


### PR DESCRIPTION
When enabled, the full upmove (pre + post jump) value for a given jump is displayed on jump speeds list, alongside the actual jump speed. This is always recorded in the background even if the display is off, so it can be toggled on/off at any point to see the data.