### PR TITLE
Stupid hack to ensure all changelog lines draw

### DIFF
--- a/src/ui/etj_utilities.cpp
+++ b/src/ui/etj_utilities.cpp
@@ -315,6 +315,12 @@ fitChangelogLinesToWidth(std::vector<std::string> &lines, const int maxW,
     fmtLines.emplace_back(line);
   }
 
+  // HACK: ensure last line never gets dropped, by inserting an empty line
+  // remove this once we have a dedicated changelog item type that handles
+  // maxscroll calculations correctly
+  // https://github.com/etjump/etjump/issues/1957
+  fmtLines.emplace_back(" ");
+
   return fmtLines;
 }
 


### PR DESCRIPTION
Dumb as hell but works as an easy workaround until I find the time and energy to write an `ITEM_TYPE_CHANGELOG`.

refs #1957 