### PR TITLE
Fix crash on follow when jump speeds are enabled and player is holding jump

### DIFF
--- a/src/cgame/etj_jump_speeds_v2.cpp
+++ b/src/cgame/etj_jump_speeds_v2.cpp
@@ -258,6 +258,7 @@ bool JumpSpeedsV2::beforeRender() {
     // otherwise just queue the reset to happen on next update
     if (ps->persistant[PERS_TEAM] == TEAM_SPECTATOR) {
       jumpSpeeds.clear();
+      pollUpmove = false;
     } else {
       resetQueued = true;
     }
@@ -266,9 +267,11 @@ bool JumpSpeedsV2::beforeRender() {
   // if 'clientNum' has switched, it means we're either spectating and changed
   // the followed client, or are joining from spectators (while following)
   // to a team -> instantly clear jump speeds so that unrelated speeds
-  // don't linger on the screen
+  // don't linger on the screen, and stop polling upmove, as any 'EV_JUMP'
+  // event that may have caused us to poll for it is no longer relevant
   if (clientNum != ps->clientNum) {
     jumpSpeeds.clear();
+    pollUpmove = false;
   }
 
   team = static_cast<team_t>(ps->persistant[PERS_TEAM]);

--- a/src/cgame/etj_jump_speeds_v2.cpp
+++ b/src/cgame/etj_jump_speeds_v2.cpp
@@ -198,13 +198,15 @@ void JumpSpeedsV2::updateJumpSpeeds() {
 }
 
 void JumpSpeedsV2::updateCurrentUpmove() {
-  // this shouldn't ever be true since events are processed before the HUD
-  // is rendered, therefore we should always have at least one jump
-  // when this gets called
-  assert(!jumpSpeeds.empty());
+  // this may be empty if we switch the spectated player,
+  // and they are currently holding jump
+  // early exit is fine here since we already missed the jump event anyway
+  if (jumpSpeeds.empty()) {
+    return;
+  }
 
   const auto &s = cgame.hudData.upmove->getState();
-  jumpSpeeds[jumpSpeeds.size() - 1].upmoveStr = std::to_string(s.fullDelay);
+  jumpSpeeds.back().upmoveStr = std::to_string(s.fullDelay);
 
   if (!s.jumping) {
     pollUpmove = false;


### PR DESCRIPTION
If jump speeds were enabled, and we switched from a player who was currently holding jump (thus upmove values were polled), jump speeds were cleared and the upmove value write would do an out of bounds access on the list.

refs #1959 