### PR TITLE
Remove bad assert from PmoveUtilsV2::skipUpdate

### DIFF
--- a/src/cgame/etj_pmove_utils_v2.cpp
+++ b/src/cgame/etj_pmove_utils_v2.cpp
@@ -1092,11 +1092,6 @@ bool PmoveUtilsV2::skipUpdate(int32_t &lastUpdateTime,
   // otherwise, fall back to 'cg.time'
   // (less accurate, things might break a bit with unstable fps)
   const int32_t frameTime = useCommandTime ? pm.ps->commandTime : cg.time;
-
-  // 'lastUpdateTime' should never be a static variable,
-  // as that makes it error prone with server time resets
-  assert(frameTime >= lastUpdateTime);
-
   const int now = frameTime - (frameTime % pm.pmove_msec);
 
   // never skip updates if lerping is requested


### PR DESCRIPTION
`frameTime >= lastUpdateTime` is a valid condition when switching from free spec to follow, as `lastUpdateTime` is never updated in free spec for majority of pmove HUD renderables.

refs #1985 