### PR TITLE
Fix etj_speedColorUsesAccel 2 updating last speed too frequently

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * crash when switching spectated player while previous player was holding jump, and jump speed list was enabled [#1971](https://github.com/etjump/etjump/pull/1971)
 * latest jump speed showed **0** as upmove value if turning on jump speeds list mid-session [#1975](https://github.com/etjump/etjump/pull/1975)
 * `join server` button in quick connect server info menu was not working [#1974](https://github.com/etjump/etjump/pull/1974)
+* `etj_speedColorUsesAccel 2` broke on high frame rates with sub-optimal network settings [#1978](github.com/etjump/etjump/pull/1978)
 
 # ETJump 3.6.0
 

--- a/src/cgame/etj_drawspeed2_v2.cpp
+++ b/src/cgame/etj_drawspeed2_v2.cpp
@@ -209,12 +209,16 @@ bool DrawSpeed2::beforeRender() {
       }
     } else if (!PmoveUtilsV2::skipUpdate(oldLastUpdateTime, std::nullopt,
                                          s.pm)) {
+      // NOTE: only update the speed values used for accel calculations
+      // when we do an update, so accel values stay true without lerping,
+      // even if the speed meter itself is lerped
       Vector2Subtract(s.pm.ps->velocity, lastSpeed, accelVec);
+      Vector2Copy(s.pm.ps->velocity, lastSpeed);
+
       setupAccelColor(s, currentSpeed);
     }
   }
 
-  Vector2Copy(s.pm.ps->velocity, lastSpeed);
   lastPmType = static_cast<pmtype_t>(s.pm.ps->pm_type);
 
   speedStr = getSpeedString();


### PR DESCRIPTION
On > 125FPS, last speed value used by `etj_speedColorUsesAccel 2` to determine acceleration was updating too frequently and wasn't gated behind actual acceleration calculation updates. This caused the coloring to break on some setups, particularly if client's network setting were sub-optimal, causing unpredictable snapshot timestamps.

refs #1921 