### PR TITLE
Improve model handling for func_static_client

### DIFF
--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -2567,12 +2567,27 @@ static void funcStaticClient(centity_t *cent) {
 
   refEntity_t ent{};
 
+  VectorCopy(cent->lerpOrigin, ent.origin);
+  VectorCopy(cent->lerpOrigin, ent.oldorigin);
+
+  // NOTE: this must be called before checking for 'modelscale',
+  // so that we scale correct axis values!
+  AnglesToAxis(cent->lerpAngles, ent.axis);
+
   // 'es->density' contains either model or shader index,
   // these are mutually exclusive so if 'es->modelindex2' is set,
   // it will be a model index, otherwise shader index
   if (es->modelindex2) {
     ent.hModel =
         hidden ? cgs.gameModels[es->density] : cgs.gameModels[es->modelindex2];
+
+    // apply 'modelscale/modelscale_vec' if set
+    if (!VectorCompare(es->angles2, vec3_origin)) {
+      VectorScale(ent.axis[0], es->angles2[0], ent.axis[0]);
+      VectorScale(ent.axis[1], es->angles2[1], ent.axis[1]);
+      VectorScale(ent.axis[2], es->angles2[2], ent.axis[2]);
+      ent.nonNormalizedAxes = qtrue;
+    }
   } else {
     ent.hModel = cgs.inlineDrawModel[es->modelindex];
 
@@ -2580,10 +2595,6 @@ static void funcStaticClient(centity_t *cent) {
       ent.customShader = cgs.gameShaders[es->density];
     }
   }
-
-  VectorCopy(cent->lerpOrigin, ent.origin);
-  VectorCopy(cent->lerpOrigin, ent.oldorigin);
-  AnglesToAxis(cent->lerpAngles, ent.axis);
 
   ETJump_SetEntityRGBA(&ent, 1.0, 1.0, 1.0, 1.0);
   trap_R_AddRefEntityToScene(&ent);

--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -2570,6 +2570,12 @@ static void funcStaticClient(centity_t *cent) {
   VectorCopy(cent->lerpOrigin, ent.origin);
   VectorCopy(cent->lerpOrigin, ent.oldorigin);
 
+  // 'angle/angles' support only if 'model2' is used,
+  // inline models don't like when you set angles to them
+  if (es->modelindex2) {
+    VectorCopy(es->angles, cent->lerpAngles);
+  }
+
   // NOTE: this must be called before checking for 'modelscale',
   // so that we scale correct axis values!
   AnglesToAxis(cent->lerpAngles, ent.axis);

--- a/src/game/etj_func_static_client.cpp
+++ b/src/game/etj_func_static_client.cpp
@@ -71,7 +71,7 @@ void FuncStaticClient::spawn(gentity_t *ent) {
 
   char *s = nullptr;
 
-  // 'model2' support so we can also use models
+  // 'model2' support so we can also use models (set via 'InitMover')
   // NOTE: using 'ent->s.density' for both 'offModel' and 'offShader',
   // since they are mutually exclusive - client knows how to interpret this
   // by checking if 'ent->s.modelindex2' is set or not
@@ -79,6 +79,18 @@ void FuncStaticClient::spawn(gentity_t *ent) {
     // alternative model if 'model2' is set, when the brush is in "off" state
     if (G_SpawnString("offModel", "", &s)) {
       ent->s.density = G_ModelIndex(s);
+    }
+
+    vec3_t modelscale{};
+
+    // 'modelscale/modelscale_vec' support, stored in 'angles2'
+    // 'modelscale_vec' is preferred over regular 'modelscale'
+    if (G_SpawnVector("modelscale_vec", "1 1 1", modelscale)) {
+      VectorCopy(modelscale, ent->s.angles2);
+    } else if (G_SpawnFloat("modelscale", "1", &modelscale[0])) {
+      modelscale[1] = modelscale[0];
+      modelscale[2] = modelscale[0];
+      VectorCopy(modelscale, ent->s.angles2);
     }
   } else {
     // custom shader when the brush is in "off" state


### PR DESCRIPTION
* Support `modelscale/modelscale_vec` keys to scale `model2/offModel`
* Support setting `angle/angles` for `model2/offModel`

Both keys affect `model2` and `offModel` simultaneously, there is no individual control per-model. Both settings are also global, and not per client, so these are just useful for setting the initial scale/angles for the model.

fixes #1963
refs #1824 