### PR TITLE
Add extended command completions for ET: Legacy clients

### DIFF
--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(cgame MODULE
 	"etj_autodemo_recorder.cpp"
 	"etj_awaited_command_handler.cpp"
 	"etj_callvote_completions.cpp"
+	"etj_call_goto_completions.cpp"
 	"etj_cgaz_data.cpp"
 	"etj_cgaz_v2.cpp"
 	"etj_chs_data.cpp"

--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(cgame MODULE
 	"etj_entity_events_handler.cpp"
 	"etj_event_loop.cpp"
 	"etj_fireteam_completions.cpp"
+	"etj_ignore_completions.cpp"
 	"etj_inline_command_parser.cpp"
 	"etj_jump_speeds_v2.cpp"
 	"etj_keyset_drawer.cpp"

--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(cgame MODULE
 	"etj_areaindicator_drawable.cpp"
 	"etj_autodemo_recorder.cpp"
 	"etj_awaited_command_handler.cpp"
+	"etj_callvote_completions.cpp"
 	"etj_cgaz_data.cpp"
 	"etj_cgaz_v2.cpp"
 	"etj_chs_data.cpp"

--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(cgame MODULE
 	"etj_drawspeed2_v2.cpp"
 	"etj_entity_events_handler.cpp"
 	"etj_event_loop.cpp"
+	"etj_fireteam_completions.cpp"
 	"etj_inline_command_parser.cpp"
 	"etj_jump_speeds_v2.cpp"
 	"etj_keyset_drawer.cpp"

--- a/src/cgame/CMakeLists.txt
+++ b/src/cgame/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(cgame MODULE
 	"etj_keyset_keybind_drawer.cpp"
 	"etj_keyset_system.cpp"
 	"etj_leaves_remapper.cpp"
+	"etj_listinfo_completions.cpp"
 	"etj_main.cpp"
 	"etj_manual.cpp"
 	"etj_maxspeed.cpp"

--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -1543,6 +1543,7 @@ void CG_InitConsoleCommands() {
   trap_AddCommand("unload");
   trap_AddCommand("goto");
   trap_AddCommand("call");
+  trap_AddCommand("iwant");
   trap_AddCommand("nogoto");
   trap_AddCommand("nocall");
   trap_AddCommand("resetmaxspeed");

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -81,7 +81,9 @@ extern "C" FN_PUBLIC intptr_t vmMain(int command, intptr_t arg0, intptr_t arg1,
       return -1;
     case CG_CONSOLE_COMPLETE_ARGUMENT:
       // qboolean for API compatibility
-      return ETJump::CommandCompletions::completeArgument() ? qtrue : qfalse;
+      return ETJump::cgame.systems.commandCompletions->completeArgument()
+                 ? qtrue
+                 : qfalse;
     default:
       CG_Error("vmMain: unknown command %i", command);
       break;

--- a/src/cgame/etj_call_goto_completions.cpp
+++ b/src/cgame/etj_call_goto_completions.cpp
@@ -1,0 +1,56 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_call_goto_completions.h"
+#include "cg_local.h"
+
+namespace ETJump {
+bool CallGotoCompletions::complete(const std::vector<std::string> &args) const {
+  if (args.size() > 1) {
+    return false;
+  }
+
+  const std::string currentArg = !args.empty() ? args[0] : "";
+
+  for (const auto &ci : cgs.clientinfo) {
+    if (!ci.infoValid || ci.clientNum == cg.clientNum) {
+      continue;
+    }
+
+    if (ci.team == TEAM_SPECTATOR) {
+      continue;
+    }
+
+    // current argument is already a valid client name
+    if (!Q_stricmp(ci.name, currentArg.c_str()) ||
+        !Q_stricmp(ci.cleanname, currentArg.c_str())) {
+      return false;
+    }
+
+    completeArg(ci.cleanname);
+  }
+
+  return true;
+}
+} // namespace ETJump

--- a/src/cgame/etj_call_goto_completions.h
+++ b/src/cgame/etj_call_goto_completions.h
@@ -1,0 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "etj_icompletion.h"
+
+namespace ETJump {
+class CallGotoCompletions : public ICompletion {
+public:
+  [[nodiscard]] bool
+  complete(const std::vector<std::string> &args) const override;
+};
+} // namespace ETJump

--- a/src/cgame/etj_callvote_completions.cpp
+++ b/src/cgame/etj_callvote_completions.cpp
@@ -1,0 +1,125 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_callvote_completions.h"
+#include "cg_local.h"
+#include "etj_command_complete_ext.h"
+#include "etj_local.h"
+
+#include "../game/etj_string_utilities.h"
+
+namespace ETJump {
+CallvoteCompletions::CallvoteCompletions() { setupCompletions(); }
+
+void CallvoteCompletions::setupCompletions() {
+  argCompletions.emplace_back(
+      "map", [](const std::vector<std::string> &args) { return map(args); });
+  argCompletions.emplace_back(
+      "devmap", [](const std::vector<std::string> &args) { return map(args); });
+  argCompletions.emplace_back("maprestart");
+  argCompletions.emplace_back("randommap",
+                              [](const std::vector<std::string> &args) {
+                                return randomMapOrRtv(args);
+                              });
+  argCompletions.emplace_back("rtv", [](const std::vector<std::string> &args) {
+    return randomMapOrRtv(args);
+  });
+  argCompletions.emplace_back("autoRtv");
+  argCompletions.emplace_back("portalPredict");
+}
+
+bool CallvoteCompletions::complete(const std::vector<std::string> &args) const {
+  if (args.empty()) {
+    return defaultCompletion(argCompletions);
+  }
+
+  for (const auto &completion : argCompletions) {
+    if (args[0] == completion.arg ||
+        CommandCompletions::isAlias(args[0], completion.aliases)) {
+      if (completion.fn == nullptr) {
+        return false;
+      }
+
+      return completion.fn(args);
+    }
+  }
+
+  return defaultCompletion(argCompletions);
+}
+
+bool CallvoteCompletions::map(const std::vector<std::string> &args) {
+  // should not be called unless we have 'map' or 'devmap' as args
+  assert(!args.empty());
+
+  if (args.size() > 2) {
+    return false;
+  }
+
+  const std::string currentArg = args.size() > 1 ? args[1] : "";
+
+  for (const auto &map : cgame.serverMapList) {
+    if (StringUtils::iEqual(currentArg, map)) {
+      return false;
+    }
+
+    completeArg(map);
+  }
+
+  return true;
+}
+
+bool CallvoteCompletions::randomMapOrRtv(const std::vector<std::string> &args) {
+  // should not be called unless we have 'randommap' or 'rtv' as args
+  assert(!args.empty());
+
+  if (args.size() > 2) {
+    return false;
+  }
+
+  // realistically there should not be time for client to get here
+  // before the amount of custom votes is requested, but check for this
+  // just in case, since the info request needs the amount to be known
+  if (!cg.numCustomvotesRequested) {
+    return false;
+  }
+
+  // we haven't requested info yet (custom vote menu has never been opened),
+  // so flip the boolean to trigger the requests to server
+  if (!cg.customvoteInfoRequested) {
+    cg.customvoteInfoRequested = true;
+  }
+
+  const std::string currentArg = args.size() > 1 ? args[1] : "";
+
+  for (const auto &list : cgame.customVoteLists) {
+    if (StringUtils::iEqual(currentArg, list)) {
+      return false;
+    }
+
+    completeArg(list);
+  }
+
+  return true;
+}
+} // namespace ETJump

--- a/src/cgame/etj_callvote_completions.h
+++ b/src/cgame/etj_callvote_completions.h
@@ -1,0 +1,46 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "etj_icompletion.h"
+
+namespace ETJump {
+class CallvoteCompletions : public ICompletion {
+public:
+  CallvoteCompletions();
+
+  [[nodiscard]] bool
+  complete(const std::vector<std::string> &args) const override;
+
+private:
+  void setupCompletions();
+
+  static bool map(const std::vector<std::string> &args);
+  // both randommap and rtv want completions from custom vote names
+  static bool randomMapOrRtv(const std::vector<std::string> &args);
+
+  std::vector<ArgCompletion> argCompletions;
+};
+} // namespace ETJump

--- a/src/cgame/etj_cgame.h
+++ b/src/cgame/etj_cgame.h
@@ -139,5 +139,10 @@ struct CGameContext {
   Visuals visuals;
   HUDData hudData;
   HUD hud;
+
+  // communicated by the server
+  std::vector<std::string> serverMapList;
+  // communicated by the server, only the strings needed for callvote commands
+  std::vector<std::string> customVoteLists;
 };
 } // namespace ETJump

--- a/src/cgame/etj_cgame.h
+++ b/src/cgame/etj_cgame.h
@@ -43,6 +43,14 @@ struct Core {
   std::shared_ptr<CvarUpdateHandler> cvarUpdate;
 };
 
+class DemoCompatibility;
+class AutoDemoRecorder;
+
+struct Demo {
+  std::unique_ptr<DemoCompatibility> compatibility;
+  std::unique_ptr<AutoDemoRecorder> autoDemoRecorder;
+};
+
 class ClientAuthentication;
 class OperatingSystem;
 class SyscallExt;
@@ -56,19 +64,13 @@ struct Platform {
 class ClientRtvHandler;
 class CustomCommandMenu;
 class Timerun;
+class CommandCompletions;
 
 struct Systems {
   std::unique_ptr<ClientRtvHandler> rtv;
   std::unique_ptr<CustomCommandMenu> customCommandMenu;
   std::shared_ptr<Timerun> timerun;
-};
-
-class DemoCompatibility;
-class AutoDemoRecorder;
-
-struct Demo {
-  std::unique_ptr<DemoCompatibility> compatibility;
-  std::unique_ptr<AutoDemoRecorder> autoDemoRecorder;
+  std::unique_ptr<CommandCompletions> commandCompletions;
 };
 
 class EventLoop;

--- a/src/cgame/etj_command_complete_ext.cpp
+++ b/src/cgame/etj_command_complete_ext.cpp
@@ -25,6 +25,7 @@
 #include "etj_command_complete_ext.h"
 #include "cg_local.h"
 #include "etj_fireteam_completions.h"
+#include "etj_callvote_completions.h"
 
 #include "../game/etj_string_utilities.h"
 
@@ -33,6 +34,8 @@ CommandCompletions::CommandCompletions() { setupCompletions(); }
 
 void CommandCompletions::setupCompletions() {
   completions.emplace_back("fireteam", std::make_unique<FireteamCompletions>());
+  completions.emplace_back("callvote", std::vector<std::string>{"cv"},
+                           std::make_unique<CallvoteCompletions>());
 }
 
 bool CommandCompletions::completeArgument() const {

--- a/src/cgame/etj_command_complete_ext.cpp
+++ b/src/cgame/etj_command_complete_ext.cpp
@@ -27,6 +27,7 @@
 #include "etj_call_goto_completions.h"
 #include "etj_callvote_completions.h"
 #include "etj_fireteam_completions.h"
+#include "etj_ignore_completions.h"
 #include "etj_listinfo_completions.h"
 
 #include "../game/etj_string_utilities.h"
@@ -43,6 +44,12 @@ void CommandCompletions::setupCompletions() {
   completions.emplace_back("call", std::vector<std::string>{"iwant"},
                            std::make_unique<CallGotoCompletions>());
   completions.emplace_back("goto", std::make_unique<CallGotoCompletions>());
+  // add 'unignore' as an alias here - both target any connected client,
+  // but there's no way to know who is already ignored, only server has that
+  // information, so we can't target only ignored clients with 'unignore',
+  // or only unignored clients with 'ignore'
+  completions.emplace_back("ignore", std::vector<std::string>{"unignore"},
+                           std::make_unique<IgnoreCompletions>());
 }
 
 bool CommandCompletions::completeArgument() const {

--- a/src/cgame/etj_command_complete_ext.cpp
+++ b/src/cgame/etj_command_complete_ext.cpp
@@ -23,22 +23,46 @@
  */
 
 #include "etj_command_complete_ext.h"
+#include "cg_local.h"
+#include "etj_fireteam_completions.h"
 
-namespace ETJump::CommandCompletions {
-bool completeArgument() {
-  // TODO: implement this - look for commands that want additional completions
-  // in e.g. std::unordered_map<std::string, std::function>, where the key
-  // is the command, and value is a function pointer to the completion
-  // implementation. The implementation itself is responsible for providing
-  // valid arguments, and calling 'trap_CommandComplete' for all the arguments
-  // that are supported by the base command. The implementations may also call
-  // additional completion requests for commands which take more than one
-  // argument, and can do this contextually (e.g. if first argument is "foo",
-  // provide a different set of completions for second argument).
-  // The syscall itself does not give context on which command is requesting
-  // autocomplete, we must call 'CG_Argv' here first to see which completion
-  // we're looking for.
+#include "../game/etj_string_utilities.h"
+
+namespace ETJump {
+CommandCompletions::CommandCompletions() { setupCompletions(); }
+
+void CommandCompletions::setupCompletions() {
+  completions.emplace_back("fireteam", std::make_unique<FireteamCompletions>());
+}
+
+bool CommandCompletions::completeArgument() const {
+  std::string cmd = StringUtils::toLowerCase(CG_Argv(0));
+
+  if (cmd[0] == '\\' || cmd[0] == '/') {
+    cmd.erase(0, 1);
+  }
+
+  for (const auto &completion : completions) {
+    if (cmd == completion.cmd || isAlias(cmd, completion.aliases)) {
+      const int32_t argc = trap_Argc();
+      std::vector<std::string> args;
+      args.reserve(argc);
+
+      for (int32_t i = 1; i < argc; i++) {
+        args.emplace_back(StringUtils::toLowerCase(CG_Argv(i)));
+      }
+
+      return completion.obj->complete(args);
+    }
+  }
 
   return false;
 }
-} // namespace ETJump::CommandCompletions
+
+bool CommandCompletions::isAlias(const std::string_view arg,
+                                 const std::vector<std::string> &aliases) {
+  return std::any_of(aliases.cbegin(), aliases.cend(),
+                     [&arg](const auto &alias) { return arg == alias; });
+};
+
+} // namespace ETJump

--- a/src/cgame/etj_command_complete_ext.cpp
+++ b/src/cgame/etj_command_complete_ext.cpp
@@ -24,6 +24,7 @@
 
 #include "etj_command_complete_ext.h"
 #include "cg_local.h"
+#include "etj_call_goto_completions.h"
 #include "etj_callvote_completions.h"
 #include "etj_fireteam_completions.h"
 #include "etj_listinfo_completions.h"
@@ -39,6 +40,9 @@ void CommandCompletions::setupCompletions() {
                            std::make_unique<CallvoteCompletions>());
   completions.emplace_back("listinfo", std::vector<std::string>{"customvotes"},
                            std::make_unique<ListInfoCompletions>());
+  completions.emplace_back("call", std::vector<std::string>{"iwant"},
+                           std::make_unique<CallGotoCompletions>());
+  completions.emplace_back("goto", std::make_unique<CallGotoCompletions>());
 }
 
 bool CommandCompletions::completeArgument() const {

--- a/src/cgame/etj_command_complete_ext.cpp
+++ b/src/cgame/etj_command_complete_ext.cpp
@@ -24,8 +24,9 @@
 
 #include "etj_command_complete_ext.h"
 #include "cg_local.h"
-#include "etj_fireteam_completions.h"
 #include "etj_callvote_completions.h"
+#include "etj_fireteam_completions.h"
+#include "etj_listinfo_completions.h"
 
 #include "../game/etj_string_utilities.h"
 
@@ -36,6 +37,8 @@ void CommandCompletions::setupCompletions() {
   completions.emplace_back("fireteam", std::make_unique<FireteamCompletions>());
   completions.emplace_back("callvote", std::vector<std::string>{"cv"},
                            std::make_unique<CallvoteCompletions>());
+  completions.emplace_back("listinfo", std::vector<std::string>{"customvotes"},
+                           std::make_unique<ListInfoCompletions>());
 }
 
 bool CommandCompletions::completeArgument() const {

--- a/src/cgame/etj_fireteam_completions.cpp
+++ b/src/cgame/etj_fireteam_completions.cpp
@@ -1,0 +1,322 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_fireteam_completions.h"
+#include "cg_local.h"
+#include "etj_command_complete_ext.h"
+
+#include "../game/etj_string_utilities.h"
+
+namespace ETJump {
+FireteamCompletions::FireteamCompletions() { setupCompletions(); }
+
+void FireteamCompletions::setupCompletions() {
+  argCompletions.emplace_back("create");
+  argCompletions.emplace_back(
+      "apply",
+      [](const std::vector<std::string> &args) { return apply(args); });
+  argCompletions.emplace_back("leave");
+  argCompletions.emplace_back("disband");
+  argCompletions.emplace_back(
+      "invite",
+      [](const std::vector<std::string> &args) { return invite(args); });
+  argCompletions.emplace_back("kick", [](const std::vector<std::string> &args) {
+    return kickOrWarn(args);
+  });
+  argCompletions.emplace_back("warn", [](const std::vector<std::string> &args) {
+    return kickOrWarn(args);
+  });
+  argCompletions.emplace_back(
+      "propose",
+      [](const std::vector<std::string> &args) { return propose(args); });
+  argCompletions.emplace_back(
+      "rules",
+      [](const std::vector<std::string> &args) { return rules(args); });
+  argCompletions.emplace_back(
+      "teamjump", std::vector<std::string>{"tj"},
+      [](const std::vector<std::string> &args) { return teamjump(args); });
+  argCompletions.emplace_back("countdown");
+}
+
+bool FireteamCompletions::complete(const std::vector<std::string> &args) const {
+  if (args.empty()) {
+    return defaultCompletion(argCompletions);
+  }
+
+  for (const auto &completion : argCompletions) {
+    if (args[0] == completion.arg ||
+        CommandCompletions::isAlias(args[0], completion.aliases)) {
+      if (completion.fn == nullptr) {
+        return false;
+      }
+
+      return completion.fn(args);
+    }
+  }
+
+  return defaultCompletion(argCompletions);
+}
+
+bool FireteamCompletions::apply(const std::vector<std::string> &args) {
+  // should not be called unless we have 'apply' as args already
+  assert(!args.empty());
+
+  if (args.size() > 2) {
+    return false;
+  }
+
+  const std::string currentArg = args.size() > 1 ? args[1] : "";
+  const auto *const ftData = cgs.clientinfo[cg.clientNum].fireteamData;
+
+  for (int32_t i = 0; i < MAX_FIRETEAMS; i++) {
+    const auto *const ft = &cg.fireTeams[i];
+
+    if (!ft || !ft->inuse) {
+      continue;
+    }
+
+    // this is our current fireteam
+    if (ftData == ft) {
+      continue;
+    }
+
+    const std::string ftName =
+        StringUtils::toLowerCase(bg_fireteamNames[ft->ident]);
+
+    // stop completion if we have a valid arg
+    if (ftName == currentArg) {
+      return false;
+    }
+
+    completeArg(ftName);
+  }
+
+  return true;
+}
+
+bool FireteamCompletions::invite(const std::vector<std::string> &args) {
+  // should not be called unless we have 'invite' as args already
+  assert(!args.empty());
+
+  if (args.size() > 2) {
+    return false;
+  }
+
+  const auto *const ftData = cgs.clientinfo[cg.clientNum].fireteamData;
+
+  // we are not in a fireteam
+  if (!ftData) {
+    return false;
+  }
+
+  const std::string currentArg = args.size() > 1 ? args[1] : "";
+
+  // skip adding 'spectator' and 'allied' aliases, no need to show both
+  completeArg("axis");
+  completeArg("allies");
+  completeArg("spectators");
+  completeArg("all");
+
+  // stop completion if one of the special strings is matched
+  // this intentionally skips the one character team names,
+  // it would be quite annoying to have every 'b', 'r' and 's' character
+  // to be treated as a completed completion
+  // we also skip 'all' and 'spectator' to allow still
+  // suggesting 'allies' and 'spectators'
+  if (currentArg == "axis" || currentArg == "allies" ||
+      currentArg == "allied" || currentArg == "spectators") {
+    return false;
+  }
+
+  for (const auto &ci : cgs.clientinfo) {
+    if (!ci.infoValid || ci.clientNum == cg.clientNum) {
+      continue;
+    }
+
+    // player is already on a fireteam
+    if (ci.fireteamData) {
+      continue;
+    }
+
+    // stop completion if we have a valid client name as arg
+    if (!Q_stricmp(ci.cleanname, currentArg.c_str()) ||
+        !Q_stricmp(ci.name, currentArg.c_str())) {
+      return false;
+    }
+
+    completeArg(ci.cleanname);
+  }
+
+  return true;
+}
+
+bool FireteamCompletions::kickOrWarn(const std::vector<std::string> &args) {
+  // should not be called unless we have 'kick' or 'warn' as args already
+  assert(!args.empty());
+
+  if (args.size() > 2) {
+    return false;
+  }
+
+  const auto *const ftData = cgs.clientinfo[cg.clientNum].fireteamData;
+
+  // we are not in a fireteam
+  if (!ftData) {
+    return false;
+  }
+
+  const std::string currentArg = args.size() > 1 ? args[1] : "";
+
+  for (const auto &ci : cgs.clientinfo) {
+    if (!ci.infoValid || ci.clientNum == cg.clientNum) {
+      continue;
+    }
+
+    // not in same fireteam
+    if (ci.fireteamData != ftData) {
+      continue;
+    }
+
+    // stop completion once we have a valid client name as arg
+    if (!Q_stricmp(ci.cleanname, currentArg.c_str()) ||
+        !Q_stricmp(ci.name, currentArg.c_str())) {
+      return false;
+    }
+
+    completeArg(ci.cleanname);
+  }
+
+  return true;
+}
+
+bool FireteamCompletions::propose(const std::vector<std::string> &args) {
+  // should not be called unless we have 'propose' as args already
+  assert(!args.empty());
+
+  if (args.size() > 2) {
+    return false;
+  }
+
+  const auto *const ftData = cgs.clientinfo[cg.clientNum].fireteamData;
+
+  // we are not in a fireteam
+  if (!ftData) {
+    return false;
+  }
+
+  const std::string currentArg = args.size() > 1 ? args[1] : "";
+
+  for (const auto &ci : cgs.clientinfo) {
+    if (!ci.infoValid || ci.clientNum == cg.clientNum) {
+      continue;
+    }
+
+    // client is already in a fireteam
+    if (ci.fireteamData) {
+      continue;
+    }
+
+    // stop completion once we have a valid client name as arg
+    if (!Q_stricmp(ci.cleanname, currentArg.c_str()) ||
+        !Q_stricmp(ci.name, currentArg.c_str())) {
+      return false;
+    }
+
+    completeArg(ci.cleanname);
+  }
+
+  return true;
+}
+
+bool FireteamCompletions::rules(const std::vector<std::string> &args) {
+  // should not be called unless we have 'rules' as args already
+  assert(!args.empty());
+
+  if (args.size() > 3) {
+    return false;
+  }
+
+  const auto *const ftData = cgs.clientinfo[cg.clientNum].fireteamData;
+
+  // only fireteam leader may use these
+  if (!ftData || ftData->leader != cg.clientNum) {
+    return false;
+  }
+
+  const std::string mainArg = args.size() > 1 ? args[1] : "";
+  const std::string secondaryArg = args.size() > 2 ? args[2] : "";
+
+  // complete secondary args if we already have a main arg as input
+  // these should maybe be in some sort of container if more are added
+  if (mainArg == "savelimit" || mainArg == "noghost") {
+    if (mainArg == "savelimit" && secondaryArg != "reset") {
+      completeArg("reset");
+
+      return true;
+    }
+
+    if (mainArg == "noghost" &&
+        (secondaryArg != "on" && secondaryArg != "off")) {
+      completeArg("on");
+      completeArg("off");
+
+      return true;
+    }
+
+    return false;
+  }
+
+  completeArg("savelimit");
+  completeArg("noghost");
+
+  return true;
+}
+
+bool FireteamCompletions::teamjump(const std::vector<std::string> &args) {
+  // should not be called unless we have 'teamjump' or 'tj' as args already
+  assert(!args.empty());
+
+  if (args.size() > 2) {
+    return false;
+  }
+
+  const auto *const ftData = cgs.clientinfo[cg.clientNum].fireteamData;
+
+  // only fireteam leader may use these
+  if (!ftData || ftData->leader != cg.clientNum) {
+    return false;
+  }
+
+  const std::string currentArg = args.size() > 1 ? args[1] : "";
+
+  if (currentArg == "on" || currentArg == "off") {
+    return false;
+  }
+
+  completeArg("on");
+  completeArg("off");
+
+  return true;
+}
+} // namespace ETJump

--- a/src/cgame/etj_fireteam_completions.h
+++ b/src/cgame/etj_fireteam_completions.h
@@ -24,39 +24,27 @@
 
 #pragma once
 
-#include <memory>
-
 #include "etj_icompletion.h"
 
 namespace ETJump {
-
-class CommandCompletions {
+class FireteamCompletions : public ICompletion {
 public:
-  CommandCompletions();
-  ~CommandCompletions() = default;
+  FireteamCompletions();
 
-  [[nodiscard]] bool completeArgument() const;
-  static bool isAlias(std::string_view arg,
-                      const std::vector<std::string> &aliases);
+  [[nodiscard]] bool
+  complete(const std::vector<std::string> &args) const override;
 
 private:
-  struct CompletionObject {
-    CompletionObject(std::string cmd, std::unique_ptr<ICompletion> obj)
-        : cmd(std::move(cmd)), obj(std::move(obj)) {}
-
-    CompletionObject(std::string cmd, std::vector<std::string> aliases,
-                     std::unique_ptr<ICompletion> obj)
-        : cmd(std::move(cmd)), aliases(std::move(aliases)),
-          obj(std::move(obj)) {}
-
-    std::string cmd;
-    std::vector<std::string> aliases;
-    std::unique_ptr<ICompletion> obj;
-  };
-
   void setupCompletions();
 
-  std::vector<CompletionObject> completions;
-};
+  static bool apply(const std::vector<std::string> &args);
+  static bool invite(const std::vector<std::string> &args);
+  // kick and warn work on exact same code
+  static bool kickOrWarn(const std::vector<std::string> &args);
+  static bool propose(const std::vector<std::string> &args);
+  static bool rules(const std::vector<std::string> &args);
+  static bool teamjump(const std::vector<std::string> &args);
 
+  std::vector<ArgCompletion> argCompletions;
+};
 } // namespace ETJump

--- a/src/cgame/etj_icompletion.h
+++ b/src/cgame/etj_icompletion.h
@@ -1,0 +1,73 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "../game/etj_syscall_ext_shared.h"
+
+namespace ETJump {
+class ICompletion {
+public:
+  struct ArgCompletion {
+    explicit ArgCompletion(std::string arg) : arg(std::move(arg)) {};
+
+    ArgCompletion(std::string arg,
+                  std::function<bool(const std::vector<std::string> &)> fn)
+        : arg(std::move(arg)), fn(std::move(fn)) {}
+
+    ArgCompletion(std::string arg, std::vector<std::string> aliases)
+        : arg(std::move(arg)), aliases(std::move(aliases)) {}
+
+    ArgCompletion(std::string arg, std::vector<std::string> aliases,
+                  std::function<bool(const std::vector<std::string> &)> fn)
+        : arg(std::move(arg)), aliases(std::move(aliases)), fn(std::move(fn)) {}
+
+    std::string arg;
+    std::vector<std::string> aliases;
+    std::function<bool(const std::vector<std::string> &args)> fn;
+  };
+
+  static void completeArg(const std::string &arg) {
+    SyscallExt::trap_CommandComplete(arg.c_str());
+  }
+
+  static bool defaultCompletion(const std::vector<ArgCompletion> &completions) {
+    for (const auto &completion : completions) {
+      completeArg(completion.arg);
+    }
+
+    return true;
+  }
+
+  virtual ~ICompletion() = default;
+
+  // 'args' should always be lowercased!
+  [[nodiscard]] virtual bool
+  complete(const std::vector<std::string> &args) const = 0;
+};
+} // namespace ETJump

--- a/src/cgame/etj_ignore_completions.cpp
+++ b/src/cgame/etj_ignore_completions.cpp
@@ -1,0 +1,52 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_ignore_completions.h"
+#include "cg_local.h"
+
+namespace ETJump {
+bool IgnoreCompletions::complete(const std::vector<std::string> &args) const {
+  if (args.size() > 1) {
+    return false;
+  }
+
+  const std::string currentArg = !args.empty() ? args[0] : "";
+
+  for (const auto &ci : cgs.clientinfo) {
+    if (!ci.infoValid || ci.clientNum == cg.clientNum) {
+      continue;
+    }
+
+    // current argument is already a valid client name
+    if (!Q_stricmp(ci.name, currentArg.c_str()) ||
+        !Q_stricmp(ci.cleanname, currentArg.c_str())) {
+      return false;
+    }
+
+    completeArg(ci.cleanname);
+  }
+
+  return true;
+}
+} // namespace ETJump

--- a/src/cgame/etj_ignore_completions.h
+++ b/src/cgame/etj_ignore_completions.h
@@ -1,0 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "etj_icompletion.h"
+
+namespace ETJump {
+class IgnoreCompletions : public ICompletion {
+public:
+  [[nodiscard]] bool
+  complete(const std::vector<std::string> &args) const override;
+};
+} // namespace ETJump

--- a/src/cgame/etj_listinfo_completions.cpp
+++ b/src/cgame/etj_listinfo_completions.cpp
@@ -1,0 +1,61 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "etj_listinfo_completions.h"
+#include "cg_local.h"
+
+#include "../game/etj_string_utilities.h"
+
+namespace ETJump {
+bool ListInfoCompletions::complete(const std::vector<std::string> &args) const {
+  if (args.size() > 1) {
+    return false;
+  }
+
+  // realistically there should not be time for client to get here
+  // before the amount of custom votes is requested, but check for this
+  // just in case, since the info request needs the amount to be known
+  if (!cg.numCustomvotesRequested) {
+    return false;
+  }
+
+  // we haven't requested info yet (custom vote menu has never been opened),
+  // so flip the boolean to trigger the requests to server
+  if (!cg.customvoteInfoRequested) {
+    cg.customvoteInfoRequested = true;
+  }
+
+  const std::string currentArg = !args.empty() ? args[0] : "";
+
+  for (const auto &list : cgame.customVoteLists) {
+    if (StringUtils::iEqual(currentArg, list)) {
+      return false;
+    }
+
+    completeArg(list);
+  }
+
+  return true;
+}
+} // namespace ETJump

--- a/src/cgame/etj_listinfo_completions.h
+++ b/src/cgame/etj_listinfo_completions.h
@@ -1,0 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 ETJump team <zero@etjump.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "etj_icompletion.h"
+
+namespace ETJump {
+class ListInfoCompletions : public ICompletion {
+public:
+  [[nodiscard]] bool
+  complete(const std::vector<std::string> &args) const override;
+};
+} // namespace ETJump

--- a/src/cgame/etj_main.cpp
+++ b/src/cgame/etj_main.cpp
@@ -36,6 +36,7 @@
 #include "etj_client_commands_handler.h"
 #include "etj_client_rtv_handler.h"
 #include "etj_color_parser.h"
+#include "etj_command_complete_ext.h"
 #include "etj_console_shader.h"
 #include "etj_consolecommands.h"
 #include "etj_crosshair.h"
@@ -173,6 +174,8 @@ static void initSystems() {
 
   cgame.systems.timerun = std::make_shared<Timerun>(cgame.core.playerEvents,
                                                     cgame.core.serverCommands);
+
+  cgame.systems.commandCompletions = std::make_unique<CommandCompletions>();
 }
 
 void initDemo() {

--- a/src/cgame/etj_servercommands.cpp
+++ b/src/cgame/etj_servercommands.cpp
@@ -38,7 +38,14 @@ using Arguments = std::vector<std::string>;
 // but now that we're always receiving a full map list from server,
 // we could use a local cache for map list instead of requesting it again.
 static void maplist(const Arguments &args) {
-  // we need to forward this command to UI to parse the list there,
+  cgame.serverMapList.insert(cgame.serverMapList.end(), args.cbegin(),
+                             args.cend());
+
+  // this gets called few times unnecessarily for an incomplete list,
+  // but it's fine, this only happens on initial cgame load
+  StringUtils::sortStrings(cgame.serverMapList, true);
+
+  // we need to forward this command to UI to parse the list there too,
   // so we can populate the map vote list
   trap_SendConsoleCommand(
       va("uiParseMaplist %s\n", StringUtils::join(args, " ").c_str()));
@@ -57,7 +64,12 @@ static void numCustomvotes(const Arguments &args) {
 }
 
 static void customvoteList(const Arguments &args) {
-  // forward to UI
+  // store the callvote name in cgame
+  if (args.size() > 2 && args[1] == "type") {
+    cgame.customVoteLists.emplace_back(args[2]);
+  }
+
+  // forward the full command to UI for parsing
   trap_SendConsoleCommand(
       va("uiParseCustomvote %s\n", StringUtils::join(args, " ").c_str()));
 }


### PR DESCRIPTION
Utilizes `trap_CommandComplete` engines extension, supported by ET: Legacy, to add contextual tab completion to various commands. By no means an exhaustive PR, these were just some that came to my mind that could use this functionality. There is also some contextual filtering performed on the completions, e.g. `fireteam kick` won't tab complete player names, unless you are the fireteam leader.

### fireteam
* All fireteam sub-commands autocompleted
* `fireteam apply` completes valid fireteam names
* `fireteam invite/kick/warn/propose` completes valid clientnames
  * `invite` also completes `all/allies/axis/spectators`
* `fireteam rules` completes `savelimit/noghost` and their arguments
* `fireteam teamjump/tj` completes `on/off`

### callvote
* All valid callvotes completed
* `callvote map` completes all maps on server
* `callvote randommap/rtv` completes all custom votes on server

### listinfo/customvotes
* Autocompletes valid customvote list names

### call/iwant/goto
* Autocompletes connected player names (non-spectators)

### ignore/unignore
* Autocompletes connected player names

This also adds a missing tab completion for `iwant` command (`call` alias).

refs #1920 