### PR TITLE
Support portal centering/size on func_static_client

### DIFF
--- a/src/game/etj_func_static_client.cpp
+++ b/src/game/etj_func_static_client.cpp
@@ -22,16 +22,12 @@
  * SOFTWARE.
  */
 
+#include <algorithm>
+
 #include "etj_func_static_client.h"
 #include "etj_entity_utilities_shared.h"
 
 namespace ETJump {
-inline constexpr int32_t SF_START_INVIS = 1 << 0;
-inline constexpr int32_t SF_PAIN = 1 << 1;
-inline constexpr int32_t SF_GIB_INSIDE = 1 << 2;
-inline constexpr int32_t SF_FT_TEAMJUMP_SYNC = 1 << 3;
-inline constexpr int32_t SF_CONSUME_PORTALS = 1 << 4;
-
 /*
  * 'ent->s.effect1Time' and 'ent->s.effect2Time' are treated as boolean
  * bitsets by this entity. Clients 0-31 map to 'effect1Time',
@@ -56,12 +52,12 @@ void FuncStaticClient::spawn(gentity_t *ent) {
   ent->s.eType = ET_STATIC_CLIENT;
 
   // hide by default for all clients if spawnflag 1 is set
-  if (ent->spawnflags & SF_START_INVIS) {
+  if (ent->spawnflags & Spawnflags::START_INVIS) {
     ent->s.effect1Time = INT_MAX;
     ent->s.effect2Time = INT_MAX;
   }
 
-  if (ent->spawnflags & SF_PAIN) {
+  if (ent->spawnflags & Spawnflags::PAIN) {
     ent->pain = pain;
     ent->takedamage = qtrue;
     // pretty sure this is useless but 'func_static' does it as well
@@ -97,6 +93,11 @@ void FuncStaticClient::spawn(gentity_t *ent) {
     if (G_SpawnString("offShader", "", &s)) {
       ent->s.density = G_ShaderIndex(s);
     }
+  }
+
+  if (ent->spawnflags & Spawnflags::PORTAL_TARGET &&
+      G_SpawnInt("portalsize", "0", &ent->count)) {
+    ent->count = std::clamp(ent->count, 0, 512);
   }
 }
 
@@ -141,13 +142,13 @@ void FuncStaticClient::turnOn(gentity_t *self, const int32_t clientNum) {
     COM_BitClear(&self->s.effect2Time, clientNum);
   }
 
-  if (self->spawnflags & SF_GIB_INSIDE &&
+  if (self->spawnflags & Spawnflags::GIB_INSIDE &&
       activatorIsInsideEnt(self, clientNum)) {
     G_Damage(g_entities + clientNum, self, self, nullptr, nullptr, 9999,
              DAMAGE_NO_PROTECTION, MOD_CRUSH);
   }
 
-  if (self->spawnflags & SF_CONSUME_PORTALS) {
+  if (self->spawnflags & Spawnflags::CONSUME_PORTALS) {
     deleteTouchingPortals(self, clientNum);
   }
 
@@ -199,7 +200,7 @@ void FuncStaticClient::syncToFireteamLeaderState(const int32_t clientNum,
       continue;
     }
 
-    if (!(ent->spawnflags & SF_FT_TEAMJUMP_SYNC)) {
+    if (!(ent->spawnflags & Spawnflags::FT_TEAMJUMP_SYNC)) {
       continue;
     }
 

--- a/src/game/etj_func_static_client.h
+++ b/src/game/etj_func_static_client.h
@@ -29,6 +29,16 @@
 namespace ETJump {
 class FuncStaticClient {
 public:
+  class Spawnflags {
+  public:
+    static constexpr int32_t START_INVIS = 1 << 0;
+    static constexpr int32_t PAIN = 1 << 1;
+    static constexpr int32_t GIB_INSIDE = 1 << 2;
+    static constexpr int32_t FT_TEAMJUMP_SYNC = 1 << 3;
+    static constexpr int32_t CONSUME_PORTALS = 1 << 4;
+    static constexpr int32_t PORTAL_TARGET = 1 << 5;
+  };
+
   static void spawn(gentity_t *ent);
   static void use(gentity_t *self, gentity_t *other, gentity_t *activator);
   static void pain(gentity_t *self, gentity_t *attacker, int32_t damage,

--- a/src/game/etj_portalgun.cpp
+++ b/src/game/etj_portalgun.cpp
@@ -27,6 +27,7 @@
 #include "etj_portalgun.h"
 #include "etj_entity_utilities.h"
 #include "etj_entity_utilities_shared.h"
+#include "etj_func_static_client.h"
 #include "etj_local.h"
 #include "etj_portalgun_shared.h"
 #include "etj_trace_utils.h"
@@ -347,9 +348,8 @@ void Portalgun::fire(gentity_t *ent, const Portal::Type type, vec3_t forward,
   // End pos
   VectorMA(trace_start, MAX_PORTAL_RANGE, forward, trace_end);
 
-  ETJump::TraceUtils::filteredTrace(ent->s.number, &tr, trace_start, nullptr,
-                                    nullptr, trace_end, ent->s.number,
-                                    MASK_PORTAL);
+  TraceUtils::filteredTrace(ent->s.number, &tr, trace_start, nullptr, nullptr,
+                            trace_end, ent->s.number, MASK_PORTAL);
 
   if (tr.surfaceFlags & SURF_NOIMPACT || tr.fraction == 1.0f) {
     return;
@@ -370,27 +370,29 @@ void Portalgun::fire(gentity_t *ent, const Portal::Type type, vec3_t forward,
   }
 
   vectoangles(tr.plane.normal, t_portalAngles);
+  const gentity_t *const traceEnt = g_entities + tr.entityNum;
 
-  // we hit a 'func_portaltarget'
+  // we hit an entity that wants portals to be centered
   if (tr.entityNum > MAX_CLIENTS + BODY_QUEUE_SIZE &&
       tr.entityNum < ENTITYNUM_WORLD &&
-      !Q_stricmp(g_entities[tr.entityNum].classname, "func_portaltarget")) {
-    const gentity_t *brushEnt = &g_entities[tr.entityNum];
-
+      (!Q_stricmp(traceEnt->classname, "func_portaltarget") ||
+       (traceEnt->s.eType == ET_STATIC_CLIENT &&
+        traceEnt->spawnflags & FuncStaticClient::Spawnflags::PORTAL_TARGET))) {
     vec3_t be_position; // brush ent position
     vec3_t delta;       // delta between brushent position and trace end
     vec3_t
         normalScaled; // plane normal scaled by dotproduct of delta and itself
 
-    EntityUtilities::getOriginOrBmodelCenter(brushEnt, be_position);
+    EntityUtilities::getOriginOrBmodelCenter(traceEnt, be_position);
 
     VectorSubtract(be_position, tr.endpos, delta);
     const float dotProduct = DotProduct(delta, tr.plane.normal);
     VectorScale(tr.plane.normal, dotProduct, normalScaled);
     VectorSubtract(be_position, normalScaled, tr_end);
 
-    if (brushEnt->count > 0) {
-      scale = static_cast<float>(brushEnt->count) / (PORTAL_BBOX_RADIUS * 2);
+    // handle 'portalsize' key
+    if (traceEnt->count > 0) {
+      scale = static_cast<float>(traceEnt->count) / (PORTAL_BBOX_RADIUS * 2);
     }
   } else {
     VectorCopy(tr.endpos, tr_end);


### PR DESCRIPTION
The entity can now act as a replacement for `func_portaltarget` if `spawnflag 32` is set. When enabled, `portalsize` key can also be used to set the size of the portal (**0 - 512**, **0** = default size).

This can be used even when using a model for the entity, as the clipping brushes may still be valid portal surfaces - however this might produce unexpected results as the brush origin is no longer determined by the center of the brush mass, but rather the origin brush, used to position the model.

refs #1824 