### PR TITLE
Upmove display fixes for jump speeds list

### DIFF
--- a/src/cgame/etj_jump_speeds_v2.cpp
+++ b/src/cgame/etj_jump_speeds_v2.cpp
@@ -193,8 +193,14 @@ void JumpSpeedsV2::updateJumpSpeeds() {
     current.relation = SpeedRelation::SLOWER;
   }
 
-  // start polling upmove value for the current jump
-  pollUpmove = true;
+  // start polling upmove if we're currently drawing the jump speeds
+  // this still gets called even if we don't render anything,
+  // as the event check happens separately from drawing
+  // if we were to unconditionally poll this, the latest jump would
+  // always show '0' as upmove after the drawing is enabled
+  if (etj_drawJumpSpeeds.integer) {
+    pollUpmove = true;
+  }
 }
 
 void JumpSpeedsV2::updateCurrentUpmove() {

--- a/src/cgame/etj_jump_speeds_v2.h
+++ b/src/cgame/etj_jump_speeds_v2.h
@@ -59,7 +59,7 @@ private:
   };
 
   struct Jump {
-    explicit Jump(int32_t speed) : speed(speed) {
+    explicit Jump(int32_t speed) : speed(speed), upmoveStr("-") {
       this->speedStr = std::to_string(speed);
     }
 


### PR DESCRIPTION
* Fix turning on jump speeds mid session displaying **0** as the latest upmove value
* Setup `-` as the default, unrecorded upmove value, if turning on jump speeds mid session

refs #1959 