### PR TITLE
Update documentation + improve agentic development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+ETJump is a C/C++ (C++17) mod for Wolfenstein: Enemy Territory. CMake build, single repo, no monorepo. Built on Linux/Windows/macOS; produces `cgame`, `qagame`, `ui` engine modules plus a packaged `.pk3`.
+
+## Build & test
+
+```sh
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug   # or Release
+cmake --build build --parallel
+ctest --test-dir build --output-on-failure        # all tests
+./build/tests/tests --gtest_filter='TimerunSharedTests.*'  # single suite / test
+```
+
+- Binaries land in `build/etjump/` (e.g. `cgame.mp.x86_64.so`, `qagame.mp.x86_64.so`, `etjump-<ver>.pk3`).
+- Packaging targets: `cmake --build build --target mod_pk3` (pk3), `mod_release` (release zip). Release zips only include `qagame*` + pk3, not cgame/ui.
+- `ctest` runs the single `tests` executable; CI runs `ctest` per config on Windows (`ctest -C Release`).
+- CMake options: `BUILD_TESTS` (ON by default), `USE_SANITIZERS` (enables ASAN+LSAN+UBSAN) and per-sanitizer `USE_ASAN`/`USE_LSAN`/`USE_UBSAN`, `USE_CLANG`. Cross-compile toolchains live in `cmake/Toolchain-*.cmake` (x86 linux, mingw x86/x64 linux/windows).
+- Do not add deps via system packages; vendored deps live in `deps/` and are wired up in the root `CMakeLists.txt`.
+
+## Configure-time generated files (source tree gets modified!)
+
+Running CMake **writes files into the source tree**, not just the build dir:
+- `assets/ui/git_version.h` — from `git describe` (falls back to `VERSION.txt` when not a git repo / no tags).
+- `assets/ui/changelog/version_headers.h` + one `assets/ui/changelog/<version>.txt` per H1 section — parsed from `changelog.md`.
+- Version comes from `VERSION.txt` (`VERSION_MAJOR/MINOR/PATCH <n>` format, regex-parsed, keep the format) but `GAME_VERSION` string uses `git describe`, so releases need a git tag.
+
+Implications: after adding assets, editing `changelog.md`, or changing `VERSION.txt`, re-run `cmake -B build` before building. These files are gitignored and regenerated on every configure, so there's nothing to commit or manually sync.
+
+## changelog.md format (parser is fragile)
+
+Parsed at configure time by `cmake/ParseChangelog.cmake`; malformed input breaks the build.
+- One `#` H1 header per version; parser splits sections on H1.
+- Bullet-list entries only; nested lists indented with 2 spaces (not tabs). Markdown links get stripped.
+
+## Formatting & style
+
+- Format with `clang-format -i` (repo `.clang-format`). **Only run it on code in `src/`** — never on `deps/` or `assets/` (shaders/menus). `git clang-format -i` is fine.
+- Style guide (`docs/styleguide.md`): new code should be modern C++ — `ETJump::` namespaces (or more specific), camelCase functions/vars, PascalCase classes/enums, uppercase `constexpr` constants, no `using namespace std`, no `_`/`m_` member prefixes, no nested ternaries, early exits over deep nesting, `enum class` + explicit casts, `[[nodiscard]]` where applicable, fixed-width int types. Old C-style code is exempt; don't refactor unrelated files. The `.clang-tidy` relaxations are deliberate (legacy C), not to be re-enabled casually.
+- Objects are constructed at module init and destroyed at shutdown, owned by a single per-module context struct (see `src/cgame/etj_cgame.h`); `shared_ptr` only for shared services/data, `unique_ptr` for sole ownership, raw refs for observers. `game` still needs migrating to this.
+
+## Tests
+
+- GoogleTest. Add new tests in `tests/` and register both the test file and any new source it needs in `tests/CMakeLists.txt` (`add_executable(tests ...)` list) — the build links individual `src/` translation units, not whole modules.
+- Test files include `src/game/etj_*.cpp` and `src/cgame/etj_*.cpp` sources directly; the game engine (q_shared, bg_*, etc.) is not linked, so tests are for self-contained modules only.
+- The repo contains no game engine to run, so gameplay/rendering changes cannot be verified by automated tests — they require interactive playtesting (see `docs/developing.md` for running the mod). Unit tests only cover self-contained logic; don't try to verify game-specific behavior via ctest.
+
+## Code layout
+
+- `src/game/` — server (qagame): entities, physics, cvars/commands, database/save systems. `src/cgame/` — client: drawing, prediction, HUD. `src/ui/` — menu rendering. All of this is mod game-code (no engine lives here); `cg_main.cpp`/`g_main.cpp`/`ui_main.cpp` are the `vmMain` entry points and `*_syscalls.cpp` wrap engine API calls. Everything is free to edit except a few API-sensitive things (e.g. networked structs).
+- `etj_*.cpp/h` files are the newer, ETJump-specific modules; `bg_*`, `cg_*`, `g_*`, `q_*` are original SDK code that is still actively edited.
+- CMake: module sources are listed explicitly in each module's `CMakeLists.txt` (`src/game`, `src/cgame`, `src/ui`) — adding a new `.cpp`/`.h` requires registering it in the relevant source list by hand and reloading the CMake project (see `docs/developing.md` for per-IDE reload steps). Cross-directory shared TUs and all `tests/` sources are likewise listed explicitly.
+- `assets/` holds runtime assets; `assets/CMakeLists.txt` packages them via `mod_pk3`.
+
+## Docs
+
+`docs/compiling.md`, `developing.md` (debugging + running against the engine), `testing.md`, `styleguide.md`. To playtest: `etl.x86_64 +set fs_basepath <build dir> +set fs_homepath <et install> +set fs_game etjump`.

--- a/docs/compiling.md
+++ b/docs/compiling.md
@@ -3,35 +3,79 @@
 Compiling the source code is a straightforward process. Below you will find instructions for each supported environment.
 
 * __[Linux](#linux)__
-    * [Makefiles](#option-1-makefiles) (Recommended)
-    * [QtCreator](#option-2-qtcreator)
+    * [CLion](#linux-clion) (Recommended)
+    * [Visual Studio Code](#linux-visual-studio-code)
+    * [Makefiles + gdb](#makefiles-gdb)
 * __[Windows](#windows)__
-    * [Visual Studio solution](#option-1-generate-visual-studio-sln-project-files) (Recommended)
-    * [Visual Studio CMake project](#option-2-open-cmake-project-in-visual-studio)
-    * [mingw-w64](#option-3-use-mingw-w64-toolchain)
-    * [Cross-compiling windows binaries on linux using mingw-w64](#option-4-cross-compiling-windows-binaries-using-mingw-w64-on-linux)
+    * [Visual Studio](#visual-studio) (Recommended)
+    * [CLion](#windows-clion) (Recommended)
+    * [Visual Studio Code](#windows-visual-studio-code)
+    * [mingw-w64](#use-mingw-w64-toolchain)
+    * [Cross-compiling windows binaries on Linux using mingw-w64](#cross-compiling-windows-binaries-on-linux-using-mingw-w64)
 * __[macOS](#macos)__
-    * [Makefiles](#option-1-makefiles-and-apple-clang)
-    * [Cross-compiling macOS binaries on linux using darling](#option-2-cross-compiling-macOS-binaries-on-linux-using-darling)
+    * [CLion](#macos-clion) (Recommended)
+    * [Visual Studio Code](#macos-visual-studio-code)
+    * [Makefiles](#makefiles-and-apple-clang)
+    * [Cross-compiling macOS binaries on Linux using darling](#cross-compiling-macos-binaries-on-linux-using-darling)
 
 ## Prerequisites
 
 To compile etjump source code, you only need a few things:
 * [Git](https://git-scm.com/) or [Git Desktop](https://desktop.github.com/) to fetch the repository. 
 * [CMake](https://cmake.org/) to generate build files.
-* [Visual Studio](https://visualstudio.microsoft.com/vs/community/) or `gcc` to compile the code.
+* A C++ compiler for your platform - supported compilers are GCC, Clang, MSVC and MinGW.
 
 ## Building 
 
-ETJump currently can be built only on `Windows` and `Linux` platforms. Supported build types are `Release` and `Debug`.
+ETJump can currently be built on `Windows`, `Linux`, and `macOS`. Supported build types are `Release`, `Debug` and `RelWithDebInfo`.
+
+### Sanitizers
+
+The build can be configured with [sanitizers](https://clang.llvm.org/docs/AddressSanitizer.html) to detect memory and undefined-behavior errors at runtime. These are controlled by CMake options:
+
+* `USE_SANITIZERS` - enables address, leak and undefined behavior sanitizers together (the per-sanitizer options below are then forced on for non-MSVC compilers).
+* `USE_ASAN` - address sanitizer. Supported on GCC, Clang and MSVC.
+* `USE_LSAN` - leak sanitizer. Not supported on MSVC. Leak sanitizer is also enabled by default whenever ASAN is on.
+* `USE_UBSAN` - undefined behavior sanitizer. Not supported on MSVC.
+
+For example, to build with all sanitizers:
+
+```sh
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZERS=ON
+cmake --build build --parallel
+```
+
+#### Additional notes:
+* The game engine may fail to load the mod when using sanitizers. If this happens, you may need to preload the sanitizer libraries, before running the engine.
+* Sanitizers are most useful with `Debug` (or `RelWithDebInfo` for profiling).
+* Leak and undefined behavior sanitizers are only supported on GCC/Clang; enabling them on MSVC fails the configuration.
+* Clang support is only tested on Linux.
+* On Windows with MSVC, running an ASAN build outside Visual Studio requires the sanitizer runtime libraries on `PATH` (Visual Studio adds these automatically).
+* On Linux with Clang, the ASAN executable links against the shared ASAN runtime (`-shared-libasan`).
 
 ### Linux
 
-There are multiple options available:
-* Compile project using `Makefiles`.
-* Use `QtCreator` IDE.
+<a id="linux-clion"></a>
+#### CLion
 
-#### Option 1. Makefiles
+[CLion](https://www.jetbrains.com/clion/) is a cross-platform C/C++ IDE with native CMake support, and the recommended fully-featured IDE on Linux.
+
+* Open the repository root in CLion — it will configure the project automatically (it uses its own build directory by default; you can point it at `build/` if you prefer).
+* Set `cgame` as the project to run, and select `All targets` to ensure all modules get built.
+* To run/debug the mod, set up a run configuration launching the game with the arguments `+set fs_basepath . +set fs_homepath <et install dir> +set fs_game etjump`, with the working directory set to `$CMakeCurrentGenerationDir$`. See [debugging with CLion](developing.md#debugging-with-clion) for more details.
+
+<a id="linux-visual-studio-code"></a>
+#### Visual Studio Code
+
+VS Code is a cross-platform editor that uses the [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) and [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extensions to configure and build the project.
+
+* Open the repository root in VS Code and let CMake Tools configure the project.
+* Use the CMake Tools status bar to select the build variant and build target.
+* See [Debugging with VS Code](developing.md#debugging-with-vs-code) in the development guide for setting up a debug launch configuration.
+
+#### Makefiles + gdb
+
+For a plain terminal workflow, compile the project with `Makefiles` (or `Ninja`) and debug with `gdb`.
 
 * Generate __x86_64__ Makefiles:
     ```sh
@@ -54,6 +98,10 @@ There are multiple options available:
     ```
 * You can find binaries in `build/etjump`.
 
+Alternatively, use Ninja as the generator (`-G Ninja`); the build command then becomes `ninja` (or `cmake --build . --parallel`).
+
+* To debug, see [Debugging with gdb](developing.md#debugging-with-gdb-linux).
+
 ##### Create mod pk3
 
 * Run `make mod_pk3` to create mod pk3
@@ -61,81 +109,38 @@ There are multiple options available:
 * Run `make mod_release` to create zip release
     * `zip` release will be created in `build` directory
 
-#### Option 2. QtCreator
-
-[QtCreator](https://www.qt.io/product/development-tools) is a free C/C++ IDE. A full featured `Visual Studio` alternative on linux.
-
-* Installation:
-    ```sh
-    # on ubuntu
-    sudo apt-get -y install openjdk-7-jre qtcreator build-essential
-    # on arch 
-    sudo pacman -S qtcreator
-    ```
-* Fetch ETJump:
-    ```sh
-    $ git clone https://github.com/etjump/etjump.git
-    # as a result you will have etjump directory containing source files
-    ```
-* Open up `CMakeLists.txt` (located in the root directory) in the editor and build the project.  
-
-_TODO: work out the steps_
-
 ### Windows
 
 There are multiple options available:
-* Generate the `sln` project files (native `Visual Studio` experience). `RECOMMENDED`
-* Load cmake project in [Visual Studio](https://visualstudio.microsoft.com/vs/community/) (`Visual Studio 2017` or later).
-* Compiling using `mingw-w64` toolchain (using `gcc` on windows).
-* Cross-compiling windows binaries on linux using `mingw-w64` toolchain.
+* Use [Visual Studio](#visual-studio) (Recommended).
+* Use [CLion](#windows-clion) (Recommended).
+* Use [Visual Studio Code](#windows-visual-studio-code).
+* Compiling using `mingw-w64` toolchain (using `gcc` on Windows).
+* Cross-compiling Windows binaries on Linux using `mingw-w64` toolchain.
 
-#### Option 1. Generate Visual Studio `sln` project files:
+#### Visual Studio
 
-This option gives best control over the solution and provides familiar usage experience. It is hence __recommended__ option for the mod [development and debugging](developing.md). 
+Visual Studio offers a complete Windows development and debugging experience. Both Visual Studio and [CLion](#windows-clion) are recommended options on Windows - pick whichever you prefer.
 
-##### CLI
+Generate the `sln` solution:
 
-1. Generate project files: 
-    ```sh
-    $ git clone https://github.com/etjump/etjump.git && cd etjump
-    $ mkdir build && cd build
-    $ cmake .. -G "Visual Studio 17 2022" -A Win32 # adjust if necessary
-    ```
-    * Replace the Visual Studio version with the version you have installed, use `cmake --help` or see [CMake documetation](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#visual-studio-generators).
-    * 64-bit architecture is also supported on Windows, and can be generated with `-A x64`. Note that ET 2.60b does not support 64-bit mods on Windows, and you need to debug and run the game with a 64-bit engine, such as [ET: Legacy](https://www.etlegacy.com/) or [ETe](https://github.com/etfdevs/ETe).
-    * CMake variable `ET_PATH` can be used to point CMake to your development installation - Visual Studio sets up debugging with some pre-defined parameters, and this path will be used as `fs_homepath` and the directory where the game is located.
-    * CMake variable `ET_EXE_NAME` can be used to set the engine that gets launched from `ET_PATH` to debug.
+```sh
+$ git clone https://github.com/etjump/etjump.git && cd etjump
+$ mkdir build && cd build
+$ cmake .. -G "Visual Studio 17 2022" -A Win32 # adjust if necessary
+```
 
-2. Open up generated `sln` solution (located in `build` directory) in `Visual Studio`. 
-3. Use `Build` > `Build Solution` option to start compilation process.
-4. Alternatively build directly from the command line:
-    ```sh
-    $ cmake --build . --config Release
-    # or "cmake --build . --config Debug" to compile debuggable builds
-    ```
+* Replace the Visual Studio version with the version you have installed, use `cmake --help` or see [CMake documentation](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#visual-studio-generators).
+* 64-bit architecture is also supported on Windows, and can be generated with `-A x64`. Note that ET 2.60b does not support 64-bit mods on Windows, and you need to debug and run the game with a 64-bit engine, such as [ET: Legacy](https://www.etlegacy.com/) or [ETe](https://github.com/etfdevs/ETe).
+* CMake variable `ET_PATH` can be used to point CMake to your development installation - Visual Studio sets up debugging with some pre-defined parameters, and this path will be used as `fs_homepath` and the directory where the game is located.
+* CMake variable `ET_EXE_NAME` can be used to set the engine that gets launched from `ET_PATH` to debug.
 
-##### CMake GUI
+Open up the generated `sln` solution (located in `build` directory) in Visual Studio and use `Build` > `Build Solution` to compile. Alternatively, build directly from the command line:
 
-1. Fetch etjump project either using `Git Desktop` or `git cli`:
-    ```sh
-    cd Documents/Git
-    $ git clone https://github.com/etjump/etjump.git
-    # as a result you will have etjump directory containing source files
-    ```
-2. Open up `CMake GUI`.
-3. For the `Where is the source code` select __etjump__ source directory.
-4. For the `Where to build` create `build` directory within the __etjump__ source directory and select it.
-5. Press `Configure` button.
-6. For the `Specify generator` select the `Visual Studio` version you have installed (eg. `Visual Studio 2019`).
-7. For the `Optional platform` select `Win32`.
-8. Press okay and let it to configure.
-9. Press `Generate` button.
-10. Press `Open Project` button to open project in the `Visual Studio`.    
-
-You can close cmake now.
-* Press `Build > Build Solution` to start the compilation.
-* You will find files in the `build/etjump` directory.
-* Checkout the [Development and Debugging](developing.md) for more information on how to run and debug etjump.
+```sh
+$ cmake --build . --config Release
+# or "cmake --build . --config Debug" to compile debuggable builds
+```
 
 ##### Create mod pk3
 
@@ -146,42 +151,30 @@ In `Solution Explorer` (File list):
 3. Similarly you can create zipped etjump release by building `mod_release` project.
     * `zip` release will be created in `build` directory.
 
-#### Option 2. Open CMake project in Visual Studio
+You can also load the project directly in Visual Studio as a CMake project (via `File > Open > CMake`, selecting the root `CMakeLists.txt`) instead of generating an `sln`. This uses the `CMake Targets View` to build individual modules and run the `mod_pk3` target, but requires `Visual Studio 2019` or later.
 
-This is simple, and easy use option, but not as much versatile as `sln` solution. This option requires `Visual Studio 2017` or later. Basically, you are able to open up `CMakeLists.txt` natively in the IDE to compile and edit the source code, without the need to run cmake generator manually.
+See [Debugging with Visual Studio](developing.md#debugging-with-visual-studio) in the development guide for setting up the debugger.
 
-1. Open up console and head to directory where you want to clone the `etjump` repository into (eg. `Documents/Git`)
-2. Clone the repository
-    ```sh
-    $ git clone https://github.com/etjump/etjump.git 
-    # as a result you will have etjump directory containing source files
-    ```
-3. Open up `Visual Studio`.
-4. If `Start Window` is opened, press `Continue without code`.
-5. In `File` > `Open`  select `CMake`.
-6. Head to directory that contains cloned repository (eg. `Documents/Git/etjump`)
-7. Select the `CMakeLists.txt` file.
-8. Let it fully __initialize__ (output window should log `CMake generation finished.`).
-9. In the `Build` menu select `Build All`.
-    * Alternatively click on `Switch View` in `Solution Explorer`, switch to `CMake Targets View` and compile modules (`cgame`, `qagame`, `ui`) separately using context menu (requires `Visual Studio 2019` and later).
-10. You will find compiled binaries in `build/etjump` directory. 
+<a id="windows-clion"></a>
+#### CLion
 
-##### Create mod pk3
+[CLion](https://www.jetbrains.com/clion/) is a cross-platform C/C++ IDE with native CMake support, and is a recommended option on Windows alongside Visual Studio.
 
-###### Visual Studio 2019
+* Open the repository root in CLion — it will configure the project automatically.
+* CLion supports both the MinGW-w64 and Microsoft Visual Studio toolchains; pick whichever you have installed.
+* Set `cgame` as the project to run, and select `All targets` to ensure all modules get built.
+* To run/debug the mod, set up a run configuration launching the game with the arguments `+set fs_basepath . +set fs_homepath <et install dir> +set fs_game etjump`, with the working directory set to `$CMakeCurrentGenerationDir$`. See [debugging with CLion](developing.md#debugging-with-clion) for more details.
 
-In `Solution Explorer` (File list):
-1. Click `Switch Views` (4th button on the icon row).
-2. Switch to `CMake Targets View`.
-3. Select `Package/mod_pk3` entry.
-4. Draw context menu and press `Build`.
-5. You will find `pk3` file in `build/etjump` directory.
-7. Similarly you can zip `pk3` and `qagame` module using `Package/mod_release` target.
+<a id="windows-visual-studio-code"></a>
+#### Visual Studio Code
 
-###### Visual Studio 2017
-* `CMake` menu entry should allow to run `mod_pk3` target.
+Visual Studio Code uses the [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) and [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extensions to configure and build the project.
 
-#### Option 3. Use mingw-w64 toolchain
+* Open the repository root in VS Code and let CMake Tools configure the project.
+* Use the CMake Tools status bar to select the build variant and build target.
+* See [Debugging with VS Code](developing.md#debugging-with-vs-code) in the development guide for setting up a debug launch configuration.
+
+#### Use mingw-w64 toolchain
 
 `mingw-w64` is a build toolchain which allows users to build software using `gcc` compiler and linking against static `libc`, making software more or less consistent among platforms (eg. linux).
 _One can also use `mingw-w64` on linux to cross-compile windows binaries (next section)._
@@ -206,7 +199,7 @@ _One can also use `mingw-w64` on linux to cross-compile windows binaries (next s
     # or use "mingw32-make mod_release" to create release zip
     ```
 
-#### Option 4. Cross-compiling windows binaries on linux using `mingw-w64` 
+#### Cross-compiling windows binaries on linux using `mingw-w64` 
 
 As prerequisites you would first need to install `mingw-w64` and all its dependencies on your system using package manager.
 
@@ -231,7 +224,27 @@ $ make -j4
 
 ### macOS
 
-#### Option 1. Makefiles and apple clang
+<a id="macos-clion"></a>
+#### CLion
+
+[CLion](https://www.jetbrains.com/clion/) is a cross-platform C/C++ IDE with native CMake support, and the recommended IDE on macOS (using the Apple Clang toolchain).
+
+* Open the repository root in CLion — it will configure the project automatically (it uses its own build directory by default; you can point it at `build/` if you prefer).
+* Set `cgame` as the project to run, and select `All targets` to ensure all modules get built.
+* To run/debug the mod, set up a run configuration launching the game with the arguments `+set fs_basepath . +set fs_homepath <et install dir> +set fs_game etjump`, with the working directory set to `$CMakeCurrentGenerationDir$`. See [debugging with CLion](developing.md#debugging-with-clion) for more details.
+
+<a id="macos-visual-studio-code"></a>
+#### Visual Studio Code
+
+VS Code is a cross-platform editor that uses the [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) and [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extensions to configure and build the project.
+
+* Open the repository root in VS Code and let CMake Tools configure the project.
+* Use the CMake Tools status bar to select the build variant and build target.
+* See [Debugging with VS Code](developing.md#debugging-with-vs-code) in the development guide for setting up a debug launch configuration.
+
+#### Makefiles and apple clang
+
+For a plain terminal workflow, install the Apple developer tools and compile with `clang`:
 
 * Install `clang` and all necessary gnu tools:
     ```sh
@@ -270,24 +283,8 @@ $ make -j4
 * Run `make mod_release` to create zip release
     * `zip` release will be created in `build` directory
 
-#### Option 2. Cross-compiling macOS binaries on linux using `darling`
+#### Cross-compiling macOS binaries on linux using `darling`
 
-* Build darling from the source code followig the [instructions](https://docs.darlinghq.org/build-instructions.html) for the platform.
+* Build darling from the source code following the [instructions](https://docs.darlinghq.org/build-instructions.html) for the platform.
 * Launch the [darling shell](https://docs.darlinghq.org/darling-shell.html).
-* Run the commands from the previous chapter (Option 1).
-
-## Building complete release package on linux with cross compile option (windows binaries)
-
-Having all necessary packages installed (`gcc`, `gcc-multilib` and `mingw-w64`), one can build complete release on a single platform (`linux`), running the `build-release.sh` script file.
-
-* Compile `x86` and `x86_64` linux release binaries and create a `zip` release package:
-    ```sh
-    $ mkdir build && cd build
-    $ sh ../scripts/build-release.sh
-    ```
-* Or compile `x86` and `x86_64` linux + cross-compile __windows__ binaries (requires `mingw-w64`):
-    ```sh
-    $ mkdir build && cd build
-    $ sh ../scripts/build-release.sh -mingw
-    ```
-* On success, you can find zip file in `build/etjump` directory.
+* Run the commands from the previous chapter (Option 3).

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -1,67 +1,169 @@
-# Development 
+# Development
 
 This section provides a helping guide on how to develop and debug ETJump.
 
-ETJump is developed using `C++`, although most of the code base is written in `C`. Essentially, you can work with code in any preferred editor, it is however recommended to use [Visual Studio](https://visualstudio.microsoft.com/vs/community/). It is assumed you know how to compile the code, else check out the [compilation guide](compiling.md). It is also assumed you know your way around `C` and/or `C++` languages. If not, it is recommended to read [C beginners tutorial](https://www.tutorialspoint.com/cprogramming/index.htm) and [C++ tutorial](https://www.learncpp.com/). The codebase is fairly straightforward and simple, so basic `C` knowledge would be sufficient to develop the mod.
+ETJump is developed using `C++` (C++17), although a large portion of the code base is written in `C` (the original SDK code). You can work with the code in any editor or IDE you like; see the [IDEs](#ides) section for setup instructions for Visual Studio, VS Code, and CLion. It is assumed you know how to compile the code, otherwise check out the [compilation guide](compiling.md). It is also assumed you know your way around `C` and/or `C++`.
 
-For running tests check [testing guide](testing.md)
+For running tests, check the [testing guide](testing.md).
 
-ETJump build system is based on [CMake](https://cmake.org/). While it's not really necessary to be an expert in this field, it would be desirable at least to get through basics of [cmake](https://cmake.org/cmake/help/latest/guide/tutorial/index.html). 
+The ETJump build system is based on [CMake](https://cmake.org/). While it's not really necessary to be an expert in this field, it would be desirable to at least get through the basics of [CMake](https://cmake.org/cmake/help/latest/guide/tutorial/index.html).
 
-For any questions, ETJump has own [discord](https://discord.gg/AcyWMqR) server, make sure to join it, if you haven't yet. ETJump documentation can be found [here](http://etjump.readthedocs.io/en/latest/). 
-
-Everyone are welcome to push edits to the development guide to make it even more informative.
+For any questions, ETJump has its own [Discord](https://discord.gg/AcyWMqR) server, make sure to join it if you haven't yet.
 
 ## Main guidelines
 
-* Prefer to have separate files for each standalone module for better isolation. 
+* Prefer separate files for each standalone module for better isolation.
 * Follow the [styleguide](styleguide.md) when formatting the code.
-* Prefer writing tests for your code if possible.
+* Prefer writing tests for your code when possible.
 
-## Project structure overview 
+## Project structure overview
 
-* `assets` contains all static files ETJump is using in runtime. Things like menus, graphics, shaders and other scripts, are stored here. 
-* `cmake` contains `CMake` scripts that are used during project generation, including toolchains for various platforms.
-* `deps` contains all bundled dependencies ETJump is using under the hood (gtest, sqlite, sha1, json, boost). In case you need to add new dependency, this should be the place for it. A glue `CMakeLists.txt` might need to be added in case library doesn't come with one.
-* `docs` contains all ETJump development related manuals.
-* `scripts` contain auxiliary bash scripts.
-* `src` the code repository.
-    * `cgame` contains client side source code of the game. 
+* `assets` contains all static files ETJump uses at runtime. Things like menus, graphics, shaders and other scripts are stored here.
+* `cmake` contains CMake scripts used during project generation, including toolchains for various platforms.
+* `deps` contains all bundled dependencies ETJump uses under the hood. If you need to add a new dependency, this is the place for it. A glue `CMakeLists.txt` might need to be added in case a library doesn't come with one.
+* `docs` contains all ETJump development related documentation.
+* `scripts` contain auxiliary shell scripts.
+* `src` is the code repository.
+    * `cgame` contains the client side source code of the game.
         * Manages entity scene setup.
         * Draws HUDs and UIs.
-        * Performs movement and weapon predictions. 
-        * Responds on game events.
-    * `game` contains server side source code of the game.
+        * Performs movement and weapon predictions.
+        * Responds to game events.
+    * `game` contains the server side source code of the game.
         * Manages entity lifecycles.
-        * Process world updates.
+        * Processes world updates.
         * Defines game rules.
         * Performs physics and weapon calculations.
     * `ui` contains menu rendering related code.
-* `tests` tests repository. All test files are added here.
+* `tests` is the test repository. All test files are added here.
 
 Note:
-* After the cmake configuration, `build/etjump` directory will contain the copy of the `assets` folder.
-* In case new asset is added, you would need to rerun the cmake configuration again (simply run `cmake .` in the `build` directory).
+* After the CMake configuration, the `build/etjump` directory will contain a copy of the `assets` folder.
+* If a new asset is added, you need to re-run the CMake configuration (simply run `cmake .` in the `build` directory).
 
-## Linux
+## IDEs
 
-### Running
+ETJump is a CMake project, so any editor or IDE with CMake support can be used to build and debug it. Choose whichever suits you best. Building and configuring the project in each IDE is covered in the [compilation guide](compiling.md); debugging setup is covered in [Debugging](#debugging) below.
+
+### Visual Studio
+
+Visual Studio is the recommended IDE on Windows and provides the most complete debugging experience out of the box. See [Debugging with Visual Studio](#debugging-with-visual-studio) below.
+
+### CLion
+
+CLion has native CMake support and works with multiple toolchains (GCC, Clang, MSVC, MinGW) on Linux, Windows, and macOS. See [Debugging with CLion](#debugging-with-clion) below.
+
+### Visual Studio Code
+
+VS Code is a cross-platform editor that works on Linux, Windows, and macOS. It uses the [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) and [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extensions to configure and build the project. See [Debugging with VS Code](#debugging-with-vs-code) below.
+
+## Running the mod
+
+The mod is not a standalone executable - it is loaded by the game engine (ET, ETe, ET: Legacy) via command line arguments. The two key paths are:
+
+* `fs_homepath` points to an ET installation directory, which contains the engine and `etmain` with the game assets (`pak0-2.pk3`, stock configs etc.).
+* `fs_basepath` is the current development directory (e.g. `build`). The mod binaries are compiled here into the `etjump` directory, which mimics the path structure of an ET installation.
+
+The game is launched with `+set fs_basepath . +set fs_homepath <install dir> +set fs_game etjump`. This launches the game executable from `fs_homepath`, which contains all the game assets, but loads the mod from `fs_basepath`, which contains the compiled mod binaries. Any files created at runtime by the game/mod will be created in `fs_homepath/etjump`, so any configs/custom maps you want to use during development should be placed inside `fs_homepath`.
+
+On Linux, run the mod from a terminal with:
 
 ```sh
-# playtest the binaries using et or etl directly from the build directory
 # replace engine/paths to match your specific environment
-$ etl.x86_64 +set fs_basepath ~/dev/etjump/build +set fs_homepath ~/games/et-dev +set fs_game etjump
+etl.x86_64 +set fs_basepath <path to build dir> +set fs_homepath <et install dir> +set fs_game etjump
 ```
 
-### Debugging
+On Windows:
 
-On linux you can use:
-* `gdb` a command line interface to inspect mod execution using terminal. 
-* `QtCreator` a `Visual Studio` like IDE with a GUI debugger.
+```sh
+# replace engine/paths to match your specific environment
+C:\Games\ETDev\ET.exe +set fs_basepath C:\Dev\etjump\build +set fs_homepath C:\Games\ETDev +set fs_game etjump
+```
 
-#### GDB
+When running from an IDE, set the **working directory** to the build directory so that `fs_basepath .` resolves to `build`, where the mod binaries live.
 
-* Make sure to [compile](compiling.md) mod as `Debug` build type first (`-DCMAKE_BUILD_TYPE=Debug`).
+## Debugging
+
+The general setup is the same across platforms: point the debugger at the game engine executable, pass the `+set fs_basepath . +set fs_homepath <install dir> +set fs_game etjump` arguments, set the working directory to the build directory, and place breakpoints in the mod source. When the game loads the mod, the breakpoints will be hit (e.g. set a breakpoint in `CG_Init` and load a map with `/devmap goldrush`).
+
+To debug the server (`qagame`) module, just run a listen server on the client - no special setup is needed.
+
+Make sure to build a `Debug` configuration first ([compiling.md](compiling.md)) for the best debugging experience.
+
+### Debugging with Visual Studio
+
+Visual Studio can configure the debugger either manually or automatically via CMake.
+
+#### Option 1 - setup debugger manually
+
+1. Right click `cgame` in Solution Explorer and select `Properties`.
+2. Select `Debugging` tab.
+3. For `Command` field browse game executable (this should be inside your desired `fs_homepath`).
+4. For `Working Directory` field, use the macro `$(SolutionDir)`.
+5. For `Command arguments`, make sure `fs_homepath` points to the correct directory, and define any other cvars you want to pass on init.
+
+#### Option 2 - automatic setup with CMake
+
+You can automatically configure the debugger to sensible defaults using CMake variables `ET_PATH` and `ET_EXE_NAME`.
+
+* `ET_PATH` will be used as `fs_homepath`, and is where `Command` field looks for the engine to run
+* `ET_EXE_NAME` is the executable being launched (ET.exe, etl.exe, ETe.exe etc.)
+
+**IMPORTANT!!!** - because Visual Studio builds the project in parallel, ensure `mod_pk3` target is re-built after the initial build of the project. Otherwise, the mod pk3 might be incomplete and the game might fail to load the mod.
+
+To ensure the mod pk3 is always up-to-date, you can add a post-build event to `cgame` which automates building the mod pk3 every time the project is built.
+
+1. Right click `cgame` in Solution Explorer and select `Properties`.
+2. Navigate to `Build Events` -> `Post-Build Events`.
+3. Set the `Command Line` field to `cd $(SolutionDir) && cmake --build . --target mod_pk3`.
+
+You can then press the green play button to launch the game in debugging mode.
+
+#### Disable console window
+
+1. Open up `cgame` project properties using context menu.
+2. Select `Linker` tab.
+3. Select `System` category.
+4. Set `SubSystem` to `Not Set`.
+
+#### CMake based project
+
+If you loaded the project as a CMake project rather than an `sln`, the flow is the same but uses the `CMake Targets View` (requires Visual Studio 2019 or later) to build individual modules and run the `mod_pk3` target.
+
+### Debugging with CLion
+
+1. Set `cgame` as the project to run.
+2. Select `All targets` to ensure all modules get built (unless you want to build everything manually).
+3. Set the **executable** to the game engine (e.g. `etl.x86_64` on Linux, `ET.exe`/`etl.exe` on Windows).
+4. Set the **program arguments** to `+set fs_basepath . +set fs_homepath <et install dir> +set fs_game etjump`.
+5. Set the **working directory** to the build directory (so `fs_basepath .` resolves to `build`, where the mod binaries live).
+6. Place breakpoints in the mod source; when the game loads the mod, they will be hit (e.g. set a breakpoint in `CG_Init` and load a map with `/devmap goldrush`).
+
+### Debugging with VS Code
+
+Install the [CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) and [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extensions, open the repository root and let CMake Tools configure the project. Use the CMake Tools status bar to select the build variant and build target, then add a `.vscode/launch.json` entry to debug the mod (set `program` to the engine executable - e.g. `etl.x86_64` on Linux, `ET.exe`/`etl.exe` on Windows, the `etl`/`ET` binary on macOS):
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "ETJump",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "<path to et executable>",
+      "args": ["+set", "fs_basepath", ".", "+set", "fs_homepath", "<et install dir>", "+set", "fs_game", "etjump"],
+      "cwd": "${workspaceFolder}/build"
+    }
+  ]
+}
+```
+
+### Debugging with gdb (Linux)
+
+`gdb` is a command line interface to inspect mod execution using the terminal, and is a good choice for a plain terminal workflow on Linux.
+
+* Make sure to [compile](compiling.md) the mod as a `Debug` build first (`-DCMAKE_BUILD_TYPE=Debug`).
 * Install gdb:
     ```sh
     # ubuntu
@@ -83,7 +185,7 @@ On linux you can use:
     # upon cgame load breakpoint will be hit
     # use gdb commands to inspect environment
     # next line:
-    n 
+    n
     # print variable value:
     p clientNum
     # list current lines:
@@ -93,71 +195,14 @@ On linux you can use:
     ```
 * There are many more useful commands you can learn at [https://www.tutorialspoint.com/gnu_debugger/index.htm](https://www.tutorialspoint.com/gnu_debugger/index.htm).
 
-#### QtCreator
+## Adding new files to the project
 
-_TODO_ 
+When you add a new source file, it is not automatically part of the build - you must register it in the module's `CMakeLists.txt` and reload the project so the build system picks it up.
 
-## Windows
-
-### Running
-
-You can test run the binaries using terminal directly:
-```sh
-# playtest the binaries directly from the build directory
-# replace engine/paths to match your specific environment
-$ C:\Games\ETDev\ET.exe +set fs_basepath C:\Dev\etjump\build +set fs_homepath C:\Games\ETDev +set fs_game etjump
-```
-Or set up debugger (instructions are below) and run the game directly from `Visual Studio`.
-
-### Debugging
-
-The general path setup for debugging and developing should be following:
-
-* `fs_homepath` points to an ET installation directory, which contains the engine and `etmain` with the game assets (`pak0-2.pk3`, stock configs etc.)
-* `fs_basepath` is the current development directory (e.g. `build`). The mod binaries are compiled here into `etjump` directory, which mimics the path structure of an ET installation.
-* Working directory should be set to the same as `fs_basepath` (Visual Studio users can use the `$(SolutionDir)` macro for this).
-* The game is launched with `+set fs_basepath . +set fs_homepath <path\to\install\dir> +set fs_game etjump`. This launches the game executable from `fs_homepath`, which contains all the game assets, but loads the mod from `fs_basepath`, which contains our compiled mod binaries. Any files created during runtime by the game/mod will be created in `fs_homepath/etjump`. Additionally, any configs/custom maps you might want to use during development should be placed inside `fs_homepath`.
-
-#### sln based project
-
-##### Option 1 - setup debugger manually
-
-1. Right click `cgame` in Solution Explorer and select `Properties`.
-2. Select `Debugging` tab.
-3. For `Command` field browse game executable (this should be inside your desired `fs_homepath`).
-4. For `Working Directory` field, use the macro `$(SolutionDir)`.
-5. For `Command arguments`, make sure `fs_homepath` points to the correct directory, and define any other cvars you want to pass on init.
-
-##### Option 2 - automatic setup with CMake
-
-You can automatically configure the debugger to sensible defaults using CMake variables `ET_PATH` and `ET_EXE_NAME`.
-
-* `ET_PATH` will be used as `fs_homepath`, and is where `Command` field looks for the engine to run
-* `ET_EXE_NAME` is the executable being launched (ET.exe, etl.exe, ETe.exe etc.)
-
-**IMPORTANT!!!** - because Visual Studio builds the project in parallel, ensure `mod_pk3` target is re-built after the initial build of the project. Otherwise, the mod pk3 might be incomplete and the game might fail to load the mod.
-
-To ensure the mod pk3 is always up-to-date, you can add a post-build event to `cgame` which automates building the mod pk3 every time the project is built.
-
-1. Right click `cgame` in Solution Explorer and select `Properties`.
-2. Navigate to `Build Events` -> `Post-Build Events`.
-3. Set the `Command Line` field to `cd $(SolutionDir) && cmake --build . --target mod_pk3`.
-
-You can then press the green play button to launch the game in debugging mode.
-
-##### Disable console window
-
-1. Open up `cgame` project properties using context menu.
-2. Select `Linker` tab.
-3. Select `System` category.
-4. Set `SubSystem` to `Not Set`.
-
-#### CMake based project
-
-_TODO_
-
-### Adding new files to solution (`sln`)
-
-1. Create file in the module directory (`cgame`, `game`, `ui`).
-2. Add file name in the modules specific `CMakeLists.txt`.
-3. Either reopen `Visual Studio` or build `CMake/ZERO_CHECK` project to make new file to appear in the `Solution View`. 
+1. Create the file(s) in the module directory (`cgame`, `game`, `ui`).
+2. Add the file name to the module-specific `CMakeLists.txt` source list (cross-directory shared sources go in the same list; test sources go in `tests/CMakeLists.txt`).
+3. Reload the CMake project so the new file is picked up:
+   * **Visual Studio** - the project should reconfigure when `CMakeLists.txt` changes; if not, build the `CMake/ZERO_CHECK` project or reopen the solution.
+   * **CLion** - use *Reload CMake Project* (or *Reset Cache and Reload Project* if a fresh configure is needed).
+   * **VS Code** - CMake Tools re-configures when `CMakeLists.txt` is saved; if it doesn't pick up the file, run the *CMake: Delete Cache and Reconfigure* command.
+   * **Command line** - simply re-run `cmake -B build` (or any build, which triggers a reconfigure).

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -26,10 +26,10 @@ git clang-format -i <file1> <file2> ... <fileN>
 
 ## Changelog formatting
 
-We include changelog in the in-game menus. The [changelog.md](../changelog.md) file is parsed as a CMake configuration step into version-specific plaintext files, which are included in the mods assets. To ensure this parsing works as excepted, there are few rules you should follow when adding content to the changelog.
+We include changelog in the in-game menus. The [changelog.md](../changelog.md) file is parsed as a CMake configuration step into version-specific plaintext files, which are included in the mods assets. To ensure this parsing works as expected, there are few rules you should follow when adding content to the changelog.
 
 * Only use `H1` headers (single `#`) and annotate each versions changelog separately with these - the parser uses `H1` headers to distinguish the versions.
-* Start each line with a `*`, the changelog should consist of only bulletpoint list entires.
+* Start each line with a `*`, the changelog should consist of only bulletpoint list entries.
   * Multi-level lists like this are fine.
   * When indenting multi-level lists, use __2__ spaces instead of tabs.
 * Markdown links are fine - the parser strips these out completely.
@@ -39,14 +39,218 @@ We include changelog in the in-game menus. The [changelog.md](../changelog.md) f
 We recognize it might be annoying to install bunch of auxiliary tools to simply format things, therefore you may consider installing and using these optional.
 
 * YAML and JSON files should be formatted with [prettier](https://prettier.io/).
-  * `.editorconfig` provides all the required settings for these
+  * [`.editorconfig`](../.editorconfig) provides all the required settings for these
 * Shell scripts should be formatted with [shfmt](https://github.com/patrickvane/shfmt).
 
 ## Coding conventions
 
-In general, it's preferred to write more "C++ style" code rather than "C-style" code. This means for example using the C++ standard template library where applicable (e.g. use `std::array` over C-style array), C++ style casts instead of C-style casts and `nullptr` instead of `NULL`. It's perfectly fine to incorporate these types of changes to your commits when working on something: if you're fixing/modifying a function, feel free to replace any old usage of `NULL` within the function with `nullptr` for example.
+In general, it's preferred to write more "C++ style" code rather than "C-style" code. This means for example using the C++ standard template library where applicable (e.g. use `std::array` over C-style array), C++ style casts instead of C-style casts and `nullptr` instead of `NULL`. It's perfectly fine to incorporate these types of changes to your commits when working on something: if you're fixing/modifying a function, feel free to replace any old usage of `NULL` within the function with `nullptr` for example. These conventions apply to the whole codebase; old, legacy code should be modernized as it is worked on.
 
 ## General guidelines
+
+### Naming
+
+* Functions, class methods and variables should be __camelCased__:
+
+```cpp
+void aCamelCasedName() {}
+```
+
+* `Class` names and `enums` should be __PascalCased__:
+
+```cpp
+class FileSystem {
+  enum FileOpenModes {};
+};
+```
+
+* Do not prefix private class members or methods with `_`, `m_`, or any other prefix.
+* Compile-time constants (replacing magic numbers or strings etc, usually via `constexpr`) should be all uppercase, with underscores separating words. This doesn't apply to function-local `const` variables:
+
+```cpp
+// bad
+inline constexpr float maxDist = 100.0f;
+
+// good
+inline constexpr float MAX_DIST = 100.0f;
+
+void myFunc() {
+  // good, function-local constant variable
+  const float maxDist = 100.0f;
+  // also good, constexpr constant inside function
+  static constexpr float MAX_DIST = 100.0f;
+}
+```
+
+### Files & headers
+
+* Every new `.h`/`.cpp` file should include the full MIT license in the header. You can add this automatically by running [`scripts/include-license.sh`](../scripts/include-license.sh) (adds it to any `etj_*` source lacking one).
+* Headers should use `#pragma once` rather than include guards.
+* Header includes should be ordered as such, with a blank space between each group:
+  * STL headers
+  * module-specific headers
+  * cross-module headers
+
+```cpp
+#include <algorithm>
+
+#include "cg_local.h"
+#include "etj_local.h"
+
+#include "../game/etj_string_utilities.h"
+```
+
+### Code style
+
+* Everything new (`ETJump` related) should be in a namespace; use `ETJump::` unless a more specific one fits (e.g. `DateTime::`):
+
+```cpp
+namespace ETJump {
+class Example {};
+}
+```
+
+* Prefer forward-declaring classes over including their headers when only a reference (pointer/reference/parameter type) is needed:
+
+```cpp
+namespace ETJump {
+class CvarUpdateHandler;
+class SnaphudData;
+
+class CGazV2 : public IRenderable {
+  // only needs a reference, so forward declaration is enough
+  std::shared_ptr<CvarUpdateHandler> cvarUpdate;
+  std::shared_ptr<SnaphudData> snaphudData;
+};
+}
+```
+
+* Prefer const-correctness: mark parameters and locals `const`, pass non-trivial objects by `const&`, and make accessors `const`.
+* Mark value-returning functions `[[nodiscard]]` when ignoring the result is a bug.
+* Prefer `enum class` over plain `enum`; use explicit `static_cast` when converting to/from integer storage:
+
+```cpp
+enum class Style { FULL = 0, PERCENT = 1, NUMBER = 2 };
+
+// converting from a cvar/integer requires an explicit cast
+const Style style = static_cast<Style>(etj_strafeQualityStyle.integer);
+```
+* Prefer `auto` for obvious types (e.g. `const auto *const`, `const auto &`), but spell out the type when it aids readability.
+* Avoid repeating type for variable declarations, when the result is assigned from a cast:
+
+```cpp
+// bad, value repeated in declaration and cast
+float foo = static_cast<float>(getValue());
+
+// good, declared as auto, value comes from cast
+auto foo = static_cast<float>(getValue());
+```
+
+* In constructors, prefer member-initializer lists over assignments in the body, and `std::move` when storing by value:
+
+```cpp
+Foo(std::string name) : name(std::move(name)) { ... }
+```
+
+* Avoid narrowing conversions: prefer explicit casting over implicit conversions.
+* Always initialize variables at declaration.
+* Use `assert()` for programmer-error preconditions (null checks, impossible states):
+
+```cpp
+void Foo(gentity_t *ent) {
+  assert(ent);   // callers must never pass null
+  ...
+}
+```
+
+* Prefer fixed-width integer types (`int32_t`, `uint32_t`) over `int`/`unsigned`.
+* *Never* use `using namespace std`.
+
+The repository's [`.clang-tidy`](../.clang-tidy) file also encodes a set of conventions. The following are reflected in how code is actually written:
+
+* Avoid magic numbers and strings: prefer `inline`/`static constexpr` over `#define` macros for compile-time constants.
+* Mark single-argument constructors `explicit` to avoid implicit conversions:
+
+```cpp
+class Wrapper {
+public:
+  explicit Wrapper(std::string value) : value(std::move(value)) {}
+};
+```
+
+* Mark internal, file-local functions/variables `static` or use anonymous namespaces to force internal linkage:
+
+```cpp
+// only used within this translation unit
+static bool isReady(const gentity_t *ent) { ... }
+
+namespace {
+struct MyStruct {
+  ...
+};
+}
+```
+
+* Avoid recursive functions, unless it is the clearest way to express the logic.
+* We don't really do runtime object destruction, copying or moving - an object is constructed on module init and destroyed on module shutdown the vast majority of the time. As such, the usual rule-of-five style obligations don't really apply - this is reflected by `cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor: true` in the [`.clang-tidy`](../.clang-tidy) file.
+
+Much of `.clang-tidy`'s strictness is deliberately disabled. The original code base is very old and contains substantial amounts of legacy C code that would require large refactors to satisfy those checks, so the relaxation is intentional, not an oversight - don't re-enable checks without good reason.
+
+### Object ownership & lifetime
+
+As mentioned above, objects should be constructed at module init, and destroyed at module shutdown the vast majority of the time. All objects of a module should be owned by a single "context" struct, to guarantee predictable construction & destruction order. This pattern is followed in `cgame` and `ui`, `game` is currently not following this correctly. See [`src/cgame/etj_cgame.h`](../src/cgame/etj_cgame.h) & [`src/cgame/etj_main.cpp`](../src/cgame/etj_main.cpp) for details.
+
+* Use `std::unique_ptr` for objects owned by the context — i.e. everything with a single owner (renderables, utilities, etc.).
+* Use `std::shared_ptr` only where an object is genuinely shared by multiple consumers, e.g. the core services (`cvarUpdate`, `consoleCommands`, `playerEvents`, ...) passed into many constructors. Because objects live for the whole process, the refcount overhead is a non-factor when it comes to performance.
+
+### Comments
+
+* Explain *why*, not what, in comments. Some code is by nature difficult to follow however - you may add more descriptive explanatory comments in such cases.
+
+```cpp
+// bad: restates the code
+// check if the speed is greater than zero
+if (speed > 0) { ... }
+
+// good: explains the reason
+// don't let interpolated frames modify jump times & sprint consumption
+const bool isLerpFrame = s.pm.pmove_msec > cg.time - s.pm.cmd.serverTime;
+```
+
+* Mark known limitations and future work inline with `// TODO:` / `// FIXME:`.
+
+### Control flow
+
+* Prefer early exits (`return`, `continue`, `break`) over deeply nested conditionals; guard clauses that bail out early keep the happy path flat and makes the code more readable:
+
+```cpp
+// good: validate and bail out early
+bool canSkipUpdate(const PmoveUtilsV2::State &s) {
+  // not strafing
+  if (!s.pm.cmd.forwardmove && !s.pm.cmd.rightmove) {
+    return true;
+  }
+
+  // only air or slick movement is important
+  if (s.pm.ps->groundEntityNum != ENTITYNUM_NONE &&
+      !(s.pml.groundTrace.surfaceFlags & SURF_SLICK)) {
+    return true;
+  }
+
+  ...
+  return false;
+}
+
+// bad: deeply nested conditionals obscuring the happy path
+bool canSkipUpdate(const PmoveUtilsV2::State &s) {
+  if (s.pm.cmd.forwardmove || s.pm.cmd.rightmove) {
+    if (s.pm.ps->groundEntityNum == ENTITYNUM_NONE ||
+        (s.pml.groundTrace.surfaceFlags & SURF_SLICK)) {
+      ...
+    }
+  }
+}
+```
 
 * Do not nest ternary operators
 
@@ -63,33 +267,7 @@ if (isAValid() || isBValid()) {
 }
 ```
 
-* Everything new (`ETJump` related) should be in a namespace. Use `ETJump::` if more appropriate is not available. (e.g. `DateTime::` for date utilities):
+### Structure
 
-```cpp
-namespace ETJump {
-class Example {};
-}; // namespace ETJump
-```
-
-* Functions, class methods and variables should be __camelCased__:
-
-```cpp
-void aCamelCasedName() {}
-```
-
-* `Class` names and `enums` should be __PascalCased__:
-
-```cpp
-class FileSystem {
-  enum FileOpenModes {};
-};
-```
-
-* Class members and methods should be declared in the following order:
-  * private (it is okay to omit the keyword)
-  * protected
-  * public
-* Do not prefix private class members or methods with `_` or `m_` or any other prefix.
+* Favor small, focused helper functions over long monolithic ones.
 * Unused code should be completely removed instead of commented out, unless it is somehow relevant.
-* Avoid narrowing conversions: prefer explicit casting rather than implicit.
-* *Never* use `using namespace std`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,10 +43,6 @@ Alternatively, in `Solution Explorer` (File list):
 
 Use `Test Explorer` from the `Test` menu, this gives better overview on discovered tests and provides a way to run only certain set of tests or debug failed tests. It takes time to discover all tests.
 
-### QtCreator
-
-_TODO_
-
 ## Adding new tests
 
 To add new test:


### PR DESCRIPTION
* Updated style guide to better reflect the currently used coding styles and conventions.
* Comprehensive cleanup and reorganization of `developing.md` and `compiling.md`.
  * Added instructions for compiling/debugging in CLion and VSCode.
  * Removed QtCreator instructions (unfinished and unmaintained).
  * Reorganized 'developing.md' to focus on IDEs, not platforms.
  * Added section about sanitizer usage in `compiling.md`
* Added `AGENTS.md` for AI agents.