### PR TITLE
Add enabled/disabled script triggers for func_static_client

### DIFF
--- a/src/game/etj_func_static_client.cpp
+++ b/src/game/etj_func_static_client.cpp
@@ -95,6 +95,7 @@ void FuncStaticClient::use(gentity_t *self, [[maybe_unused]] gentity_t *other,
   }
 
   const int32_t clientNum = ClientNum(activator);
+  self->activator = activator;
 
   if (clientNum < MAX_CLIENTS / 2) {
     COM_BitCheck(&self->s.effect1Time, clientNum) ? turnOn(self, clientNum)
@@ -137,6 +138,10 @@ void FuncStaticClient::turnOn(gentity_t *self, const int32_t clientNum) {
   if (self->spawnflags & SF_CONSUME_PORTALS) {
     deleteTouchingPortals(self, clientNum);
   }
+
+  if (self->scriptName) {
+    scriptEvent(self, "enabled");
+  }
 }
 
 void FuncStaticClient::turnOff(gentity_t *self, const int32_t clientNum) {
@@ -144,6 +149,10 @@ void FuncStaticClient::turnOff(gentity_t *self, const int32_t clientNum) {
     COM_BitSet(&self->s.effect1Time, clientNum);
   } else {
     COM_BitSet(&self->s.effect2Time, clientNum);
+  }
+
+  if (self->scriptName) {
+    scriptEvent(self, "disabled");
   }
 }
 
@@ -207,6 +216,18 @@ void FuncStaticClient::deleteTouchingPortals(const gentity_t *self,
       trap_EntityContact(activator->portalRed->r.currentOrigin,
                          activator->portalRed->r.currentOrigin, self)) {
     G_FreeEntity(activator->portalRed);
+  }
+}
+
+void FuncStaticClient::scriptEvent(gentity_t *self, const char *trigger) {
+  assert(self->activator);
+
+  const team_t team = self->activator->client->sess.sessionTeam;
+
+  if (team == TEAM_ALLIES || team == TEAM_AXIS) {
+    G_Script_ScriptEvent(self, trigger, team == TEAM_AXIS ? "axis" : "allies");
+  } else {
+    G_Script_ScriptEvent(self, trigger, nullptr);
   }
 }
 } // namespace ETJump

--- a/src/game/etj_func_static_client.h
+++ b/src/game/etj_func_static_client.h
@@ -33,10 +33,14 @@ public:
   static void use(gentity_t *self, gentity_t *other, gentity_t *activator);
   static void pain(gentity_t *self, gentity_t *attacker, int32_t damage,
                    vec3_t point);
+
+  static void syncToFireteamLeaderState(int32_t clientNum, int32_t leaderNum);
+
+private:
   static void turnOn(gentity_t *self, int32_t clientNum);
   static void turnOff(gentity_t *self, int32_t clientNum);
   static bool activatorIsInsideEnt(const gentity_t *self, int32_t clientNum);
-  static void syncToFireteamLeaderState(int32_t clientNum, int32_t leaderNum);
   static void deleteTouchingPortals(const gentity_t *self, int32_t clientNum);
+  static void scriptEvent(gentity_t *self, const char *trigger);
 };
 } // namespace ETJump

--- a/src/game/g_script.cpp
+++ b/src/game/g_script.cpp
@@ -278,6 +278,10 @@ g_script_event_define_t gScriptEvents[] = {
     {"mg42", G_Script_EventMatch_StringEqual},
     {"message",
      G_Script_EventMatch_StringEqual}, // contains a sequence of VO in a message
+    // entity was enabled (turned on)
+    {"enabled", G_Script_EventMatch_StringEqual},
+    // entity was disabled (turned off)
+    {"disabled", G_Script_EventMatch_StringEqual},
 
     {NULL, NULL}};
 


### PR DESCRIPTION
If `scriptname` is set, the entity will call `enabled` and `disabled` script triggers when it gets turned on/off, respectively. Both support `team` as a parameter too, so Axis/Allies can call different triggers.

refs #1824 